### PR TITLE
[build] Make post_status function generic for all URLs

### DIFF
--- a/src/send_status.py
+++ b/src/send_status.py
@@ -67,7 +67,11 @@ def post_status(state):
     context = f"{trigger_job}_{project_name}"
     description = set_build_description(state, project_name, trigger_job)
 
-    handler = GitHubHandler()
+    # Example: "https://github.com/aws/deep-learning-containers.git"
+    repo_url = os.getenv("CODEBUILD_SOURCE_REPO_URL")
+    _, user, repo_name = repo_url.rstrip(".git").rsplit("/", 2)
+
+    handler = GitHubHandler(user, repo_name)
     handler.set_status(
         state=state,
         context=context,


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
The post_status() function did not consider repository name and user in the input to GithubHandler. Fixed by adding this information from CodeBuild Env Variables.

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

