### PR TITLE
[tensorflow] | [build, test] | [ec2] Add extra shm for TF Hvd GPU test on p2.8xlarge

### DIFF
--- a/test/dlc_tests/ec2/tensorflow/training/test_tensorflow_training.py
+++ b/test/dlc_tests/ec2/tensorflow/training/test_tensorflow_training.py
@@ -49,7 +49,8 @@ def test_tensorflow_train_mnist_cpu(tensorflow_training, ec2_connection, cpu_onl
 @pytest.mark.parametrize("ec2_instance_type", TF_EC2_GPU_INSTANCE_TYPE, indirect=True)
 def test_tensorflow_with_horovod_gpu(tensorflow_training, ec2_connection, gpu_only):
     test_script = TF1_HVD_CMD if is_tf1(tensorflow_training) else TF2_HVD_CMD
-    execute_ec2_training_test(ec2_connection, tensorflow_training, test_script)
+    execute_ec2_training_test(ec2_connection, tensorflow_training, test_script,
+                              large_shm=True if "p2.8xlarge" in TF_EC2_GPU_INSTANCE_TYPE else False)
 
 
 # TODO: Change this back TF_EC2_CPU_INSTANCE_TYPE. Currently this test times out on c4.8x, m4.16x and t2.2x,


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [tensorflow] | [build, test] | [ec2]

*Description:*
Fix the shm issue for TF HVD GPU  teset.

*Tests run:*
Local test passed.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

