### PR TITLE
[build] Add yaml linter step for all top level yml files

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -1,7 +1,6 @@
 extends: default
 
 rules:
-  # 80 chars should be enough, but don't fail if a line is longer
   line-length:
     max: 120
     level: warning

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,8 @@
+extends: default
+
+rules:
+  # 80 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 120
+    level: warning
+

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,6 +12,7 @@ phases:
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
       - pip install -r src/requirements.txt
       - bash src/setup.sh $FRAMEWORK
+      - yamllint -d .yamllint *.yml
   build:
     commands:
       - echo Build started on `date`

--- a/release_images.yml
+++ b/release_images.yml
@@ -74,7 +74,7 @@ release_images:
     framework: "tensorflow"
     version: "2.3.0"
     training:
-      device_types: ["cpu","gpu"]
+      device_types: ["cpu", "gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
       cuda_version: "cu102"

--- a/release_images.yml
+++ b/release_images.yml
@@ -74,7 +74,7 @@ release_images:
     framework: "tensorflow"
     version: "2.3.0"
     training:
-      device_types: ["cpu", "gpu"]
+      device_types: ["cpu","gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
       cuda_version: "cu102"

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -7,3 +7,4 @@ ruamel.yaml==0.16.7
 boto3==1.11.11
 black==19.10b0
 junit-xml==1.9
+yamllint

--- a/testspec.yml
+++ b/testspec.yml
@@ -1,4 +1,3 @@
-
 version: 0.2
 
 phases:


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
Currently, we have no yaml linting process. Since changes to some top level yaml files do not result in builds/tests, added a pre-build step to run yaml linting.

Note: I did not add this for $FRAMEWORK/*.yml files because a) they require significant changes and would be better scoped to a different PR and b) they are exercised in the build process

*Tests run:*
- Ran tool locally
- See builds on "add a failure condition for testing purposes" for example failure.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

