### PR TITLE
fix: [test] Skip git secrets test for non PR builds

### DIFF
--- a/test/dlc_tests/sanity/test_git_secrets.py
+++ b/test/dlc_tests/sanity/test_git_secrets.py
@@ -6,7 +6,7 @@ import pytest
 
 from invoke.context import Context
 
-from test.test_utils import is_pr_context, SKIP_NOT_PR_REASON
+from test.test_utils import is_pr_context, PR_ONLY_REASON
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
@@ -23,7 +23,7 @@ def _recursive_find_repo_path():
     return repository_path
 
 
-@pytest.mark.skipif(not is_pr_context(), reason=SKIP_NOT_PR_REASON)
+@pytest.mark.skipif(not is_pr_context(), reason=PR_ONLY_REASON)
 def test_git_secrets():
     ctx = Context()
     repository_path = os.getenv("CODEBUILD_SRC_DIR")

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -33,7 +33,7 @@ UBUNTU_HOME_DIR = "/home/ubuntu"
 SKIP_PR_REASON = "Skipping test in PR context to speed up iteration time. Test will be run in nightly/release pipeline."
 
 # Reason string for skipping tests in non-PR context
-SKIP_NOT_PR_REASON = "Skipping test that doesn't need to be run outside of PR context."
+PR_ONLY_REASON = "Skipping test that doesn't need to be run outside of PR context."
 
 KEYS_TO_DESTROY_FILE = os.path.join(os.sep, "tmp", "keys_to_destroy.txt")
 


### PR DESCRIPTION
## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the tests I've run on the DLC image

*Description:*
- Non PR builds don't use deep-learning-containers as a git-repository, but rather as an artifact. 
- Hence, it is not possible to run the git-secrets test outside of the PR context.

*Tests run:*
- Tested by running the new version of the test through a non-PR build
- Output upon testing with a string placed in the code that matches a forbidden pattern:
```
--COMMAND--
cd /codebuild/output/src027745241/src/github.com/aws/deep-learning-containers && git secrets --scan
--STDOUT--

--STDERR--
test/dlc_tests/sanity/test_git_secrets.py:35:    SOME_FAKE_CREDENTIALS = "ASIA1234567890123456"  # "ASIA[A-Z0-9]{16}"

[ERROR] Matched one or more prohibited patterns

Possible mitigations:
- Mark false positives as allowed using: git config --add secrets.allowed ...
- Mark false positives as allowed by adding regular expressions to .gitallowed at repository's root directory
- List your configured patterns: git config --get-all secrets.patterns
- List your configured allowed patterns: git config --get-all secrets.allowed
- List your configured allowed patterns in .gitallowed at repository's root directory
- Use --no-verify if this is a one-time false positive
----------
```
- Output when no forbidden patterns are detected:
```
--COMMAND--
cd /codebuild/output/src027745241/src/github.com/aws/deep-learning-containers && git secrets --scan
--STDOUT--

--STDERR--
----------
```

*DLC image/dockerfile:*
- N/A

*Additional context:*
- N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

