### PR TITLE
[test] Skip TF mnist training test temporarily

### DIFF
--- a/test/dlc_tests/ec2/tensorflow/training/test_tensorflow_training.py
+++ b/test/dlc_tests/ec2/tensorflow/training/test_tensorflow_training.py
@@ -44,6 +44,7 @@ def test_tensorflow_train_mnist_gpu(tensorflow_training, ec2_connection, gpu_onl
     execute_ec2_training_test(ec2_connection, tensorflow_training, TF_MNIST_CMD)
 
 
+@pytest.mark.skip(reason="Temporarily skip test due to timeout on small instance types")
 @pytest.mark.model("mnist")
 @pytest.mark.parametrize("ec2_instance_type", TF_EC2_CPU_INSTANCE_TYPE, indirect=True)
 def test_tensorflow_train_mnist_cpu(tensorflow_training, ec2_connection, cpu_only):


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | 

*Description:*
Skip the TF mnist training test temporarily due to timeout on small instance types.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

