### PR TITLE
[mxnet, tensorflow, pytorch] | [release] | Remove usage of environment variables in github publishing workflow

### DIFF
--- a/generate_dlc_image_release_information.py
+++ b/generate_dlc_image_release_information.py
@@ -55,12 +55,23 @@ if __name__ == "__main__":
 
     args = parse_args()
     dlc_artifact_bucket = args.artifact_bucket
+    github_publishing_metadata_path = os.path.join(os.sep, "tmp", "github_publishing_metadata.dict")
 
-    dlc_account_id = os.getenv("TARGET_ACCOUNT_ID_CLASSIC")
-    dlc_tag = os.getenv("TAG_WITH_DLC_VERSION")
-    dlc_repository = os.getenv("TARGET_ECR_REPOSITORY")
+    if not os.path.exists(github_publishing_metadata_path):
+        LOGGER.error(
+            f"file {github_publishing_metadata_path} does not exist. Cannot publish github release information to bucket {dlc_artifact_bucket}."
+            f"Note: exiting successfully nonetheless to avoid codebuild failure."
+        )
+        sys.exit(0)
+
+    with open(github_publishing_metadata_path, "r") as f:
+        github_publishing_metadata = json.loads(f.read())
+
+    dlc_account_id = github_publishing_metadata.get("target_account_id_classic")
+    dlc_tag = github_publishing_metadata.get("tag_with_dlc_version")
+    dlc_repository = github_publishing_metadata.get("target_ecr_repository")
+    dlc_release_successful = github_publishing_metadata.get("release_successful")
     dlc_region = os.getenv("REGION")
-    dlc_release_successful = os.getenv("RELEASE_SUCCESSFUL")
 
     if dlc_release_successful != "1":
         LOGGER.error("Skipping generation of release information as the DLC release failed/skipped.")


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### EIA Checklist
* When creating a PR:
- [ ] I've modified ```src/config/build_config.py``` in my PR branch by setting ```ENABLE_EI_MODE = True```
* When PR is reviewed and ready to be merged:
- [ ] I've reverted the code change on the config file mentioned above

* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
Tested on images:
```
763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:2.2.0-gpu-py37-cu101-ubuntu18.04-v1.1
763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:2.2.0-cpu-py37-ubuntu18.04-v1.1
763104351884.dkr.ecr.us-west-2.amazonaws.com/aws-samples-tensorflow-training:2.2.0-gpu-py37-cu101-ubuntu18.04-example-v1.1
763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-inference:2.2.0-gpu-py37-cu102-ubuntu18.04-v1.0
763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-inference:2.2.0-cpu-py37-ubuntu18.04-v1.0
763104351884.dkr.ecr.us-west-2.amazonaws.com/tensorflow-training:2.2.0-gpu-py37-cu102-ubuntu18.04-v2.0
763104351884.dkr.ecr.us-west-2.amazonaws.com/aws-samples-tensorflow-training:2.2.0-gpu-py37-cu102-ubuntu18.04-example-v2.0
```
*Tests run:*
```
python $(pwd)/generate_dlc_image_release_information.py --artifact-bucket <bucket_name>
```
*DLC image/dockerfile:*
Relates to any container generated as part of release workflow

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

