### PR TITLE
[test] [sagemaker] Re-enable sagemaker local tests

### DIFF
--- a/src/start_testbuilds.py
+++ b/src/start_testbuilds.py
@@ -92,11 +92,9 @@ def main():
                 run_test_job(commit, pr_test_job, images_str)
 
                 # Trigger sagemaker local test jobs when there are changes in sagemaker_tests
-                # Note: Commenting out the following lines because there is currently no flag to turn off local
-                # sagemaker tests
-                # if test_type == "sagemaker":
-                #     test_job = f"dlc-pr-{test_type}-local-test"
-                #     run_test_job(commit, test_job, images_str)
+                if test_type == "sagemaker":
+                    test_job = f"dlc-pr-{test_type}-local-test"
+                    run_test_job(commit, test_job, images_str)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
SageMaker local tests were disabled in #338 .
Re-enabling these tests

*Tests run:*
Tested locally to check if sm local tests are run.

*DLC image/dockerfile:*
N/A

*Additional context:*
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

