### PR TITLE
Update GluonNLP in mxnet training images

### DIFF
--- a/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
+++ b/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
@@ -130,7 +130,7 @@ RUN ${PIP} install --no-cache --upgrade \
     scikit-learn==0.20.4 \
     dgl==0.4.* \
     scipy==1.2.2 \
-    gluonnlp==0.9.1 \
+    gluonnlp==0.10.0 \
     gluoncv==0.6.0 \
     urllib3==1.25.8 \
     python-dateutil==2.8.0 \

--- a/mxnet/training/docker/1.6.0/py3/cu101/Dockerfile.gpu
+++ b/mxnet/training/docker/1.6.0/py3/cu101/Dockerfile.gpu
@@ -172,7 +172,7 @@ RUN ${PIP} install --no-cache --upgrade \
     scikit-learn==0.20.4 \
     scipy==1.2.2 \
     dgl-cu101==0.4.* \
-    gluonnlp==0.9.1 \
+    gluonnlp==0.10.0 \
     gluoncv==0.6.0 \
     urllib3==1.25.8 \
     python-dateutil==2.8.0 \


### PR DESCRIPTION
Training images shipped a separate version of GluonNLP than inference images;
the search-replace update in https://github.com/aws/deep-learning-containers/pull/498 missed the training images.


Thanks @TusharKanekiDey for noting the discrepancy