### PR TITLE
[Draft] Add dlc major version label to TF 1.15.2, MX 1.6.0, PT 1.5.1 on Draft

### DIFF
--- a/mxnet/inference/docker/1.6.0/py2/Dockerfile.cpu
+++ b/mxnet/inference/docker/1.6.0/py2/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="3"
 
 # Specify accept-bind-to-port LABEL for inference pipelines to use SAGEMAKER_BIND_TO_PORT
 # https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipeline-real-time.html

--- a/mxnet/inference/docker/1.6.0/py2/Dockerfile.gpu
+++ b/mxnet/inference/docker/1.6.0/py2/Dockerfile.gpu
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:10.1-cudnn7-runtime-ubuntu16.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="3"
 
 # Specify accept-bind-to-port LABEL for inference pipelines to use SAGEMAKER_BIND_TO_PORT
 # https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipeline-real-time.html

--- a/mxnet/inference/docker/1.6.0/py3/Dockerfile.cpu
+++ b/mxnet/inference/docker/1.6.0/py3/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="3"
 
 # Specify accept-bind-to-port LABEL for inference pipelines to use SAGEMAKER_BIND_TO_PORT
 # https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipeline-real-time.html

--- a/mxnet/inference/docker/1.6.0/py3/Dockerfile.gpu
+++ b/mxnet/inference/docker/1.6.0/py3/Dockerfile.gpu
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:10.1-cudnn7-runtime-ubuntu16.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="3"
 
 # Specify accept-bind-to-port LABEL for inference pipelines to use SAGEMAKER_BIND_TO_PORT
 # https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipeline-real-time.html

--- a/mxnet/training/docker/1.6.0/py2/Dockerfile.cpu
+++ b/mxnet/training/docker/1.6.0/py2/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="3"
 
 ARG MX_URL=https://aws-mxnet-pypi.s3-us-west-2.amazonaws.com/1.6.0/aws_mxnet_mkl-1.6.0-py2.py3-none-manylinux1_x86_64.whl
 

--- a/mxnet/training/docker/1.6.0/py2/Dockerfile.gpu
+++ b/mxnet/training/docker/1.6.0/py2/Dockerfile.gpu
@@ -2,6 +2,7 @@
 FROM nvidia/cuda:10.1-base-ubuntu16.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="3"
 
 ARG MX_URL=https://aws-mxnet-pypi.s3-us-west-2.amazonaws.com/1.6.0/aws_mxnet_cu101mkl-1.6.0-py2.py3-none-manylinux1_x86_64.whl
 

--- a/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
+++ b/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="3"
 
 ARG PYTHON=python3
 ARG PIP=pip3

--- a/mxnet/training/docker/1.6.0/py3/Dockerfile.gpu
+++ b/mxnet/training/docker/1.6.0/py3/Dockerfile.gpu
@@ -2,6 +2,7 @@
 FROM nvidia/cuda:10.1-base-ubuntu16.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="3"
 
 ARG PYTHON=python3
 ARG PIP=pip3

--- a/pytorch/inference/docker/1.5.1/py3/Dockerfile.cpu
+++ b/pytorch/inference/docker/1.5.1/py3/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="2"
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
 

--- a/pytorch/inference/docker/1.5.1/py3/Dockerfile.gpu
+++ b/pytorch/inference/docker/1.5.1/py3/Dockerfile.gpu
@@ -1,6 +1,8 @@
 FROM nvidia/cuda:10.1-cudnn7-devel-ubuntu16.04
 # NCCL_VERSION=2.4.7, CUDNN_VERSION=7.6.2.24
+
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="2"
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 
 # Add arguments to achieve the version, python and url

--- a/pytorch/training/docker/1.5.1/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/1.5.1/py3/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:16.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="2"
 
 # Add arguments to achieve the version, python and url
 ARG PYTHON_VERSION=3.6.10

--- a/pytorch/training/docker/1.5.1/py3/Dockerfile.gpu
+++ b/pytorch/training/docker/1.5.1/py3/Dockerfile.gpu
@@ -2,6 +2,7 @@
 FROM nvidia/cuda@sha256:4979db047661dc0003594fb20d37cce6d6c7e989252f4e3fb0beb39874a078e2
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="2"
 
 ARG PYTHON_VERSION=3.6.10
 ARG OPEN_MPI_VERSION=4.0.1

--- a/tensorflow/inference/docker/1.15.2/py2/Dockerfile.cpu
+++ b/tensorflow/inference/docker/1.15.2/py2/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="4"
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \

--- a/tensorflow/inference/docker/1.15.2/py2/Dockerfile.gpu
+++ b/tensorflow/inference/docker/1.15.2/py2/Dockerfile.gpu
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:10.0-base-ubuntu18.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="4"
 
 ENV NCCL_VERSION=2.4.7-1+cuda10.0
 ENV CUDNN_VERSION=7.5.1.10-1+cuda10.0

--- a/tensorflow/inference/docker/1.15.2/py3/Dockerfile.cpu
+++ b/tensorflow/inference/docker/1.15.2/py3/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="7"
 # Specify LABEL for inference pipelines to use SAGEMAKER_BIND_TO_PORT
 # https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipeline-real-time.html
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true

--- a/tensorflow/inference/docker/1.15.2/py3/Dockerfile.gpu
+++ b/tensorflow/inference/docker/1.15.2/py3/Dockerfile.gpu
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:10.0-base-ubuntu18.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="7"
 # Specify LABEL for inference pipelines to use SAGEMAKER_BIND_TO_PORT
 # https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipeline-real-time.html
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true

--- a/tensorflow/inference/docker/1.15.2/py36/Dockerfile.cpu
+++ b/tensorflow/inference/docker/1.15.2/py36/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="4"
 # Specify LABEL for inference pipelines to use SAGEMAKER_BIND_TO_PORT
 # https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipeline-real-time.html
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true

--- a/tensorflow/inference/docker/1.15.2/py36/Dockerfile.gpu
+++ b/tensorflow/inference/docker/1.15.2/py36/Dockerfile.gpu
@@ -1,6 +1,7 @@
 FROM nvidia/cuda:10.0-base-ubuntu18.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="4"
 # Specify LABEL for inference pipelines to use SAGEMAKER_BIND_TO_PORT
 # https://docs.aws.amazon.com/sagemaker/latest/dg/inference-pipeline-real-time.html
 LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true

--- a/tensorflow/training/docker/1.15.2/py2/Dockerfile.cpu
+++ b/tensorflow/training/docker/1.15.2/py2/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="4"
 
 # Prevent docker build get stopped by requesting user interaction
 ENV DEBIAN_FRONTEND=noninteractive

--- a/tensorflow/training/docker/1.15.2/py2/Dockerfile.gpu
+++ b/tensorflow/training/docker/1.15.2/py2/Dockerfile.gpu
@@ -3,6 +3,7 @@
 FROM nvidia/cuda:10.0-base-ubuntu18.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="4"
 
 # Prevent docker build get stopped by requesting user interaction
 ENV DEBIAN_FRONTEND=noninteractive

--- a/tensorflow/training/docker/1.15.2/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/1.15.2/py3/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="7"
 
 # Prevent docker build get stopped by requesting user interaction
 ENV DEBIAN_FRONTEND=noninteractive

--- a/tensorflow/training/docker/1.15.2/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/1.15.2/py3/Dockerfile.gpu
@@ -3,6 +3,7 @@
 FROM nvidia/cuda:10.0-base-ubuntu18.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="7"
 
 # Prevent docker build get stopped by requesting user interaction
 ENV DEBIAN_FRONTEND=noninteractive

--- a/tensorflow/training/docker/1.15.2/py36/Dockerfile.cpu
+++ b/tensorflow/training/docker/1.15.2/py36/Dockerfile.cpu
@@ -1,6 +1,7 @@
 FROM ubuntu:18.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="4"
 
 # Prevent docker build get stopped by requesting user interaction
 ENV DEBIAN_FRONTEND=noninteractive

--- a/tensorflow/training/docker/1.15.2/py36/Dockerfile.gpu
+++ b/tensorflow/training/docker/1.15.2/py36/Dockerfile.gpu
@@ -3,6 +3,7 @@
 FROM nvidia/cuda:10.0-base-ubuntu18.04
 
 LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="4"
 
 # Prevent docker build get stopped by requesting user interaction
 ENV DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
This Draft PR is submitted because https://github.com/aws/deep-learning-containers/pull/278 which needs to be merged cannot run all CI tests simultaneously. Therefore, changes to these framework versions have been split up as part of another draft PR, where the test results of CI will be made available.

*Tests run:*
Built images locally

*DLC image/dockerfile:*
TensorFlow 1.15.2
MXNet 1.6.0
PyTorch 1.5.1

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

