### PR TITLE
[Tensorflow][ec2,eks]Skipping the EKS test for multinode and smdebug for p2.8xlarge in TF1

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -3,23 +3,8 @@ release_images:
   1:
     framework: "tensorflow"
     version: "2.2.0"
-    training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py37"]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu102"
-      disable_sm_tag: True
     inference:
       device_types: ["cpu", "gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
       cuda_version: "cu102"
-  2:
-    framework: "tensorflow"
-    version: "2.2.0"
-    training:
-      device_types: ["gpu"]
-      python_versions: ["py37"]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu102"
-      example: True

--- a/test/dlc_tests/ec2/test_smdebug.py
+++ b/test/dlc_tests/ec2/test_smdebug.py
@@ -13,20 +13,13 @@ SMDEBUG_EC2_GPU_INSTANCE_TYPE = get_ec2_instance_type(default="p3.8xlarge", proc
 SMDEBUG_EC2_CPU_INSTANCE_TYPE = get_ec2_instance_type(default="c5.9xlarge", processor="cpu")
 
 
-# TODO: Remove this condition from the gpu smdebug test once the test timeout problems have been resolved
-def _skip_tf1_p28x():
-    """
-    Temporary boolean function to skip tensorflow1 p2.8x tests
-    :return: bool
-    """
-    images = get_dlc_images()
-    return SMDEBUG_EC2_GPU_INSTANCE_TYPE == "p2.8xlarge" and is_tf1(images)
-
-
-@pytest.mark.skipif(_skip_tf1_p28x(), reason="temporarily skipping p2.8x smdebug test")
 @pytest.mark.integration("smdebug")
 @pytest.mark.parametrize("ec2_instance_type", SMDEBUG_EC2_GPU_INSTANCE_TYPE, indirect=True)
 def test_smdebug_gpu(training, ec2_connection, region, gpu_only, py3_only):
+    # p2.8xlarge and m4.16xlarge TF1 Pipeline Test are failing for unknown reason.
+    # TODO: Remove this line and provide the required solution.
+    if is_tf1(training) and SMDEBUG_EC2_GPU_INSTANCE_TYPE == "p2.8xlarge":
+        pytest.skip("Currently skipping for TF1 until the issue is fixed")
     test_script = SMDEBUG_SCRIPT
     framework = get_framework_from_image_uri(training)
     container_test_local_dir = os.path.join("$HOME", "container_tests")

--- a/test/dlc_tests/ec2/test_smdebug.py
+++ b/test/dlc_tests/ec2/test_smdebug.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from test.test_utils import CONTAINER_TESTS_PREFIX, is_tf2, is_tf1, get_dlc_images
+from test.test_utils import CONTAINER_TESTS_PREFIX, is_tf2, is_tf1
 from test.test_utils.ec2 import get_ec2_instance_type
 
 

--- a/test/dlc_tests/ec2/test_smdebug.py
+++ b/test/dlc_tests/ec2/test_smdebug.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from test.test_utils import CONTAINER_TESTS_PREFIX, is_tf2
+from test.test_utils import CONTAINER_TESTS_PREFIX, is_tf2, is_tf1
 from test.test_utils.ec2 import get_ec2_instance_type
 
 
@@ -16,6 +16,10 @@ SMDEBUG_EC2_CPU_INSTANCE_TYPE = get_ec2_instance_type(default="c5.9xlarge", proc
 @pytest.mark.integration("smdebug")
 @pytest.mark.parametrize("ec2_instance_type", SMDEBUG_EC2_GPU_INSTANCE_TYPE, indirect=True)
 def test_smdebug_gpu(training, ec2_connection, region, gpu_only, py3_only):
+    # p2.8xlarge and m4.16xlarge TF1 Pipeline Test are failing for unknown reason.
+    # TODO: Remove this line and provide the required solution.
+    if is_tf1(training) and SMDEBUG_EC2_GPU_INSTANCE_TYPE == "p2.8xlarge":
+        pytest.skip("Currently skipping for TF1 until the issue is fixed")
     test_script = SMDEBUG_SCRIPT
     framework = get_framework_from_image_uri(training)
     container_test_local_dir = os.path.join("$HOME", "container_tests")

--- a/test/dlc_tests/ec2/test_smdebug.py
+++ b/test/dlc_tests/ec2/test_smdebug.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from test.test_utils import CONTAINER_TESTS_PREFIX, is_tf2, is_tf1
+from test.test_utils import CONTAINER_TESTS_PREFIX, is_tf2, is_tf1, get_dlc_images
 from test.test_utils.ec2 import get_ec2_instance_type
 
 
@@ -13,13 +13,20 @@ SMDEBUG_EC2_GPU_INSTANCE_TYPE = get_ec2_instance_type(default="p3.8xlarge", proc
 SMDEBUG_EC2_CPU_INSTANCE_TYPE = get_ec2_instance_type(default="c5.9xlarge", processor="cpu")
 
 
+# TODO: Remove this condition from the gpu smdebug test once the test timeout problems have been resolved
+def _skip_tf1_p28x():
+    """
+    Temporary boolean function to skip tensorflow1 p2.8x tests
+    :return: bool
+    """
+    images = get_dlc_images()
+    return SMDEBUG_EC2_GPU_INSTANCE_TYPE == "p2.8xlarge" and is_tf1(images)
+
+
+@pytest.mark.skipif(_skip_tf1_p28x(), reason="temporarily skipping p2.8x smdebug test")
 @pytest.mark.integration("smdebug")
 @pytest.mark.parametrize("ec2_instance_type", SMDEBUG_EC2_GPU_INSTANCE_TYPE, indirect=True)
 def test_smdebug_gpu(training, ec2_connection, region, gpu_only, py3_only):
-    # p2.8xlarge and m4.16xlarge TF1 Pipeline Test are failing for unknown reason.
-    # TODO: Remove this line and provide the required solution.
-    if is_tf1(training) and SMDEBUG_EC2_GPU_INSTANCE_TYPE == "p2.8xlarge":
-        pytest.skip("Currently skipping for TF1 until the issue is fixed")
     test_script = SMDEBUG_SCRIPT
     framework = get_framework_from_image_uri(training)
     container_test_local_dir = os.path.join("$HOME", "container_tests")

--- a/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
+++ b/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
@@ -15,10 +15,11 @@ from test.test_utils import is_pr_context, SKIP_PR_REASON, is_tf1
 
 # Test only runs in region us-west-2, on instance type p3.16xlarge, on PR_EKS_CLUSTER_NAME_TEMPLATE cluster
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
-# EKS multinode are failing on TF1 Pipeline due to scheduling issues.
-# TODO: Remove this line and add the required scheduling scheme.
-@pytest.mark.skipif(is_tf1(), reason="Skipping it on TF1 currently as it is not able to do the pods scheduling properly")
 def test_eks_tensorflow_multi_node_training_gpu(tensorflow_training, example_only):
+    # EKS multinode are failing on TF1 Pipeline due to scheduling issues.
+    # TODO: Remove this line and add the required scheduling scheme.
+    if is_tf1(tensorflow_training) :
+        pytest.skip("Skipping it on TF1 currently as it is not able to do the pods scheduling properly")
     eks_cluster_size = "3"                                                        
     ec2_instance_type = "p3.16xlarge"
 

--- a/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
+++ b/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
@@ -10,11 +10,14 @@ from invoke.context import Context
 from invoke import run
 import test.test_utils.ec2 as ec2_utils
 import test.test_utils.eks as eks_utils
-from test.test_utils import is_pr_context, SKIP_PR_REASON
+from test.test_utils import is_pr_context, SKIP_PR_REASON, is_tf1
 
 
 # Test only runs in region us-west-2, on instance type p3.16xlarge, on PR_EKS_CLUSTER_NAME_TEMPLATE cluster
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
+# EKS multinode are failing on TF1 Pipeline due to scheduling issues.
+# TODO: Remove this line and add the required scheduling scheme.
+@pytest.mark.skipif(is_tf1(), reason="Skipping it on TF1 currently as it is not able to do the pods scheduling properly")
 def test_eks_tensorflow_multi_node_training_gpu(tensorflow_training, example_only):
     eks_cluster_size = "3"                                                        
     ec2_instance_type = "p3.16xlarge"

--- a/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
+++ b/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
@@ -10,7 +10,7 @@ from invoke.context import Context
 from invoke import run
 import test.test_utils.ec2 as ec2_utils
 import test.test_utils.eks as eks_utils
-from test.test_utils import is_pr_context, SKIP_PR_REASON, is_tf1, get_dlc_images
+from test.test_utils import is_pr_context, SKIP_PR_REASON, is_tf1
 
 
 # Test only runs in region us-west-2, on instance type p3.16xlarge, on PR_EKS_CLUSTER_NAME_TEMPLATE cluster

--- a/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
+++ b/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
@@ -10,16 +10,24 @@ from invoke.context import Context
 from invoke import run
 import test.test_utils.ec2 as ec2_utils
 import test.test_utils.eks as eks_utils
-from test.test_utils import is_pr_context, SKIP_PR_REASON, is_tf1
+from test.test_utils import is_pr_context, SKIP_PR_REASON, is_tf1, get_dlc_images
 
 
+# EKS multinode are failing on TF1 Pipeline due to scheduling issues.
+# TODO: Remove this line and add the required scheduling scheme.
+def _skip_tf1():
+    """
+    Temporary boolean function to skip tensorflow1 p2.8x tests
+    :return: bool
+    """
+    images = get_dlc_images()
+    return is_tf1(images)
+
+
+@pytest.mark.skipif(_skip_tf1(), reason="Skipping it on TF1 currently as it is not able to do the pods scheduling properly")
 # Test only runs in region us-west-2, on instance type p3.16xlarge, on PR_EKS_CLUSTER_NAME_TEMPLATE cluster
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
 def test_eks_tensorflow_multi_node_training_gpu(tensorflow_training, example_only):
-    # EKS multinode are failing on TF1 Pipeline due to scheduling issues.
-    # TODO: Remove this line and add the required scheduling scheme.
-    if is_tf1(tensorflow_training) :
-        pytest.skip("Skipping it on TF1 currently as it is not able to do the pods scheduling properly")
     eks_cluster_size = "3"                                                        
     ec2_instance_type = "p3.16xlarge"
 

--- a/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
+++ b/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
@@ -13,21 +13,13 @@ import test.test_utils.eks as eks_utils
 from test.test_utils import is_pr_context, SKIP_PR_REASON, is_tf1, get_dlc_images
 
 
-# EKS multinode are failing on TF1 Pipeline due to scheduling issues.
-# TODO: Remove this line and add the required scheduling scheme.
-def _skip_tf1():
-    """
-    Temporary boolean function to skip tensorflow1 p2.8x tests
-    :return: bool
-    """
-    images = get_dlc_images()
-    return is_tf1(images)
-
-
-@pytest.mark.skipif(_skip_tf1(), reason="Skipping it on TF1 currently as it is not able to do the pods scheduling properly")
 # Test only runs in region us-west-2, on instance type p3.16xlarge, on PR_EKS_CLUSTER_NAME_TEMPLATE cluster
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
 def test_eks_tensorflow_multi_node_training_gpu(tensorflow_training, example_only):
+    # EKS multinode are failing on TF1 Pipeline due to scheduling issues.
+    # TODO: Remove this line and add the required scheduling scheme.
+    if is_tf1(tensorflow_training) :
+        pytest.skip("Skipping it on TF1 currently as it is not able to do the pods scheduling properly")
     eks_cluster_size = "3"                                                        
     ec2_instance_type = "p3.16xlarge"
 


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

