### PR TITLE
[test][sanity] Update safety test to return empty list

### DIFF
--- a/test/dlc_tests/sanity/test_safety_check.py
+++ b/test/dlc_tests/sanity/test_safety_check.py
@@ -80,13 +80,14 @@ def _get_safety_ignore_list(image_uri):
     python_version = "py2" if "py2" in image_uri else "py3"
 
     # TODO: Remove each if condition on each subsequent release
+    additional_skips = []
     if is_canary_context():
         if (framework == "tensorflow" and "2.1" in image_uri) or \
                 (framework == "pytorch" and "1.4" in image_uri) or \
                 (framework == "pytorch" and job_type == "training" and "1.5" in image_uri):
-            IGNORE_SAFETY_IDS[framework][job_type]["py3"].append('38414')
+            additional_skips.append('38414')
 
-    return IGNORE_SAFETY_IDS.get(framework, {}).get(job_type, {}).get(python_version)
+    return IGNORE_SAFETY_IDS.get(framework, {}).get(job_type, {}).get(python_version, []) + additional_skips
 
 
 def _get_latest_package_version(docker_exec_cmd, package, num_tries=3):


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
- Update canary logic to add additional skips without updating the global IGNORE_SAFETY_IDS


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

