### PR TITLE
[release] [tensorflow] Change tf release version to 2.2.0

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -7,12 +7,12 @@ release_images:
       device_types: ["cpu", "gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
-      cuda_version: "cu101"
+      cuda_version: "cu102"
     inference:
       device_types: ["cpu", "gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
-      cuda_version: "cu101"
+      cuda_version: "cu102"
   2:
     framework: "tensorflow"
     version: "2.2.0"
@@ -20,5 +20,5 @@ release_images:
       device_types: ["gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
-      cuda_version: "cu101"
+      cuda_version: "cu102"
       example: True

--- a/release_images.yml
+++ b/release_images.yml
@@ -2,26 +2,23 @@
 release_images:
   1:
     framework: "tensorflow"
-    version: "2.1.1"
+    version: "2.2.0"
     training:
       device_types: ["cpu", "gpu"]
-      python_versions: ["py27", "py36"]
+      python_versions: ["py37"]
       os_version: "ubuntu18.04"
       cuda_version: "cu101"
-      dlc_version: "6.4"
     inference:
       device_types: ["cpu", "gpu"]
-      python_versions: ["py27", "py36"]
+      python_versions: ["py37"]
       os_version: "ubuntu18.04"
       cuda_version: "cu101"
-      dlc_version: "6.4"
   2:
     framework: "tensorflow"
-    version: "2.1.1"
+    version: "2.2.0"
     training:
       device_types: ["gpu"]
-      python_versions: ["py36"]
+      python_versions: ["py37"]
       os_version: "ubuntu18.04"
       cuda_version: "cu101"
-      dlc_version: "6.4"
       example: True


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
Change release version of TensorFlow images to 2.2.0

*Tests run:*
N/A

*DLC image/dockerfile:*
N/A

*Additional context:*
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

