### PR TITLE
[pytorch] [build, test] | [ec2, ecs, eks, sagemaker] Disable single-node pytorch training EKS for mainline pipeline

### DIFF
--- a/test/dlc_tests/eks/pytorch/training/test_eks_pytorch_training.py
+++ b/test/dlc_tests/eks/pytorch/training/test_eks_pytorch_training.py
@@ -16,6 +16,7 @@ from test.test_utils import is_pr_context, SKIP_PR_REASON
 LOGGER = eks_utils.LOGGER
 
 
+@pytest.mark.skipif(not is_pr_context(), reason="Skip this test. It is already tested under PR context and we do not have enough resouces to test it again on mainline pipeline")
 def test_eks_pytorch_single_node_training(pytorch_training):
     """
     Function to create a pod using kubectl and given container image, and run MXNet training

--- a/test/dlc_tests/eks/pytorch/training/test_eks_pytorch_training.py
+++ b/test/dlc_tests/eks/pytorch/training/test_eks_pytorch_training.py
@@ -64,6 +64,7 @@ def test_eks_pytorch_single_node_training(pytorch_training):
         run("kubectl delete pods {}".format(pod_name))
 
 
+@pytest.mark.skipif(not is_pr_context(), reason="Skip this test. It is already tested under PR context")
 def test_eks_pytorch_dgl_single_node_training(pytorch_training, py3_only):
 
     """


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [pytorch] [build, test] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
It is a temp infra change to unblock PT14 release
*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

