### PR TITLE
[EIA]Skipping p3dn instance for EIA Instances

### DIFF
--- a/test/dlc_tests/ec2/tensorflow/inference/test_tensorflow_inference.py
+++ b/test/dlc_tests/ec2/tensorflow/inference/test_tensorflow_inference.py
@@ -30,7 +30,7 @@ def test_ec2_tensorflow_inference_cpu(tensorflow_inference, ec2_connection, regi
 
 
 @pytest.mark.integration("elastic_inference")
-@pytest.mark.model("half_plus_two")
+@pytest.mark.model("mnist")
 @pytest.mark.parametrize("ec2_instance_type", TF_EC2_CPU_INSTANCE_TYPE, indirect=True)
 @pytest.mark.parametrize("ei_accelerator_type", TF_EC2_EIA_ACCELERATOR_TYPE, indirect=True)
 def test_ec2_tensorflow_inference_eia_cpu(tensorflow_inference_eia, ec2_connection, region, eia_only):
@@ -38,7 +38,7 @@ def test_ec2_tensorflow_inference_eia_cpu(tensorflow_inference_eia, ec2_connecti
 
 
 @pytest.mark.integration("elastic_inference")
-@pytest.mark.model("half_plus_two")
+@pytest.mark.model("mnist")
 @pytest.mark.parametrize("ec2_instance_type", TF_EC2_GPU_INSTANCE_TYPE, indirect=True)
 @pytest.mark.parametrize("ei_accelerator_type", TF_EC2_EIA_ACCELERATOR_TYPE, indirect=True)
 def test_ec2_tensorflow_inference_eia_gpu(tensorflow_inference_eia, ec2_connection, region, eia_only):

--- a/test/test_utils/ec2.py
+++ b/test/test_utils/ec2.py
@@ -37,7 +37,8 @@ def get_ec2_instance_type(default, processor, disable_p3dn=False):
             "Default instance type should never be p3dn.24xlarge"
         )
     instance_type = os.getenv(f"EC2_{processor.upper()}_INSTANCE_TYPE", default)
-    if instance_type == p3dn and disable_p3dn:
+    #Not running eia test on p3dn instances
+    if instance_type == p3dn and (disable_p3dn or processor == "eia"):
         instance_type = default
     return [instance_type]
 


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]


#### EIA Checklist
* When creating a PR:
- [ ] I've modified ```src/config/build_config.py``` in my PR branch by setting ```ENABLE_EI_MODE = True```
* When PR is reviewed and ready to be merged:
- [x] I've reverted the code change on the config file mentioned above

* For reviewer, before merging, please cross-check:
- [x] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
Skipping the expensive p3dn instance for EIA Test as ideally the customer will not use such expensive GPU instances with EIA Instances.
*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

