### PR TITLE
[test]|[canary] Temporarily remove EC2 canaries

### DIFF
--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -126,7 +126,7 @@ def test_framework_version_cpu(cpu):
         assert tag_framework_version == output.stdout.strip()
 
 
-@pytest.mark.canary("Run gpu framework version test regularly on production images")
+# TODO: Enable as canary once resource cleaning lambda is added
 @pytest.mark.parametrize("ec2_instance_type", ['p2.xlarge'], indirect=True)
 def test_framework_version_gpu(gpu, ec2_connection):
     """


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
Temporarily remove canaries that use EC2 resources until we have added external cleanup measures.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

