### PR TITLE
change: Read from "sanity" key in test_type_images.json

### DIFF
--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -34,7 +34,7 @@ collect_ignore = [os.path.join("container_tests", "*")]
 
 
 def pytest_addoption(parser):
-    default_images = test_utils.get_dlc_images(os.getenv("TEST_TYPE"))
+    default_images = test_utils.get_dlc_images()
     parser.addoption(
         "--images", default=default_images.split(" "), nargs="+", help="Specify image(s) to run",
     )

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -280,13 +280,13 @@ def delete_uploaded_tests_from_s3(s3_test_location):
     run(f"aws s3 rm --recursive {s3_test_location}")
 
 
-def get_dlc_images(test_type):
+def get_dlc_images():
     if os.getenv("BUILD_CONTEXT") == "PR":
         return os.getenv("DLC_IMAGES")
     test_env_file = os.path.join(os.getenv("CODEBUILD_SRC_DIR_DLC_IMAGES_JSON"), "test_type_images.json")
     with open(test_env_file) as test_env:
         test_images = json.load(test_env)
     for dlc_test_type, images in test_images.items():
-        if test_type == dlc_test_type:
+        if dlc_test_type == "sanity":
             return " ".join(images)
-    raise RuntimeError(f"Cannot find any images for {test_type} in {test_images}")
+    raise RuntimeError(f"Cannot find any images for in {test_images}")

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -119,7 +119,7 @@ def pull_dlc_images(images):
 def main():
     # Define constants
     test_type = os.getenv("TEST_TYPE")
-    dlc_images = get_dlc_images(test_type)
+    dlc_images = get_dlc_images()
     LOGGER.info(f"Images tested: {dlc_images}")
     all_image_list = dlc_images.split(" ")
     standard_images_list = [image_uri for image_uri in all_image_list if "example" not in image_uri]


### PR DESCRIPTION
*Description of changes:*
- I believe this small change will fix the pipelines. Basically the test_type_images.json file does not properly get populated except for sanity test images in mainline context. I would like to merge this in to see whether this fixes things without necessitating infrastructure changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
