### PR TITLE
[test]|[ec2, ecs, eks]Add pytest timeout for PR tests

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,7 +2,7 @@ docker==4.2.0
 fabric==2.5.0
 pytest==5.3.5
 pytest-rerunfailures==9.0
-pytest-timeout==1.3.4
+pytest-timeout
 pytest-xdist==1.31.0
 boto3
 retrying

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -163,7 +163,8 @@ def main():
             pytest_cmd = ["-s", "-rA", test_path, f"--junitxml={report}", "-n=auto"]
             if test_type == "ec2":
                 pytest_cmd += ["--reruns=1", "--reruns-delay=10"]
-                pytest_cmd[1] = "-rAR"
+            if is_pr_context():
+                pytest_cmd.append("--timeout=4860")
 
             pytest_cmds = [pytest_cmd]
         # Execute separate cmd for canaries

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -158,6 +158,9 @@ def main():
                  "-m", "not multinode"],
                 ["-s", "-rA", test_path, f"--junitxml={report_multinode_train}", "--multinode"],
             ]
+            if is_pr_context():
+                for cmd in pytest_cmds:
+                    cmd.append("--timeout=2340")
         else:
             # Execute dlc_tests pytest command
             pytest_cmd = ["-s", "-rA", test_path, f"--junitxml={report}", "-n=auto"]


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
- Add global pytest timeout for ec2/ecs. I have kept the timeout at 81 minutes, to give 9 minutes for any pre-pytest setup or teardown
- For eks, it might make less sense to add a pytest timeout since we have to add one for training/inference/multinode, respectively since they use different pytest commands are are run sequentially. As of now, I have timed training/inference at 39 minutes each, as there is longer pytest setup associated with eks clusters

*Tests run:*
- Testing on this PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

