### PR TITLE
[test][sagemaker] Remove defaults from fw version to avoid confusion

### DIFF
--- a/test/sagemaker_tests/mxnet/inference/conftest.py
+++ b/test/sagemaker_tests/mxnet/inference/conftest.py
@@ -35,7 +35,7 @@ SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 def pytest_addoption(parser):
     parser.addoption('--docker-base-name', default='preprod-mxnet-serving')
     parser.addoption('--region', default='us-west-2')
-    parser.addoption('--framework-version', default=MXNet.LATEST_VERSION)
+    parser.addoption('--framework-version', default='')
     parser.addoption('--py-version', default='3', choices=['2', '3', '2,3'])
     parser.addoption('--processor', default='cpu', choices=['gpu', 'cpu', 'cpu,gpu', 'eia'])
     parser.addoption('--aws-id', default=None)

--- a/test/sagemaker_tests/mxnet/training/conftest.py
+++ b/test/sagemaker_tests/mxnet/training/conftest.py
@@ -38,7 +38,7 @@ def pytest_addoption(parser):
     parser.addoption('--docker-base-name', default='preprod-mxnet')
     parser.addoption('--region', default='us-west-2')
     parser.addoption('--instance-count', default='1,2', choices=['1', '2', '1,2'])
-    parser.addoption('--framework-version', default=MXNet.LATEST_VERSION)
+    parser.addoption('--framework-version', default='')
     parser.addoption('--py-version', default='3', choices=['2', '3', '2,3'])
     parser.addoption('--processor', default='cpu', choices=['gpu', 'cpu', 'cpu,gpu'])
     parser.addoption('--aws-id', default=None)

--- a/test/sagemaker_tests/pytorch/inference/conftest.py
+++ b/test/sagemaker_tests/pytorch/inference/conftest.py
@@ -52,7 +52,7 @@ def pytest_addoption(parser):
     parser.addoption('--accelerator-type', default=None)
     parser.addoption('--docker-base-name', default='pytorch')
     parser.addoption('--region', default='us-west-2')
-    parser.addoption('--framework-version', default=PyTorch.LATEST_VERSION)
+    parser.addoption('--framework-version', default='')
     parser.addoption('--py-version', choices=['2', '3'], default=str(sys.version_info.major))
     # Processor is still "cpu" for EIA tests
     parser.addoption('--processor', choices=['gpu', 'cpu', 'eia'], default='cpu')

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -53,7 +53,7 @@ def pytest_addoption(parser):
     parser.addoption('--instance-type')
     parser.addoption('--docker-base-name', default='pytorch')
     parser.addoption('--region', default='us-west-2')
-    parser.addoption('--framework-version', default=PyTorch.LATEST_VERSION)
+    parser.addoption('--framework-version', default='')
     parser.addoption('--py-version', choices=['2', '3'], default=str(sys.version_info.major))
     parser.addoption('--processor', choices=['gpu', 'cpu'], default='cpu')
     # If not specified, will default to {framework-version}-{processor}-py{py-version}

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/conftest.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/conftest.py
@@ -36,7 +36,7 @@ def pytest_addoption(parser):
     parser.addoption('--docker-base-name', default='sagemaker-tensorflow-scriptmode')
     parser.addoption('--tag', default=None)
     parser.addoption('--region', default='us-west-2')
-    parser.addoption('--framework-version', default=TensorFlow.LATEST_VERSION)
+    parser.addoption('--framework-version', default='')
     parser.addoption('--processor', default='cpu', choices=['cpu', 'gpu', 'cpu,gpu'])
     parser.addoption('--py-version', default='3', choices=['2', '3', '2,3', '37'])
     parser.addoption('--account-id', default='142577830533')

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/conftest.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/conftest.py
@@ -36,7 +36,7 @@ def pytest_addoption(parser):
     parser.addoption('--docker-base-name', default='sagemaker-tensorflow-scriptmode')
     parser.addoption('--tag', default=None)
     parser.addoption('--region', default='us-west-2')
-    parser.addoption('--framework-version', default=TensorFlow.LATEST_VERSION)
+    parser.addoption('--framework-version', default='')
     parser.addoption('--processor', default='cpu', choices=['cpu', 'gpu', 'cpu,gpu'])
     parser.addoption('--py-version', default='3', choices=['2', '3', '2,3', '37'])
     parser.addoption('--account-id', default='142577830533')


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
We are currently not using the framework version options, but it can be confusing in terms of defaults. Removing for now to avoid any confusion.

*Tests run:*
Run SM tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

