### PR TITLE
[test] Explicitly call out multinode tests, break out parametrized tests into separate test functions

### DIFF
--- a/test/dlc_tests/benchmark/sagemaker/tensorflow/training/test_performance_tensorflow_sm_training.py
+++ b/test/dlc_tests/benchmark/sagemaker/tensorflow/training/test_performance_tensorflow_sm_training.py
@@ -12,10 +12,19 @@ from test.test_utils import BENCHMARK_RESULTS_S3_BUCKET, LOGGER
 
 
 @pytest.mark.integration("imagenet dataset")
-@pytest.mark.multinode("multinode")
+@pytest.mark.multinode(4)
 @pytest.mark.model("resnet50")
-@pytest.mark.parametrize("num_nodes", [1, 4], indirect=True)
-def test_tensorflow_sagemaker_training_performance(tensorflow_training, num_nodes, region):
+def test_tensorflow_sagemaker_training_performance_multinode(tensorflow_training, region):
+    run_sm_perf_test(tensorflow_training, 4, region)
+
+
+@pytest.mark.integration("imagenet dataset")
+@pytest.mark.model("resnet50")
+def test_tensorflow_sagemaker_training_performance_singlenode(tensorflow_training, region):
+    run_sm_perf_test(tensorflow_training, 1, region)
+
+
+def run_sm_perf_test(image_uri, num_nodes, region):
     """
     Run TF sagemaker training performance tests
 
@@ -29,15 +38,15 @@ def test_tensorflow_sagemaker_training_performance(tensorflow_training, num_node
     :param num_nodes: Number of nodes to run on
     :param region: AWS region
     """
-    framework_version = re.search(r"[1,2](\.\d+){2}", tensorflow_training).group()
+    framework_version = re.search(r"[1,2](\.\d+){2}", image_uri).group()
     if framework_version.startswith("1."):
         pytest.skip("Skipping benchmark test on TF 1.x images.")
 
-    processor = "gpu" if "gpu" in tensorflow_training else "cpu"
+    processor = "gpu" if "gpu" in image_uri else "cpu"
 
     ec2_instance_type = "p3.16xlarge" if processor == "gpu" else "c5.18xlarge"
 
-    py_version = "py2" if "py2" in tensorflow_training else "py37" if "py37" in tensorflow_training else "py3"
+    py_version = "py2" if "py2" in image_uri else "py37" if "py37" in image_uri else "py3"
 
     time_str = time.strftime('%Y-%m-%d-%H-%M-%S')
     commit_info = os.getenv("CODEBUILD_RESOLVED_SOURCE_VERSION")
@@ -60,7 +69,7 @@ def test_tensorflow_sagemaker_training_performance(tensorflow_training, num_node
         log_file = f"results-{commit_info}-{time_str}-{framework_version}-{processor}-{py_version}-{num_nodes}-node.txt"
         run_out = ctx.run(f"timeout 45m python tf_sm_benchmark.py "
                           f"--framework-version {framework_version} "
-                          f"--image-uri {tensorflow_training} "
+                          f"--image-uri {image_uri} "
                           f"--instance-type ml.{ec2_instance_type} "
                           f"--node-count {num_nodes} "
                           f"--python {py_version} "

--- a/test/dlc_tests/eks/mxnet/training/test_eks_mxnet_multinode_training.py
+++ b/test/dlc_tests/eks/mxnet/training/test_eks_mxnet_multinode_training.py
@@ -20,7 +20,7 @@ LOGGER = eks_utils.LOGGER
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
 @pytest.mark.integration("horovod")
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(3)")
+@pytest.mark.multinode(3)
 def test_eks_mxnet_multi_node_training_horovod_mnist(mxnet_training, example_only):
     """
     Run MXNet distributed training on EKS using docker images with MNIST dataset (horovod)
@@ -72,7 +72,7 @@ def _run_eks_mxnet_multinode_training_horovod_mpijob(example_image_uri, cluster_
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
 @pytest.mark.integration("parameter server")
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(3)")
+@pytest.mark.multinode(3)
 def test_eks_mxnet_multinode_training(mxnet_training, example_only):
     """
     Run MXNet distributed training on EKS using docker images with MNIST dataset (parameter server)

--- a/test/dlc_tests/eks/pytorch/training/test_eks_pytorch_training.py
+++ b/test/dlc_tests/eks/pytorch/training/test_eks_pytorch_training.py
@@ -129,7 +129,7 @@ def test_eks_pytorch_dgl_single_node_training(pytorch_training, py3_only):
 
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(4)")
+@pytest.mark.multinode(4)
 def test_eks_pytorch_multinode_node_training(pytorch_training, example_only):
     """
        Function to create mutliple pods using kubectl and given container image, and run Pytorch training

--- a/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
+++ b/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
@@ -17,7 +17,7 @@ from test.test_utils import is_pr_context, SKIP_PR_REASON, is_tf1
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
 @pytest.mark.integration("horovod")
 @pytest.mark.model("resnet")
-@pytest.mark.multinode("multinode(3)")
+@pytest.mark.multinode(3)
 def test_eks_tensorflow_multi_node_training_gpu(tensorflow_training, example_only):
     eks_cluster_size = "3"
     ec2_instance_type = "p3.16xlarge"

--- a/test/sagemaker_tests/mxnet/training/integration/local/test_mnist_training.py
+++ b/test/sagemaker_tests/mxnet/training/integration/local/test_mnist_training.py
@@ -39,7 +39,7 @@ def test_single_machine(docker_image, sagemaker_local_session, local_instance_ty
 
 
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(2)")
+@pytest.mark.multinode(2)
 @pytest.mark.processor("cpu")
 def test_distributed(docker_image, sagemaker_local_session, framework_version, processor, tmpdir):
     if processor == 'gpu':

--- a/test/sagemaker_tests/mxnet/training/integration/sagemaker/test_horovod.py
+++ b/test/sagemaker_tests/mxnet/training/integration/sagemaker/test_horovod.py
@@ -23,7 +23,7 @@ from ...integration import RESOURCE_PATH
 from ...integration.utils import unique_name_from_base
 
 
-@pytest.mark.multinode("multinode")
+@pytest.mark.multinode(2)
 @pytest.mark.integration("horovod")
 @pytest.mark.model("mnist")
 def test_distributed_training_horovod(sagemaker_session,

--- a/test/sagemaker_tests/pytorch/inference/integration/sagemaker/test_mnist.py
+++ b/test/sagemaker_tests/pytorch/inference/integration/sagemaker/test_mnist.py
@@ -24,7 +24,7 @@ from ...integration.sagemaker.timeout import timeout_and_delete_endpoint
 
 
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode")
+@pytest.mark.multinode("multinode(needs_clarification)")
 @pytest.mark.processor("cpu")
 @pytest.mark.cpu_test
 def test_mnist_distributed_cpu(sagemaker_session, ecr_image, instance_type):
@@ -34,7 +34,7 @@ def test_mnist_distributed_cpu(sagemaker_session, ecr_image, instance_type):
 
 
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode")
+@pytest.mark.multinode("multinode(needs_clarification)")
 @pytest.mark.processor("gpu")
 @pytest.mark.gpu_test
 def test_mnist_distributed_gpu(sagemaker_session, ecr_image, instance_type):

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_distributed_operations.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_distributed_operations.py
@@ -27,7 +27,7 @@ MULTI_GPU_INSTANCE = 'ml.p3.8xlarge'
 
 
 @pytest.mark.processor("cpu")
-@pytest.mark.multinode("multinode")
+@pytest.mark.multinode(3)
 @pytest.mark.model("unknown_model")
 @pytest.mark.skip_gpu
 @pytest.mark.deploy_test
@@ -38,25 +38,29 @@ def test_dist_operations_cpu(sagemaker_session, ecr_image, instance_type, dist_c
 
 
 @pytest.mark.processor("gpu")
-@pytest.mark.multinode("multinode")
+@pytest.mark.multinode(3)
 @pytest.mark.model("unknown_model")
 @pytest.mark.skip_cpu
 @pytest.mark.deploy_test
 def test_dist_operations_gpu(sagemaker_session, instance_type, ecr_image, dist_gpu_backend):
+    """
+    Test is run as multinode
+    """
     instance_type = instance_type or 'ml.p2.xlarge'
     _test_dist_operations(sagemaker_session, ecr_image, instance_type, dist_gpu_backend)
 
 
 @pytest.mark.processor("gpu")
-@pytest.mark.multinode("multinode")
 @pytest.mark.model("unknown_model")
 @pytest.mark.skip_cpu
 def test_dist_operations_multi_gpu(sagemaker_session, ecr_image, dist_gpu_backend):
+    """
+    Test is run as single node, but multi-gpu
+    """
     _test_dist_operations(sagemaker_session, ecr_image, MULTI_GPU_INSTANCE, dist_gpu_backend, 1)
 
 
 @pytest.mark.processor("gpu")
-@pytest.mark.multinode("multinode")
 @pytest.mark.integration("fastai")
 @pytest.mark.model("cifar")
 @pytest.mark.skip_cpu
@@ -83,6 +87,7 @@ def test_dist_operations_fastai_gpu(sagemaker_session, ecr_image):
 
 @pytest.mark.processor("gpu")
 @pytest.mark.model("mnist")
+@pytest.mark.multinode(2)
 @pytest.mark.skip_cpu
 @pytest.mark.skip_py2_containers
 def test_mnist_gpu(sagemaker_session, ecr_image, dist_gpu_backend):

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_mnist.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_mnist.py
@@ -21,7 +21,7 @@ from ...integration.sagemaker.timeout import timeout
 
 @pytest.mark.processor("cpu")
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode")
+@pytest.mark.multinode(2)
 @pytest.mark.integration("smexperiments")
 @pytest.mark.skip_gpu
 def test_mnist_distributed_cpu(sagemaker_session, ecr_image, instance_type, dist_cpu_backend):
@@ -31,7 +31,7 @@ def test_mnist_distributed_cpu(sagemaker_session, ecr_image, instance_type, dist
 
 @pytest.mark.processor("gpu")
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode")
+@pytest.mark.multinode(2)
 @pytest.mark.integration("smexperiments")
 @pytest.mark.skip_cpu
 def test_mnist_distributed_gpu(sagemaker_session, ecr_image, instance_type, dist_gpu_backend):

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/local/test_horovod.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/local/test_horovod.py
@@ -25,46 +25,94 @@ RESOURCE_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
 
 
 @pytest.mark.processor("cpu")
-@pytest.mark.multinode("multinode")
 @pytest.mark.integration("horovod")
 @pytest.mark.model("mnist")
 @pytest.mark.skip_gpu
-@pytest.mark.parametrize('instances, processes', [
-    [1, 2],
-    (2, 1),
-    (2, 2),
-    (5, 2)])
-def test_distributed_training_horovod_basic(instances,
-                                            processes,
-                                            sagemaker_local_session,
-                                            docker_image,
-                                            tmpdir,
-                                            framework_version):
-    output_path = 'file://%s' % tmpdir
+@pytest.mark.parametrize("instances, processes", [(1, 2)])
+def test_distributed_training_horovod_basic_singlenode(
+    instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+):
+    _run_distributed_training_horovod_basic(
+        instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+    )
+
+
+@pytest.mark.processor("cpu")
+@pytest.mark.multinode(2)
+@pytest.mark.integration("horovod")
+@pytest.mark.model("mnist")
+@pytest.mark.skip_gpu
+@pytest.mark.parametrize("instances, processes", [(2, 1)])
+def test_distributed_training_horovod_basic_two_nodes(
+    instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+):
+    _run_distributed_training_horovod_basic(
+        instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+    )
+
+
+@pytest.mark.processor("cpu")
+@pytest.mark.multinode(2)
+@pytest.mark.integration("horovod")
+@pytest.mark.model("mnist")
+@pytest.mark.skip_gpu
+@pytest.mark.parametrize("instances, processes", [(2, 2)])
+def test_distributed_training_horovod_basic_two_nodes_two_processes(
+    instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+):
+    _run_distributed_training_horovod_basic(
+        instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+    )
+
+
+@pytest.mark.processor("cpu")
+@pytest.mark.multinode(5)
+@pytest.mark.integration("horovod")
+@pytest.mark.model("mnist")
+@pytest.mark.skip_gpu
+@pytest.mark.parametrize("instances, processes", [(5, 2)])
+def test_distributed_training_horovod_basic_five_nodes_two_processes(
+    instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+):
+    _run_distributed_training_horovod_basic(
+        instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+    )
+
+
+def _run_distributed_training_horovod_basic(
+    instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+):
+    output_path = "file://%s" % tmpdir
     estimator = TensorFlow(
-        entry_point=os.path.join(RESOURCE_PATH, 'hvdbasic', 'train_hvd_basic.py'),
-        role='SageMakerRole',
-        train_instance_type='local',
+        entry_point=os.path.join(RESOURCE_PATH, "hvdbasic", "train_hvd_basic.py"),
+        role="SageMakerRole",
+        train_instance_type="local",
         sagemaker_session=sagemaker_local_session,
         train_instance_count=instances,
         image_name=docker_image,
         output_path=output_path,
         framework_version=framework_version,
-        hyperparameters={'sagemaker_mpi_enabled': True,
-                         'sagemaker_network_interface_name': 'eth0',
-                         'sagemaker_mpi_num_of_processes_per_host': processes})
+        hyperparameters={
+            "sagemaker_mpi_enabled": True,
+            "sagemaker_network_interface_name": "eth0",
+            "sagemaker_mpi_num_of_processes_per_host": processes,
+        },
+    )
 
-    estimator.fit('file://{}'.format(os.path.join(RESOURCE_PATH, 'mnist', 'data-distributed')))
+    estimator.fit("file://{}".format(os.path.join(RESOURCE_PATH, "mnist", "data-distributed")))
 
     tmp = str(tmpdir)
-    extract_files(output_path.replace('file://', ''), tmp)
+    extract_files(output_path.replace("file://", ""), tmp)
 
     size = instances * processes
 
     for rank in range(size):
         local_rank = rank % processes
-        assert read_json('local-rank-%s-rank-%s' % (local_rank, rank), tmp) == {
-            'local-rank': local_rank, 'rank': rank, 'size': size}
+        assert read_json("local-rank-%s-rank-%s" % (local_rank, rank), tmp) == {
+            "local-rank": local_rank,
+            "rank": rank,
+            "size": size,
+        }
 
 
 def read_json(file, tmp):

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/local/test_training.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/local/test_training.py
@@ -89,7 +89,7 @@ def test_gpu(sagemaker_local_session, docker_image, framework_version):
 
 @pytest.mark.processor("cpu")
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(2)")
+@pytest.mark.multinode(2)
 @pytest.mark.integration("no parameter server")
 @pytest.mark.skip_gpu
 def test_distributed_training_cpu_no_ps(sagemaker_local_session,
@@ -112,7 +112,7 @@ def test_distributed_training_cpu_no_ps(sagemaker_local_session,
 @pytest.mark.processor("cpu")
 @pytest.mark.integration("parameter server")
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(2)")
+@pytest.mark.multinode(2)
 @pytest.mark.skip_gpu
 def test_distributed_training_cpu_ps(sagemaker_local_session,
                                      docker_image,

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/sagemaker/test_horovod.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/sagemaker/test_horovod.py
@@ -26,7 +26,7 @@ RESOURCE_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
 
 @pytest.mark.integration("horovod")
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(2)")
+@pytest.mark.multinode(2)
 def test_distributed_training_horovod(sagemaker_session,
                                       instance_type,
                                       ecr_image,
@@ -58,7 +58,7 @@ def test_distributed_training_horovod(sagemaker_session,
 
 
 @pytest.mark.integration("horovod")
-@pytest.mark.multinode("multinode(2)")
+@pytest.mark.multinode(2)
 @pytest.mark.model("unknown_model")
 def test_distributed_training_horovod_with_env_vars(
         sagemaker_session, instance_type, ecr_image, tmpdir, framework_version

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/sagemaker/test_mnist.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/sagemaker/test_mnist.py
@@ -48,7 +48,7 @@ def test_mnist(sagemaker_session, ecr_image, instance_type, framework_version):
 
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(2)")
+@pytest.mark.multinode(2)
 @pytest.mark.integration("no parameter server")
 def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type, framework_version):
     resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
@@ -69,7 +69,7 @@ def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type, fr
 
 
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(2)")
+@pytest.mark.multinode(2)
 @pytest.mark.integration("parameter server")
 def test_distributed_mnist_ps(sagemaker_session, ecr_image, instance_type, framework_version):
     resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/local/test_horovod.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/local/test_horovod.py
@@ -21,50 +21,98 @@ from sagemaker.tensorflow import TensorFlow
 
 from ...integration.utils import processor, py_version  # noqa: F401
 
-RESOURCE_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
+RESOURCE_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "resources")
 
 
 @pytest.mark.processor("cpu")
-@pytest.mark.multinode("multinode")
 @pytest.mark.integration("horovod")
 @pytest.mark.model("mnist")
 @pytest.mark.skip_gpu
-@pytest.mark.parametrize('instances, processes', [
-    [1, 2],
-    (2, 1),
-    (2, 2),
-    (5, 2)])
-def test_distributed_training_horovod_basic(instances,
-                                            processes,
-                                            sagemaker_local_session,
-                                            docker_image,
-                                            tmpdir,
-                                            framework_version):
-    output_path = 'file://%s' % tmpdir
+@pytest.mark.parametrize("instances, processes", [(1, 2)])
+def test_distributed_training_horovod_basic_singlenode(
+    instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+):
+    _run_distributed_training_horovod_basic(
+        instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+    )
+
+
+@pytest.mark.processor("cpu")
+@pytest.mark.multinode(2)
+@pytest.mark.integration("horovod")
+@pytest.mark.model("mnist")
+@pytest.mark.skip_gpu
+@pytest.mark.parametrize("instances, processes", [(2, 1)])
+def test_distributed_training_horovod_basic_two_nodes(
+    instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+):
+    _run_distributed_training_horovod_basic(
+        instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+    )
+
+
+@pytest.mark.processor("cpu")
+@pytest.mark.multinode(2)
+@pytest.mark.integration("horovod")
+@pytest.mark.model("mnist")
+@pytest.mark.skip_gpu
+@pytest.mark.parametrize("instances, processes", [(2, 2)])
+def test_distributed_training_horovod_basic_two_nodes_two_processes(
+    instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+):
+    _run_distributed_training_horovod_basic(
+        instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+    )
+
+
+@pytest.mark.processor("cpu")
+@pytest.mark.multinode(5)
+@pytest.mark.integration("horovod")
+@pytest.mark.model("mnist")
+@pytest.mark.skip_gpu
+@pytest.mark.parametrize("instances, processes", [(5, 2)])
+def test_distributed_training_horovod_basic_five_nodes_two_processes(
+    instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+):
+    _run_distributed_training_horovod_basic(
+        instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+    )
+
+
+def _run_distributed_training_horovod_basic(
+    instances, processes, sagemaker_local_session, docker_image, tmpdir, framework_version
+):
+    output_path = "file://%s" % tmpdir
     estimator = TensorFlow(
-        entry_point=os.path.join(RESOURCE_PATH, 'hvdbasic', 'train_hvd_basic.py'),
-        role='SageMakerRole',
-        train_instance_type='local',
+        entry_point=os.path.join(RESOURCE_PATH, "hvdbasic", "train_hvd_basic.py"),
+        role="SageMakerRole",
+        train_instance_type="local",
         sagemaker_session=sagemaker_local_session,
         train_instance_count=instances,
         image_name=docker_image,
         output_path=output_path,
         framework_version=framework_version,
-        hyperparameters={'sagemaker_mpi_enabled': True,
-                         'sagemaker_network_interface_name': 'eth0',
-                         'sagemaker_mpi_num_of_processes_per_host': processes})
+        hyperparameters={
+            "sagemaker_mpi_enabled": True,
+            "sagemaker_network_interface_name": "eth0",
+            "sagemaker_mpi_num_of_processes_per_host": processes,
+        },
+    )
 
-    estimator.fit('file://{}'.format(os.path.join(RESOURCE_PATH, 'mnist', 'data-distributed')))
+    estimator.fit("file://{}".format(os.path.join(RESOURCE_PATH, "mnist", "data-distributed")))
 
     tmp = str(tmpdir)
-    extract_files(output_path.replace('file://', ''), tmp)
+    extract_files(output_path.replace("file://", ""), tmp)
 
     size = instances * processes
 
     for rank in range(size):
         local_rank = rank % processes
-        assert read_json('local-rank-%s-rank-%s' % (local_rank, rank), tmp) == {
-            'local-rank': local_rank, 'rank': rank, 'size': size}
+        assert read_json("local-rank-%s-rank-%s" % (local_rank, rank), tmp) == {
+            "local-rank": local_rank,
+            "rank": rank,
+            "size": size,
+        }
 
 
 def read_json(file, tmp):
@@ -73,14 +121,14 @@ def read_json(file, tmp):
 
 
 def assert_files_exist_in_tar(output_path, files):
-    if output_path.startswith('file://'):
+    if output_path.startswith("file://"):
         output_path = output_path[7:]
-    model_file = os.path.join(output_path, 'model.tar.gz')
+    model_file = os.path.join(output_path, "model.tar.gz")
     with tarfile.open(model_file) as tar:
         for f in files:
             tar.getmember(f)
 
 
 def extract_files(output_path, tmpdir):
-    with tarfile.open(os.path.join(output_path, 'model.tar.gz')) as tar:
+    with tarfile.open(os.path.join(output_path, "model.tar.gz")) as tar:
         tar.extractall(tmpdir)

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/local/test_training.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/local/test_training.py
@@ -89,7 +89,7 @@ def test_gpu(sagemaker_local_session, docker_image, framework_version):
 
 @pytest.mark.processor("cpu")
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(2)")
+@pytest.mark.multinode(2)
 @pytest.mark.integration("no parameter server")
 @pytest.mark.skip_gpu
 def test_distributed_training_cpu_no_ps(sagemaker_local_session,
@@ -112,7 +112,7 @@ def test_distributed_training_cpu_no_ps(sagemaker_local_session,
 @pytest.mark.processor("cpu")
 @pytest.mark.integration("parameter server")
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(2)")
+@pytest.mark.multinode(2)
 @pytest.mark.skip_gpu
 def test_distributed_training_cpu_ps(sagemaker_local_session,
                                      docker_image,

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/sagemaker/test_horovod.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/sagemaker/test_horovod.py
@@ -26,7 +26,7 @@ RESOURCE_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
 
 @pytest.mark.integration("horovod")
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(2)")
+@pytest.mark.multinode(2)
 def test_distributed_training_horovod(sagemaker_session,
                                       instance_type,
                                       ecr_image,
@@ -58,7 +58,7 @@ def test_distributed_training_horovod(sagemaker_session,
 
 
 @pytest.mark.integration("horovod")
-@pytest.mark.multinode("multinode(2)")
+@pytest.mark.multinode(2)
 @pytest.mark.model("unknown_model")
 def test_distributed_training_horovod_with_env_vars(
         sagemaker_session, instance_type, ecr_image, tmpdir, framework_version

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/sagemaker/test_mnist.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/sagemaker/test_mnist.py
@@ -48,7 +48,7 @@ def test_mnist(sagemaker_session, ecr_image, instance_type, framework_version):
 
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(2)")
+@pytest.mark.multinode(2)
 @pytest.mark.integration("no parameter server")
 def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type, framework_version):
     resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
@@ -69,7 +69,7 @@ def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type, fr
 
 
 @pytest.mark.model("mnist")
-@pytest.mark.multinode("multinode(2)")
+@pytest.mark.multinode(2)
 @pytest.mark.integration("parameter server")
 def test_distributed_mnist_ps(sagemaker_session, ecr_image, instance_type, framework_version):
     resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')

--- a/test/test_utils/test_reporting.py
+++ b/test/test_utils/test_reporting.py
@@ -280,11 +280,6 @@ class TestReportGenerator:
                 ("_dgl_", "smdebug", "gluonnlp", "smexperiments", "_mme_", "pipemode", "tensorboard", "_s3_", "nccl"),
                 str_keywords,
             )
-            num_instances = _infer_field_value(
-                1, ("_multinode_", "_multi-node_", "_multi_node_", "_dist_"), str_fspath, str_keywords
-            )
-            if num_instances != 1:
-                num_instances = "multinode"
             processor_scope = _infer_field_value("all", ("cpu", "gpu", "eia"), str_keywords)
             if processor_scope == "gpu":
                 processor_scope = self.handle_single_gpu_instances_test_report(function_key, str_keywords)
@@ -296,7 +291,7 @@ class TestReportGenerator:
                 "Name": function_name,
                 "Scope": framework_scope,
                 "Job_Type": job_type_scope,
-                "Num_Instances": self.get_marker_arg_value(item, function_key, "multinode", num_instances),
+                "Num_Instances": self.get_marker_arg_value(item, function_key, "multinode", 1),
                 "Processor": self.get_marker_arg_value(item, function_key, "processor", processor_scope),
                 "Integration": self.get_marker_arg_value(item, function_key, "integration", integration_scope),
                 "Model": self.get_marker_arg_value(item, function_key, "model"),


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
When tests are parametrized with different numbers of nodes, it becomes unclear from a reporting standpoint how many nodes the function is testing. I broke these parametrized functions out into separate functions in order to reduce ambiguity, and factored out repeated logic into local functions where possible.

*Tests run:*
PR tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

