### PR TITLE
[release] [mxnet] Force release MXNet 1.6 Training gpu py2

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -4,21 +4,8 @@ release_images:
     framework: "mxnet"
     version: "1.6.0"
     training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py27", "py36"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu101"
-    inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py27", "py36"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu101"
-  2:
-    framework: "mxnet"
-    version: "1.6.0"
-    training:
       device_types: ["gpu"]
-      python_versions: ["py36"]
+      python_versions: ["py27"]
       os_version: "ubuntu16.04"
       cuda_version: "cu101"
-      example: True
+      force_release: True


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
Force MXNet 1.6.0 Training GPU Py27 re-release to account for release issues

*Tests run:*
N/A

*DLC image/dockerfile:*
N/A

*Additional context:*
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

