### PR TITLE
[build] [pytorch] Build only pytorch 1.5.1 inference images

### DIFF
--- a/pytorch/buildspec.yml
+++ b/pytorch/buildspec.yml
@@ -1,7 +1,7 @@
   account_id: &ACCOUNT_ID <set-$ACCOUNT_ID-in-environment>
   region: &REGION <set-$REGION-in-environment>
   framework: &FRAMEWORK pytorch
-  version: &VERSION 1.6.0
+  version: &VERSION 1.5.1
   cuda_version: &CUDA_VERSION cu101
   os_version: &OS_VERSION ubuntu16.04
 
@@ -18,20 +18,10 @@
         repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ]
 
   context:
-    training_context: &TRAINING_CONTEXT
-      changehostname:
-        source: docker/build_artifacts/changehostname.c
-        target: changehostname.c
-      start_with_right_hostname:
-        source: docker/build_artifacts/start_with_right_hostname.sh
-        target: start_with_right_hostname.sh
-      example_mnist_file:
-        source: docker/build_artifacts/mnist.py
-        target: mnist.py
     inference_context: &INFERENCE_CONTEXT
-      torchserve-entrypoint:
-        source: docker/build_artifacts/torchserve-entrypoint.py
-        target: torchserve-entrypoint.py
+      mms-entrypoint:
+        source: docker/build_artifacts/mms-entrypoint.py
+        target: mms-entrypoint.py
       config:
         source: docker/build_artifacts/config.properties
         target: config.properties
@@ -40,41 +30,6 @@
         target: deep_learning_container.py
 
   images:
-    BuildCPUPTTrainPy3DockerImage:
-      <<: *TRAINING_REPOSITORY
-      build: &PYTORCH_CPU_TRAINING_PY3 false
-      image_size_baseline: 4899
-      device_type: &DEVICE_TYPE cpu
-      python_version: &DOCKER_PYTHON_VERSION py3
-      tag_python_version: &TAG_PYTHON_VERSION py36
-      tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION ]
-      docker_file: !join [ docker/, *VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
-      context:
-        <<: *TRAINING_CONTEXT
-    BuildGPUPTTrainPy3DockerImage:
-      <<: *TRAINING_REPOSITORY
-      build: &PYTORCH_GPU_TRAINING_PY3 false
-      image_size_baseline: 9228
-      device_type: &DEVICE_TYPE gpu
-      python_version: &DOCKER_PYTHON_VERSION py3
-      tag_python_version: &TAG_PYTHON_VERSION py36
-      tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION ]
-      docker_file: !join [ docker/, *VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile., *DEVICE_TYPE ]
-      context:
-        <<: *TRAINING_CONTEXT
-    BuildPyTorchExampleGPUTrainPy3DockerImage:
-      <<: *TRAINING_REPOSITORY
-      build: &PYTORCH_GPU_TRAINING_PY3 false
-      image_size_baseline: 8500
-      base_image_name: BuildGPUPTTrainPy3DockerImage
-      device_type: &DEVICE_TYPE gpu
-      python_version: &DOCKER_PYTHON_VERSION py3
-      tag_python_version: &TAG_PYTHON_VERSION py36
-      tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION,
-                   "-example" ]
-      docker_file: !join [ docker/, *VERSION, /, *DOCKER_PYTHON_VERSION, /example, /Dockerfile., *DEVICE_TYPE ]
-      context:
-        <<: *TRAINING_CONTEXT
     BuildCPUPTInferencePy3DockerImage:
       <<: *INFERENCE_REPOSITORY
       build: &PYTORCH_CPU_INFERENCE_PY3 false


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to

* For reviewer, before merging, please cross-check:
- [x] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
Rebuild PyTorch 1.5.1 Inference DLC images

*Tests run:*
N/A

*DLC image/dockerfile:*
https://github.com/aws/deep-learning-containers/blob/master/pytorch/inference/docker/1.5.1/py3/Dockerfile.cpu
https://github.com/aws/deep-learning-containers/blob/master/pytorch/inference/docker/1.5.1/py3/cu101/Dockerfile.gpu

*Additional context:*
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

