### PR TITLE
[test] [tensorflow] Increase minimum version for major version test

### DIFF
--- a/test/dlc_tests/sanity/test_dlc_labels.py
+++ b/test/dlc_tests/sanity/test_dlc_labels.py
@@ -68,7 +68,7 @@ def test_dlc_major_version_dockerfiles(image):
     root_dir = os.path.join(dlc_dir, framework, job_type, "docker")
 
     # Skip older FW versions that did not use this versioning scheme
-    references = {"tensorflow2": "2.3.0", "tensorflow1": "1.16.0", "mxnet": "1.7.0", "pytorch": "1.5.0"}
+    references = {"tensorflow2": "2.4.0", "tensorflow1": "1.16.0", "mxnet": "1.7.0", "pytorch": "1.5.0"}
     if test_utils.is_tf1(image):
         reference_fw = "tensorflow1"
     elif test_utils.is_tf2(image):


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
Increase the major version number for TensorFlow 2 images on the `test_dlc_major_version_dockerfiles` test so that TensorFlow 2.3.1 images can be maintained alongside TensorFlow 2.3.0.

*Tests run:*
Tested by running
```
python -m pytest -s -rA sanity/test_dlc_labels.py::test_dlc_major_version_dockerfiles
```
locally with TensorFlow 2.3.1 image URIs

*DLC image/dockerfile:*
N/A

*Additional context:*
None


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

