### PR TITLE
install openssl before all other apt packages

### DIFF
--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -35,9 +35,9 @@ ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/est
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.
 ARG SMDEBUG_VERSION=0.7.2
 
-RUN apt remove -y --purge openssl \
+RUN apt-get update \
+ && apt remove -y --purge openssl \
  && rm -rf /usr/include/openssl \
- && apt-get update \
  && apt-get install -y \
     wget \
     ca-certificates \

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -35,13 +35,13 @@ ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/est
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.
 ARG SMDEBUG_VERSION=0.7.2
 
-RUN wget -c https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
- && apt remove -y --purge openssl \
+RUN apt remove -y --purge openssl \
  && rm -rf /usr/include/openssl \
  && apt-get update \
  && apt-get install -y \
     wget \
     ca-certificates \
+ &&  wget -c https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
  && tar -xzvf openssl-${OPENSSL_VERSION}.tar.gz \
  && cd openssl-${OPENSSL_VERSION} \
  && ./config && make && make test \

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -35,15 +35,27 @@ ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/est
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.
 ARG SMDEBUG_VERSION=0.7.2
 
+RUN wget -c https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+ && apt remove -y --purge openssl \
+ && rm -rf /usr/include/openssl \
+ && apt-get update \
+ && apt-get install -y \
+    wget \
+    ca-certificates \
+ && tar -xzvf openssl-${OPENSSL_VERSION}.tar.gz \
+ && cd openssl-${OPENSSL_VERSION} \
+ && ./config && make && make test \
+ && make install \
+ && ldconfig \
+ && cd .. && rm -rf openssl-*
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     openssh-client \
     openssh-server \
-    ca-certificates \
     curl \
     git \
     libtemplate-perl \
-    wget \
     vim \
     zlib1g-dev \
     # Install dependent library for OpenCV
@@ -110,18 +122,6 @@ RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSIO
 RUN ${PIP} --no-cache-dir install --upgrade \
     pip \
     setuptools
-
-RUN wget -c https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
- && apt remove -y --purge openssl \
- && rm -rf /usr/include/openssl \
- && apt-get update \
- && apt-get install -y \
-    ca-certificates \
- && tar -xzvf openssl-${OPENSSL_VERSION}.tar.gz \
- && cd openssl-${OPENSSL_VERSION} \
- && ./config && make && make test \
- && make install \
- && cd .. && rm -rf openssl-*
 
 # when we remove previous openssl, the ca-certificates pkgs and its symlinks gets deleted
 # causing sslcertverificationerror the below steps are to fix that

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -34,8 +34,22 @@ ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/est
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.
 ARG SMDEBUG_VERSION=0.7.2
 
-RUN apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
+
+RUN wget -c https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
+ && apt remove -y --purge openssl \
+ && rm -rf /usr/include/openssl \
+ && apt-get update \
+ && apt-get install -y \
+    wget \
     ca-certificates \
+ && tar -xzvf openssl-${OPENSSL_VERSION}.tar.gz \
+ && cd openssl-${OPENSSL_VERSION} \
+ && ./config && make && make test \
+ && make install \
+ && ldconfig \
+ && cd .. && rm -rf openssl-*
+
+RUN apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
     cuda-command-line-tools-10-1 \
     cuda-cudart-dev-10-1 \
     cuda-cufft-dev-10-1 \
@@ -55,7 +69,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends --allow-unauthe
     libtemplate-perl \
     libzmq3-dev \
     git \
-    wget \
     vim \
     build-essential \
     openssh-client \
@@ -155,22 +168,6 @@ RUN ${PIP} --no-cache-dir install --upgrade \
     pip \
     setuptools
 
-RUN wget -c https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
- && apt-get update \
- && apt remove -y --purge openssl \
- && rm -rf /usr/include/openssl \
- && apt-get install -y \
-    ca-certificates \
- && tar -xzvf openssl-${OPENSSL_VERSION}.tar.gz \
- && cd openssl-${OPENSSL_VERSION} \
- && ./config && make && make test \
- && make install \
- && ldconfig \
- && cd .. && rm -rf openssl-*
-
-# when we remove previous openssl, the ca-certificates pkgs and its symlinks gets deleted
-# causing sslcertverificationerror the below steps are to fix that
-ENV SSL_CERT_DIR=/etc/ssl/certs
 
 # Some TF tools expect a "python" binary
 RUN ln -s $(which ${PYTHON}) /usr/local/bin/python \

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -35,9 +35,9 @@ ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/est
 ARG SMDEBUG_VERSION=0.7.2
 
 
-RUN apt remove -y --purge openssl \
+RUN apt-get update \
+ && apt remove -y --purge openssl \
  && rm -rf /usr/include/openssl \
- && apt-get update \
  && apt-get install -y \
     wget \
     ca-certificates \

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -35,13 +35,13 @@ ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/est
 ARG SMDEBUG_VERSION=0.7.2
 
 
-RUN wget -c https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
- && apt remove -y --purge openssl \
+RUN apt remove -y --purge openssl \
  && rm -rf /usr/include/openssl \
  && apt-get update \
  && apt-get install -y \
     wget \
     ca-certificates \
+ &&  wget -c https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
  && tar -xzvf openssl-${OPENSSL_VERSION}.tar.gz \
  && cd openssl-${OPENSSL_VERSION} \
  && ./config && make && make test \


### PR DESCRIPTION
*Issue #, if available:*
to fix the certificate verfication error on sagemaker tests we try to install openssl first before all apt packages
## Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

