### PR TITLE
[mxnet][pytorch] Updated urllib3 to v1.25.10 because of security issue in v1.25.8

### DIFF
--- a/mxnet/training/docker/1.6.0/py2/Dockerfile.cpu
+++ b/mxnet/training/docker/1.6.0/py2/Dockerfile.cpu
@@ -109,7 +109,8 @@ RUN pip install --no-cache --upgrade \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     scipy==1.2.2 \
-    urllib3==1.25.8 \
+    # Putting a cap in versions number to avoid potential issues with a new major version
+    "urllib3>=1.25.10,<1.26.0" \
     python-dateutil==2.8.0 \
     mpi4py==3.0.2 \
     ${MX_URL} \

--- a/mxnet/training/docker/1.6.0/py2/cu101/Dockerfile.gpu
+++ b/mxnet/training/docker/1.6.0/py2/cu101/Dockerfile.gpu
@@ -150,7 +150,8 @@ RUN pip install --no-cache-dir --upgrade \
     requests==2.22.0 \
     scikit-learn==0.20.4 \
     scipy==1.2.2 \
-    urllib3==1.25.8 \
+    # Putting a cap in versions number to avoid potential issues with a new major version
+    "urllib3>=1.25.10,<1.26.0" \
     python-dateutil==2.8.0 \
     mpi4py==3.0.2 \
     ${MX_URL} \

--- a/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
+++ b/mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
@@ -132,7 +132,8 @@ RUN ${PIP} install --no-cache --upgrade \
     scipy==1.2.2 \
     gluonnlp==0.10.0 \
     gluoncv==0.6.0 \
-    urllib3==1.25.8 \
+    # Putting a cap in versions number to avoid potential issues with a new major version
+    "urllib3>=1.25.10,<1.26.0" \
     python-dateutil==2.8.0 \
     tqdm==4.39.0 \
     sagemaker-experiments==0.* \

--- a/mxnet/training/docker/1.6.0/py3/cu101/Dockerfile.gpu
+++ b/mxnet/training/docker/1.6.0/py3/cu101/Dockerfile.gpu
@@ -174,7 +174,8 @@ RUN ${PIP} install --no-cache --upgrade \
     dgl-cu101==0.4.* \
     gluonnlp==0.10.0 \
     gluoncv==0.6.0 \
-    urllib3==1.25.8 \
+    # Putting a cap in versions number to avoid potential issues with a new major version
+    "urllib3>=1.25.10,<1.26.0" \
     python-dateutil==2.8.0 \
     tqdm==4.39.0 \
     sagemaker-experiments==0.* \

--- a/mxnet/training/docker/1.7.0/py3/Dockerfile.cpu
+++ b/mxnet/training/docker/1.7.0/py3/Dockerfile.cpu
@@ -132,7 +132,8 @@ RUN ${PIP} install --no-cache --upgrade \
     scipy==1.2.2 \
     gluonnlp==0.10.0 \
     gluoncv==0.6.0 \
-    urllib3==1.25.8 \
+    # Putting a cap in versions number to avoid potential issues with a new major version
+    "urllib3>=1.25.10,<1.26.0" \
     python-dateutil==2.8.0 \
     tqdm==4.39.0 \
     sagemaker-experiments==0.* \

--- a/mxnet/training/docker/1.7.0/py3/cu101/Dockerfile.gpu
+++ b/mxnet/training/docker/1.7.0/py3/cu101/Dockerfile.gpu
@@ -174,7 +174,8 @@ RUN ${PIP} install --no-cache --upgrade \
     dgl-cu101==0.4.* \
     gluonnlp==0.10.0 \
     gluoncv==0.6.0 \
-    urllib3==1.25.8 \
+    # Putting a cap in versions number to avoid potential issues with a new major version
+    "urllib3>=1.25.10,<1.26.0" \
     python-dateutil==2.8.0 \
     tqdm==4.39.0 \
     sagemaker-experiments==0.* \

--- a/pytorch/inference/docker/1.4.0/py2/Dockerfile.cpu
+++ b/pytorch/inference/docker/1.4.0/py2/Dockerfile.cpu
@@ -87,7 +87,8 @@ RUN pip install --no-cache-dir "sagemaker-pytorch-inference<2"
 RUN curl https://aws-dlc-licenses.s3.amazonaws.com/pytorch-1.4.0/license.txt -o /license.txt
 
 RUN conda install -y -c conda-forge pyyaml==5.3.1
-RUN pip install -U pillow==6.2.2 urllib3==1.25.8 awscli
+# Putting a cap in urllib3's versions number to avoid potential issues with a new major version
+RUN pip install -U pillow==6.2.2 "urllib3>=1.25.10,<1.26.0" awscli
 
 EXPOSE 8080 8081
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]

--- a/pytorch/inference/docker/1.4.0/py2/cu101/Dockerfile.gpu
+++ b/pytorch/inference/docker/1.4.0/py2/cu101/Dockerfile.gpu
@@ -110,7 +110,8 @@ RUN pip install --no-cache-dir "sagemaker-pytorch-inference<2"
 RUN curl https://aws-dlc-licenses.s3.amazonaws.com/pytorch-1.4.0/license.txt -o /license.txt
 
 RUN conda install -y -c conda-forge pyyaml==5.3.1
-RUN pip install -U pillow==6.2.2 urllib3==1.25.8 awscli
+# Putting a cap in urllib3's versions number to avoid potential issues with a new major version
+RUN pip install -U pillow==6.2.2 "urllib3>=1.25.10,<1.26.0" awscli
 
 EXPOSE 8080 8081
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
updated urllib3 to v1.25.10 because of security issue in v1.25.8

*Tests run:*
executed locally

*DLC image/dockerfile:*
mxnet/training/docker/1.6.0/py2/Dockerfile.cpu
mxnet/training/docker/1.6.0/py2/cu101/Dockerfile.gpu
mxnet/training/docker/1.6.0/py3/Dockerfile.cpu
mxnet/training/docker/1.6.0/py3/cu101/Dockerfile.gpu
mxnet/training/docker/1.6.0/py3/herring/cu101/Dockerfile.gpu
mxnet/training/docker/1.7.0/py3/Dockerfile.cpu
mxnet/training/docker/1.7.0/py3/cu101/Dockerfile.gpu
pytorch/inference/docker/1.4.0/py2/Dockerfile.cpu
pytorch/inference/docker/1.4.0/py2/cu101/Dockerfile.gpu

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

