### PR TITLE
[benchmark] | [mxnet] | [ec2] Set MXNet cpu/gpu inference and gpu training dedicated for py3 and re…

### DIFF
--- a/test/dlc_tests/benchmark/ec2/mxnet/test_performance_mxnet_inference.py
+++ b/test/dlc_tests/benchmark/ec2/mxnet/test_performance_mxnet_inference.py
@@ -16,12 +16,12 @@ MX_EC2_CPU_INSTANCE_TYPE = "c5.18xlarge"
 @pytest.mark.integration("imagenet dataset")
 @pytest.mark.model("resnet50_v2")
 @pytest.mark.parametrize("ec2_instance_type", [MX_EC2_GPU_INSTANCE_TYPE], indirect=True)
-def test_performance_ec2_mxnet_inference_gpu(mxnet_inference, ec2_connection, gpu_only):
+def test_performance_ec2_mxnet_inference_gpu(mxnet_inference, ec2_connection, gpu_only, py3_only):
     execute_ec2_inference_performance_test(ec2_connection, mxnet_inference, MX_PERFORMANCE_INFERENCE_GPU_CMD)
 
 
 @pytest.mark.integration("imagenet dataset")
 @pytest.mark.model("resnet50_v2")
 @pytest.mark.parametrize("ec2_instance_type", [MX_EC2_CPU_INSTANCE_TYPE], indirect=True)
-def test_performance_ec2_mxnet_inference_cpu(mxnet_inference, ec2_connection, cpu_only):
+def test_performance_ec2_mxnet_inference_cpu(mxnet_inference, ec2_connection, cpu_only, py3_only):
     execute_ec2_inference_performance_test(ec2_connection, mxnet_inference, MX_PERFORMANCE_INFERENCE_CPU_CMD)

--- a/test/dlc_tests/benchmark/ec2/mxnet/test_performance_mxnet_training.py
+++ b/test/dlc_tests/benchmark/ec2/mxnet/test_performance_mxnet_training.py
@@ -16,7 +16,7 @@ MX_EC2_CPU_INSTANCE_TYPE = "c5.18xlarge"
 @pytest.mark.integration("imagenet dataset")
 @pytest.mark.model("resnet50_v2")
 @pytest.mark.parametrize("ec2_instance_type", [MX_EC2_GPU_INSTANCE_TYPE], indirect=True)
-def test_performance_ec2_mxnet_training_gpu(mxnet_training, ec2_connection, gpu_only):
+def test_performance_ec2_mxnet_training_gpu(mxnet_training, ec2_connection, gpu_only, py3_only):
     execute_ec2_training_performance_test(ec2_connection, mxnet_training, MX_PERFORMANCE_TRAINING_GPU_CMD)
 
 

--- a/test/dlc_tests/container_tests/bin/benchmark/run_mxnet_training_performance_gpu
+++ b/test/dlc_tests/container_tests/bin/benchmark/run_mxnet_training_performance_gpu
@@ -22,7 +22,7 @@ echo Fetch finished >&2
 git clone https://github.com/rahul003/deep-learning-benchmark-mirror.git ${HOME_DIR}/artifacts/mxnet/deep-learning-benchmark-mirror  && cd ${HOME_DIR}/artifacts/mxnet/
 START=$(date +%s)
 pip install psutil gluoncv && python deep-learning-benchmark-mirror/mxnet_benchmark/train_imagenet.py --use-rec --batch-size 256 --dtype float16 --num-data-workers 40 \
---num-epochs 50 --gpus 0,1,2,3,4,5,6,7 --lr 0.8 --lr-decay-epoch 30,60,80 --warmup-epochs 5 --last-gamma \
+--num-epochs 20 --gpus 0,1,2,3,4,5,6,7 --lr 0.8 --lr-decay-epoch 30,60,80 --warmup-epochs 5 --last-gamma \
 --mode symbolic --model resnet50_v2 --rec-train /home/ubuntu/data/train-passthrough.rec --rec-train-idx /home/ubuntu/data/train-passthrough.idx \
 --rec-val /home/ubuntu/data/val-passthrough.rec --rec-val-idx /home/ubuntu/data/val-passthrough.idx 2>&1 | tee ${LOG_DIR}/"${LOG_FILE}"
 python /test/bin/benchmark/get_mxnet_avg_throughput.py ${LOG_DIR}/"${LOG_FILE}" 4 >> ${LOG_DIR}/"${LOG_FILE}"


### PR DESCRIPTION
…duce gpu training epochs

*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
Set MXNet cpu/gpu inference and gpu training dedicated for py3 and reduce gpu training epochs


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

