### PR TITLE
[build] fix: Provide default value for CodeBuild project name to fix local builds

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -468,4 +468,5 @@ def set_test_env(images, images_env="DLC_IMAGES", **kwargs):
 
 
 def get_codebuild_project_name():
-    return os.getenv("CODEBUILD_BUILD_ID").split(":")[0]
+    # Default value for codebuild project name is "local_test" when run outside of CodeBuild
+    return os.getenv("CODEBUILD_BUILD_ID", "local_test").split(":")[0]


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/deep-learning-containers/issues/265

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]


*Description:*
- Add a default value for CodeBuild project name

*Testing*
- Ran `python src/main.py --buildspec mxnet/buildspec.yml --framework mxnet --image_types training --device_types gpu --py_versions py3`

Build succeeded and successfully pushed py3 gpu mxnet training images

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

