### PR TITLE
change: Remove outdated comment from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Example:
     # ECS
     pytest -s -rA ecs/ -n=auto
     
-    #EKS (Assumes a cluster with name `dlc-eks-pr-<framework>-test-cluster` is already setup)
+    #EKS
     export TEST_TYPE=eks
     python test/testrunner.py
     ```


### PR DESCRIPTION
*Description:*
- EKS tests no longer require a cluster spun up with the aforementioned name. Updating README to reflect these changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

