### PR TITLE
[Release][Tensorflow] update available_images.md for tf2.3

### DIFF
--- a/available_images.md
+++ b/available_images.md
@@ -86,9 +86,6 @@ You can pin your version by adding the version tag to your URL as follows:
 |-------------------|------------------------|---------------------------------|------------|---------------------------|----------------------------------------------------------------------------------------------------| --------------|
 |TensorFlow 2.3.0   |training 	             |Yes                        	   |CPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.3.0-cpu-py37-ubuntu18.04   |v1.0
 |TensorFlow 2.3.0   |training 	             |Yes                        	   |GPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.3.0-gpu-py37-cu102-ubuntu18.04   |v2.0
-|TensorFlow 2.2.0   |training 	             |Yes                        	   |GPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.2.0-gpu-py37-cu102-ubuntu18.04   |v2.1           |
-|TensorFlow 2.2.0   |training 	             |Yes                        	   |GPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.2.0-gpu-py37-cu101-ubuntu18.04   |v1.2           |
-|TensorFlow 2.2.0   |training                |Yes 	                           |CPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.2.0-cpu-py37-ubuntu18.04         |v1.3           |
 |TensorFlow 2.2.0   |inference               |No 	                           |GPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-inference:2.2.0-gpu-py37-cu102-ubuntu18.04  |v1.3           |
 |TensorFlow 2.2.0   |inference               |No 	                           |CPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-inference:2.2.0-cpu-py37-ubuntu18.04        |v1.3           |
 |TensorFlow 1.15.3  |training 	             |Yes                        	   |GPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:1.15.3-gpu-py37-cu100-ubuntu18.04  |v7.2           |
@@ -120,6 +117,9 @@ Prior Versions
 
 | Framework 			                      |Job Type 			   |Horovod Options 			     |CPU/GPU 	  |Python Version Options 			      |Example URL 			                                                                               |
 |---------------------------------------------|------------------------|---------------------------------|------------|---------------------------------------|----------------------------------------------------------------------------------------------------|
+|TensorFlow 2.2.0   |training 	             |Yes                        	   |GPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.2.0-gpu-py37-cu102-ubuntu18.04   |
+|TensorFlow 2.2.0   |training 	             |Yes                        	   |GPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.2.0-gpu-py37-cu101-ubuntu18.04   |
+|TensorFlow 2.2.0   |training                |Yes 	                           |CPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.2.0-cpu-py37-ubuntu18.04         |
 |PyTorch 1.5.1                                |training                |No                               |CPU 		  |3.6 (py36) 			                  | 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:1.5.1-cpu-py36-ubuntu16.04           |
 |PyTorch 1.5.1                                |training                |Yes                              |GPU 	      |3.6 (py36) 			                  | 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-training:1.5.1-gpu-py36-cu101-ubuntu16.04     |
 |TensorFlow 2.1.1			                  |training, inference 	   |Training: Yes, Inference: No     |CPU 	      |2.7 (py27), 3.6 (py36) 			      | 763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.1.1-cpu-py36-ubuntu18.04        |

--- a/available_images.md
+++ b/available_images.md
@@ -84,6 +84,8 @@ You can pin your version by adding the version tag to your URL as follows:
 
 | Framework         |Job Type 			     |Horovod Options 			       |CPU/GPU 	|Python Version Options     |  			 Example URL 			                                                                 | Latest Version|
 |-------------------|------------------------|---------------------------------|------------|---------------------------|----------------------------------------------------------------------------------------------------| --------------|
+|TensorFlow 2.3.0   |training 	             |Yes                        	   |CPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.3.0-cpu-py37-ubuntu18.04   |v1.0
+|TensorFlow 2.3.0   |training 	             |Yes                        	   |GPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.3.0-gpu-py37-cu102-ubuntu18.04   |v2.0
 |TensorFlow 2.2.0   |training 	             |Yes                        	   |GPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.2.0-gpu-py37-cu102-ubuntu18.04   |v2.1           |
 |TensorFlow 2.2.0   |training 	             |Yes                        	   |GPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.2.0-gpu-py37-cu101-ubuntu18.04   |v1.2           |
 |TensorFlow 2.2.0   |training                |Yes 	                           |CPU 		| 3.7 (py37) 			    |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.2.0-cpu-py37-ubuntu18.04         |v1.3           |


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*

- Update available_images.md for TF-2.3 images
- Move the TF-2.2 training images to `Prior Version` section
- As TF-2.3 inference image is not released, keep the TF-2.2 inference image as it is. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

