### PR TITLE
[tensorflow][tensorflowserving][build][WIP] update nccl version to 2.7.6

### DIFF
--- a/tensorflow/inference/docker/2.2.0/py3/Dockerfile.gpu
+++ b/tensorflow/inference/docker/2.2.0/py3/Dockerfile.gpu
@@ -15,7 +15,7 @@ ARG OPENSSL_VERSION=1.1.1g
 ARG TFS_SHORT_VERSION=2.2
 ARG TFS_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/serving/r2.2_aws/20200611-220145/gpu/py37/tensorflow_model_server
 
-ENV NCCL_VERSION=2.6.4-1+cuda10.2
+ENV NCCL_VERSION=2.7.6-1+cuda10.2
 ENV CUDNN_VERSION=7.6.5.32-1+cuda10.2
 ENV TF_TENSORRT_VERSION=6.0.1
 

--- a/tensorflow/training/docker/2.2.0/py3/cu102/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.2.0/py3/cu102/Dockerfile.gpu
@@ -47,9 +47,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends --allow-unauthe
     emacs \
     libcudnn7=7.6.5.32-1+cuda10.2 \
     # TensorFlow doesn't require libnccl anymore but Open MPI still depends on it
-    libnccl2=2.6.4-1+cuda10.2 \
+    libnccl2=2.7.6-1+cuda10.2 \
     libgomp1 \
-    libnccl-dev=2.6.4-1+cuda10.2 \
+    libnccl-dev=2.7.6-1+cuda10.2 \
     libfreetype6-dev \
     libhdf5-serial-dev \
     liblzma-dev \


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
we are seeing the issues with build containers stage in our 2.2 pipeline with nccl2 2.6.4 and we are updating them. To be in sync, we want DLC team to update the nccl2 version to 2.7.6 for TF and TFS2 gpu docker files
*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

