### PR TITLE
disable test triggers for test_utils changes temporarily

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -276,8 +276,9 @@ def pr_build_setup(pr_number, framework):
 
     parse_modifed_root_files_info(files, pattern="src\/\S+")
 
+    # Todo remove test_utils to enable the builds and test triggers for test_utils file changes
     parse_modifed_root_files_info(
-        files, pattern="(?:test\/(?!(dlc_tests|sagemaker_tests))\S+)"
+        files, pattern="(?:test\/(?!(dlc_tests|sagemaker_tests|test_utils))\S+)"
     )
 
     parse_modifed_root_files_info(files, pattern="testspec\.yml")


### PR DESCRIPTION
*Issue #, if available:*
1. disable the test triggers for test_utils changes.

*Description of changes:*
for the pr builds testing if a commit has test_utils changes then all the tests are triggered for every commit in the pr which cause more resource usage. disabling this behavior temporarily.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
