### PR TITLE
[test] [sagemaker] Make SM local tests py35 compatible

### DIFF
--- a/src/start_testbuilds.py
+++ b/src/start_testbuilds.py
@@ -92,11 +92,9 @@ def main():
                 run_test_job(commit, pr_test_job, images_str)
 
                 # Trigger sagemaker local test jobs when there are changes in sagemaker_tests
-                # Note: Commenting out the following lines because there is currently no flag to turn off local
-                # sagemaker tests
-                # if test_type == "sagemaker":
-                #     test_job = f"dlc-pr-{test_type}-local-test"
-                #     run_test_job(commit, test_job, images_str)
+                if test_type == "sagemaker":
+                    test_job = f"dlc-pr-{test_type}-local-test"
+                    run_test_job(commit, test_job, images_str)
 
 
 if __name__ == "__main__":

--- a/test/sagemaker_tests/mxnet/inference/conftest.py
+++ b/test/sagemaker_tests/mxnet/inference/conftest.py
@@ -87,7 +87,7 @@ def aws_id(request):
 @pytest.fixture(scope='session')
 def tag(request, framework_version, processor, py_version):
     provided_tag = request.config.getoption('--tag')
-    default_tag = f'{framework_version}-{processor}-{py_version}'
+    default_tag = '{}-{}-{}'.format(framework_version, processor, py_version)
     return provided_tag if provided_tag is not None else default_tag
 
 
@@ -105,13 +105,13 @@ def accelerator_type(request):
 
 @pytest.fixture(scope='session')
 def docker_image(docker_base_name, tag):
-    return f'{docker_base_name}:{tag}'
+    return '{}:{}'.format(docker_base_name, tag)
 
 
 @pytest.fixture(scope='session')
 def ecr_image(aws_id, docker_base_name, tag, region):
     registry = get_ecr_registry(aws_id, region)
-    return f'{registry}/{docker_base_name}:{tag}'
+    return '{}/{}:{}'.format(registry, docker_base_name, tag)
 
 
 @pytest.fixture(scope='session')
@@ -134,18 +134,18 @@ def skip_gpu_instance_restricted_regions(region, instance_type):
     no_p2 = region in NO_P2_REGIONS and instance_type.startswith('ml.p2')
     no_p3 = region in NO_P3_REGIONS and instance_type.startswith('ml.p3')
     if no_p2 or no_p3:
-        pytest.skip(f'Skipping GPU test in region {region} to avoid insufficient capacity')
+        pytest.skip('Skipping GPU test in region {} to avoid insufficient capacity'.format(region))
 
 
 @pytest.fixture(autouse=True)
 def skip_py2_containers(request, tag):
     if request.node.get_closest_marker('skip_py2_containers'):
         if 'py2' in tag:
-            pytest.skip(f'Skipping python2 container with tag {tag}')
+            pytest.skip('Skipping python2 container with tag {}'.format(tag))
 
 
 @pytest.fixture(autouse=True)
 def skip_eia_containers(request, docker_base_name):
     if request.node.get_closest_marker('skip_eia_containers'):
         if 'eia' in docker_base_name:
-            pytest.skip(f'Skipping eia container with tag {docker_base_name}')
+            pytest.skip('Skipping eia container with tag {}'.format(docker_base_name))

--- a/test/sagemaker_tests/mxnet/inference/integration/__init__.py
+++ b/test/sagemaker_tests/mxnet/inference/integration/__init__.py
@@ -48,4 +48,4 @@ def get_ecr_registry(account, region):
     :return: AWS ECR registry
     """
     endpoint_data = _botocore_resolver().construct_endpoint('ecr', region)
-    return f'{account}.dkr.{endpoint_data["hostname"]}'
+    return '{}.dkr.{}'.format(account, endpoint_data['hostname'])

--- a/test/sagemaker_tests/mxnet/training/conftest.py
+++ b/test/sagemaker_tests/mxnet/training/conftest.py
@@ -93,7 +93,7 @@ def aws_id(request):
 @pytest.fixture(scope='session')
 def tag(request, framework_version, processor, py_version):
     provided_tag = request.config.getoption('--tag')
-    default_tag = f'{framework_version}-{processor}-{py_version}'
+    default_tag = '{}-{}-{}'.format(framework_version, processor, py_version)
     return provided_tag if provided_tag is not None else default_tag
 
 
@@ -106,18 +106,18 @@ def instance_type(request, processor):
 
 @pytest.fixture(scope='session')
 def docker_image(docker_base_name, tag):
-    return f'{docker_base_name}:{tag}'
+    return '{}:{}'.format(docker_base_name, tag)
 
 
 @pytest.fixture(scope='session')
 def ecr_image(aws_id, docker_base_name, tag, region):
     registry = get_ecr_registry(aws_id, region)
-    return f'{registry}/{docker_base_name}:{tag}'
+    return '{}/{}:{}'.format(registry, docker_base_name, tag)
 
 
 @pytest.fixture(scope='session')
 def image_uri(docker_base_name, tag):
-    return f'{docker_base_name}:{tag}'
+    return '{}:{}'.format(docker_base_name, tag)
 
 
 @pytest.fixture(scope='session')
@@ -139,7 +139,7 @@ def local_instance_type(processor):
 def skip_test_in_region(request, region):
     if request.node.get_closest_marker('skip_test_in_region'):
         if region == 'me-south-1':
-            pytest.skip(f'Skipping SageMaker test in region {region}')
+            pytest.skip('Skipping SageMaker test in region {}'.format(region))
 
 
 @pytest.fixture(autouse=True)
@@ -147,17 +147,17 @@ def skip_by_device_type(request, processor):
     is_gpu = (processor == 'gpu')
     if (request.node.get_closest_marker('skip_gpu') and is_gpu) or \
             (request.node.get_closest_marker('skip_cpu') and not is_gpu):
-        pytest.skip(f'Skipping because running on "{processor}" instance')
+        pytest.skip('Skipping because running on \'{}\' instance'.format(processor))
 
 
 @pytest.fixture(autouse=True)
 def skip_gpu_instance_restricted_regions(region, instance_type):
     if region in NO_P2_REGIONS and instance_type.startswith('ml.p2'):
-        pytest.skip(f'Skipping GPU test in region {region} to avoid insufficient capacity')
+        pytest.skip('Skipping GPU test in region {} to avoid insufficient capacity'.format(region))
 
 
 @pytest.fixture(autouse=True)
 def skip_py2_containers(request, tag):
     if request.node.get_closest_marker('skip_py2_containers'):
         if 'py2' in tag:
-            pytest.skip(f'Skipping python2 container with tag {tag}')
+            pytest.skip('Skipping python2 container with tag {}'.format(tag))

--- a/test/sagemaker_tests/mxnet/training/integration/utils.py
+++ b/test/sagemaker_tests/mxnet/training/integration/utils.py
@@ -26,7 +26,7 @@ def unique_name_from_base(base, max_length=63):
     ts = str(int(time.time()))
     available_length = max_length - 2 - len(ts) - len(unique)
     trimmed = base[:available_length]
-    return f'{trimmed}-{ts}-{unique}'
+    return '{}-{}-{}'.format(trimmed, ts, unique)
 
 
 def _botocore_resolver():
@@ -46,4 +46,4 @@ def get_ecr_registry(account, region):
     :return: AWS ECR registry
     """
     endpoint_data = _botocore_resolver().construct_endpoint('ecr', region)
-    return f'{account}.dkr.{endpoint_data["hostname"]}'
+    return '{}.dkr.{}'.format(account, endpoint_data['hostname'])

--- a/test/sagemaker_tests/pytorch/inference/conftest.py
+++ b/test/sagemaker_tests/pytorch/inference/conftest.py
@@ -86,7 +86,7 @@ def fixture_framework_version(request):
 
 @pytest.fixture(scope='session', name='py_version')
 def fixture_py_version(request):
-    return f'py{int(request.config.getoption("--py-version"))}'
+    return 'py{}'.format(int(request.config.getoption('--py-version')))
 
 
 @pytest.fixture(scope='session', name='processor')
@@ -97,13 +97,13 @@ def fixture_processor(request):
 @pytest.fixture(scope='session', name='tag')
 def fixture_tag(request, framework_version, processor, py_version):
     provided_tag = request.config.getoption('--tag')
-    default_tag = f'{framework_version}-{processor}-{py_version}'
+    default_tag = '{}-{}-{}'.format(framework_version, processor, py_version)
     return provided_tag if provided_tag else default_tag
 
 
 @pytest.fixture(scope='session', name='docker_image')
 def fixture_docker_image(docker_base_name, tag):
-    return f'{docker_base_name}:{tag}'
+    return '{}:{}'.format(docker_base_name, tag)
 
 
 @pytest.fixture
@@ -113,7 +113,7 @@ def opt_ml():
 
     # Docker cannot mount Mac OS /var folder properly see
     # https://forums.docker.com/t/var-folders-isnt-mounted-properly/9600
-    opt_ml_dir = f'/private{tmp}' if platform.system() == 'Darwin' else tmp
+    opt_ml_dir = '/private{}'.format(tmp) if platform.system() == 'Darwin' else tmp
     yield opt_ml_dir
 
     shutil.rmtree(tmp, True)
@@ -172,7 +172,7 @@ def fixture_docker_registry(aws_id, region):
 
 @pytest.fixture(name='ecr_image', scope='session')
 def fixture_ecr_image(docker_registry, docker_base_name, tag):
-    return f'{docker_registry}/{docker_base_name}:{tag}'
+    return '{}/{}:{}'.format(docker_registry, docker_base_name, tag)
 
 
 @pytest.fixture(autouse=True)
@@ -184,15 +184,15 @@ def skip_by_device_type(request, use_gpu, instance_type, accelerator_type):
     # When running GPU test, skip CPU test. When running CPU test, skip GPU test.
     if (request.node.get_closest_marker('gpu_test') and not is_gpu) or \
             (request.node.get_closest_marker('cpu_test') and is_gpu):
-        pytest.skip(f'Skipping because running on "{instance_type}" instance')
+        pytest.skip('Skipping because running on \'{}\' instance'.format(instance_type))
 
     # When running EIA test, skip the CPU and GPU functions
     elif (request.node.get_closest_marker('gpu_test') or request.node.get_closest_marker('cpu_test')) and is_eia:
-        pytest.skip(f'Skipping because running on "{instance_type}" instance')
+        pytest.skip('Skipping because running on \'{}\' instance'.format(instance_type))
 
     # When running CPU or GPU test, skip EIA test.
     elif request.node.get_closest_marker('eia_test') and not is_eia:
-        pytest.skip(f'Skipping because running on "{instance_type}" instance')
+        pytest.skip('Skipping because running on \'{}\' instance'.format(instance_type))
 
 
 @pytest.fixture(autouse=True)
@@ -205,7 +205,7 @@ def skip_by_py_version(request, py_version):
 def skip_gpu_instance_restricted_regions(region, instance_type):
     if (region in NO_P2_REGIONS and instance_type.startswith('ml.p2')) \
        or (region in NO_P3_REGIONS and instance_type.startswith('ml.p3')):
-        pytest.skip(f'Skipping GPU test in region {region}')
+        pytest.skip('Skipping GPU test in region {}'.format(region))
 
 
 @pytest.fixture(autouse=True)

--- a/test/sagemaker_tests/pytorch/inference/utils/__init__.py
+++ b/test/sagemaker_tests/pytorch/inference/utils/__init__.py
@@ -33,4 +33,4 @@ def get_ecr_registry(account, region):
     :return: AWS ECR registry
     """
     endpoint_data = _botocore_resolver().construct_endpoint('ecr', region)
-    return f'{account}.dkr.{endpoint_data["hostname"]}'
+    return '{}.dkr.{}'.format(account, endpoint_data['hostname'])

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -86,7 +86,7 @@ def fixture_framework_version(request):
 
 @pytest.fixture(scope='session', name='py_version')
 def fixture_py_version(request):
-    return f'py{int(request.config.getoption("--py-version"))}'
+    return 'py{}'.format(int(request.config.getoption('--py-version')))
 
 
 @pytest.fixture(scope='session', name='processor')
@@ -97,13 +97,13 @@ def fixture_processor(request):
 @pytest.fixture(scope='session', name='tag')
 def fixture_tag(request, framework_version, processor, py_version):
     provided_tag = request.config.getoption('--tag')
-    default_tag = f'{framework_version}-{processor}-{py_version}'
+    default_tag = '{}-{}-{}'.format(framework_version, processor, py_version)
     return provided_tag if provided_tag else default_tag
 
 
 @pytest.fixture(scope='session', name='docker_image')
 def fixture_docker_image(docker_base_name, tag):
-    return f'{docker_base_name}:{tag}'
+    return '{}:{}'.format(docker_base_name, tag)
 
 
 @pytest.fixture
@@ -113,7 +113,7 @@ def opt_ml():
 
     # Docker cannot mount Mac OS /var folder properly see
     # https://forums.docker.com/t/var-folders-isnt-mounted-properly/9600
-    opt_ml_dir = f'/private{tmp}' if platform.system() == 'Darwin' else tmp
+    opt_ml_dir = '/private{}'.format(tmp) if platform.system() == 'Darwin' else tmp
     yield opt_ml_dir
 
     shutil.rmtree(tmp, True)
@@ -167,7 +167,7 @@ def fixture_docker_registry(aws_id, region):
 
 @pytest.fixture(name='ecr_image', scope='session')
 def fixture_ecr_image(docker_registry, docker_base_name, tag):
-    return f'{docker_registry}/{docker_base_name}:{tag}'
+    return '{}/{}:{}'.format(docker_registry, docker_base_name, tag)
 
 
 @pytest.fixture(scope='session', name='dist_cpu_backend', params=['gloo'])
@@ -185,7 +185,7 @@ def skip_by_device_type(request, use_gpu, instance_type):
     is_gpu = use_gpu or instance_type[3] in ['g', 'p']
     if (request.node.get_closest_marker('skip_gpu') and is_gpu) or \
             (request.node.get_closest_marker('skip_cpu') and not is_gpu):
-        pytest.skip(f'Skipping because running on "{instance_type}" instance')
+        pytest.skip('Skipping because running on \'{}\' instance'.format(instance_type))
 
 
 @pytest.fixture(autouse=True)
@@ -203,18 +203,18 @@ def skip_by_py_version(request, py_version):
 def skip_test_in_region(request, region):
     if request.node.get_closest_marker('skip_test_in_region'):
         if region == 'me-south-1':
-            pytest.skip(f'Skipping SageMaker test in region {region}')
+            pytest.skip('Skipping SageMaker test in region {}'.format(region))
 
 
 @pytest.fixture(autouse=True)
 def skip_gpu_instance_restricted_regions(region, instance_type):
     if ((region in NO_P2_REGIONS and instance_type.startswith('ml.p2'))
        or (region in NO_P3_REGIONS and instance_type.startswith('ml.p3'))):
-        pytest.skip(f'Skipping GPU test in region {region}')
+        pytest.skip('Skipping GPU test in region {}'.format(region))
 
 
 @pytest.fixture(autouse=True)
 def skip_py2_containers(request, tag):
     if request.node.get_closest_marker('skip_py2_containers'):
         if 'py2' in tag:
-            pytest.skip(f'Skipping python2 container with tag {tag}')
+            pytest.skip('Skipping python2 container with tag {}'.format(tag))

--- a/test/sagemaker_tests/pytorch/training/utils/__init__.py
+++ b/test/sagemaker_tests/pytorch/training/utils/__init__.py
@@ -33,4 +33,4 @@ def get_ecr_registry(account, region):
     :return: AWS ECR registry
     """
     endpoint_data = _botocore_resolver().construct_endpoint('ecr', region)
-    return f'{account}.dkr.{endpoint_data["hostname"]}'
+    return '{}.dkr.{}'.format(account, endpoint_data['hostname'])

--- a/test/sagemaker_tests/tensorflow/inference/test/integration/local/test_pre_post_processing.py
+++ b/test/sagemaker_tests/tensorflow/inference/test/integration/local/test_pre_post_processing.py
@@ -37,13 +37,13 @@ def volume(tmpdir_factory, request):
         shutil.copytree(model_src_dir, model_dir)
         shutil.copytree(test_example, code_dir)
 
-        volume_name = f'model_volume_{request.param}'
+        volume_name = 'model_volume_{}'.format(request.param)
         subprocess.check_call(
             'docker volume create --name {} --opt type=none '
             '--opt device={} --opt o=bind'.format(volume_name, model_dir).split())
         yield volume_name
     finally:
-        subprocess.check_call(f'docker volume rm {volume_name}'.split())
+        subprocess.check_call('docker volume rm {}'.format(volume_name).split())
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/test/sagemaker_tests/tensorflow/inference/test/integration/local/test_pre_post_processing_mme.py
+++ b/test/sagemaker_tests/tensorflow/inference/test/integration/local/test_pre_post_processing_mme.py
@@ -42,13 +42,13 @@ def volume(tmpdir_factory, request):
         shutil.copytree(model_src_dir, model_dir)
         shutil.copytree(test_example, code_dir)
 
-        volume_name = f'model_volume_1'
+        volume_name = 'model_volume_1'
         subprocess.check_call(
             'docker volume create --name {} --opt type=none '
             '--opt device={} --opt o=bind'.format(volume_name, model_dir).split())
         yield volume_name
     finally:
-        subprocess.check_call(f'docker volume rm {volume_name}'.split())
+        subprocess.check_call('docker volume rm {}'.format(volume_name).split())
 
 
 @pytest.fixture(scope='module', autouse=True)

--- a/test/sagemaker_tests/tensorflow/inference/test/integration/sagemaker/conftest.py
+++ b/test/sagemaker_tests/tensorflow/inference/test/integration/sagemaker/conftest.py
@@ -95,7 +95,7 @@ def registry(request, region):
         return request.config.getoption('--registry')
 
     domain_suffix = '.cn' if region in ('cn-north-1', 'cn-northwest-1') else ''
-    sts_regional_endpoint = f'https://sts.{region}.amazonaws.com{domain_suffix}'
+    sts_regional_endpoint = 'https://sts.{}.amazonaws.com{}'.format(region, domain_suffix)
 
     sts = boto3.client(
         'sts',
@@ -125,7 +125,7 @@ def unique_name_from_base(base, max_length=63):
     ts = str(int(time.time()))
     available_length = max_length - 2 - len(ts) - len(unique)
     trimmed = base[:available_length]
-    return f'{trimmed}-{ts}-{unique}'
+    return '{}-{}-{}'.format(trimmed, ts, unique)
 
 
 @pytest.fixture
@@ -137,7 +137,7 @@ def model_name():
 def skip_gpu_instance_restricted_regions(region, instance_type):
     if (region in NO_P2_REGIONS and instance_type.startswith('ml.p2')) or \
             (region in NO_P3_REGIONS and instance_type.startswith('ml.p3')):
-        pytest.skip(f'Skipping GPU test in region {region}')
+        pytest.skip('Skipping GPU test in region {}'.format(region))
 
 
 @pytest.fixture(autouse=True)
@@ -145,4 +145,4 @@ def skip_by_device_type(request, instance_type):
     is_gpu = instance_type[3] in ['g', 'p']
     if (request.node.get_closest_marker('skip_gpu') and is_gpu) or \
             (request.node.get_closest_marker('skip_cpu') and not is_gpu):
-        pytest.skip(f'Skipping because running on "{instance_type}" instance')
+        pytest.skip('Skipping because running on \'{}\' instance'.format(instance_type))

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/__init__.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/__init__.py
@@ -70,4 +70,4 @@ def get_ecr_registry(account, region):
     :return: AWS ECR registry
     """
     endpoint_data = _botocore_resolver().construct_endpoint("ecr", region)
-    return f"{account}.dkr.{endpoint_data['hostname']}"
+    return '{}.dkr.{}'.format(account, endpoint_data['hostname'])

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/conftest.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/conftest.py
@@ -75,7 +75,7 @@ def framework_version(request):
 @pytest.fixture
 def tag(request, framework_version, processor, py_version):
     provided_tag = request.config.getoption('--tag')
-    default_tag = f'{framework_version}-{processor}-py{py_version}'
+    default_tag = '{}-{}-py{}'.format(framework_version, processor, py_version)
     return provided_tag if provided_tag is not None else default_tag
 
 
@@ -120,29 +120,29 @@ def skip_by_device_type(request, processor):
     is_gpu = (processor == 'gpu')
     if (request.node.get_closest_marker('skip_gpu') and is_gpu) or \
             (request.node.get_closest_marker('skip_cpu') and not is_gpu):
-        pytest.skip(f'Skipping because running on "{processor}" instance')
+        pytest.skip('Skipping because running on \'{}\' instance'.format(processor))
 
 
 @pytest.fixture(autouse=True)
 def skip_gpu_instance_restricted_regions(region, instance_type):
     if (region in NO_P2_REGIONS and instance_type.startswith('ml.p2')) or \
             (region in NO_P3_REGIONS and instance_type.startswith('ml.p3')):
-        pytest.skip(f'Skipping GPU test in region {region}')
+        pytest.skip('Skipping GPU test in region {}'.format(region))
 
 
 @pytest.fixture
 def docker_image(docker_base_name, tag):
-    return f'{docker_base_name}:{tag}'
+    return '{}:{}'.format(docker_base_name, tag)
 
 
 @pytest.fixture(autouse=True)
 def skip_py2_containers(request, tag):
     if request.node.get_closest_marker('skip_py2_containers'):
         if 'py2' in tag:
-            pytest.skip(f'Skipping python2 container with tag {tag}')
+            pytest.skip('Skipping python2 container with tag {}'.format(tag))
 
 
 @pytest.fixture
 def ecr_image(account_id, docker_base_name, tag, region):
     registry = get_ecr_registry(account_id, region)
-    return f'{registry}/{docker_base_name}:{tag}'
+    return '{}/{}:{}'.format(registry, docker_base_name, tag)

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/__init__.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/__init__.py
@@ -71,4 +71,4 @@ def get_ecr_registry(account, region):
     :return: AWS ECR registry
     """
     endpoint_data = _botocore_resolver().construct_endpoint("ecr", region)
-    return f"{account}.dkr.{endpoint_data['hostname']}"
+    return '{}.dkr.{}'.format(account, endpoint_data['hostname'])

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/conftest.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/conftest.py
@@ -75,7 +75,7 @@ def framework_version(request):
 @pytest.fixture
 def tag(request, framework_version, processor, py_version):
     provided_tag = request.config.getoption('--tag')
-    default_tag = f'{framework_version}-{processor}-py{py_version}'
+    default_tag = '{}-{}-py{}'.format(framework_version, processor, py_version)
     return provided_tag if provided_tag is not None else default_tag
 
 
@@ -120,29 +120,29 @@ def skip_by_device_type(request, processor):
     is_gpu = (processor == 'gpu')
     if (request.node.get_closest_marker('skip_gpu') and is_gpu) or \
             (request.node.get_closest_marker('skip_cpu') and not is_gpu):
-        pytest.skip(f'Skipping because running on "{processor}" instance')
+        pytest.skip('Skipping because running on \'{}\' instance'.format(processor))
 
 
 @pytest.fixture(autouse=True)
 def skip_gpu_instance_restricted_regions(region, instance_type):
     if (region in NO_P2_REGIONS and instance_type.startswith('ml.p2')) or \
             (region in NO_P3_REGIONS and instance_type.startswith('ml.p3')):
-        pytest.skip(f'Skipping GPU test in region {region}')
+        pytest.skip('Skipping GPU test in region {}'.format(region))
 
 
 @pytest.fixture
 def docker_image(docker_base_name, tag):
-    return f'{docker_base_name}:{tag}'
+    return '{}:{}'.format(docker_base_name, tag)
 
 
 @pytest.fixture
 def ecr_image(account_id, docker_base_name, tag, region):
     registry = get_ecr_registry(account_id, region)
-    return f'{registry}/{docker_base_name}:{tag}'
+    return '{}/{}:{}'.format(registry, docker_base_name, tag)
 
 
 @pytest.fixture(autouse=True)
 def skip_py2_containers(request, tag):
     if request.node.get_closest_marker('skip_py2_containers'):
         if 'py2' in tag:
-            pytest.skip(f'Skipping python2 container with tag {tag}')
+            pytest.skip('Skipping python2 container with tag {}'.format(tag))


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
SageMaker Local tests are run on an EC2 instance where py35 is the default python version. Recent changes use the form `f"abc-{variable}-xyz` instead of `"abc-{}-xyz".format(variable)`, which is incompatible with python versions below 3.6.

This PR ensures that all code relevant to SageMaker Local tests conforms to py35 requirements.

*Tests run:*
Local tests

*DLC image/dockerfile:*
N/A

*Additional context:*
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

