### PR TITLE
change: [build, test] Add start dockerd to buildspec and testspec

### DIFF
--- a/test/dlc_tests/sanity/test_git_secrets.py
+++ b/test/dlc_tests/sanity/test_git_secrets.py
@@ -1,20 +1,55 @@
+import logging
 import os
+import sys
+
+import pytest
 
 from invoke.context import Context
 
+from test.test_utils import is_pr_context, PR_ONLY_REASON
 
-def test_git_secrets():
-    ctx = Context()
-    pwd = ctx.run("pwd").stdout.strip("\n")
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+LOGGER.addHandler(logging.StreamHandler(sys.stderr))
+
+
+def _recursive_find_repo_path():
+    pwd = os.getcwd()
     repository_path = pwd
     while os.path.basename(repository_path) != "deep-learning-containers":
         repository_path = os.path.dirname(repository_path)
+        if repository_path == "/":
+            raise EnvironmentError(f"Repository path could not be found from {pwd}")
+    return repository_path
+
+
+@pytest.mark.skipif(not is_pr_context(), reason=PR_ONLY_REASON)
+def test_git_secrets():
+    ctx = Context()
+    repository_path = os.getenv("CODEBUILD_SRC_DIR")
+    if not repository_path:
+        repository_path = _recursive_find_repo_path()
+    LOGGER.info(f"repository_path = {repository_path}")
+
+    # Replace the regex pattern below with a matching string to run test that makes scan fail:
+    SOME_FAKE_CREDENTIALS = "ASIA[A-Z0-9]{16}"
+    WHITELISTED_CREDENTIALS = "AKIAIOSFODNN7EXAMPLE"
+    # End of Test Section
+
     with ctx.cd(repository_path):
         ctx.run("git clone https://github.com/awslabs/git-secrets.git")
         with ctx.cd("git-secrets"):
             ctx.run("make install")
         ctx.run("git secrets --install")
         ctx.run("git secrets --register-aws")
-        ctx.run("git secrets --list", echo=True)
-        scan_results = ctx.run("git secrets --scan", echo=True)
+        output = ctx.run("git secrets --list")
+        LOGGER.info(f"\n--COMMAND--\n{output.command}\n"
+                    f"--STDOUT--\n{output.stdout}\n"
+                    f"--STDERR--\n{output.stderr}\n"
+                    f"----------")
+        scan_results = ctx.run("git secrets --scan", hide=True, warn=True)
+        LOGGER.info(f"\n--COMMAND--\n{scan_results.command}\n"
+                    f"--STDOUT--\n{scan_results.stdout}\n"
+                    f"--STDERR--\n{scan_results.stderr}"
+                    f"----------")
     assert scan_results.ok, scan_results.stderr

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -32,6 +32,9 @@ UBUNTU_HOME_DIR = "/home/ubuntu"
 # Reason string for skipping tests in PR context
 SKIP_PR_REASON = "Skipping test in PR context to speed up iteration time. Test will be run in nightly/release pipeline."
 
+# Reason string for skipping tests in non-PR context
+PR_ONLY_REASON = "Skipping test that doesn't need to be run outside of PR context."
+
 KEYS_TO_DESTROY_FILE = os.path.join(os.sep, "tmp", "keys_to_destroy.txt")
 
 


### PR DESCRIPTION
… CodeBuild image
## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
Just like the release spec, we need to add start-dockerd to testspec and buildspec to support the new codebuild images.

*Tests run:*
Ensured that builds executed successfully in my personal account.

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

