### PR TITLE
[release] Add TF 2.1.1 training to release_images.yml

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -132,6 +132,28 @@ release_images:
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
   10:
+    framework: "tensorflow"
+    version: "2.1.1"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py36"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu101"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  11:
+    framework: "tensorflow"
+    version: "2.1.1"
+    training:
+      device_types: ["gpu"]
+      python_versions: ["py36"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu101"
+      example: True
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  12:
     framework: "mxnet"
     version: "1.6.0"
     training:
@@ -152,7 +174,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  11:
+  13:
     framework: "mxnet"
     version: "1.6.0"
     training:
@@ -163,7 +185,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  12:
+  14:
     framework: "mxnet"
     version: "1.7.0"
     training:
@@ -184,7 +206,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  13:
+  15:
     framework: "mxnet"
     version: "1.7.0"
     training:


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
Add TF 2.1.1 to list of image types to be released on release_images.yml

*Tests run:*
Ran local yaml linting tool

*DLC image/dockerfile:*
N/A

*Additional context:*
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

