### PR TITLE
[test] Pass canary tests when no release tags exist

### DIFF
--- a/src/send_status.py
+++ b/src/send_status.py
@@ -67,7 +67,11 @@ def post_status(state):
     context = f"{trigger_job}_{project_name}"
     description = set_build_description(state, project_name, trigger_job)
 
-    handler = GitHubHandler()
+    # Example: "https://github.com/aws/deep-learning-containers.git"
+    repo_url = os.getenv("CODEBUILD_SOURCE_REPO_URL")
+    _, user, repo_name = repo_url.rstrip(".git").rsplit("/", 2)
+
+    handler = GitHubHandler(user, repo_name)
     handler.set_status(
         state=state,
         context=context,

--- a/test/dlc_tests/sanity/test_canary_integration.py
+++ b/test/dlc_tests/sanity/test_canary_integration.py
@@ -31,5 +31,7 @@ def test_canary_images_pullable(region):
 
     images = parse_canary_images(framework, region)
     login_to_ecr_registry(ctx, PUBLIC_DLC_REGISTRY, region)
+    if not images:
+        return
     for image in images.split(" "):
         ctx.run(f"docker pull {image}", hide=True)

--- a/test/dlc_tests/sanity/test_canary_integration.py
+++ b/test/dlc_tests/sanity/test_canary_integration.py
@@ -31,5 +31,5 @@ def test_canary_images_pullable(region):
 
     images = parse_canary_images(framework, region)
     login_to_ecr_registry(ctx, PUBLIC_DLC_REGISTRY, region)
-    for image in images.split(" "):
+    for image in images:
         ctx.run(f"docker pull {image}", hide=True)

--- a/test/dlc_tests/sanity/test_canary_integration.py
+++ b/test/dlc_tests/sanity/test_canary_integration.py
@@ -31,5 +31,5 @@ def test_canary_images_pullable(region):
 
     images = parse_canary_images(framework, region)
     login_to_ecr_registry(ctx, PUBLIC_DLC_REGISTRY, region)
-    for image in images:
+    for image in images.split(" "):
         ctx.run(f"docker pull {image}", hide=True)

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -450,7 +450,7 @@ def parse_canary_images(framework, region):
     framework_versions = versions if len(versions) < 4 else versions[:3]
     dlc_images = ""
     for fw_version in framework_versions:
-        py_minor_version = '7' if framework == "tensorflow2" and fw_version == '2.2' else ''
+        py_minor_version = '7' if framework == "tensorflow2" and Version(fw_version) >= Version('2.2') else ''
         images = {
             "tensorflow1":
                 f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-training:{fw_version}-gpu-py3 "

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -400,7 +400,8 @@ def get_dlc_images():
     if is_pr_context() or is_empty_build_context():
         return os.getenv("DLC_IMAGES")
     elif is_canary_context():
-        return parse_canary_images(os.getenv("FRAMEWORK"), os.getenv("AWS_REGION"))
+        image_uris_list = parse_canary_images(os.getenv("FRAMEWORK"), os.getenv("AWS_REGION"))
+        return " ".join(image_uris_list)
     test_env_file = os.path.join(os.getenv("CODEBUILD_SRC_DIR_DLC_IMAGES_JSON"), "test_type_images.json")
     with open(test_env_file) as test_env:
         test_images = json.load(test_env)
@@ -416,7 +417,7 @@ def parse_canary_images(framework, region):
 
     :param framework: ML framework (mxnet, tensorflow, pytorch)
     :param region: AWS region
-    :return: dlc_images string (space separated string of image URIs)
+    :return: dlc_images list of image URIs
     """
     if framework == "tensorflow":
         if "tensorflow2" in os.getenv("CODEBUILD_BUILD_ID") or "tensorflow2" in os.getenv("CODEBUILD_INITIATOR"):
@@ -447,43 +448,47 @@ def parse_canary_images(framework, region):
     versions = sorted(versions, reverse=True)
 
     registry = PUBLIC_DLC_REGISTRY
-    framework_versions = versions if len(versions) < 4 else versions[:3]
-    dlc_images = ""
+    framework_versions = versions[:3]
+    dlc_images = []
     for fw_version in framework_versions:
-        py_minor_version = '7' if framework == "tensorflow2" and fw_version == '2.2' else ''
+        py_version = '37' if framework == "tensorflow2" and Version(fw_version) >= Version('2.2') else '3'
         images = {
             "tensorflow1":
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-training:{fw_version}-gpu-py3 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-training:{fw_version}-cpu-py3 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-training:{fw_version}-cpu-py2 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-training:{fw_version}-gpu-py2 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-inference:{fw_version}-gpu "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-inference:{fw_version}-cpu",
+                [
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-training:{fw_version}-gpu-py3",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-training:{fw_version}-cpu-py3",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-training:{fw_version}-cpu-py2",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-training:{fw_version}-gpu-py2",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-inference:{fw_version}-gpu",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-inference:{fw_version}-cpu",
+                ],
             "tensorflow2":
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-training:{fw_version}-gpu-py3{py_minor_version} "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-training:{fw_version}-cpu-py3{py_minor_version} "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-inference:{fw_version}-gpu "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-inference:{fw_version}-cpu",
-
+                [
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-training:{fw_version}-gpu-py{py_version}",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-training:{fw_version}-cpu-py{py_version}",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-inference:{fw_version}-gpu",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/tensorflow-inference:{fw_version}-cpu",
+                ],
             "mxnet":
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-training:{fw_version}-gpu-py3 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-training:{fw_version}-cpu-py3 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-training:{fw_version}-gpu-py2 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-training:{fw_version}-cpu-py2 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-inference:{fw_version}-gpu-py3 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-inference:{fw_version}-cpu-py3 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-inference:{fw_version}-gpu-py2 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-inference:{fw_version}-cpu-py2",
+                [
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-training:{fw_version}-gpu-py3",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-training:{fw_version}-cpu-py3",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-training:{fw_version}-gpu-py2",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-training:{fw_version}-cpu-py2",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-inference:{fw_version}-gpu-py3",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-inference:{fw_version}-cpu-py3",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-inference:{fw_version}-gpu-py2",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/mxnet-inference:{fw_version}-cpu-py2",
+                ],
             "pytorch":
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/pytorch-training:{fw_version}-gpu-py3 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/pytorch-training:{fw_version}-cpu-py3 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/pytorch-inference:{fw_version}-gpu-py3 "
-                f"{registry}.dkr.ecr.{region}.amazonaws.com/pytorch-inference:{fw_version}-cpu-py3"
+                [
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/pytorch-training:{fw_version}-gpu-py3",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/pytorch-training:{fw_version}-cpu-py3",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/pytorch-inference:{fw_version}-gpu-py3",
+                    f"{registry}.dkr.ecr.{region}.amazonaws.com/pytorch-inference:{fw_version}-cpu-py3",
+                ],
         }
-        if not dlc_images:
-            dlc_images = images[framework]
-        else:
-            dlc_images += f" {images[framework]}"
+        dlc_images += images[framework]
 
     return dlc_images
 


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
The canary test assumes that at least one release tag exists for each framework. The test should be able to run when there are no tags, as well.

*Tests run:*
Tested locally.

*DLC image/dockerfile:*
N/A

*Additional context:*
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

