### PR TITLE
[mxnet, tensorflow, pytorch]|  [test] | [ec2] Increase testSmdebug Timeout

### DIFF
--- a/test/dlc_tests/container_tests/bin/testSmdebug
+++ b/test/dlc_tests/container_tests/bin/testSmdebug
@@ -84,7 +84,7 @@ if [[ ${FRAMEWORK} == "tensorflow2" ]]; then
 fi
 
 echo "Running ZCC tests."
-timeout 1800s pytest mock/tests/zero_code_change/${ZCC_TEST_NAME[$FRAMEWORK]}
+timeout 2100s pytest mock/tests/zero_code_change/${ZCC_TEST_NAME[$FRAMEWORK]}
 
 if [ "$?" -eq "0" ]
 then


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
- testSmdebug failed on TF 2.0.0 DLC containers with a timeout error.
- The commit https://github.com/awslabs/sagemaker-debugger/commit/5a8d8b62e72d8d7c5c2ecef2527d4bb63b3112cc#diff-acd36218400aa72acf5ef4dd7483c7fc doubled the number of tests that were executed.
- Increasing the timeout to `2100s` accommodates the additional tests that are executed at this stage.

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

