### PR TITLE
[test] | [canary] Log into prod ECR for canary tests

### DIFF
--- a/testspec.yml
+++ b/testspec.yml
@@ -13,6 +13,7 @@ phases:
     commands:
       - echo Logging in to Amazon ECR...
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+      - export TEST_TYPE='canary'
       - |
         if expr "${TEST_TYPE}" : "canary" >/dev/null; then
           $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 763104351884)

--- a/testspec.yml
+++ b/testspec.yml
@@ -13,7 +13,6 @@ phases:
     commands:
       - echo Logging in to Amazon ECR...
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
-      - export TEST_TYPE='canary'
       - |
         if expr "${TEST_TYPE}" : "canary" >/dev/null; then
           $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 763104351884)

--- a/testspec.yml
+++ b/testspec.yml
@@ -13,6 +13,10 @@ phases:
     commands:
       - echo Logging in to Amazon ECR...
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+      - |
+        if expr "${TEST_TYPE}" : "canary" >/dev/null; then
+          $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 763104351884)
+        fi
       - pip install -r test/requirements.txt
       - echo Running pytest $TEST_TYPE tests on $DLC_IMAGES...
       - python test/testrunner.py


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
Canary tests require log in to the prod repo, updating testspec to conditionally do so

*Tests run:*
- Tested on the PR in the revision marked "test"


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

