### PR TITLE
[mxnet] | [build] Remove openssl 1.0.2g for MX1.6.0 training

### DIFF
--- a/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
+++ b/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
@@ -83,6 +83,8 @@ RUN wget -c https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
 # when we remove previous openssl, the ca-certificates pkgs and its symlinks gets deleted
 # causing sslcertverificationerror the below steps are to fix that
 RUN ln -s /etc/ssl/certs/*.* /usr/local/ssl/certs/
+# Remove 1.0.2g again, which been reinstalled during the time installing 1.1.1g
+RUN apt remove -y --purge openssl && rm -rf /usr/include/openssl
 
 RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz \
  && tar -xvf Python-$PYTHON_VERSION.tgz \

--- a/mxnet/training/docker/1.6.0/py3/cu101/Dockerfile.gpu
+++ b/mxnet/training/docker/1.6.0/py3/cu101/Dockerfile.gpu
@@ -126,6 +126,8 @@ RUN wget -c https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz \
 # when we remove previous openssl, the ca-certificates pkgs and its symlinks gets deleted
 # causing sslcertverificationerror the below steps are to fix that
 RUN ln -s /etc/ssl/certs/*.* /usr/local/ssl/certs/
+# Remove 1.0.2g again, which been reinstalled during the time installing 1.1.1g
+RUN apt remove -y --purge openssl && rm -rf /usr/include/openssl
 
 RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz \
  && tar -xvf Python-$PYTHON_VERSION.tgz \


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet] | [build]
*Description:*
Remove openssl 1.0.2g for MX1.6.0 training


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

