### PR TITLE
[test][sanity, sagemaker] Pin sagemaker package to <2 to avoid breaking changes

### DIFF
--- a/test/sagemaker_tests/mxnet/inference/requirements.txt
+++ b/test/sagemaker_tests/mxnet/inference/requirements.txt
@@ -7,7 +7,7 @@ pytest-cov
 pytest-rerunfailures==9.0
 pytest-xdist
 mock
-sagemaker
+sagemaker<2
 docker-compose
 mxnet==1.4.0
 awslogs

--- a/test/sagemaker_tests/mxnet/training/requirements.txt
+++ b/test/sagemaker_tests/mxnet/training/requirements.txt
@@ -6,7 +6,7 @@ pytest-cov
 pytest-rerunfailures==9.0
 pytest-xdist
 mock
-sagemaker
+sagemaker<2
 docker-compose
 boto3
 six==1.13.0

--- a/test/sagemaker_tests/pytorch/inference/requirements.txt
+++ b/test/sagemaker_tests/pytorch/inference/requirements.txt
@@ -9,7 +9,7 @@ pytest-cov==2.7.1
 pytest-rerunfailures==8.0
 pytest-xdist==1.28.0
 PyYAML==5.3
-sagemaker
+sagemaker<2
 six==1.12.0
 requests==2.20.0
 torchvision==0.5.0

--- a/test/sagemaker_tests/pytorch/training/requirements.txt
+++ b/test/sagemaker_tests/pytorch/training/requirements.txt
@@ -9,7 +9,7 @@ pytest-cov==2.7.1
 pytest-rerunfailures==8.0
 pytest-xdist==1.28.0
 PyYAML==5.3
-sagemaker
+sagemaker<2
 requests==2.20
 torch==1.4.0
 torchvision==0.5.0

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/requirements.txt
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/requirements.txt
@@ -11,7 +11,7 @@ pytest-cov
 pytest-rerunfailures==9.0
 pytest-xdist
 mock
-sagemaker
+sagemaker<2
 docker-compose
 boto3
 six==1.13.0

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/requirements.txt
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/requirements.txt
@@ -11,7 +11,7 @@ pytest-cov
 pytest-rerunfailures==9.0
 pytest-xdist
 mock
-sagemaker
+sagemaker<2
 docker-compose
 boto3
 six==1.13.0


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
- SageMaker and sanity tests were failing due to breaking changes coming in from v2 of the pysdk. Updated the requirements.txt files to pin sagemaker package to <2 in order to fix this issue.

*Tests run:*
- Run sanity/sagemaker tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

