### PR TITLE
[release] release tf-1.15 training images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -102,6 +102,29 @@ release_images:
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
   8:
+    framework: "tensorflow"
+    version: "1.15.3"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py37", "py36", "py27"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu100"
+      example: False        
+      disable_sm_tag: False             
+      force_release: False  
+                    
+  9:
+    framework: "tensorflow"
+    version: "1.15.3"
+    training:
+      device_types: ["gpu"]
+      python_versions: ["py37", "py36"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu100"
+      example: True
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  10:
     framework: "mxnet"
     version: "1.6.0"
     training:
@@ -122,7 +145,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  9:
+  11:
     framework: "mxnet"
     version: "1.6.0"
     training:

--- a/release_images.yml
+++ b/release_images.yml
@@ -112,7 +112,6 @@ release_images:
       example: False        
       disable_sm_tag: False             
       force_release: False  
-                    
   9:
     framework: "tensorflow"
     version: "1.15.3"


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
- Release TF-1.15 Training images for CPU/GPU and python version: py27, py36 and py37
 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

