### PR TITLE
Change ECR repo to which PR jobs push

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__
 logs
+venv
+.idea

--- a/mxnet/buildspec.yml
+++ b/mxnet/buildspec.yml
@@ -7,13 +7,13 @@
     training_repository: &TRAINING_REPOSITORY
       image_type: &TRAINING_IMAGE_TYPE training
       root: !join [ *FRAMEWORK, "/", *TRAINING_IMAGE_TYPE ]
-      repository_name: &REPOSITORY_NAME !join [beta, "-", *FRAMEWORK, "-", *TRAINING_IMAGE_TYPE]
+      repository_name: &REPOSITORY_NAME !join [pr, "-", *FRAMEWORK, "-", *TRAINING_IMAGE_TYPE]
       repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ] 
     
     inference_repository: &INFERENCE_REPOSITORY
       image_type: &INFERENCE_IMAGE_TYPE inference
       root: !join [ *FRAMEWORK, "/", *INFERENCE_IMAGE_TYPE ]
-      repository_name: &REPOSITORY_NAME !join [beta, "-", *FRAMEWORK, "-", *INFERENCE_IMAGE_TYPE]
+      repository_name: &REPOSITORY_NAME !join [pr, "-", *FRAMEWORK, "-", *INFERENCE_IMAGE_TYPE]
       repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ] 
 
   context:

--- a/pytorch/buildspec.yml
+++ b/pytorch/buildspec.yml
@@ -8,12 +8,12 @@
     training_repository: &TRAINING_REPOSITORY
         image_type: &IMAGE_TYPE training
         root: !join [ *FRAMEWORK, "/", *IMAGE_TYPE ]
-        repository_name: &REPOSITORY_NAME !join [beta, "-", *FRAMEWORK, "-", *IMAGE_TYPE]
+        repository_name: &REPOSITORY_NAME !join [pr, "-", *FRAMEWORK, "-", *IMAGE_TYPE]
         repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ] 
     inference_repository: &INFERENCE_REPOSITORY
         image_type: &IMAGE_TYPE inference
         root: !join [ *FRAMEWORK, "/", *IMAGE_TYPE ]
-        repository_name: &REPOSITORY_NAME !join [beta, "-", *FRAMEWORK, "-", *IMAGE_TYPE]
+        repository_name: &REPOSITORY_NAME !join [pr, "-", *FRAMEWORK, "-", *IMAGE_TYPE]
         repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ]
 
   context:

--- a/tensorflow/buildspec.yml
+++ b/tensorflow/buildspec.yml
@@ -7,12 +7,12 @@
     training_repository: &TRAINING_REPOSITORY
       image_type: &IMAGE_TYPE training
       root: !join [ *FRAMEWORK, "/", *IMAGE_TYPE ]
-      repository_name: &REPOSITORY_NAME !join [beta, "-", *FRAMEWORK, "-", *IMAGE_TYPE]
+      repository_name: &REPOSITORY_NAME !join [pr, "-", *FRAMEWORK, "-", *IMAGE_TYPE]
       repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ]
     inference_repository: &INFERENCE_REPOSITORY
       image_type: &IMAGE_TYPE inference
       root: !join [ *FRAMEWORK, "/", *IMAGE_TYPE ]
-      repository_name: &REPOSITORY_NAME !join [beta, "-", *FRAMEWORK, "-", *IMAGE_TYPE]
+      repository_name: &REPOSITORY_NAME !join [pr, "-", *FRAMEWORK, "-", *IMAGE_TYPE]
       repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ]
 
   context:


### PR DESCRIPTION
*Description of changes:*
1. Infra to run the PR builds has changed in design, and repos for PR will be different than repos used when the PR is merged [PR for changing repos on merge will be sent later]
2. Instead of using repos starting with beta-, repos starting with pr- will be used.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
