### PR TITLE
[test]|[ec2] Skip smdebug test on TF1/p2.8xlarge due to timeout error

### DIFF
--- a/test/dlc_tests/ec2/test_smdebug.py
+++ b/test/dlc_tests/ec2/test_smdebug.py
@@ -9,7 +9,7 @@ from test.test_utils.ec2 import get_ec2_instance_type
 SMDEBUG_SCRIPT = os.path.join(CONTAINER_TESTS_PREFIX, "testSmdebug")
 
 
-SMDEBUG_EC2_GPU_INSTANCE_TYPE = get_ec2_instance_type(default="p3.8xlarge", processor="gpu")
+SMDEBUG_EC2_GPU_INSTANCE_TYPE = get_ec2_instance_type(default="p2.8xlarge", processor="gpu")
 SMDEBUG_EC2_CPU_INSTANCE_TYPE = get_ec2_instance_type(default="c5.9xlarge", processor="cpu")
 
 

--- a/test/dlc_tests/ec2/test_smdebug.py
+++ b/test/dlc_tests/ec2/test_smdebug.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from test.test_utils import CONTAINER_TESTS_PREFIX, is_tf2
+from test.test_utils import CONTAINER_TESTS_PREFIX, is_tf2, is_tf1, get_dlc_images
 from test.test_utils.ec2 import get_ec2_instance_type
 
 
@@ -13,6 +13,18 @@ SMDEBUG_EC2_GPU_INSTANCE_TYPE = get_ec2_instance_type(default="p3.8xlarge", proc
 SMDEBUG_EC2_CPU_INSTANCE_TYPE = get_ec2_instance_type(default="c5.9xlarge", processor="cpu")
 
 
+# TODO: Remove this condition from the gpu smdebug test once the test timeout problems have been resolved
+def _skip_tf1_p28x():
+    """
+    Temporary boolean function to skip tensorflow1 p2.8x tests
+
+    :return: bool
+    """
+    images = get_dlc_images()
+    return SMDEBUG_EC2_GPU_INSTANCE_TYPE == "p2.8xlarge" and is_tf1(images)
+
+
+@pytest.mark.skipif(_skip_tf1_p28x(), reason="temporarily skipping p2.8x smdebug test")
 @pytest.mark.integration("smdebug")
 @pytest.mark.parametrize("ec2_instance_type", SMDEBUG_EC2_GPU_INSTANCE_TYPE, indirect=True)
 def test_smdebug_gpu(training, ec2_connection, region, gpu_only, py3_only):


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
Skip SMDebug test for TF1 on p2.8x due to timeout issue

*Tests run:*
Second commit is a test to ensure that it skips only for tf1 on p2.8x


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

