### PR TITLE
[mxnet] | [test] | [eks] Fix import error for EKS

### DIFF
--- a/test/dlc_tests/eks/mxnet/training/test_eks_mxnet_multinode_training.py
+++ b/test/dlc_tests/eks/mxnet/training/test_eks_mxnet_multinode_training.py
@@ -12,8 +12,10 @@ from retrying import retry
 
 import test.test_utils.eks as eks_utils
 import test.test_utils.ec2 as ec2_utils
+from test.test_utils import is_pr_context, SKIP_PR_REASON
 
 LOGGER = eks_utils.LOGGER
+
 
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
 def test_eks_mxnet_multi_node_training_horovod_mnist(mxnet_training, example_only):


### PR DESCRIPTION
*Issue #, if available:*
```
==================================== ERRORS ====================================
___ ERROR collecting eks/mxnet/training/test_eks_mxnet_multinode_training.py ___
eks/mxnet/training/test_eks_mxnet_multinode_training.py:18: in <module>
    @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
E   NameError: name 'is_pr_context' is not defined
```

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet] | [test] | [eks]


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

