### PR TITLE
[test] Enable coverage test in mainline, remove from canary

### DIFF
--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -82,6 +82,10 @@ def is_canary_context():
     return os.getenv("BUILD_CONTEXT") == "CANARY"
 
 
+def is_mainline_context():
+    return os.getenv("BUILD_CONTEXT") == "MAINLINE"
+
+
 def is_empty_build_context():
     return not os.getenv("BUILD_CONTEXT")
 


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
- Coverage test was previously failing in mainline, the issue is fixed 
- Publish the coverage file from mainline instead of canary

*Tests run:*
- Locally tested outside of PR context


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

