### PR TITLE
[test]|[canary] Write out test coverage files in canaries and push them to s3

### DIFF
--- a/test/dlc_tests/sanity/test_generate_coverage_doc.py
+++ b/test/dlc_tests/sanity/test_generate_coverage_doc.py
@@ -27,7 +27,7 @@ def coverage_doc_skip_condition():
     coverage_doc_skip_condition(), reason=f"Run only in PR context or {TEST_COVERAGE_REPORT_REGION} canary context"
 )
 @pytest.mark.integration("Generating this coverage doc")
-@pytest.mark.canary("runs only in us-west-2")
+@pytest.mark.canary(f"runs only in {TEST_COVERAGE_REPORT_REGION}")
 def test_generate_coverage_doc():
     """
     Test generating the test coverage doc

--- a/test/dlc_tests/sanity/test_generate_coverage_doc.py
+++ b/test/dlc_tests/sanity/test_generate_coverage_doc.py
@@ -23,7 +23,9 @@ def coverage_doc_skip_condition():
     return True
 
 
-@pytest.mark.skipif(coverage_doc_skip_condition(), reason="Run only in PR context or us-west-2 canary context")
+@pytest.mark.skipif(
+    coverage_doc_skip_condition(), reason=f"Run only in PR context or {TEST_COVERAGE_REPORT_REGION} canary context"
+)
 @pytest.mark.integration("Generating this coverage doc")
 @pytest.mark.canary("runs only in us-west-2")
 def test_generate_coverage_doc():
@@ -34,8 +36,11 @@ def test_generate_coverage_doc():
     ctx = Context()
     # Set DLC_TESTS to 'test' to avoid image names affecting function metadata (due to parametrization)
     # Set CODEBUILD_RESOLVED_SOURCE_VERSION to test for ease of running this test locally
-    ctx.run("export DLC_TESTS='test' && export CODEBUILD_RESOLVED_SOURCE_VERSION='test' && export BUILD_CONTEXT=''"
-            "&& pytest -s --collect-only  --generate-coverage-doc --ignore=container_tests/", hide=True)
+    ctx.run(
+        "export DLC_TESTS='test' && export CODEBUILD_RESOLVED_SOURCE_VERSION='test' && export BUILD_CONTEXT=''"
+        "&& pytest -s --collect-only  --generate-coverage-doc --ignore=container_tests/",
+        hide=True,
+    )
 
     # Ensure that the coverage report is created
     assert os.path.exists(test_coverage_file), f"Cannot find test coverage report file {test_coverage_file}"
@@ -47,9 +52,7 @@ def test_generate_coverage_doc():
         client = boto3.client("s3")
         with open(test_coverage_file, "rb") as test_file:
             try:
-                client.put_object(Bucket=report_bucket,
-                                  Key=os.path.basename(test_coverage_file),
-                                  Body=test_file)
+                client.put_object(Bucket=report_bucket, Key=os.path.basename(test_coverage_file), Body=test_file)
             except ClientError as e:
                 LOGGER.error(f"Unable to upload report to bucket {report_bucket}. Error: {e}")
                 raise

--- a/test/dlc_tests/sanity/test_generate_coverage_doc.py
+++ b/test/dlc_tests/sanity/test_generate_coverage_doc.py
@@ -1,14 +1,25 @@
 import os
 
+import boto3
 import pytest
 from invoke.context import Context
 
-from test.test_utils import is_pr_context, PR_ONLY_REASON
+from test.test_utils import is_pr_context, is_canary_context
 from test.test_utils.test_reporting import get_test_coverage_file_path
 
 
-@pytest.mark.skipif(not is_pr_context(), reason=PR_ONLY_REASON)
+def coverage_doc_skip_condition():
+    # Run this only in us-west-2
+    if is_canary_context() and os.getenv("AWS_REGION") == "us-west-2":
+        return False
+    elif is_pr_context():
+        return False
+    return True
+
+
+@pytest.mark.skipif(coverage_doc_skip_condition(), reason="Run only in PR context or us-west-2 canary context")
 @pytest.mark.integration("Generating this coverage doc")
+@pytest.mark.canary("runs only in us-west-2")
 def test_generate_coverage_doc():
     """
     Test generating the test coverage doc
@@ -22,3 +33,9 @@ def test_generate_coverage_doc():
 
     # Ensure that the coverage report is created
     assert os.path.exists(test_coverage_file), f"Cannot find test coverage report file {test_coverage_file}"
+
+    # Write test coverage file to S3
+    if is_canary_context():
+        client = boto3.client("s3")
+        with open(test_coverage_file, "rb") as test_file:
+            client.put_object(Bucket="dlc-test-report", Key=os.path.basename(test_coverage_file), Body=test_file)


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]


*Description:*
- Have coverage doc test run in canaries, push to s3 in one region for easy access to the current version of the file

*Tests run:*
- Tested locally, ensured that s3 file gets populated


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

