### PR TITLE
[release] Add pytorch 1.5.1 inference to release images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -25,6 +25,19 @@ release_images:
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
   3:
+    framework: "pytorch"
+    version: "1.5.1"
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py36"]
+      os_version: "ubuntu16.04"
+      cuda_version: "cu101"
+      example: False        # [Default: False] Set to True to denote that this image is an Example image
+      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
+      # to images being published.
+      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
+      # has already been published. Re-released image will have minor version incremented by 1.
+  4:
     framework: "tensorflow"
     version: "2.2.0"
     training:
@@ -37,7 +50,7 @@ release_images:
       # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-  4:
+  5:
     framework: "tensorflow"
     version: "2.2.0"
     training:
@@ -48,7 +61,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  5:
+  6:
     framework: "tensorflow"
     version: "2.3.0"
     training:
@@ -69,7 +82,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  6:
+  7:
     framework: "tensorflow"
     version: "2.3.0"
     training:
@@ -80,7 +93,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  7:
+  8:
     framework: "mxnet"
     version: "1.6.0"
     training:
@@ -101,7 +114,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  8:
+  9:
     framework: "mxnet"
     version: "1.6.0"
     training:


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [build] | [test] | [build, test] | [ec2, ecs, eks, sagemaker]

*Description:*
Update release_images.yml to allow the release of PyTorch 1.5.1 Inference DLC images

*Tests run:*
N/A

*DLC image/dockerfile:*
N/A

*Additional context:*
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

