### PR TITLE
run ldconfig for cpu containers after openssl installation

### DIFF
--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -126,6 +126,7 @@ RUN wget -c https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
 
 # when we remove previous openssl, the ca-certificates pkgs and its symlinks gets deleted
 # causing sslcertverificationerror the below steps are to fix that
+RUN update-ca-certificates --fresh
 ENV SSL_CERT_DIR=/etc/ssl/certs
 
 # Some TF tools expect a "python" binary

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -121,6 +121,7 @@ RUN wget -c https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
  && cd openssl-${OPENSSL_VERSION} \
  && ./config && make && make test \
  && make install \
+ && ldconfig \
  && cd .. && rm -rf openssl-*
 
 # when we remove previous openssl, the ca-certificates pkgs and its symlinks gets deleted


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
run ldconfig for cpu containers after openssl installation
*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

