### PR TITLE
[test][tensorflow][ec2] Add flaky marker to telemetry test

### DIFF
--- a/test/dlc_tests/container_tests/bin/test_tf_dlc_telemetry_test.py
+++ b/test/dlc_tests/container_tests/bin/test_tf_dlc_telemetry_test.py
@@ -2,51 +2,50 @@ import os
 import numpy as np
 import time
 
+
 def opt_in_opt_out_test():
-    os.environ['TEST_MODE']='1'
+    os.environ["TEST_MODE"] = "1"
     if os.path.exists("/tmp/test_request.txt"):
         os.system("rm /tmp/test_request.txt")
-    os.environ["OPT_OUT_TRACKING"]="True"
+    os.environ["OPT_OUT_TRACKING"] = "True"
     cmd = "python -c 'import tensorflow'"
     os.system(cmd)
     assert not os.path.exists("/tmp/test_request.txt"), "Test failed on OPT_OUT_TRACKING."
 
     if os.path.exists("/tmp/test_request.txt"):
         os.system("rm /tmp/test_request.txt")
-    os.environ["OPT_OUT_TRACKING"]="False"
+    os.environ["OPT_OUT_TRACKING"] = "False"
     cmd = "python -c 'import tensorflow'"
     os.system(cmd)
     assert os.path.exists("/tmp/test_request.txt")
 
-
     if os.path.exists("/tmp/test_request.txt"):
         os.system("rm /tmp/test_request.txt")
-    os.environ["OPT_OUT_TRACKING"]="TRUE"
+    os.environ["OPT_OUT_TRACKING"] = "TRUE"
     cmd = "python -c 'import tensorflow'"
     os.system(cmd)
     assert not os.path.exists("/tmp/test_request.txt"), "Test failed on OPT_OUT_TRACKING."
 
     if os.path.exists("/tmp/test_request.txt"):
         os.system("rm /tmp/test_request.txt")
-    os.environ["OPT_OUT_TRACKING"]="true"
+    os.environ["OPT_OUT_TRACKING"] = "true"
     cmd = "python -c 'import tensorflow'"
     os.system(cmd)
     assert not os.path.exists("/tmp/test_request.txt"), "Test failed on OPT_OUT_TRACKING."
 
-
     if os.path.exists("/tmp/test_request.txt"):
         os.system("rm /tmp/test_request.txt")
-    os.environ["OPT_OUT_TRACKING"]="XYgg"
+    os.environ["OPT_OUT_TRACKING"] = "XYgg"
     cmd = "python -c 'import tensorflow'"
     os.system(cmd)
     assert os.path.exists("/tmp/test_request.txt")
-
 
     print("Opt-In/Opt-Out Test passed")
 
+
 def performance_test():
-    os.environ['TEST_MODE']='0'
-    os.environ["OPT_OUT_TRACKING"]="False"
+    os.environ["TEST_MODE"] = "0"
+    os.environ["OPT_OUT_TRACKING"] = "False"
     NUM_ITERATIONS = 5
 
     for itr in range(NUM_ITERATIONS):
@@ -55,20 +54,21 @@ def performance_test():
             cmd = "python -c 'import tensorflow'"
             start = time.time()
             os.system(cmd)
-            total_time_in += time.time()-start
-        print("avg out time: ", total_time_in/NUM_ITERATIONS)
+            total_time_in += time.time() - start
+        print("avg out time: ", total_time_in / NUM_ITERATIONS)
 
         total_time_out = 0
         for x in range(NUM_ITERATIONS):
             cmd = "export OPT_OUT_TRACKING='true' && python -c 'import tensorflow'"
             start = time.time()
             os.system(cmd)
-            total_time_out += time.time()-start
-        print("avg out time: ", total_time_out/NUM_ITERATIONS)
+            total_time_out += time.time() - start
+        print("avg out time: ", total_time_out / NUM_ITERATIONS)
 
-        np.testing.assert_allclose(total_time_in/NUM_ITERATIONS, total_time_out/NUM_ITERATIONS, rtol=0.2, atol=0.5)
+        np.testing.assert_allclose(total_time_in / NUM_ITERATIONS, total_time_out / NUM_ITERATIONS, rtol=0.2, atol=0.5)
 
         print("DLC Telemetry performance test Passed")
+
 
 performance_test()
 opt_in_opt_out_test()

--- a/test/dlc_tests/ec2/tensorflow/training/test_tensorflow_training.py
+++ b/test/dlc_tests/ec2/tensorflow/training/test_tensorflow_training.py
@@ -89,6 +89,7 @@ def test_tensorflow_opencv_cpu(tensorflow_training, ec2_connection, cpu_only):
 
 
 # Testing Telemetry Script on only one GPU instance
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.integration("telemetry")
 @pytest.mark.model("N/A")
 @pytest.mark.parametrize("ec2_instance_type", ["p2.xlarge"], indirect=True)
@@ -97,6 +98,7 @@ def test_tensorflow_telemetry_gpu(tensorflow_training, ec2_connection, gpu_only)
 
 
 # Testing Telemetry Script on only one CPU instance
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.integration("telemetry")
 @pytest.mark.model("N/A")
 @pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge"], indirect=True)
@@ -140,6 +142,7 @@ def test_tensorflow_tensorboard_cpu(tensorflow_training, ec2_connection, cpu_onl
     if is_tf1(tensorflow_training):
         pytest.skip("This test is for TF2 only")
     execute_ec2_training_test(ec2_connection, tensorflow_training, TF_TENSORBOARD_CMD)
+
 
 # TensorFlow Addons is actively working towards forward compatibility with TensorFlow 2.x
 # https://github.com/tensorflow/addons#python-op-compatility


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
The tensorflow telemetry test appears to be flaky, and requires more reruns than just the 1. While we dive into the flaky issues, I am marking this as flaky to a) ensure that failures are functional failures and b) avoid additional iteration cycles on PRs/pipelines


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

