### PR TITLE
[tensorflow, build] update sagemaker-tensorflow-training versions for TF 1.15.2 and 2.2

### DIFF
--- a/tensorflow/training/docker/1.15.2/py2/Dockerfile.cpu
+++ b/tensorflow/training/docker/1.15.2/py2/Dockerfile.cpu
@@ -100,7 +100,7 @@ RUN pip install --no-cache-dir -U \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
-    "sagemaker-tensorflow-training>=2,<3" \
+    "sagemaker-tensorflow-training>=10,<20" \
     # Let's install TensorFlow separately in the end to avoid the library version to be overwritten
  && pip install --force-reinstall --no-cache-dir -U \
     ${TF_URL} \

--- a/tensorflow/training/docker/1.15.2/py2/Dockerfile.gpu
+++ b/tensorflow/training/docker/1.15.2/py2/Dockerfile.gpu
@@ -133,7 +133,7 @@ RUN pip install --no-cache-dir -U \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
-    "sagemaker-tensorflow-training>=2,<3" \
+    "sagemaker-tensorflow-training>=10,<20" \
     # Let's install TensorFlow separately in the end to avoid the library version to be overwritten
  && pip install --force-reinstall --no-cache-dir -U \
     ${TF_URL} \

--- a/tensorflow/training/docker/1.15.2/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/1.15.2/py3/Dockerfile.cpu
@@ -119,7 +119,7 @@ RUN ${PIP} install --no-cache-dir -U \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
-    sagemaker-tensorflow-training==10.1.0 \
+    "sagemaker-tensorflow-training>=10,<20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --force-reinstall --no-cache-dir -U \

--- a/tensorflow/training/docker/1.15.2/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/1.15.2/py3/Dockerfile.gpu
@@ -156,7 +156,7 @@ RUN ${PIP} install --no-cache-dir -U \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
-    sagemaker-tensorflow-training==10.1.0 \
+    "sagemaker-tensorflow-training>=10,<20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --force-reinstall --no-cache-dir -U \

--- a/tensorflow/training/docker/1.15.2/py36/Dockerfile.cpu
+++ b/tensorflow/training/docker/1.15.2/py36/Dockerfile.cpu
@@ -105,7 +105,7 @@ RUN pip install --no-cache-dir -U \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
-    "sagemaker-tensorflow-training>=2,<3" \
+    "sagemaker-tensorflow-training>=10,<20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && pip install --force-reinstall --no-cache-dir -U \

--- a/tensorflow/training/docker/1.15.2/py36/Dockerfile.gpu
+++ b/tensorflow/training/docker/1.15.2/py36/Dockerfile.gpu
@@ -143,7 +143,7 @@ RUN pip install --no-cache-dir -U \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
-    "sagemaker-tensorflow-training>=2,<3" \
+    "sagemaker-tensorflow-training>=10,<20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && pip install --force-reinstall --no-cache-dir -U \

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.cpu
@@ -150,7 +150,7 @@ RUN ${PIP} install --no-cache-dir -U \
     sagemaker==1.58.2 \
     sagemaker-experiments==0.1.13 \
     "sagemaker-tensorflow>=2.2,<2.3" \
-    sagemaker-tensorflow-training==4.0.1 \
+    "sagemaker-tensorflow-training>=20" \
 
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten

--- a/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/Dockerfile.gpu
@@ -194,7 +194,7 @@ RUN ${PIP} install --no-cache-dir -U \
     sagemaker==1.58.2 \
     sagemaker-experiments==0.1.13 \
     "sagemaker-tensorflow>=2.2,<2.3" \
-    sagemaker-tensorflow-training==4.0.1 \
+    "sagemaker-tensorflow-training>=20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --no-cache-dir -U \


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
We changed the versioning for sagemaker-tensorflow-training because the previous scheme relied on the assumption that we would stop supporting TF 1.x soon. That's no longer the case, so now the versions work out as:

TF version | toolkit version
---|---
1.x | >=10, <20
2.x | >=20

*Tests run:*
ran [our local SageMaker tests](https://github.com/aws/sagemaker-tensorflow-container/tree/master/test/integration/local) for CPU

*DLC image/dockerfile:*
* TF 1.15.2, all Python versions, CPU and GPU
* TF 2.2, all Python versions, CPU and GPU

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

