### PR TITLE
[release] [tensorflow] Add TF 2.2.1 training to release_images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -47,33 +47,25 @@ release_images:
       # has already been published. Re-released image will have minor version incremented by 1.
   4:
     framework: "tensorflow"
-    version: "2.2.0"
+    version: "2.2.1"
     training:
       device_types: ["cpu", "gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
-      cuda_version: "cu102"
+      cuda_version: "cu101"
       example: False        # [Default: False] Set to True to denote that this image is an Example image
       disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
-    inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py37"]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu102"
-      example: False
-      disable_sm_tag: False
-      force_release: False
   5:
     framework: "tensorflow"
-    version: "2.2.0"
+    version: "2.2.1"
     training:
       device_types: ["gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
-      cuda_version: "cu102"
+      cuda_version: "cu101"
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False

--- a/release_images.yml
+++ b/release_images.yml
@@ -49,14 +49,14 @@ release_images:
     framework: "tensorflow"
     version: "2.2.1"
     training:
-      device_types: ["gpu"]
+      device_types: ["cpu", "gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
       cuda_version: "cu101"
       example: False        # [Default: False] Set to True to denote that this image is an Example image
       disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
                             # to images being published.
-      force_release: True  # [Default: False] Set to True to force images to be published even if the same image
+      force_release: True   # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
   5:
     framework: "tensorflow"

--- a/release_images.yml
+++ b/release_images.yml
@@ -56,7 +56,7 @@ release_images:
       example: False        # [Default: False] Set to True to denote that this image is an Example image
       disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
                             # to images being published.
-      force_release: True   # [Default: False] Set to True to force images to be published even if the same image
+      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
   5:
     framework: "tensorflow"


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
Add TensorFlow 2.2.1 to release_images.yml, and remove TensorFlow 2.2.0

*Tests run:*
N/A

*DLC image/dockerfile:*
N/A

*Additional context:*
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

