### PR TITLE
fix: [release] correct the formatting mistake in release_images.yml

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -15,7 +15,7 @@ release_images:
       os_version: "ubuntu16.04"
       cuda_version: "cu101"
       dlc_version: "1.1"
- 2:
+  2:
     framework: "pytorch"
     version: "1.5.0"
     training:
@@ -25,7 +25,7 @@ release_images:
       cuda_version: "cu101"
       dlc_version: "1.1"
       example: True
- 3:
+  3:
     framework: "tensorflow"
     version: "2.1.0"
     training:
@@ -40,7 +40,7 @@ release_images:
       os_version: "ubuntu18.04"
       cuda_version: "cu101"
       dlc_version: "1.0"
- 4:
+  4:
     framework: "tensorflow"
     version: "2.1.0"
     training:


### PR DESCRIPTION
## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to

*Description:*
- The indentation on the entries in the release_images.yml file was off, which caused release jobs to fail. This PR corrects the indentation.

*Tests run:*
- Ran the YAML parser on the yml file, which successfully produced the image details for images to be released.

*DLC image/dockerfile:*
- N/A

*Additional context:*
- N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

