### PR TITLE
[test] Skip smdebug test on TF2 m4.16x

### DIFF
--- a/test/dlc_tests/ec2/test_smdebug.py
+++ b/test/dlc_tests/ec2/test_smdebug.py
@@ -32,8 +32,8 @@ def test_smdebug_gpu(training, ec2_connection, region, gpu_only, py3_only):
 @pytest.mark.parametrize("ec2_instance_type", SMDEBUG_EC2_CPU_INSTANCE_TYPE, indirect=True)
 def test_smdebug_cpu(training, ec2_connection, region, cpu_only, py3_only):
     # TODO: Remove this once test timeout has been debugged (failures especially on m4.16xlarge)
-    if is_tf2(training) and "2.3.0" in training and "m4.16xlarge" in SMDEBUG_EC2_CPU_INSTANCE_TYPE:
-        pytest.skip("Currently skipping for TF2.3.0 on m4.16xlarge until the issue is fixed")
+    if is_tf2(training) and "m4.16xlarge" in SMDEBUG_EC2_CPU_INSTANCE_TYPE:
+        pytest.skip("Currently skipping for TF2 on m4.16xlarge until the issue is fixed")
     if is_tf1(training):
         pytest.skip("Currently skipping for TF1 until the issue is fixed")
     run_smdebug_test(training, ec2_connection, region)


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
Test issue from #609 also observed on tf2.2, skipping smdebug on m4.16x for TF2 for now.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

