### PR TITLE
[release] release MXNET-1.7 training/inference images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -102,6 +102,28 @@ release_images:
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
   8:
+    framework: "tensorflow"
+    version: "1.15.3"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py37", "py36", "py27"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu100"
+      example: False        
+      disable_sm_tag: False             
+      force_release: False  
+  9:
+    framework: "tensorflow"
+    version: "1.15.3"
+    training:
+      device_types: ["gpu"]
+      python_versions: ["py37", "py36"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu100"
+      example: True
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  10:
     framework: "mxnet"
     version: "1.6.0"
     training:
@@ -122,7 +144,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  9:
+  11:
     framework: "mxnet"
     version: "1.6.0"
     training:
@@ -133,3 +155,35 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
+  12:
+      framework: "mxnet"
+      version: "1.7.0"
+      training:
+        device_types: ["cpu", "gpu"]
+        python_versions: ["py36"]
+        os_version: "ubuntu16.04"
+        cuda_version: "cu101"
+        example: False        # [Default: False] Set to True to denote that this image is an Example image
+        disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
+                              # to images being published.
+        force_release: False  # [Default: False] Set to True to force images to be published even if the same image
+                              # has already been published. Re-released image will have minor version incremented by 1.
+      inference:
+        device_types: ["cpu", "gpu"]
+        python_versions: ["py36"]
+        os_version: "ubuntu16.04"
+        cuda_version: "cu101"
+        example: False
+        disable_sm_tag: False
+        force_release: False
+    13:
+      framework: "mxnet"
+      version: "1.7.0"
+      training:
+        device_types: ["gpu"]
+        python_versions: ["py36"]
+        os_version: "ubuntu16.04"
+        cuda_version: "cu101"
+        example: True
+        disable_sm_tag: False  # [Default: False] This option is not used by Example images
+        force_release: False


### PR DESCRIPTION
## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
- Release MXNET-1.7 Training/Inference images for CPU/GPU with
   - py36
   - UL16.04 
   - cu101

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.