### PR TITLE
[pytorch][inference] Bump version for Torchserve to 0.2.1

### DIFF
--- a/pytorch/buildspec.yml
+++ b/pytorch/buildspec.yml
@@ -1,7 +1,7 @@
   account_id: &ACCOUNT_ID <set-$ACCOUNT_ID-in-environment>
   region: &REGION <set-$REGION-in-environment>
   framework: &FRAMEWORK pytorch
-  version: &VERSION 1.5.1
+  version: &VERSION 1.6
   cuda_version: &CUDA_VERSION cu101
   os_version: &OS_VERSION ubuntu16.04
 

--- a/pytorch/buildspec.yml
+++ b/pytorch/buildspec.yml
@@ -1,7 +1,7 @@
   account_id: &ACCOUNT_ID <set-$ACCOUNT_ID-in-environment>
   region: &REGION <set-$REGION-in-environment>
   framework: &FRAMEWORK pytorch
-  version: &VERSION 1.6
+  version: &VERSION 1.6.0
   cuda_version: &CUDA_VERSION cu101
   os_version: &OS_VERSION ubuntu16.04
 

--- a/pytorch/buildspec.yml
+++ b/pytorch/buildspec.yml
@@ -19,9 +19,9 @@
 
   context:
     inference_context: &INFERENCE_CONTEXT
-      mms-entrypoint:
-        source: docker/build_artifacts/mms-entrypoint.py
-        target: mms-entrypoint.py
+      torchserve-entrypoint:
+        source: docker/build_artifacts/torchserve-entrypoint.py
+        target: torchserve-entrypoint.py
       config:
         source: docker/build_artifacts/config.properties
         target: config.properties

--- a/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
+++ b/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
@@ -93,7 +93,7 @@ RUN conda install -c \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
  && pip install packaging==20.4 \
-    enum-compat=0.0.3 \
+    enum-compat==0.0.3 \
  && conda install -y -c pytorch torchserve=$TS_VERSION \
  && conda install -y -c pytorch torch-model-archiver=$TS_VERSION
 

--- a/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
+++ b/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
@@ -92,8 +92,10 @@ RUN conda install -c \
  && conda clean -ya \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
- && conda install -y -c pytorch torchserve==$TS_VERSION \
- && conda install -y -c pytorch torch-model-archiver==$TS_VERSION
+ && pip install packaging==20.4 \
+    enum-compat=0.0.3 \
+ && conda install -y -c pytorch torchserve=$TS_VERSION \
+ && conda install -y -c pytorch torch-model-archiver=$TS_VERSION
 
 
 # Uninstall and re-install torch and torchvision from the PyTorch website

--- a/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
+++ b/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
@@ -10,7 +10,8 @@ ARG OPEN_MPI_VERSION=4.0.1
 ARG TS_VERSION=0.2.1
 ARG PT_INFERENCE_URL=https://aws-pytorch-binaries.s3-us-west-2.amazonaws.com/r1.6.0_inference/20200727-223446/b0251e7e070e57f34ee08ac59ab4710081b41918/cpu/torch-1.6.0-cp36-cp36m-manylinux1_x86_64.whl
 ARG PT_VISION_URL=https://torchvision-build.s3.amazonaws.com/1.6.0/cpu/torchvision-0.7.0-cp36-cp36m-linux_x86_64.whl
-
+ARG TS_URL=https://download.pytorch.org/whl/test/torchserve-0.2.1-py2.py3-none-any.whl
+ARG TS_MAR_URL=https://download.pytorch.org/whl/test/torch_model_archiver-0.2.1-py2.py3-none-any.whl
 
 # See http://bugs.python.org/issue19846
 ENV LANG C.UTF-8
@@ -93,8 +94,8 @@ RUN conda install -c \
  && conda clean -ya \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
- && conda install -y -c pytorch-test torchserve==$TS_VERSION \
- && conda install -y -c pytorch-test torch-model-archiver==$TS_VERSION
+ && pip install --no-cache-dir -U $TS_URL \
+ && pip install --no-cache-dir -U $TS_MAR_URL
 
 
 # Uninstall and re-install torch and torchvision from the PyTorch website

--- a/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
+++ b/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
@@ -7,7 +7,7 @@ LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
 
 ARG PYTHON_VERSION=3.6.10
 ARG OPEN_MPI_VERSION=4.0.1
-ARG TS_VERSION=0.2.1
+ARG TS_VERSION="0.2.1=py36_0"
 ARG PT_INFERENCE_URL=https://aws-pytorch-binaries.s3-us-west-2.amazonaws.com/r1.6.0_inference/20200727-223446/b0251e7e070e57f34ee08ac59ab4710081b41918/cpu/torch-1.6.0-cp36-cp36m-manylinux1_x86_64.whl
 ARG PT_VISION_URL=https://torchvision-build.s3.amazonaws.com/1.6.0/cpu/torchvision-0.7.0-cp36-cp36m-linux_x86_64.whl
 

--- a/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
+++ b/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
@@ -10,8 +10,6 @@ ARG OPEN_MPI_VERSION=4.0.1
 ARG TS_VERSION=0.2.1
 ARG PT_INFERENCE_URL=https://aws-pytorch-binaries.s3-us-west-2.amazonaws.com/r1.6.0_inference/20200727-223446/b0251e7e070e57f34ee08ac59ab4710081b41918/cpu/torch-1.6.0-cp36-cp36m-manylinux1_x86_64.whl
 ARG PT_VISION_URL=https://torchvision-build.s3.amazonaws.com/1.6.0/cpu/torchvision-0.7.0-cp36-cp36m-linux_x86_64.whl
-ARG TS_URL=https://download.pytorch.org/whl/test/torchserve-0.2.1-py2.py3-none-any.whl
-ARG TS_MAR_URL=https://download.pytorch.org/whl/test/torch_model_archiver-0.2.1-py2.py3-none-any.whl
 
 # See http://bugs.python.org/issue19846
 ENV LANG C.UTF-8
@@ -94,8 +92,8 @@ RUN conda install -c \
  && conda clean -ya \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
- && pip install --no-cache-dir -U $TS_URL \
- && pip install --no-cache-dir -U $TS_MAR_URL
+ && conda install -y -c pytorch torchserve==$TS_VERSION \
+ && conda install -y -c pytorch torch-model-archiver==$TS_VERSION
 
 
 # Uninstall and re-install torch and torchvision from the PyTorch website

--- a/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
+++ b/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
@@ -93,8 +93,8 @@ RUN conda install -c \
  && conda clean -ya \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
- && conda install -y torchserve==$TS_VERSION \
- && conda install -y torch-model-archiver==$TS_VERSION
+ && conda install -y -c pytorch-test torchserve==$TS_VERSION \
+ && conda install -y -c pytorch-test torch-model-archiver==$TS_VERSION
 
 
 # Uninstall and re-install torch and torchvision from the PyTorch website

--- a/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
+++ b/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
@@ -7,7 +7,7 @@ LABEL com.amazonaws.sagemaker.capabilities.multi-models=true
 
 ARG PYTHON_VERSION=3.6.10
 ARG OPEN_MPI_VERSION=4.0.1
-ARG TS_VERSION=0.2.0
+ARG TS_VERSION=0.2.1
 ARG PT_INFERENCE_URL=https://aws-pytorch-binaries.s3-us-west-2.amazonaws.com/r1.6.0_inference/20200727-223446/b0251e7e070e57f34ee08ac59ab4710081b41918/cpu/torch-1.6.0-cp36-cp36m-manylinux1_x86_64.whl
 ARG PT_VISION_URL=https://torchvision-build.s3.amazonaws.com/1.6.0/cpu/torchvision-0.7.0-cp36-cp36m-linux_x86_64.whl
 
@@ -93,8 +93,8 @@ RUN conda install -c \
  && conda clean -ya \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
- && pip install torchserve==$TS_VERSION \
- && pip install torch-model-archiver==$TS_VERSION
+ && conda install -y torchserve==$TS_VERSION \
+ && conda install -y torch-model-archiver==$TS_VERSION
 
 
 # Uninstall and re-install torch and torchvision from the PyTorch website

--- a/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
+++ b/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
@@ -11,8 +11,6 @@ ARG OPEN_MPI_VERSION=4.0.1
 ARG TS_VERSION=0.2.1
 ARG PT_INFERENCE_URL=https://aws-pytorch-binaries.s3-us-west-2.amazonaws.com/r1.6.0_inference/20200727-223446/b0251e7e070e57f34ee08ac59ab4710081b41918/gpu/torch-1.6.0-cp36-cp36m-manylinux1_x86_64.whl
 ARG PT_VISION_URL=https://torchvision-build.s3.amazonaws.com/1.6.0/gpu/torchvision-0.7.0-cp36-cp36m-linux_x86_64.whl
-ARG TS_URL=https://download.pytorch.org/whl/test/torchserve-0.2.1-py2.py3-none-any.whl
-ARG TS_MAR_URL=https://download.pytorch.org/whl/test/torch_model_archiver-0.2.1-py2.py3-none-any.whl
 
 
 # See http://bugs.python.org/issue19846
@@ -106,8 +104,8 @@ RUN conda install -c \
  && /opt/conda/bin/conda config --set ssl_verify False \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
- && pip install --no-cache-dir -U $TS_URL \
- && pip install --no-cache-dir -U $TS_MAR_URL
+ && conda install -y -c pytorch torchserve==$TS_VERSION \
+ && conda install -y -c pytorch torch-model-archiver==$TS_VERSION
 
 # Uninstall and re-install torch and torchvision from the PyTorch website
 RUN pip uninstall -y torch \

--- a/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
+++ b/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
@@ -8,7 +8,7 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 # Add arguments to achieve the version, python and url
 ARG PYTHON_VERSION=3.6.10
 ARG OPEN_MPI_VERSION=4.0.1
-ARG TS_VERSION=0.2.0
+ARG TS_VERSION=0.2.1
 ARG PT_INFERENCE_URL=https://aws-pytorch-binaries.s3-us-west-2.amazonaws.com/r1.6.0_inference/20200727-223446/b0251e7e070e57f34ee08ac59ab4710081b41918/gpu/torch-1.6.0-cp36-cp36m-manylinux1_x86_64.whl
 ARG PT_VISION_URL=https://torchvision-build.s3.amazonaws.com/1.6.0/gpu/torchvision-0.7.0-cp36-cp36m-linux_x86_64.whl
 
@@ -104,8 +104,8 @@ RUN conda install -c \
  && /opt/conda/bin/conda config --set ssl_verify False \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
- && pip install torchserve==$TS_VERSION \
- && pip install torch-model-archiver==$TS_VERSION
+ && conda install -y torchserve==$TS_VERSION \
+ && conda install -y torch-model-archiver==$TS_VERSION
 
 # Uninstall and re-install torch and torchvision from the PyTorch website
 RUN pip uninstall -y torch \

--- a/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
+++ b/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
@@ -11,6 +11,8 @@ ARG OPEN_MPI_VERSION=4.0.1
 ARG TS_VERSION=0.2.1
 ARG PT_INFERENCE_URL=https://aws-pytorch-binaries.s3-us-west-2.amazonaws.com/r1.6.0_inference/20200727-223446/b0251e7e070e57f34ee08ac59ab4710081b41918/gpu/torch-1.6.0-cp36-cp36m-manylinux1_x86_64.whl
 ARG PT_VISION_URL=https://torchvision-build.s3.amazonaws.com/1.6.0/gpu/torchvision-0.7.0-cp36-cp36m-linux_x86_64.whl
+ARG TS_URL=https://download.pytorch.org/whl/test/torchserve-0.2.1-py2.py3-none-any.whl
+ARG TS_MAR_URL=https://download.pytorch.org/whl/test/torch_model_archiver-0.2.1-py2.py3-none-any.whl
 
 
 # See http://bugs.python.org/issue19846
@@ -104,8 +106,8 @@ RUN conda install -c \
  && /opt/conda/bin/conda config --set ssl_verify False \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
- && conda install -y -c pytorch-test torchserve==$TS_VERSION \
- && conda install -y -c pytorch-test torch-model-archiver==$TS_VERSION
+ && pip install --no-cache-dir -U $TS_URL \
+ && pip install --no-cache-dir -U $TS_MAR_URL
 
 # Uninstall and re-install torch and torchvision from the PyTorch website
 RUN pip uninstall -y torch \

--- a/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
+++ b/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
@@ -104,8 +104,8 @@ RUN conda install -c \
  && /opt/conda/bin/conda config --set ssl_verify False \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
- && conda install -y torchserve==$TS_VERSION \
- && conda install -y torch-model-archiver==$TS_VERSION
+ && conda install -y -c pytorch-test torchserve==$TS_VERSION \
+ && conda install -y -c pytorch-test torch-model-archiver==$TS_VERSION
 
 # Uninstall and re-install torch and torchvision from the PyTorch website
 RUN pip uninstall -y torch \

--- a/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
+++ b/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
@@ -105,7 +105,7 @@ RUN conda install -c \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
  && pip install packaging==20.4 \
-    enum-compat=0.0.3 \
+    enum-compat==0.0.3 \
  && conda install -y -c pytorch torchserve=$TS_VERSION \
  && conda install -y -c pytorch torch-model-archiver=$TS_VERSION
 

--- a/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
+++ b/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
@@ -8,7 +8,7 @@ LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
 # Add arguments to achieve the version, python and url
 ARG PYTHON_VERSION=3.6.10
 ARG OPEN_MPI_VERSION=4.0.1
-ARG TS_VERSION=0.2.1
+ARG TS_VERSION="0.2.1=py36_0"
 ARG PT_INFERENCE_URL=https://aws-pytorch-binaries.s3-us-west-2.amazonaws.com/r1.6.0_inference/20200727-223446/b0251e7e070e57f34ee08ac59ab4710081b41918/gpu/torch-1.6.0-cp36-cp36m-manylinux1_x86_64.whl
 ARG PT_VISION_URL=https://torchvision-build.s3.amazonaws.com/1.6.0/gpu/torchvision-0.7.0-cp36-cp36m-linux_x86_64.whl
 

--- a/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
+++ b/pytorch/inference/docker/1.6.0/py3/cu101/Dockerfile.gpu
@@ -104,8 +104,10 @@ RUN conda install -c \
  && /opt/conda/bin/conda config --set ssl_verify False \
  && pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
- && conda install -y -c pytorch torchserve==$TS_VERSION \
- && conda install -y -c pytorch torch-model-archiver==$TS_VERSION
+ && pip install packaging==20.4 \
+    enum-compat=0.0.3 \
+ && conda install -y -c pytorch torchserve=$TS_VERSION \
+ && conda install -y -c pytorch torch-model-archiver=$TS_VERSION
 
 # Uninstall and re-install torch and torchvision from the PyTorch website
 RUN pip uninstall -y torch \


### PR DESCRIPTION


## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.


**Bump version for Torchserve to 0.2.1**

This version of Torchserve has support for Naked Dirs which are required for MME support for SageMaker.

*Tests run:*

MME integration tests on SM.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

