### PR TITLE
[tensorflow]|[test]|[sagemaker] Add integration test for MPI env vars propagation

### DIFF
--- a/tensorflow/training/docker/1.15.3/py2/Dockerfile.cpu
+++ b/tensorflow/training/docker/1.15.3/py2/Dockerfile.cpu
@@ -119,7 +119,7 @@ RUN pip install --no-cache-dir -U \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
-    "sagemaker-tensorflow-training>=2,<3" \
+    "sagemaker-tensorflow-training>=10,<20" \
     # Let's install TensorFlow separately in the end to avoid the library version to be overwritten
  && pip install --force-reinstall --no-cache-dir -U \
     ${TF_URL} \

--- a/tensorflow/training/docker/1.15.3/py2/Dockerfile.gpu
+++ b/tensorflow/training/docker/1.15.3/py2/Dockerfile.gpu
@@ -156,7 +156,7 @@ RUN pip install --no-cache-dir -U \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
-    "sagemaker-tensorflow-training>=2,<3" \
+    "sagemaker-tensorflow-training>=10,<20" \
     # Let's install TensorFlow separately in the end to avoid the library version to be overwritten
  && pip install --force-reinstall --no-cache-dir -U \
     ${TF_URL} \

--- a/tensorflow/training/docker/1.15.3/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/1.15.3/py3/Dockerfile.cpu
@@ -138,7 +138,7 @@ RUN ${PIP} install --no-cache-dir -U \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
-    sagemaker-tensorflow-training==10.1.0 \
+    "sagemaker-tensorflow-training>=10,<20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --force-reinstall --no-cache-dir -U \

--- a/tensorflow/training/docker/1.15.3/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/1.15.3/py3/Dockerfile.gpu
@@ -179,7 +179,7 @@ RUN ${PIP} install --no-cache-dir -U \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
-    sagemaker-tensorflow-training==10.1.0 \
+    "sagemaker-tensorflow-training>=10,<20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --force-reinstall --no-cache-dir -U \

--- a/tensorflow/training/docker/1.15.3/py36/Dockerfile.cpu
+++ b/tensorflow/training/docker/1.15.3/py36/Dockerfile.cpu
@@ -128,7 +128,7 @@ RUN pip install --no-cache-dir -U \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
-    "sagemaker-tensorflow-training>=2,<3" \
+    "sagemaker-tensorflow-training>=10,<20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && pip install --force-reinstall --no-cache-dir -U \

--- a/tensorflow/training/docker/1.15.3/py36/Dockerfile.gpu
+++ b/tensorflow/training/docker/1.15.3/py36/Dockerfile.gpu
@@ -168,7 +168,7 @@ RUN pip install --no-cache-dir -U \
     mpi4py==3.0.2 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=1.15,<1.16" \
-    "sagemaker-tensorflow-training>=2,<3" \
+    "sagemaker-tensorflow-training>=10,<20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && pip install --force-reinstall --no-cache-dir -U \

--- a/tensorflow/training/docker/2.0.2/py2/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.0.2/py2/Dockerfile.gpu
@@ -160,7 +160,7 @@ RUN ${PIP} install --no-cache-dir -U \
     opencv-python==4.2.0.32 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=2.0,<2.1" \
-    "sagemaker-tensorflow-training>2,<4" \
+    "sagemaker-tensorflow-training>=20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --no-cache-dir -U \

--- a/tensorflow/training/docker/2.0.2/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.0.2/py3/Dockerfile.cpu
@@ -133,7 +133,7 @@ RUN ${PIP} install --no-cache-dir -U \
     sagemaker-experiments==0.1.7 \
     "sagemaker-tensorflow>=2.0,<2.1" \
     smdebug==0.8.1 \
-    "sagemaker-tensorflow-training>=3.0<4.0" \
+    "sagemaker-tensorflow-training>=20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --no-cache-dir -U \

--- a/tensorflow/training/docker/2.1.0/py2/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.1.0/py2/Dockerfile.cpu
@@ -109,7 +109,7 @@ RUN ${PIP} install --no-cache-dir -U \
     opencv-python==4.2.0.32 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=2.1,<2.2" \
-    "sagemaker-tensorflow-training>2,<4" \
+    "sagemaker-tensorflow-training>=20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --no-cache-dir -U \

--- a/tensorflow/training/docker/2.1.0/py2/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.1.0/py2/Dockerfile.gpu
@@ -142,7 +142,7 @@ RUN ${PIP} install --no-cache-dir -U \
     opencv-python==4.2.0.32 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=2.1,<2.2" \
-    "sagemaker-tensorflow-training>2,<4" \
+    "sagemaker-tensorflow-training>=20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --no-cache-dir -U \

--- a/tensorflow/training/docker/2.1.0/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.1.0/py3/Dockerfile.cpu
@@ -115,7 +115,7 @@ RUN ${PIP} install --no-cache-dir -U \
     "sagemaker<2" \
     sagemaker-experiments==0.1.7 \
     "sagemaker-tensorflow>=2.1,<2.2" \
-    "sagemaker-tensorflow-training>2,<4" \
+    "sagemaker-tensorflow-training>=20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --no-cache-dir -U \

--- a/tensorflow/training/docker/2.1.0/py3/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.1.0/py3/Dockerfile.gpu
@@ -159,7 +159,7 @@ RUN ${PIP} install --no-cache-dir -U \
     "sagemaker<2" \
     sagemaker-experiments==0.1.7 \
     "sagemaker-tensorflow>=2.1,<2.2" \
-    "sagemaker-tensorflow-training>2,<4" \
+    "sagemaker-tensorflow-training>=20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --no-cache-dir -U \

--- a/tensorflow/training/docker/2.1.1/py2/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.1.1/py2/Dockerfile.cpu
@@ -128,7 +128,7 @@ RUN ${PIP} install --no-cache-dir -U \
     opencv-python==4.2.0.32 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=2.1,<2.2" \
-    "sagemaker-tensorflow-training>2,<4" \
+    "sagemaker-tensorflow-training>=20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --no-cache-dir -U \

--- a/tensorflow/training/docker/2.1.1/py2/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.1.1/py2/Dockerfile.gpu
@@ -165,7 +165,7 @@ RUN ${PIP} install --no-cache-dir -U \
     opencv-python==4.2.0.32 \
     "cryptography>=2.3" \
     "sagemaker-tensorflow>=2.1,<2.2" \
-    "sagemaker-tensorflow-training>2,<4" \
+    "sagemaker-tensorflow-training>=20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --no-cache-dir -U \

--- a/tensorflow/training/docker/2.1.1/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.1.1/py3/Dockerfile.cpu
@@ -136,7 +136,7 @@ RUN ${PIP} install --no-cache-dir -U \
     "sagemaker<2" \
     sagemaker-experiments==0.1.7 \
     "sagemaker-tensorflow>=2.1,<2.2" \
-    "sagemaker-tensorflow-training>2,<4" \
+    "sagemaker-tensorflow-training>=20" \
     # Let's install TensorFlow separately in the end to avoid
     # the library version to be overwritten
  && ${PIP} install --no-cache-dir -U \

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/sagemaker/test_horovod.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/sagemaker/test_horovod.py
@@ -50,3 +50,28 @@ def test_distributed_training_horovod(sagemaker_session,
 
     for filename in model_data_source.get_file_list():
         assert os.path.basename(filename) == 'model.tar.gz'
+
+
+def test_distributed_training_horovod_with_env_vars(
+        sagemaker_session, instance_type, ecr_image, tmpdir, framework_version
+):
+
+    mpi_options = "-verbose -x orte_base_help_aggregate=0"
+    estimator = TensorFlow(
+        entry_point=os.path.join(RESOURCE_PATH, "hvdbasic", "train_hvd_env_vars.py"),
+        role="SageMakerRole",
+        train_instance_type=instance_type,
+        train_instance_count=2,
+        image_name=ecr_image,
+        framework_version=framework_version,
+        py_version="py3",
+        script_mode=True,
+        hyperparameters={
+            "sagemaker_mpi_enabled": True,
+            "sagemaker_mpi_custom_mpi_options": mpi_options,
+            "sagemaker_mpi_num_of_processes_per_host": 2,
+        },
+        sagemaker_session=sagemaker_session,
+    )
+
+    estimator.fit(job_name=unique_name_from_base("test-tf-horovod-env-vars"))

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/resources/hvdbasic/train_hvd_env_vars.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/resources/hvdbasic/train_hvd_env_vars.py
@@ -1,0 +1,19 @@
+import json
+import os
+import horovod.tensorflow as hvd
+
+hvd.init()
+
+with open('/opt/ml/model/local-rank-%s-rank-%s' % (hvd.local_rank(), hvd.rank()), 'w+') as f:
+    basic_info = {'local-rank': hvd.local_rank(), 'rank': hvd.rank(), 'size': hvd.size()}
+
+    print(basic_info)
+    json.dump(basic_info, f)
+
+val = os.environ.get('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI')
+host = os.environ.get('SM_CURRENT_HOST')
+
+assert val is not None
+assert host is not None
+
+print('host {}: AWS_CONTAINER_CREDENTIALS_RELATIVE_URI={}'.format(host, val))

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/sagemaker/test_horovod.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/sagemaker/test_horovod.py
@@ -50,3 +50,28 @@ def test_distributed_training_horovod(sagemaker_session,
 
     for filename in model_data_source.get_file_list():
         assert os.path.basename(filename) == 'model.tar.gz'
+
+
+def test_distributed_training_horovod_with_env_vars(
+        sagemaker_session, instance_type, ecr_image, tmpdir, framework_version
+):
+
+    mpi_options = "-verbose -x orte_base_help_aggregate=0"
+    estimator = TensorFlow(
+        entry_point=os.path.join(RESOURCE_PATH, "hvdbasic", "train_hvd_env_vars.py"),
+        role="SageMakerRole",
+        train_instance_type=instance_type,
+        train_instance_count=2,
+        image_name=ecr_image,
+        framework_version=framework_version,
+        py_version="py3",
+        script_mode=True,
+        hyperparameters={
+            "sagemaker_mpi_enabled": True,
+            "sagemaker_mpi_custom_mpi_options": mpi_options,
+            "sagemaker_mpi_num_of_processes_per_host": 2,
+        },
+        sagemaker_session=sagemaker_session,
+    )
+
+    estimator.fit(job_name=unique_name_from_base("test-tf-horovod-env-vars"))

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/resources/hvdbasic/train_hvd_env_vars.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/resources/hvdbasic/train_hvd_env_vars.py
@@ -1,0 +1,19 @@
+import json
+import os
+import horovod.tensorflow as hvd
+
+hvd.init()
+
+with open('/opt/ml/model/local-rank-%s-rank-%s' % (hvd.local_rank(), hvd.rank()), 'w+') as f:
+    basic_info = {'local-rank': hvd.local_rank(), 'rank': hvd.rank(), 'size': hvd.size()}
+
+    print(basic_info)
+    json.dump(basic_info, f)
+
+val = os.environ.get('AWS_CONTAINER_CREDENTIALS_RELATIVE_URI')
+host = os.environ.get('SM_CURRENT_HOST')
+
+assert val is not None
+assert host is not None
+
+print('host {}: AWS_CONTAINER_CREDENTIALS_RELATIVE_URI={}'.format(host, val))


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
- Adds test for changes consumed from aws/sagemaker-training-toolkit#68
- The above changes are automatically consumed by the [tensorflow-training-toolkit](https://github.com/aws/sagemaker-tensorflow-training-toolkit)

*Tests run:*
- Tested manually with TF2.2 (details in aws/sagemaker-training-toolkit#68)
- Ran integration tests in the SageMaker [TF1](https://github.com/aws/sagemaker-tensorflow-training-toolkit/pull/395) and [TF2](https://github.com/aws/sagemaker-tensorflow-training-toolkit/pull/396) training toolkits

*DLC image/dockerfile:*
- This relates to all Tensorflow 1 Dockerfiles that install `sagemaker-tensorflow-training>=10,<20` and all Tensorflow 2 Dockerfiles that install `sagemaker-tensorflow-training>=20`.

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

