### PR TITLE
[test][canary] Remove canary that uses safety-check tool

### DIFF
--- a/test/dlc_tests/sanity/test_safety_check.py
+++ b/test/dlc_tests/sanity/test_safety_check.py
@@ -111,7 +111,6 @@ def _get_latest_package_version(docker_exec_cmd, package, num_tries=3):
 
 
 @pytest.mark.model("N/A")
-@pytest.mark.canary("Run safety tests regularly on production images")
 @pytest.mark.skipif(not is_dlc_cicd_context(), reason="Skipping test because it is not running in dlc cicd infra")
 def test_safety(image):
     """


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
Removing safety-check tool from canary tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

