### PR TITLE
[mxnet][build] Return buildspec back to 1.7.0 for MXNet

### DIFF
--- a/mxnet/buildspec.yml
+++ b/mxnet/buildspec.yml
@@ -1,7 +1,7 @@
   account_id: &ACCOUNT_ID <set-$ACCOUNT_ID-in-environment>
   region: &REGION <set-$REGION-in-environment>
   framework: &FRAMEWORK mxnet
-  version: &VERSION 1.6.0
+  version: &VERSION 1.7.0
   cuda_version: &CUDA_VERSION cu101
   os_version: &OS_VERSION ubuntu16.04
 


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
- We had briefly updated mxnet buildspec to 1.6. This PR is to change it back.

*Tests run:*
PR tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

