### PR TITLE
[Tensorflow][Build]Resolve missing libcupti.so issue

### DIFF
--- a/tensorflow/buildspec.yml
+++ b/tensorflow/buildspec.yml
@@ -2,7 +2,7 @@
   region: &REGION <set-$REGION-in-environment>
   framework: &FRAMEWORK tensorflow
   version: &VERSION 2.2.0
-  cuda_version: &CUDA_VERSION cu102
+  cuda_version: &CUDA_VERSION cu101
   os_version: &OS_VERSION ubuntu18.04
 
   repository_info:

--- a/tensorflow/training/docker/2.2.0/py3/cu101/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/cu101/Dockerfile.gpu
@@ -116,6 +116,10 @@ RUN echo "hwloc_base_binding_policy = none" >> /usr/local/etc/openmpi-mca-params
 RUN echo NCCL_DEBUG=INFO >> /etc/nccl.conf
 
 ENV LD_LIBRARY_PATH=/usr/local/openmpi/lib:$LD_LIBRARY_PATH
+# Resolve missing libcuda.so issue
+RUN cp /usr/local/cuda-10.1/extras/CUPTI/lib64/libcupti* /usr/local/cuda/lib64/
+ENV LD_LIBRARY_PATH=/usr/local/cuda/lib64/:$LD_LIBRARY_PATH
+
 ENV PATH /usr/local/openmpi/bin/:$PATH
 ENV PATH=/usr/local/nvidia/bin:$PATH
 


### PR DESCRIPTION
*Issue #, if available:*
for cuda 10.1, there's an issue when enable tensorboard profiling
Could not load dynamic library 'libcuda.so.1'; dlerror: libcuda.so.1: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/openmpi/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [tensorflow] | [test]  | [ec2]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
With TensorBoard profiling turned on, we get this error on the new recently released TF2.2 container:
2020-06-03 01:47:51.923816: W tensorflow/stream_executor/platform/default/dso_loader.cc:55] Could not load dynamic library 'libcupti.so.10.1'; dlerror: libcupti.so.10.1: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /usr/local/openmpi/lib:/usr/local/nvidia/lib:/usr/local/nvidia/lib64

By this PR, we add the libcupti.so to the LD_LIBRARY_PATH to avoid the issue.

*Tests run:*
Local test on ec2

*DLC image/dockerfile:*
tensorflow/2.2.0/101/Dockefile.gpu

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

