### PR TITLE
[release] Update release for TF2 cu102 images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -52,12 +52,20 @@ release_images:
       device_types: ["cpu", "gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
-      cuda_version: "cu101"
+      cuda_version: "cu102"
       example: False        # [Default: False] Set to True to denote that this image is an Example image
       disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py37"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu102"
+      example: False
+      disable_sm_tag: False
+      force_release: False
   5:
     framework: "tensorflow"
     version: "2.2.0"
@@ -65,7 +73,7 @@ release_images:
       device_types: ["gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
-      cuda_version: "cu101"
+      cuda_version: "cu102"
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False

--- a/test/dlc_tests/ec2/test_smdebug.py
+++ b/test/dlc_tests/ec2/test_smdebug.py
@@ -32,8 +32,8 @@ def test_smdebug_gpu(training, ec2_connection, region, gpu_only, py3_only):
 @pytest.mark.parametrize("ec2_instance_type", SMDEBUG_EC2_CPU_INSTANCE_TYPE, indirect=True)
 def test_smdebug_cpu(training, ec2_connection, region, cpu_only, py3_only):
     # TODO: Remove this once test timeout has been debugged (failures especially on m4.16xlarge)
-    if is_tf2(training) and "2.3.0" in training and "m4.16xlarge" in SMDEBUG_EC2_CPU_INSTANCE_TYPE:
-        pytest.skip("Currently skipping for TF2.3.0 on m4.16xlarge until the issue is fixed")
+    if is_tf2(training) and "m4.16xlarge" in SMDEBUG_EC2_CPU_INSTANCE_TYPE:
+        pytest.skip("Currently skipping for TF2 on m4.16xlarge until the issue is fixed")
     if is_tf1(training):
         pytest.skip("Currently skipping for TF1 until the issue is fixed")
     run_smdebug_test(training, ec2_connection, region)


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
Add tf2.2 cu102 images for release, as well as add back inference images to the release images yml

*Tests run:*
Locally ran linter

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

