### PR TITLE
Adding telemetry tracking in PyTorch 1.5

### DIFF
--- a/pytorch/training/docker/1.5.0/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/1.5.0/py3/Dockerfile.cpu
@@ -107,6 +107,10 @@ RUN pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pytho
 
 RUN chmod +x /usr/local/bin/start_with_right_hostname.sh
 
+ADD https://raw.githubusercontent.com/aws/aws-deep-learning-containers-utils/master/deep_learning_container.py /usr/local/bin/deep_learning_container.py
+
+RUN chmod +x /usr/local/bin/deep_learning_container.py
+
 RUN curl -o /license.txt https://aws-dlc-licenses.s3.amazonaws.com/pytorch-1.5.0/license.txt
 
 # fix safety issues

--- a/pytorch/training/docker/1.5.0/py3/Dockerfile.gpu
+++ b/pytorch/training/docker/1.5.0/py3/Dockerfile.gpu
@@ -171,6 +171,10 @@ RUN pip install --no-cache-dir "sagemaker-pytorch-training<2"
 
 RUN chmod +x /usr/local/bin/start_with_right_hostname.sh
 
+ADD https://raw.githubusercontent.com/aws/aws-deep-learning-containers-utils/master/deep_learning_container.py /usr/local/bin/deep_learning_container.py
+
+RUN chmod +x /usr/local/bin/deep_learning_container.py
+
 RUN curl -o /license.txt https://aws-dlc-licenses.s3.amazonaws.com/pytorch-1.5.0/license.txt
 
 # Starts framework

--- a/test/dlc_tests/container_tests/bin/pytorch_tests/test_pt_dlc_telemetry_test
+++ b/test/dlc_tests/container_tests/bin/pytorch_tests/test_pt_dlc_telemetry_test
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+HOME_DIR=/test
+BIN_DIR=${HOME_DIR}/bin
+LOG_DIR=${HOME_DIR}/logs
+TRAINING_LOG=${LOG_DIR}/pytorch_telemetry_test.log
+set -e
+
+echo "Verify pytorch telemetry test. You can follow progress on the log file : $TRAINING_LOG" | tee -a $TRAINING_LOG
+
+python ${BIN_DIR}/pytorch_tests/test_pt_dlc_telemetry_test.py > ${TRAINING_LOG} 2>&1
+
+if grep "DLC Telemetry perf test Passed" $TRAINING_LOG; then
+  echo "Successfully verified Telemetry perf test."
+else
+  echo "Telemetry perf test failed."
+  cat ${TRAINING_LOG}
+  exit 1
+fi
+
+if grep "Opt-In/Opt-Out Test passed" $TRAINING_LOG; then
+  echo "Successfully verified Opt-In/Opt-Out Test "
+else
+  echo "Opt-In/Opt-Out Test failed."
+  cat ${TRAINING_LOG}
+  exit 1
+fi
+
+exit 0

--- a/test/dlc_tests/container_tests/bin/pytorch_tests/test_pt_dlc_telemetry_test.py
+++ b/test/dlc_tests/container_tests/bin/pytorch_tests/test_pt_dlc_telemetry_test.py
@@ -1,0 +1,76 @@
+import os
+import numpy as np
+import time
+
+def opt_in_opt_out_test():
+  os.environ['TEST_MODE']='1'
+  if os.path.exists("/tmp/test_request.txt"):
+    os.system("rm /tmp/test_request.txt")
+  os.environ["OPT_OUT_TRACKING"]="True"
+  cmd = "python -c 'import torch'"
+  os.system(cmd)
+  assert(os.path.exists("/tmp/test_request.txt")==False)
+
+  if os.path.exists("/tmp/test_request.txt"):
+    os.system("rm /tmp/test_request.txt")
+  os.environ["OPT_OUT_TRACKING"]="False"
+  cmd = "python -c 'import torch'"
+  os.system(cmd)
+  assert(os.path.exists("/tmp/test_request.txt")==True)
+
+
+  if os.path.exists("/tmp/test_request.txt"):
+    os.system("rm /tmp/test_request.txt")
+  os.environ["OPT_OUT_TRACKING"]="TRUE"
+  cmd = "python -c 'import torch'"
+  os.system(cmd)
+  assert(os.path.exists("/tmp/test_request.txt")==False)
+
+  if os.path.exists("/tmp/test_request.txt"):
+    os.system("rm /tmp/test_request.txt")
+  os.environ["OPT_OUT_TRACKING"]="true"
+  cmd = "python -c 'import torch'"
+  os.system(cmd)
+  assert(os.path.exists("/tmp/test_request.txt")==False)
+
+
+  if os.path.exists("/tmp/test_request.txt"):
+    os.system("rm /tmp/test_request.txt")
+  os.environ["OPT_OUT_TRACKING"]="XYgg"
+  cmd = "python -c 'import torch'"
+  os.system(cmd)
+  assert(os.path.exists("/tmp/test_request.txt")==True)
+
+
+  print("Opt-In/Opt-Out Test passed")
+
+def perf_test():
+  os.environ['TEST_MODE']='0'
+  os.environ["OPT_OUT_TRACKING"]="False"
+  NUM_ITERATIONS = 5
+
+  for itr in range(NUM_ITERATIONS):
+    total_time_in = 0
+    for x in range(NUM_ITERATIONS):
+      cmd = "python -c 'import time; start= time.time();import torch; '"
+      start = time.time()
+      os.system(cmd)
+      total_time_in += time.time()-start
+    print("avg out  time: ", total_time_in/NUM_ITERATIONS)
+
+    total_time_out = 0
+    for x in range(NUM_ITERATIONS):
+      cmd = "export OPT_OUT_TRACKING='true' && python -c 'import time;start= time.time();import torch; '"
+      start = time.time()
+      os.system(cmd)
+      total_time_out += time.time()-start
+    print("avg out  time: ", total_time_out/NUM_ITERATIONS)
+
+    np.testing.assert_allclose(total_time_in/NUM_ITERATIONS, total_time_out/NUM_ITERATIONS, rtol=0.2, atol=0.5)
+
+    print("DLC Telemetry perf test Passed")
+
+perf_test()
+opt_in_opt_out_test()
+
+print("All DLC telemetry test passed")

--- a/test/dlc_tests/ec2/pytorch/training/test_pytorch_training.py
+++ b/test/dlc_tests/ec2/pytorch/training/test_pytorch_training.py
@@ -93,10 +93,10 @@ def test_nvapex(pytorch_training, ec2_connection, gpu_only):
 
 
 @pytest.mark.parametrize("ec2_instance_type", PT_EC2_GPU_INSTANCE_TYPE, indirect=True)
-def test_tensorflow_telemetry_gpu(pytorch_training, ec2_connection, gpu_only):
+def test_pytorch_telemetry_gpu(pytorch_training, ec2_connection, gpu_only):
     execute_ec2_training_test(ec2_connection, pytorch_training, PT_TELEMETRY_CMD)
 
 
 @pytest.mark.parametrize("ec2_instance_type", PT_EC2_CPU_INSTANCE_TYPE, indirect=True)
-def test_tensorflow_telemetry_cpu(pytorch_training, ec2_connection, cpu_only):
+def test_pytorch_telemetry_cpu(pytorch_training, ec2_connection, cpu_only):
     execute_ec2_training_test(ec2_connection, pytorch_training, PT_TELEMETRY_CMD)

--- a/test/dlc_tests/ec2/pytorch/training/test_pytorch_training.py
+++ b/test/dlc_tests/ec2/pytorch/training/test_pytorch_training.py
@@ -11,6 +11,7 @@ PT_MNIST_CMD = os.path.join(CONTAINER_TESTS_PREFIX, "pytorch_tests", "testPyTorc
 PT_REGRESSION_CMD = os.path.join(CONTAINER_TESTS_PREFIX, "pytorch_tests", "testPyTorchRegression")
 PT_DGL_CMD = os.path.join(CONTAINER_TESTS_PREFIX, "dgl_tests", "testPyTorchDGL")
 PT_APEX_CMD = os.path.join(CONTAINER_TESTS_PREFIX, "pytorch_tests", "testNVApex")
+PT_TELEMETRY_CMD = os.path.join(CONTAINER_TESTS_PREFIX, "pytorch_tests", "test_pt_dlc_telemetry_test")
 
 if is_pr_context():
     PT_EC2_GPU_INSTANCE_TYPE = ["p3.2xlarge"]
@@ -89,3 +90,13 @@ def test_pytorch_mpi(pytorch_training, ec2_connection, gpu_only, py3_only):
 @pytest.mark.parametrize("ec2_instance_type", PT_EC2_GPU_INSTANCE_TYPE, indirect=True)
 def test_nvapex(pytorch_training, ec2_connection, gpu_only):
     execute_ec2_training_test(ec2_connection, pytorch_training, PT_APEX_CMD)
+
+
+@pytest.mark.parametrize("ec2_instance_type", PT_EC2_GPU_INSTANCE_TYPE, indirect=True)
+def test_tensorflow_telemetry_gpu(pytorch_training, ec2_connection, gpu_only):
+    execute_ec2_training_test(ec2_connection, pytorch_training, PT_TELEMETRY_CMD)
+
+
+@pytest.mark.parametrize("ec2_instance_type", PT_EC2_CPU_INSTANCE_TYPE, indirect=True)
+def test_tensorflow_telemetry_cpu(pytorch_training, ec2_connection, cpu_only):
+    execute_ec2_training_test(ec2_connection, pytorch_training, PT_TELEMETRY_CMD)


### PR DESCRIPTION
Changes:
* Modified training docker files to include telemetry tracking script. Inference DLCs use public binaries so I have skipped those docker files.
* Pytorch binaries (with telemetry tracking enabled) have been updated in s3. The URLs remain unchanged.
* Added an ec2 test following https://github.com/aws/deep-learning-containers/pull/180

