### PR TITLE
[tensorflow] [test] [ec2, ecs] update tensorboard tests to handle cases for tf < 2.2

### DIFF
--- a/test/dlc_tests/container_tests/bin/testTensorBoard
+++ b/test/dlc_tests/container_tests/bin/testTensorBoard
@@ -8,7 +8,13 @@ LOG_DIR=/logs/train/plugins/profile
 
 python ${BIN_DIR}/testTensorBoard.py || exit 1
 
-LOG_RESULT=$(find $LOG_DIR -name "*.pb")
+# profiler: tf > 2.* and < 2.2 generates local.trace where as tf > 2.2 generates *.pb
+if [[ $(python -c 'import tensorflow as tf; print(tf.__version__)') < 2.2 ]]; then
+    LOG_RESULT=$(find $PROFILER_LOG_DIR -name "local.trace")
+else
+    LOG_RESULT=$(find $PROFILER_LOG_DIR -name "*.pb")
+fi
+
 echo "Checking the logs result: $LOG_RESULT"
 
 [ -z "$LOG_RESULT" ] && echo "Cannot find Profiler logs!" && exit 1

--- a/test/dlc_tests/container_tests/bin/testTensorFlow
+++ b/test/dlc_tests/container_tests/bin/testTensorFlow
@@ -32,14 +32,18 @@ python ${BIN_DIR}/testTensorflow.py >$TRAINING_LOG 2>&1
 RETURN_VAL=`echo $?`
 set -e
 
-echo "Verify tensorfolow profiler can generate logs."
-LOG_RESULT=$(find $PROFILER_LOG_DIR -name "*.pb")
+echo "Verify tensorflow profiler can generate logs."
+
+# profiler: tf > 2.* and < 2.2 generates local.trace where as tf > 2.2 generates *.pb
+if [[ $(python -c 'import tensorflow as tf; print(tf.__version__)') < 2.2 ]]; then
+    LOG_RESULT=$(find $PROFILER_LOG_DIR -name "local.trace")
+else
+    LOG_RESULT=$(find $PROFILER_LOG_DIR -name "*.pb")
+fi
+
 echo "Checking the logs result: $LOG_RESULT"
 
-# Will only generage log files for 2.x
-if [[ $(python -c 'import tensorflow as tf; print(tf.__version__)') == 2.*.* ]]; then
-    [ -z "$LOG_RESULT" ] && echo "Cannot find Profiler logs!" && exit 1
-fi
+[ -z "$LOG_RESULT" ] && echo "Cannot find Profiler logs!" && exit 1
 
 if [ ${RETURN_VAL} -eq 0 ]; then
     echo "Training mnist Complete using $KERAS_BACKEND."


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### EIA/NEURON Checklist
* When creating a PR:
- [ ] I've modified `src/config/build_config.py` in my PR branch by setting `ENABLE_EI_MODE = True` or `ENABLE_NEURON_MODE = True`
* When PR is reviewed and ready to be merged:
- [ ] I've reverted the code change on the config file mentioned above
#### Benchmark Checklist
* When creating a PR:
- [ ] I've modified `src/config/test_config.py` in my PR branch by setting `ENABLE_BENCHMARK_DEV_MODE = True`
* When PR is reviewed and ready to be merged:
- [ ] I've reverted the code change on the config file mentioned above

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*
updated the scripts to handle tensorboard test failures on 2.1
The current tests look for all *.pb files in tf 2.*. The tensorboard profiler doesn't generated protobuf files in versions < 2.2

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

