### PR TITLE
[tensorflow]| [test] | [eks] | Change mpi-operator properties to look for during pod status check

### DIFF
--- a/test/test_utils/eks.py
+++ b/test/test_utils/eks.py
@@ -540,7 +540,7 @@ def is_mpijob_launcher_pod_ready(ctx, namespace, job_name):
     # mpi-job-name and mpi-job-type properties derived from:
     # https://github.com/kubeflow/mpi-operator/blob/master/pkg/controllers/v1/mpi_job_controller.go#L74
     pod_name = ctx.run(
-        f"kubectl get pods -n {namespace} -l mpi-job-name={job_name},mpi-job-type=launcher -o name"
+        f"kubectl get pods -n {namespace} -l mpi-job-name={job_name},mpi-job-role=launcher -o name"
     ).stdout.strip("\n")
     if pod_name:
         return pod_name


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries to make sure the licenses are on the list of acceptable license types
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
The mpi operator label convention changed upstream: https://github.com/kubeflow/mpi-operator/pull/252/files

Although we have pinned the operator image being used, it seems that the 'v1' convention is still pulled from master.

*Tests run:*
python test/testrunner.py for EKS tests.

*DLC image/dockerfile:*
- 669063966089.dkr.ecr.us-west-2.amazonaws.com/beta-tensorflow-training:2.1.0-gpu-py36-cu101-ubuntu18.04-example-2020-05-15-07-25-06
- 669063966089.dkr.ecr.us-west-2.amazonaws.com/beta-tensorflow-training:2.1.0-gpu-py27-cu101-ubuntu18.04-example-2020-05-15-07-25-06
*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

