### PR TITLE
[pytorch] | [build, test] | [sanity] Install click for pytorch images

### DIFF
--- a/pytorch/training/docker/1.6.0/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/1.6.0/py3/Dockerfile.cpu
@@ -99,6 +99,7 @@ RUN pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pytho
     "awscli<2" \
     fastai==1.0.59 \
     scipy==1.2.2 \
+    click \
     smdebug==${SMDEBUG_VERSION} \
     "sagemaker<2" \
     sagemaker-experiments==0.* \

--- a/pytorch/training/docker/1.6.0/py3/cu101/Dockerfile.gpu
+++ b/pytorch/training/docker/1.6.0/py3/cu101/Dockerfile.gpu
@@ -134,6 +134,7 @@ RUN pip install \
     psutil \
     Pillow \
     scipy \
+    click \
  && pip install --no-cache-dir -U ${PT_TRAINING_URL} \
  && pip uninstall -y torchvision \
  && pip install --no-deps --no-cache-dir -U \


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [pytorch] | [build, test] | [sanity]

*Description:*
Sanity test for PyTorch training is failing:
```
archspec 0.1.1 requires click, which is not installed.
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

