### PR TITLE
[Release][Tensorflow]GPU py27 and py37 Images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -15,6 +15,17 @@ release_images:
                             # has already been published. Re-released image will have minor version incremented by 1.
   2:
     framework: "tensorflow"
+    version: "1.15.3"
+    training:
+      device_types: ["gpu"]
+      python_versions: ["py37", "py36"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu100"
+      example: True
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  3:
+    framework: "tensorflow"
       version: "2.2.0"
       training:
         device_types: ["cpu", "gpu"]
@@ -31,7 +42,7 @@ release_images:
         python_versions: ["py37"]
         os_version: "ubuntu18.04"
         cuda_version: "cu102"
-  3:
+  4:
     framework: "tensorflow"
       version: "2.2.0"
       training:

--- a/release_images.yml
+++ b/release_images.yml
@@ -4,31 +4,41 @@ release_images:
     framework: "tensorflow"
     version: "1.15.3"
     training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py37", "py36", "py27"]
+      device_types: ["gpu"]
+      python_versions: ["py37", "py27"]
       os_version: "ubuntu18.04"
       cuda_version: "cu100"
       example: False        # [Default: False] Set to True to denote that this image is an Example image
       disable_sm_tag: False  # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
                             # to images being published.
-      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
+      force_release: True  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
-    inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py36", "py27"]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu100"
-      example: False
-      disable_sm_tag: False
-      force_release: False
   2:
     framework: "tensorflow"
-    version: "1.15.3"
-    training:
-      device_types: ["gpu"]
-      python_versions: ["py37", "py36"]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu100"
-      example: True
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
+      version: "2.2.0"
+      training:
+        device_types: ["cpu", "gpu"]
+        python_versions: ["py37"]
+        os_version: "ubuntu18.04"
+        cuda_version: "cu101"
+        example: False        # [Default: False] Set to True to denote that this image is an Example image
+          disable_sm_tag: False  # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
+          # to images being published.
+          force_release: False  # [Default: False] Set to True to force images to be published even if the same image
+          # has already been published. Re-released image will have minor version incremented by 1.
+      inference:
+        device_types: ["cpu", "gpu"]
+        python_versions: ["py37"]
+        os_version: "ubuntu18.04"
+        cuda_version: "cu102"
+  3:
+    framework: "tensorflow"
+      version: "2.2.0"
+      training:
+        device_types: ["gpu"]
+        python_versions: ["py37"]
+        os_version: "ubuntu18.04"
+        cuda_version: "cu101"
+        example: True
+        disable_sm_tag: False  # [Default: False] This option is not used by Example images
+        force_release: False

--- a/release_images.yml
+++ b/release_images.yml
@@ -39,6 +39,10 @@ release_images:
         python_versions: ["py37"]
         os_version: "ubuntu18.04"
         cuda_version: "cu102"
+        disable_sm_tag: False  # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
+        # to images being published.
+        force_release: False  # [Default: False] Set to True to force images to be published even if the same image
+        # has already been published. Re-released image will have minor version incremented by 1.
   3:
     framework: "tensorflow"
       version: "2.2.0"

--- a/release_images.yml
+++ b/release_images.yml
@@ -13,18 +13,15 @@ release_images:
                             # to images being published.
       force_release: True  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
-  2:
-    framework: "tensorflow"
-    version: "1.15.3"
-    training:
-      device_types: ["gpu"]
-      python_versions: ["py37", "py36"]
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py36", "py27"]
       os_version: "ubuntu18.04"
       cuda_version: "cu100"
-      example: True
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      example: False
+      disable_sm_tag: False
       force_release: False
-  3:
+  2:
     framework: "tensorflow"
       version: "2.2.0"
       training:
@@ -42,7 +39,7 @@ release_images:
         python_versions: ["py37"]
         os_version: "ubuntu18.04"
         cuda_version: "cu102"
-  4:
+  3:
     framework: "tensorflow"
       version: "2.2.0"
       training:

--- a/release_images.yml
+++ b/release_images.yml
@@ -22,10 +22,10 @@ release_images:
         os_version: "ubuntu18.04"
         cuda_version: "cu101"
         example: False        # [Default: False] Set to True to denote that this image is an Example image
-          disable_sm_tag: False  # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-          # to images being published.
-          force_release: False  # [Default: False] Set to True to force images to be published even if the same image
-          # has already been published. Re-released image will have minor version incremented by 1.
+        disable_sm_tag: False  # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
+        # to images being published.
+        force_release: False  # [Default: False] Set to True to force images to be published even if the same image
+        # has already been published. Re-released image will have minor version incremented by 1.
       inference:
         device_types: ["cpu", "gpu"]
         python_versions: ["py37"]


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
Releasing GPU py27 and py37 Images for TF1.15


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

