### PR TITLE
[mxnet, tensorflow, pytorch] | [build, test] | [sagemaker] Update Pillow version

### DIFF
--- a/mxnet/training/docker/1.6.0/py2/Dockerfile.cpu
+++ b/mxnet/training/docker/1.6.0/py2/Dockerfile.cpu
@@ -80,7 +80,7 @@ RUN pip install --no-cache --upgrade \
     onnx==1.6.0 \
     numpy==1.16.5 \
     pandas==0.24.2 \
-    Pillow==6.2.0 \
+    Pillow==6.2.2 \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     scipy==1.2.2 \

--- a/mxnet/training/docker/1.6.0/py2/Dockerfile.gpu
+++ b/mxnet/training/docker/1.6.0/py2/Dockerfile.gpu
@@ -121,7 +121,7 @@ RUN pip install --no-cache-dir --upgrade \
     "setuptools<45" \
     onnx==1.6.0 \
     pandas==0.24.2 \
-    Pillow==6.2.0 \
+    Pillow==6.2.2 \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     scipy==1.2.2 \

--- a/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
+++ b/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
@@ -105,7 +105,7 @@ RUN ${PIP} install --no-cache --upgrade \
     onnx==1.6.0 \
     numpy==1.17.2 \
     pandas==0.25.1 \
-    Pillow==6.2.2 \
+    Pillow \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     dgl==0.4.1 \

--- a/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
+++ b/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
@@ -105,7 +105,7 @@ RUN ${PIP} install --no-cache --upgrade \
     onnx==1.6.0 \
     numpy==1.17.2 \
     pandas==0.25.1 \
-    Pillow==6.2.0 \
+    Pillow==6.2.2 \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     dgl==0.4.1 \

--- a/mxnet/training/docker/1.6.0/py3/Dockerfile.gpu
+++ b/mxnet/training/docker/1.6.0/py3/Dockerfile.gpu
@@ -146,7 +146,7 @@ RUN ${PIP} install --no-cache --upgrade \
     numpy==1.17.2 \
     onnx==1.6.0 \
     pandas==0.25.1 \
-    Pillow==6.2.2 \
+    Pillow \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     scipy==1.2.2 \

--- a/mxnet/training/docker/1.6.0/py3/Dockerfile.gpu
+++ b/mxnet/training/docker/1.6.0/py3/Dockerfile.gpu
@@ -146,7 +146,7 @@ RUN ${PIP} install --no-cache --upgrade \
     numpy==1.17.2 \
     onnx==1.6.0 \
     pandas==0.25.1 \
-    Pillow==6.2.0 \
+    Pillow==6.2.2 \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     scipy==1.2.2 \

--- a/pytorch/training/docker/1.4.0/py2/Dockerfile.cpu
+++ b/pytorch/training/docker/1.4.0/py2/Dockerfile.cpu
@@ -73,7 +73,7 @@ RUN conda install -c conda-forge \
  && conda install -y \
     scikit-learn==0.20.3 \
     pandas==0.24.2 \
-    Pillow==6.2.0 \
+    Pillow==6.2.2 \
     h5py==2.9.0 \
     requests==2.22.0 \
  && conda clean -ya \

--- a/pytorch/training/docker/1.4.0/py2/Dockerfile.gpu
+++ b/pytorch/training/docker/1.4.0/py2/Dockerfile.gpu
@@ -102,7 +102,7 @@ RUN conda install -c pytorch magma-cuda101==2.5.1 \
  && conda install -y \
     scikit-learn==0.20.3 \
     pandas==0.24.2 \
-    Pillow==6.2.0 \
+    Pillow==6.2.2 \
     h5py==2.9.0 \
     requests==2.22.0 \
  && pip install -U \

--- a/pytorch/training/docker/1.4.0/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/1.4.0/py3/Dockerfile.cpu
@@ -82,7 +82,7 @@ RUN curl -L -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-lat
  && conda install -y \
     scikit-learn==0.21.2 \
     pandas==0.25.0 \
-    Pillow==6.2.2 \
+    Pillow \
     h5py==2.9.0 \
     requests==2.22.0 \
  && conda install -c dglteam -y dgl==0.4.1 \

--- a/pytorch/training/docker/1.4.0/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/1.4.0/py3/Dockerfile.cpu
@@ -82,7 +82,7 @@ RUN curl -L -o ~/miniconda.sh https://repo.continuum.io/miniconda/Miniconda3-lat
  && conda install -y \
     scikit-learn==0.21.2 \
     pandas==0.25.0 \
-    Pillow==6.2.0 \
+    Pillow==6.2.2 \
     h5py==2.9.0 \
     requests==2.22.0 \
  && conda install -c dglteam -y dgl==0.4.1 \

--- a/pytorch/training/docker/1.4.0/py3/Dockerfile.gpu
+++ b/pytorch/training/docker/1.4.0/py3/Dockerfile.gpu
@@ -101,7 +101,7 @@ RUN conda install -c pytorch magma-cuda101==2.5.1 \
     opencv==4.0.1 \
  && conda install -y scikit-learn==0.21.2 \
     pandas==0.25.0 \
-    Pillow==6.2.0 \
+    Pillow==6.2.2 \
     h5py==2.9.0 \
     requests==2.22.0 \
  && conda clean -ya

--- a/pytorch/training/docker/1.4.0/py3/Dockerfile.gpu
+++ b/pytorch/training/docker/1.4.0/py3/Dockerfile.gpu
@@ -101,7 +101,7 @@ RUN conda install -c pytorch magma-cuda101==2.5.1 \
     opencv==4.0.1 \
  && conda install -y scikit-learn==0.21.2 \
     pandas==0.25.0 \
-    Pillow==6.2.2 \
+    Pillow \
     h5py==2.9.0 \
     requests==2.22.0 \
  && conda clean -ya

--- a/tensorflow/training/docker/2.0.1/py2/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.0.1/py2/Dockerfile.cpu
@@ -95,7 +95,7 @@ RUN ${PIP} install --no-cache-dir -U \
     scipy==1.2.2 \
     scikit-learn==0.20.4 \
     pandas==0.24.2 \
-    Pillow==6.2.1 \
+    Pillow==6.2.2 \
     h5py==2.10.0 \
     keras_applications==1.0.8 \
     keras_preprocessing==1.1.0 \

--- a/tensorflow/training/docker/2.0.1/py2/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.0.1/py2/Dockerfile.gpu
@@ -123,7 +123,7 @@ RUN ${PIP} install --no-cache-dir -U \
     scipy==1.2.2 \
     scikit-learn==0.20.4 \
     pandas==0.24.2 \
-    Pillow==6.2.1 \
+    Pillow==6.2.2 \
     h5py==2.10.0 \
     keras_applications==1.0.8 \
     keras_preprocessing==1.1.0 \

--- a/tensorflow/training/docker/2.0.1/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.0.1/py3/Dockerfile.cpu
@@ -95,7 +95,7 @@ RUN ${PIP} install --no-cache-dir -U \
     scipy==1.2.2 \
     scikit-learn==0.22 \
     pandas==0.25.3 \
-    Pillow==6.2.1 \
+    Pillow==6.2.2 \
     h5py==2.10.0 \
     keras_applications==1.0.8 \
     keras_preprocessing==1.1.0 \

--- a/tensorflow/training/docker/2.0.1/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.0.1/py3/Dockerfile.cpu
@@ -95,7 +95,7 @@ RUN ${PIP} install --no-cache-dir -U \
     scipy==1.2.2 \
     scikit-learn==0.22 \
     pandas==0.25.3 \
-    Pillow==6.2.2 \
+    Pillow \
     h5py==2.10.0 \
     keras_applications==1.0.8 \
     keras_preprocessing==1.1.0 \

--- a/tensorflow/training/docker/2.0.1/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.0.1/py3/Dockerfile.gpu
@@ -134,7 +134,7 @@ RUN ${PIP} install --no-cache-dir -U \
     scipy==1.2.2 \
     scikit-learn==0.22 \
     pandas==0.25.3 \
-    Pillow==6.2.0 \
+    Pillow==6.2.2 \
     h5py==2.10.0 \
     keras_applications==1.0.8 \
     keras_preprocessing==1.1.0 \

--- a/tensorflow/training/docker/2.0.1/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.0.1/py3/Dockerfile.gpu
@@ -134,7 +134,7 @@ RUN ${PIP} install --no-cache-dir -U \
     scipy==1.2.2 \
     scikit-learn==0.22 \
     pandas==0.25.3 \
-    Pillow==6.2.2 \
+    Pillow \
     h5py==2.10.0 \
     keras_applications==1.0.8 \
     keras_preprocessing==1.1.0 \

--- a/test/sagemaker_tests/pytorch/inference/requirements.txt
+++ b/test/sagemaker_tests/pytorch/inference/requirements.txt
@@ -17,7 +17,7 @@ torchvision==0.5.0
 tox==3.7.0
 requests_mock==1.6.0
 numpy==1.16.4
-Pillow==6.2.2
+Pillow
 retrying==1.3.3
 requests_mock==1.6.0
 sagemaker-inference==1.1.2

--- a/test/sagemaker_tests/pytorch/inference/requirements.txt
+++ b/test/sagemaker_tests/pytorch/inference/requirements.txt
@@ -17,7 +17,7 @@ torchvision==0.5.0
 tox==3.7.0
 requests_mock==1.6.0
 numpy==1.16.4
-Pillow==6.2.0
+Pillow==6.2.2
 retrying==1.3.3
 requests_mock==1.6.0
 sagemaker-inference==1.1.2


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to

*Description:*
Part of this is updating old Dockerfiles (i.e. 2.0.1) so that if people use these Dockerfiles they will not use the Pillow version with security update. The main issue we resolve is updating the test dependency for SM PT tests

*Tests run:*

*DLC image/dockerfile:*
mxnet 1.6, pt 1.4, tf 2.0.1


*Additional context:*
Resolving Pillow issue

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

