### PR TITLE
[build] fix: Move dlc import statement to allow local builds

### DIFF
--- a/src/send_status.py
+++ b/src/send_status.py
@@ -3,8 +3,6 @@ import argparse
 
 import utils
 
-from dlc.github_handler import GitHubHandler
-
 
 def get_args():
     """
@@ -57,6 +55,8 @@ def post_status(state):
 
     :param state: <str> choices are "success", "failure", "error" or "pending"
     """
+    from dlc.github_handler import GitHubHandler
+
     project_name = utils.get_codebuild_project_name()
     trigger_job = os.getenv("TEST_TRIGGER", "UNKNOWN-TEST-TRIGGER")
     target_url = get_target_url(project_name)

--- a/src/send_status.py
+++ b/src/send_status.py
@@ -3,6 +3,8 @@ import argparse
 
 import utils
 
+from dlc.github_handler import GitHubHandler
+
 
 def get_args():
     """
@@ -55,8 +57,6 @@ def post_status(state):
 
     :param state: <str> choices are "success", "failure", "error" or "pending"
     """
-    from dlc.github_handler import GitHubHandler
-
     project_name = utils.get_codebuild_project_name()
     trigger_job = os.getenv("TEST_TRIGGER", "UNKNOWN-TEST-TRIGGER")
     target_url = get_target_url(project_name)

--- a/src/utils.py
+++ b/src/utils.py
@@ -19,7 +19,7 @@ import logging
 import sys
 
 import constants
-from dlc.github_handler import GitHubHandler
+
 from config import build_config
 
 
@@ -66,6 +66,8 @@ def get_pr_modified_files(pr_number):
     :param pr_number: int
     :return: str with all the modified files
     """
+    from dlc.github_handler import GitHubHandler
+
     github_handler = GitHubHandler("aws", "deep-learning-containers")
     files = github_handler.get_pr_files_changed(pr_number)
     files = "\n".join(files)

--- a/src/utils.py
+++ b/src/utils.py
@@ -66,6 +66,8 @@ def get_pr_modified_files(pr_number):
     :param pr_number: int
     :return: str with all the modified files
     """
+    # This import statement has been placed inside this function because it creates a dependency that is unnecessary
+    # for local builds and builds outside of Pull Requests.
     from dlc.github_handler import GitHubHandler
 
     github_handler = GitHubHandler("aws", "deep-learning-containers")


### PR DESCRIPTION
## Issue
Local builds fail because of an import statement that doesn't need to be used: https://github.com/aws/deep-learning-containers/issues/263

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
Fixed this issue by moving the import statement into the only functions where it is used, rather than a generic import at the head of a file.

*Tests run:*
Built images for TensorFlow on a clone of the repository on my local setup.

*DLC image/dockerfile:*
- N/A

*Additional context:*
- N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

