### PR TITLE
[release][test][sagemaker] Update release images and no p2 regions

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -159,14 +159,14 @@ release_images:
     framework: "mxnet"
     version: "1.7.0"
     training:
-      device_types: ["cpu", "gpu"]
+      device_types: ["gpu"]
       python_versions: ["py36"]
       os_version: "ubuntu16.04"
       cuda_version: "cu101"
       example: False        # [Default: False] Set to True to denote that this image is an Example image
       disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
                             # to images being published.
-      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
+      force_release: True  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
     inference:
       device_types: ["cpu", "gpu"]

--- a/test/sagemaker_tests/mxnet/inference/integration/__init__.py
+++ b/test/sagemaker_tests/mxnet/inference/integration/__init__.py
@@ -25,7 +25,7 @@ EI_SUPPORTED_REGIONS = ['us-east-1', 'us-east-2', 'us-west-2', 'eu-west-1', 'ap-
 
 # These regions have some p2 and p3 instances, but not enough for automated testing
 NO_P2_REGIONS = ['ca-central-1', 'eu-central-1', 'eu-west-2', 'us-west-1', 'eu-west-3',
-                 'eu-north-1', 'sa-east-1', 'ap-east-1', 'me-south-1', 'cn-northwest-1']
+                 'eu-north-1', 'sa-east-1', 'ap-east-1', 'me-south-1', 'cn-northwest-1', 'us-west-2']
 NO_P3_REGIONS = ['ap-southeast-1', 'ap-southeast-2', 'ap-south-1', 'ca-central-1',
                  'eu-central-1', 'eu-west-2', 'us-west-1', 'eu-west-3', 'eu-north-1',
                  'sa-east-1', 'ap-east-1', 'me-south-1', 'cn-northwest-1']

--- a/test/sagemaker_tests/mxnet/training/integration/__init__.py
+++ b/test/sagemaker_tests/mxnet/training/integration/__init__.py
@@ -28,6 +28,7 @@ NO_P2_REGIONS = [
     'ap-east-1',
     'me-south-1',
     'cn-northwest-1',
+    'us-west-2'
 ]
 
 MODEL_SUCCESS_FILES = {


### PR DESCRIPTION
*Issue #, if available:*

## Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
- Adding PDX to no p2 regions due to low instance availability


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

