### PR TITLE
[test][pytorch, mxnet][eks] Pin dgl branch to 0.4.x until new version is released

### DIFF
--- a/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
+++ b/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
@@ -128,7 +128,7 @@ RUN ${PIP} install --no-cache --upgrade \
     Pillow \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
-    dgl==0.4.3 \
+    dgl==0.4.* \
     scipy==1.2.2 \
     gluonnlp==0.9.1 \
     gluoncv==0.6.0 \

--- a/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
+++ b/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
@@ -128,7 +128,7 @@ RUN ${PIP} install --no-cache --upgrade \
     Pillow \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
-    dgl \
+    dgl==0.4.3 \
     scipy==1.2.2 \
     gluonnlp==0.9.1 \
     gluoncv==0.6.0 \

--- a/mxnet/training/docker/1.6.0/py3/cu101/Dockerfile.gpu
+++ b/mxnet/training/docker/1.6.0/py3/cu101/Dockerfile.gpu
@@ -171,7 +171,7 @@ RUN ${PIP} install --no-cache --upgrade \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     scipy==1.2.2 \
-    dgl-cu101==0.4.3 \
+    dgl-cu101==0.4.* \
     gluonnlp==0.9.1 \
     gluoncv==0.6.0 \
     urllib3==1.25.8 \

--- a/mxnet/training/docker/1.6.0/py3/cu101/Dockerfile.gpu
+++ b/mxnet/training/docker/1.6.0/py3/cu101/Dockerfile.gpu
@@ -171,7 +171,7 @@ RUN ${PIP} install --no-cache --upgrade \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     scipy==1.2.2 \
-    dgl-cu101 \
+    dgl-cu101==0.4.3 \
     gluonnlp==0.9.1 \
     gluoncv==0.6.0 \
     urllib3==1.25.8 \

--- a/test/dlc_tests/eks/mxnet/training/test_eks_mxnet_training.py
+++ b/test/dlc_tests/eks/mxnet/training/test_eks_mxnet_training.py
@@ -82,13 +82,12 @@ def test_eks_mxnet_dgl_single_node_training(mxnet_training, py3_only):
     """
 
     training_result = False
-    ctx = Context()
     rand_int = random.randint(4001, 6000)
 
     yaml_path = os.path.join(os.sep, "tmp", f"mxnet_single_node_training_dgl_{rand_int}.yaml")
     pod_name = f"mxnet-single-node-training-dgl-{rand_int}"
 
-    dgl_branch = eks_utils.get_dgl_branch(ctx, mxnet_training)
+    dgl_branch = "0.4.x"
 
     args = (
         f"git clone -b {dgl_branch} https://github.com/dmlc/dgl.git && "

--- a/test/dlc_tests/eks/pytorch/training/test_eks_pytorch_training.py
+++ b/test/dlc_tests/eks/pytorch/training/test_eks_pytorch_training.py
@@ -78,13 +78,12 @@ def test_eks_pytorch_dgl_single_node_training(pytorch_training, py3_only):
     """
 
     training_result = False
-    ctx = Context()
     rand_int = random.randint(4001, 6000)
 
     yaml_path = os.path.join(os.sep, "tmp", f"pytorch_single_node_training_dgl_{rand_int}.yaml")
     pod_name = f"pytorch-single-node-training-dgl-{rand_int}"
 
-    dgl_branch = eks_utils.get_dgl_branch(ctx, pytorch_training)
+    dgl_branch = "0.4.x"
 
     args = (
         f"git clone -b {dgl_branch} https://github.com/dmlc/dgl.git && "


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image

*Description:*
It appears the dgl team has cut a release branch for 0.5.x before the 0.5.x release. We will not rely on automatically getting the latest branch from now on and instead pin to a minor.x version so that breaking changes are not introduced. It appears that breaking changes are introduced in minor versions with dgl.

*Tests run:*
- EKS tests pass for mx and pt

*DLC image/dockerfile:*
- mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
- mxnet/training/docker/1.6.0/py3/cu101/Dockerfile.gpu


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

