### PR TITLE
[test] increase timer for test_batch_transform test

### DIFF
--- a/test/sagemaker_tests/tensorflow/inference/test/integration/sagemaker/util.py
+++ b/test/sagemaker_tests/tensorflow/inference/test/integration/sagemaker/util.py
@@ -235,7 +235,7 @@ def run_batch_transform_job(region, boto_session, model_data, image_uri,
                sagemaker_client=sagemaker_client,
                model_name=model_name,
                poll=5, # seconds
-               timeout=300) # seconds
+               timeout=600) # seconds
 
 
 def invoke_endpoint(sagemaker_runtime_client, endpoint_name, input_data):


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
SM test: test_batch_transform times out after the set timeout of 300 sec. Increasing the timeout to 600 for longer running jobs.

*Tests run:*
- test_batch_transform


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

