### PR TITLE
fix: Delete all services if no service name given

### DIFF
--- a/test/dlc_tests/ecs/mxnet/inference/test_ecs_mxnet_inference.py
+++ b/test/dlc_tests/ecs/mxnet/inference/test_ecs_mxnet_inference.py
@@ -58,5 +58,5 @@ def test_ecs_mxnet_inference(mxnet_inference, region):
         inference_result = request_mxnet_inference_squeezenet(public_ip_address)
         assert inference_result, f"Failed to perform inference at IP address: {public_ip_address}"
     finally:
-        ecs_utils.tear_down_ecs_inference_service(cluster_arn, service_name, task_family, revision)
+        ecs_utils.tear_down_ecs_inference_service(cluster_arn, service_name, task_family, revision, region=region)
         ecs_utils.cleanup_worker_node_cluster(worker_instance_id, cluster_arn)

--- a/test/test_utils/ecs.py
+++ b/test/test_utils/ecs.py
@@ -536,13 +536,14 @@ def delete_ecs_cluster(cluster_arn, region=DEFAULT_REGION):
         raise Exception(f"Failed to delete cluster. Exception - {e}")
 
 
-def tear_down_ecs_inference_service(cluster_arn, service_name, task_family, revision):
+def tear_down_ecs_inference_service(cluster_arn, service_name, task_family, revision, region=DEFAULT_REGION):
     """
     Function to clean up ECS task definition, service resources if exist
     :param cluster_arn:
     :param service_name:
     :param task_family:
     :param revision:
+    :param region:
     """
 
     if task_family and revision:
@@ -555,7 +556,13 @@ def tear_down_ecs_inference_service(cluster_arn, service_name, task_family, revi
         update_ecs_service(cluster_arn, service_name, 0)
         delete_ecs_service(cluster_arn, service_name)
     else:
-        print("Skipped - Service and cluster deletion")
+        ecs_client = boto3.Session(region_name=region).client("ecs")
+        response = ecs_client.list_services(cluster=cluster_arn)
+        services_list = response["serviceArns"]
+        for service in services_list:
+            update_ecs_service(cluster_arn, service, 0)
+            delete_ecs_service(cluster_arn, service)
+        print(f"Deleted all services in {cluster_arn}")
 
 
 def tear_down_ecs_training_task(cluster_arn, task_arn, task_family, revision):


### PR DESCRIPTION
*Description of changes:*
- Previous behavior was to not delete anything if no service name was given to the `tear_down_ecs_inference_service` function.
- The new behavior will be to delete all services if a valid service name is not given.
- This will allow for a clean cluster termination at the end of a test regardless of whether the test succeeded or failed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
