### PR TITLE
[test][benchmark][MXNet] Temporarily skip single node MXNet benchmarks

### DIFF
--- a/test/dlc_tests/benchmark/bai/mxnet/training/test_performance_mxnet_training.py
+++ b/test/dlc_tests/benchmark/bai/mxnet/training/test_performance_mxnet_training.py
@@ -5,6 +5,7 @@ from invoke.context import Context
 from test.test_utils.benchmark import execute_single_node_benchmark, get_py_version
 
 
+@pytest.mark.skip(reason="Temp skip due to timeout")
 @pytest.mark.model("resnet18_v2")
 @pytest.mark.integration("cifar10 dataset")
 def test_performance_mxnet_cpu(mxnet_training, cpu_only):


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
- Skipping single node MXNet benchmarks due to timeouts. 

*Tests run:*
- Tested other benchmarks passed in the allotted time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

