### PR TITLE
[test]|[sanity] Enable the generate coverage doc test in PR context

### DIFF
--- a/test/dlc_tests/sanity/test_generate_coverage_doc.py
+++ b/test/dlc_tests/sanity/test_generate_coverage_doc.py
@@ -3,12 +3,10 @@ import os
 import pytest
 from invoke.context import Context
 
-from test.test_utils import TEST_COVERAGE_FILE
+from test.test_utils import TEST_COVERAGE_FILE, is_pr_context, PR_ONLY_REASON
 
 
-#Skipping this test temporary for upcoming release.
-##TODO: Unskip this test and find out why it is failing
-@pytest.mark.skip()
+@pytest.mark.skipif(not is_pr_context(), reason=PR_ONLY_REASON)
 @pytest.mark.integration("Generating this coverage doc")
 def test_generate_coverage_doc():
     """


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
The coverage doc test was skipped in order to unblock mainline pipelines. I believe this is due to git being used, but this will be addressed in PRs 361 and 363. Since those are both large reviews and may take some time to merge in, I wanted to ensure that we are at least running the coverage doc test in PR context so that we get utility from it.

*Tests run:*
- Manually run coverage doc test


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

