### PR TITLE
change: [tensorflow] | [ec2] | [test] Make two CPU tests run on c5.18

### DIFF
--- a/test/dlc_tests/ec2/tensorflow/training/test_tensorflow_training.py
+++ b/test/dlc_tests/ec2/tensorflow/training/test_tensorflow_training.py
@@ -43,6 +43,8 @@ def test_tensorflow_train_mnist_gpu(tensorflow_training, ec2_connection, gpu_onl
     execute_ec2_training_test(ec2_connection, tensorflow_training, TF_MNIST_CMD)
 
 
+# TODO: Change this back TF_EC2_CPU_INSTANCE_TYPE. Currently this test times out on c4.8x, m4.16x and t2.2x,
+#       though passes on all three when run manually. For now we are pinning to c5.18 until we can resolve the issue.
 @pytest.mark.parametrize("ec2_instance_type", ["c5.18xlarge"], indirect=True)
 def test_tensorflow_train_mnist_cpu(tensorflow_training, ec2_connection, cpu_only):
     execute_ec2_training_test(ec2_connection, tensorflow_training, TF_MNIST_CMD)
@@ -54,6 +56,8 @@ def test_tensorflow_with_horovod_gpu(tensorflow_training, ec2_connection, gpu_on
     execute_ec2_training_test(ec2_connection, tensorflow_training, test_script)
 
 
+# TODO: Change this back TF_EC2_CPU_INSTANCE_TYPE. Currently this test times out on c4.8x, m4.16x and t2.2x,
+#       though passes on all three when run manually. For now we are pinning to c5.18 until we can resolve the issue.
 @pytest.mark.parametrize("ec2_instance_type", ["c5.18xlarge"], indirect=True)
 def test_tensorflow_with_horovod_cpu(tensorflow_training, ec2_connection, cpu_only):
     test_script = TF1_HVD_CMD if is_tf1(tensorflow_training) else TF2_HVD_CMD


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

