### PR TITLE
[release] Change TF 2.2 CUDA version to 10.1

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -41,15 +41,15 @@ release_images:
     framework: "tensorflow"
     version: "2.2.0"
     training:
-      device_types: ["gpu"]
+      device_types: ["cpu", "gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
-      cuda_version: "cu102"
+      cuda_version: "cu101"
       example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: True  # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-      # to images being published.
+      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
+                            # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
+                            # has already been published. Re-released image will have minor version incremented by 1.
   5:
     framework: "tensorflow"
     version: "2.2.0"
@@ -57,7 +57,7 @@ release_images:
       device_types: ["gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
-      cuda_version: "cu102"
+      cuda_version: "cu101"
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
Set the CUDA version for TF 2.2 to be cu101, and enable CPU images, on release_images.yml

*Tests run:*
N/A

*DLC image/dockerfile:*
N/A

*Additional context:*
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

