### PR TITLE
[tensorflow][build] Update TF 2.2 binaries with some performance optimization

### DIFF
--- a/tensorflow/inference/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/inference/docker/2.2.0/py3/Dockerfile.cpu
@@ -1,0 +1,107 @@
+FROM ubuntu:18.04
+
+LABEL maintainer="Amazon AI" 
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
+
+
+ARG PYTHON=python3.7
+ARG PYTHON_PIP=python3-pip
+ARG PIP=pip3
+ARG PYTHON_VERSION=3.7.7
+ARG OPENSSL_VERSION=1.1.1g
+ARG TFS_SHORT_VERSION=2.2
+ARG TFS_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/serving/r2.2_aws/20200605-005334/cpu/tensorflow_model_server
+
+# See http://bugs.python.org/issue19846
+ENV LANG=C.UTF-8
+# Python won’t try to write .pyc or .pyo files on the import of source modules
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV SAGEMAKER_TFS_VERSION="${TFS_SHORT_VERSION}"
+ENV PATH="$PATH:/sagemaker"
+ENV LD_LIBRARY_PATH='/usr/local/lib:$LD_LIBRARY_PATH'
+ENV MODEL_BASE_PATH=/models
+# The only required piece is the model name in order to differentiate endpoints
+ENV MODEL_NAME=model
+ENV DEBIAN_FRONTEND=noninteractive
+
+
+
+# nginx + njs 
+RUN apt-get update \
+ && apt-get -y install --no-install-recommends \
+    curl \
+    gnupg2 \
+    ca-certificates \
+    git \
+    wget \
+    vim \
+    build-essential \
+    zlib1g-dev \
+ && curl -s http://nginx.org/keys/nginx_signing.key | apt-key add - \ 
+ && echo 'deb http://nginx.org/packages/ubuntu/ bionic nginx' >> /etc/apt/sources.list \
+ && apt-get update \
+ && apt-get -y install --no-install-recommends \
+    nginx \
+    nginx-module-njs \
+    python3 \
+    python3-pip \
+    python3-setuptools \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN ${PIP} --no-cache-dir install --upgrade pip setuptools
+
+# cython, falcon, gunicorn, grpc
+RUN ${PIP} install --no-cache-dir \
+    awscli \
+    cython==0.29.14 \
+    falcon==2.0.0 \
+    gunicorn==20.0.4 \
+    gevent==1.4.0 \
+    requests==2.22.0 \
+    grpcio==1.27.1 \
+    protobuf==3.11.1 \
+# using --no-dependencies to avoid installing tensorflow binary
+ && ${PIP} install --no-dependencies --no-cache-dir \
+    tensorflow-serving-api==2.2.0
+
+COPY ./sagemaker /sagemaker
+
+# put tensorflow library (with only error_codes) to python dist-packages
+WORKDIR /
+RUN cd /usr/local/lib/python3.*/dist-packages/ \
+ && mv /sagemaker/tensorflow-2.2 ./tensorflow \
+# Delete the remaining tensorflow folder to avoid confusing python import
+ && rm -rf /sagemaker/tensorflow
+
+# Some TF tools expect a "python" binary
+RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
+
+RUN curl https://tensorflow-aws.s3-us-west-2.amazonaws.com/MKL-Libraries/libiomp5.so -o /usr/local/lib/libiomp5.so
+RUN curl https://tensorflow-aws.s3-us-west-2.amazonaws.com/MKL-Libraries/libmklml_intel.so -o /usr/local/lib/libmklml_intel.so
+
+RUN curl $TFS_URL -o /usr/bin/tensorflow_model_server \
+ && chmod 555 /usr/bin/tensorflow_model_server
+
+# Expose ports
+# gRPC and REST
+EXPOSE 8500 8501
+
+# Set where models should be stored in the container
+RUN mkdir -p ${MODEL_BASE_PATH}
+
+# Create a script that runs the model server so we can use environment variables
+# while also passing in arguments from the docker command line
+RUN echo '#!/bin/bash \n\n' > /usr/bin/tf_serving_entrypoint.sh \
+ && echo '/usr/bin/tensorflow_model_server --port=8500 --rest_api_port=8501 --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} "$@"' >> /usr/bin/tf_serving_entrypoint.sh \
+ && chmod +x /usr/bin/tf_serving_entrypoint.sh
+
+ADD https://raw.githubusercontent.com/aws/aws-deep-learning-containers-utils/master/deep_learning_container.py /usr/local/bin/deep_learning_container.py
+
+RUN chmod +x /usr/local/bin/deep_learning_container.py
+
+RUN curl https://aws-dlc-licenses.s3.amazonaws.com/tensorflow-2.2/license.txt -o /license.txt
+
+CMD ["/usr/bin/tf_serving_entrypoint.sh"]
+

--- a/tensorflow/inference/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/inference/docker/2.2.0/py3/Dockerfile.cpu
@@ -10,7 +10,7 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 ARG TFS_SHORT_VERSION=2.2
-ARG TFS_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/serving/r2.2_aws/20200605-005334/cpu/tensorflow_model_server
+ARG TFS_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/serving/r2.2_aws/20200605-232554/cpu/py37/tensorflow_model_server
 
 # See http://bugs.python.org/issue19846
 ENV LANG=C.UTF-8

--- a/tensorflow/inference/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/inference/docker/2.2.0/py3/Dockerfile.cpu
@@ -10,7 +10,7 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 ARG TFS_SHORT_VERSION=2.2
-ARG TFS_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/serving/r2.2_aws/20200605-232554/cpu/py37/tensorflow_model_server
+ARG TFS_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/serving/r2.2_aws/20200606-011120/cpu/py37/tensorflow_model_server
 
 # See http://bugs.python.org/issue19846
 ENV LANG=C.UTF-8

--- a/tensorflow/inference/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/inference/docker/2.2.0/py3/Dockerfile.gpu
@@ -10,7 +10,7 @@ ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
 ARG TFS_SHORT_VERSION=2.2
-ARG TFS_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/serving/r2.2_aws/20200605-005334/gpu/tensorflow_model_server
+ARG TFS_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/serving/r2.2_aws/20200605-232554/gpu/py37/tensorflow_model_server
 
 ENV NCCL_VERSION=2.6.4-1+cuda10.2
 ENV CUDNN_VERSION=7.6.5.32-1+cuda10.2

--- a/tensorflow/inference/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/inference/docker/2.2.0/py3/Dockerfile.gpu
@@ -10,7 +10,7 @@ ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
 ARG TFS_SHORT_VERSION=2.2
-ARG TFS_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/serving/r2.2_aws/20200605-232554/gpu/py37/tensorflow_model_server
+ARG TFS_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/serving/r2.2_aws/20200606-011120/gpu/py37/tensorflow_model_server
 
 ENV NCCL_VERSION=2.6.4-1+cuda10.2
 ENV CUDNN_VERSION=7.6.5.32-1+cuda10.2

--- a/tensorflow/inference/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/inference/docker/2.2.0/py3/Dockerfile.gpu
@@ -1,0 +1,139 @@
+FROM nvidia/cuda:10.2-base-ubuntu18.04
+
+LABEL maintainer="Amazon AI" 
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
+
+ARG PYTHON=python3.7
+ARG PYTHON_PIP=python3-pip
+ARG PIP=pip3
+ARG PYTHON_VERSION=3.7.7
+ARG OPENSSL_VERSION=1.1.1g
+
+ARG TFS_SHORT_VERSION=2.2
+ARG TFS_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/serving/r2.2_aws/20200605-005334/gpu/tensorflow_model_server
+
+ENV NCCL_VERSION=2.6.4-1+cuda10.2
+ENV CUDNN_VERSION=7.6.5.32-1+cuda10.2
+ENV TF_TENSORRT_VERSION=6.0.1
+
+# See http://bugs.python.org/issue19846
+ENV LANG=C.UTF-8
+ENV PYTHONDONTWRITEBYTECODE=1
+# Python won’t try to write .pyc or .pyo files on the import of source modules
+ENV PYTHONUNBUFFERED=1
+ENV SAGEMAKER_TFS_VERSION="${TFS_SHORT_VERSION}"
+ENV PATH="$PATH:/sagemaker"
+ENV MODEL_BASE_PATH=/models
+# The only required piece is the model name in order to differentiate endpoints
+ENV MODEL_NAME=model
+# Fix for the interactive mode during an install in step 21
+ENV DEBIAN_FRONTEND=noninteractive
+
+# allow unauthenticated and allow downgrades for special libcublas library
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends --allow-unauthenticated --allow-downgrades\
+    ca-certificates \
+    cuda-command-line-tools-10-2 \
+    cuda-cufft-10-2 \
+    cuda-curand-10-2 \
+    cuda-cusolver-10-2 \
+    cuda-cusparse-10-2 \
+    #cuda-cublas-dev not available with 10-1, install libcublas instead
+    libcublas10=10.2.1.243-1 \
+    libcublas-dev=10.2.1.243-1 \
+    libcudnn7=${CUDNN_VERSION} \
+    libnccl2=${NCCL_VERSION} \
+    libgomp1 \
+    curl \
+    git \
+    wget \
+    vim \
+    build-essential \
+    zlib1g-dev \
+    python3 \
+    python3-pip \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# The 'apt-get install' of nvinfer-runtime-trt-repo-ubuntu1804-4.0.1-ga-cuda10.0
+# adds a new list which contains libnvinfer library, so it needs another
+# 'apt-get update' to retrieve that list before it can actually install the
+# library.
+# We don't install libnvinfer-dev since we don't need to build against TensorRT,
+# and libnvinfer4 doesn't contain libnvinfer.a static library.
+RUN apt-get update \
+# nvinfer-runtime-trt-repo doesn't have a 1804-cuda10.1 version yet. see:
+# https://developer.download.nvidia.cn/compute/machine-learning/repos/ubuntu1804/x86_64/
+ && apt-get install -y --no-install-recommends nvinfer-runtime-trt-repo-ubuntu1804-5.0.2-ga-cuda10.0 \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends libnvinfer6=${TF_TENSORRT_VERSION}-1+cuda10.2 \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+RUN ${PIP} --no-cache-dir install --upgrade \
+    pip \
+    setuptools
+
+# Some TF tools expect a "python" binary
+RUN ln -s $(which ${PYTHON}) /usr/local/bin/python
+
+# nginx + njs
+RUN apt-get update \
+ && apt-get -y install --no-install-recommends \
+    curl \
+    gnupg2 \
+ && curl -s http://nginx.org/keys/nginx_signing.key | apt-key add - \
+ && echo 'deb http://nginx.org/packages/ubuntu/ bionic nginx' >> /etc/apt/sources.list \
+ && apt-get update \
+ && apt-get -y install --no-install-recommends \
+    nginx \
+    nginx-module-njs \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# cython, falcon, gunicorn, grpc
+RUN ${PIP} install -U --no-cache-dir \
+    awscli \
+    cython==0.29.14 \
+    falcon==2.0.0 \
+    gunicorn==20.0.4 \
+    gevent==1.4.0 \
+    requests==2.22.0 \
+    grpcio==1.27.1  \
+    protobuf==3.11.1 \
+# using --no-dependencies to avoid installing tensorflow binary
+ && ${PIP} install --no-dependencies --no-cache-dir \
+    tensorflow-serving-api-gpu==2.2.0
+
+COPY ./sagemaker /sagemaker
+
+RUN curl $TFS_URL -o /usr/bin/tensorflow_model_server \
+ && chmod 555 /usr/bin/tensorflow_model_server
+
+# put tensorflow library (with only error_codes) to python dist-packages
+WORKDIR /
+RUN cd /usr/local/lib/python3.*/dist-packages/ \
+ && mv /sagemaker/tensorflow-2.2 ./tensorflow \
+# Delete the remaining tensorflow folder to avoid confusing python import
+ && rm -rf /sagemaker/tensorflow
+
+# Expose gRPC and REST port
+EXPOSE 8500 8501
+
+# Set where models should be stored in the container
+RUN mkdir -p ${MODEL_BASE_PATH}
+
+# Create a script that runs the model server so we can use environment variables
+# while also passing in arguments from the docker command line
+RUN echo '#!/bin/bash \n\n' > /usr/bin/tf_serving_entrypoint.sh \
+ && echo '/usr/bin/tensorflow_model_server --port=8500 --rest_api_port=8501 --model_name=${MODEL_NAME} --model_base_path=${MODEL_BASE_PATH}/${MODEL_NAME} "$@"' >> /usr/bin/tf_serving_entrypoint.sh \
+ && chmod +x /usr/bin/tf_serving_entrypoint.sh
+
+ADD https://raw.githubusercontent.com/aws/aws-deep-learning-containers-utils/master/deep_learning_container.py /usr/local/bin/deep_learning_container.py
+
+RUN chmod +x /usr/local/bin/deep_learning_container.py
+
+RUN curl https://aws-dlc-licenses.s3.amazonaws.com/tensorflow-2.2/license.txt -o /license.txt
+
+CMD ["/usr/bin/tf_serving_entrypoint.sh"]
+

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -27,9 +27,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200605-053815/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200606-011033/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200605-053815/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200606-011033/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -27,9 +27,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200604-221439/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200605-032027/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200604-221439/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200605-032027/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -27,9 +27,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200522-151400/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200528-180342/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200522-151400/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200528-180342/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -27,9 +27,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200601-170225/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200603-025047/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200601-170225/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200603-025047/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -27,9 +27,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200605-032027/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200605-053815/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200605-032027/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200605-053815/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -27,9 +27,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200518-193206/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200522-151400/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200518-193206/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200522-151400/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -27,9 +27,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200601-144303/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200601-170225/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200601-144303/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200601-170225/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -27,9 +27,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200603-025047/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200604-221439/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200603-025047/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200604-221439/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -27,9 +27,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200518-000848/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200518-193206/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200518-000848/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200518-193206/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -27,9 +27,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200606-011033/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200606-033049/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200606-011033/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200606-033049/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -27,9 +27,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200528-180342/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200601-144303/cpu/py37/tensorflow_cpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200528-180342/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200601-144303/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -26,9 +26,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200528-180342/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200601-144303/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200528-180342/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200601-144303/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -26,9 +26,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200603-025047/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200604-221439/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200603-025047/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200604-221439/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -26,9 +26,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200522-151400/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200528-180342/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200522-151400/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200528-180342/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -26,9 +26,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200605-053815/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200606-011033/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200605-053815/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200606-011033/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -26,9 +26,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200606-011033/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200606-033049/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200606-011033/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200606-033049/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -26,9 +26,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200605-032027/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200605-053815/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200605-032027/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200605-053815/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -26,9 +26,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200518-000848/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200518-193206/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200518-000848/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200518-193206/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -26,9 +26,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200601-144303/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200601-170225/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200601-144303/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200601-170225/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -26,9 +26,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200518-193206/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200522-151400/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200518-193206/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200522-151400/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -26,9 +26,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200601-170225/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200603-025047/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200601-170225/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200603-025047/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -26,9 +26,9 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.7
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200604-221439/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.2_aws/20200605-032027/gpu/py37/tensorflow_gpu-2.2.0-cp37-cp37m-manylinux2010_x86_64.whl
 
-ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200604-221439/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
+ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/estimator/r2.2_aws/20200605-032027/tensorflow_estimator-2.2.0-py2.py3-none-any.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
Binaries are now optimized for the CPU architectures we have on AWS. FIxes the warning that says binaries not built with AVX2, etc

*Tests run:*
Tests from TF pipeline

*DLC image/dockerfile:*
TF2.2 py37 cpu and gpu

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

