### PR TITLE
[test]|[ec2] Add instance type to ec2 key pair

### DIFF
--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -207,14 +207,16 @@ def generate_unique_values_for_fixtures(metafunc_obj, images_to_parametrize, val
             if key in metafunc_obj.fixturenames:
                 fixtures_parametrized[new_fixture_name] = []
                 for index, image in enumerate(images_to_parametrize):
-                    if "gpu" in image:
-                        gpu_env = os.getenv("EC2_GPU_INSTANCE_TYPE")
-                        instance_tag = f"-{gpu_env.replace('.', '-')}" if gpu_env else ""
-                    elif "cpu" in image:
-                        cpu_env = os.getenv("EC2_CPU_INSTANCE_TYPE")
-                        instance_tag = f"-{cpu_env.replace('.', '-')}" if cpu_env else ""
-                    else:
-                        instance_tag = ""
+
+                    # Tag fixtures with EC2 instance types if env variable is present
+                    allowed_processors = ("gpu", "cpu", "eia")
+                    instance_tag = ""
+                    for processor in allowed_processors:
+                        if processor in image:
+                            instance_type = os.getenv(f"EC2_{processor.upper()}_INSTANCE_TYPE")
+                            if instance_type:
+                                instance_tag = f"-{instance_type.replace('.', '-')}"
+                                break
 
                     image_tag = image.split(":")[-1].replace(".", "-")
                     fixtures_parametrized[new_fixture_name].append(

--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -207,12 +207,21 @@ def generate_unique_values_for_fixtures(metafunc_obj, images_to_parametrize, val
             if key in metafunc_obj.fixturenames:
                 fixtures_parametrized[new_fixture_name] = []
                 for index, image in enumerate(images_to_parametrize):
+                    if "gpu" in image:
+                        gpu_env = os.getenv("EC2_GPU_INSTANCE_TYPE")
+                        instance_tag = f"-{gpu_env.replace('.', '-')}" if gpu_env else ""
+                    elif "cpu" in image:
+                        cpu_env = os.getenv("EC2_CPU_INSTANCE_TYPE")
+                        instance_tag = f"-{cpu_env.replace('.', '-')}" if cpu_env else ""
+                    else:
+                        instance_tag = ""
+
                     image_tag = image.split(":")[-1].replace(".", "-")
                     fixtures_parametrized[new_fixture_name].append(
                         (
                             image,
                             f"{metafunc_obj.function.__name__}-{image_tag}-"
-                            f"{os.getenv('CODEBUILD_RESOLVED_SOURCE_VERSION')}-{index}",
+                            f"{os.getenv('CODEBUILD_RESOLVED_SOURCE_VERSION')}-{index}{instance_tag}",
                         )
                     )
     return fixtures_parametrized


### PR DESCRIPTION
## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
If running in mainline context, add the instance type to ensure we are using unique ec2 key pairs.

*Tests run:*
Testing in personal account


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

