### PR TITLE
[pytorch] | [test] | [ec2] flaky marker for pytorch cpu mnist test

### DIFF
--- a/test/dlc_tests/ec2/pytorch/training/test_pytorch_training.py
+++ b/test/dlc_tests/ec2/pytorch/training/test_pytorch_training.py
@@ -38,6 +38,7 @@ def test_pytorch_train_mnist_gpu(pytorch_training, ec2_connection, gpu_only):
     execute_ec2_training_test(ec2_connection, pytorch_training, PT_MNIST_CMD)
 
 
+@pytest.mark.flaky(reruns=3)
 @pytest.mark.model("mnist")
 @pytest.mark.parametrize("ec2_instance_type", PT_EC2_CPU_INSTANCE_TYPE, indirect=True)
 def test_pytorch_train_mnist_cpu(pytorch_training, ec2_connection, cpu_only):


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
Add flaky marker for pytorch cpu mnist test


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

