### PR TITLE
use custom binary for kfctl client

### DIFF
--- a/test/dlc_tests/eks/eks_manifest_templates/kubeflow/install_kubeflow_custom_kfctl.sh
+++ b/test/dlc_tests/eks/eks_manifest_templates/kubeflow/install_kubeflow_custom_kfctl.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+set -e
+
+install_kfctl(){
+    #install kfctl cli
+    KFCTL_VERSION="v1.0.2"
+    S3_BUCKET="kfctl-binary"
+
+    if ! command -v kfctl &> /dev/null
+    then
+        aws s3 cp s3://${S3_BUCKET}/kfctl_${KFCTL_VERSION}-1-g93e95e1_linux.tar.gz /tmp/kfctl_${KFCTL_VERSION}_linux.tar.gz
+        tar -xvf /tmp/kfctl_${KFCTL_VERSION}_linux.tar.gz -C /tmp --strip-components=1
+        mv /tmp/kfctl /usr/local/bin
+    fi
+}
+
+setup_kubeflow(){
+    #install kubeflow in EKS cluster
+    local REGION=$1
+    KUBEFLOW_URL="https://raw.githubusercontent.com/aws/deep-learning-containers/master/test/dlc_tests/eks/eks_manifest_templates/kubeflow/kfctl_aws.yaml"
+    CONFIG_FILE=kfctl_aws.yaml
+    wget -O ${CONFIG_FILE} ${KUBEFLOW_URL} 
+    sed -i -e 's/<REGION>/'"$REGION"'/' ${CONFIG_FILE}
+    kfctl apply -V -f ${CONFIG_FILE}
+}
+
+install_mpi_operator() {
+    #install mpi operator in EKS cluster
+    MPI_OPERATOR_URL=https://raw.githubusercontent.com/kubeflow/mpi-operator/v0.2.3/deploy/v1alpha2/mpi-operator.yaml
+    wget -O mpi-operator.yaml ${MPI_OPERATOR_URL}
+    kubectl create -f mpi-operator.yaml
+}
+
+install_mxnet_operator() {
+    #install mxnet operator in EKS cluster
+    git clone https://github.com/kubeflow/mxnet-operator.git
+    kubectl create -k mxnet-operator/manifests/overlays/v1beta1/
+}
+
+create_dir(){
+    local EKS_CLUSTER_NAME=$1
+    DIRECTORY="$HOME/$EKS_CLUSTER_NAME"
+
+    if [ -d "$DIRECTORY" ]; then
+        rm -rf $DIRECTORY;
+    fi
+        
+    mkdir $DIRECTORY 
+    cd $DIRECTORY
+}
+
+if [ $# -ne 2 ]; then
+    echo $0: usage: ./install_kubeflow eks_cluster_name region_name
+    exit 1
+fi
+
+eks_cluster_name=$1
+region_name=$2
+
+echo "> Setup installation directory"
+create_dir $eks_cluster_name
+
+echo "> Installing kfctl"
+install_kfctl 
+
+echo "> Setting up kubeflow"
+setup_kubeflow $region_name
+
+echo "> Installing mxnet operator"
+install_mxnet_operator
+
+echo "> Installing mpi operator"
+install_mpi_operator
+
+echo "> Installation complete"

--- a/test/dlc_tests/eks/eks_manifest_templates/kubeflow/install_kubeflow_custom_kfctl.sh
+++ b/test/dlc_tests/eks/eks_manifest_templates/kubeflow/install_kubeflow_custom_kfctl.sh
@@ -4,7 +4,7 @@ set -e
 install_kfctl(){
     #install kfctl cli
     KFCTL_VERSION="v1.0.2"
-    S3_BUCKET="kfctl-binary"
+    S3_BUCKET="kubeflow-kfctl-binary"
 
     if ! command -v kfctl &> /dev/null
     then

--- a/test/test_utils/eks.py
+++ b/test/test_utils/eks.py
@@ -397,7 +397,7 @@ def setup_kubeflow(eks_cluster_name,region=os.getenv("AWS_REGION", DEFAULT_REGIO
         "eks",
         "eks_manifest_templates",
         "kubeflow",
-        "install_kubeflow.sh"
+        "install_kubeflow_custom_kfctl.sh"
     )
 
     run(f"chmod +x {local_template_file_path}")


### PR DESCRIPTION
*Issues:*
- kfctl issue [5245](https://github.com/kubeflow/kubeflow/issues/5245)
- PR [kfctl/401](https://github.com/kubeflow/kfctl/pull/401)

*Description:*
- kfctl fails to install kubeflow as it is unable to download the kubeflow v1.0.2 tar file.
- Untill the PR [kfctl/401](https://github.com/kubeflow/kfctl/pull/401) is merged and the changes are released on kfctl repo, we will use the custom kfctl binary provided by @Jeffwan that consumes the PR [kfctl/401](https://github.com/kubeflow/kfctl/pull/401)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.