### PR TITLE
[mxnet, pytorch] | [inference] | [build, test] Modify on MMS config

### DIFF
--- a/mxnet/inference/docker/artifacts/config.properties
+++ b/mxnet/inference/docker/artifacts/config.properties
@@ -1,4 +1,4 @@
-vmargs=-Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError
+vmargs=-XX:-UseContainerSupport
 model_store=/opt/ml/model
 load_models=ALL
 inference_address=http://0.0.0.0:8080

--- a/pytorch/inference/docker/build_artifacts/config.properties
+++ b/pytorch/inference/docker/build_artifacts/config.properties
@@ -1,4 +1,4 @@
-vmargs=-Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError
+vmargs=-XX:-UseContainerSupport
 model_store=/opt/ml/model
 load_models=ALL
 inference_address=http://0.0.0.0:8080


### PR DESCRIPTION
*Issue #, if available:*
Some of the inference tests failing on certain instance type.
e.g. this test is succeeding on c5.4xlarge, but failed on m4.16xlarge.
```
ubuntu@ip-172-31-11-62:~$ docker run -it --name beta-mxnet-inference-1.6.0-cpu-py27-ubuntu16.04-2020-07-16-00-17-28-ec2-squeezenet -p 80:8080 -p 8081:8081 669063966089.dkr.ecr.us-west-2.amazonaws.com/beta-mxnet-inference:1.6.0-cpu-py27-ubuntu16.04-2020-07-16-00-17-28 multi-model-server --start --mms-config /home/model-server/config.properties --models squeezenet=https://s3.amazonaws.com/model-server/models/squeezenet_v1.1/squeezenet_v1.1.model
Warning: MMS is using non-default JVM parameters: -Xmx128m -XX:-UseLargePages -XX:+UseG1GC -XX:MaxMetaspaceSize=32M -XX:MaxDirectMemorySize=10m -XX:+ExitOnOutOfMemoryError
java.lang.OutOfMemoryError: Direct buffer memory
	at java.nio.Bits.reserveMemory(Bits.java:695)
	at java.nio.DirectByteBuffer.<init>(DirectByteBuffer.java:123)
	at java.nio.ByteBuffer.allocateDirect(ByteBuffer.java:311)
	at io.netty.channel.unix.Buffer.allocateDirectWithNativeOrder(Buffer.java:40)
	at io.netty.channel.epoll.EpollEventArray.<init>(EpollEventArray.java:56)
	at io.netty.channel.epoll.EpollEventLoop.<init>(EpollEventLoop.java:95)
	at io.netty.channel.epoll.EpollEventLoopGroup.newChild(EpollEventLoopGroup.java:151)
	at io.netty.channel.epoll.EpollEventLoopGroup.newChild(EpollEventLoopGroup.java:35)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:84)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:58)
	at io.netty.util.concurrent.MultithreadEventExecutorGroup.<init>(MultithreadEventExecutorGroup.java:47)
	at io.netty.channel.MultithreadEventLoopGroup.<init>(MultithreadEventLoopGroup.java:59)
	at io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:112)
	at io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:99)
	at io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:76)
	at io.netty.channel.epoll.EpollEventLoopGroup.<init>(EpollEventLoopGroup.java:52)
	at com.amazonaws.ml.mms.util.Connector.newEventLoopGroup(Connector.java:156)
	at com.amazonaws.ml.mms.util.ServerGroups.init(ServerGroups.java:50)
	at com.amazonaws.ml.mms.util.ServerGroups.<init>(ServerGroups.java:42)
	at com.amazonaws.ml.mms.ModelServer.<init>(ModelServer.java:72)
	at com.amazonaws.ml.mms.ModelServer.main(ModelServer.java:86)
```
## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, pytorch] | [inference] | [build, test]

*DLC image/dockerfile:*
MXNet, PyTorch Inference Images

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

