### PR TITLE
[Tensorflow][Release]Keeping SM tags for both py36 and py37 in TF1.15

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -5,7 +5,7 @@ release_images:
     version: "1.15.3"
     training:
       device_types: ["cpu", "gpu"]
-      python_versions: ["py36", "py27"]
+      python_versions: ["py37", "py36", "py27"]
       os_version: "ubuntu18.04"
       cuda_version: "cu100"
       example: False        # [Default: False] Set to True to denote that this image is an Example image
@@ -32,16 +32,3 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  3:
-    framework: "tensorflow"
-      version: "1.15.3"
-      training:
-        device_types: ["cpu", "gpu"]
-        python_versions: ["py37"]
-        os_version: "ubuntu18.04"
-        cuda_version: "cu100"
-        example: False        # [Default: False] Set to True to denote that this image is an Example image
-        disable_sm_tag: True  # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-        # to images being published.
-        force_release: False  # [Default: False] Set to True to force images to be published even if the same image
-        # has already been published. Re-released image will have minor version incremented by 1.


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]


*Description:*
Keeping SM tags for both py36 and py37 in TF1.15

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

