### PR TITLE
[smdebug][testing]Fixed smdebug memory issue

### DIFF
--- a/test/dlc_tests/ec2/test_smdebug.py
+++ b/test/dlc_tests/ec2/test_smdebug.py
@@ -53,7 +53,7 @@ def run_smdebug_test(
     ec2_connection.run(f"$(aws ecr get-login --no-include-email --region {region})", hide=True)
 
     ec2_connection.run(
-        f"{docker_executable} run --name {container_name} -v "
+        f"{docker_executable} run --shm-size=1g --name {container_name} -v "
         f"{container_test_local_dir}:{os.path.join(os.sep, 'test')} -itd {image_uri}",
         hide=True,
     )

--- a/test/dlc_tests/ec2/test_smdebug.py
+++ b/test/dlc_tests/ec2/test_smdebug.py
@@ -23,7 +23,8 @@ def test_smdebug_gpu(training, ec2_connection, region, gpu_only, py3_only):
         pytest.skip("Currently skipping for TF2.3.0 on p2.8xlarge until the issue is fixed")
     if is_tf1(training):
         pytest.skip("Currently skipping for TF1 until the issue is fixed")
-    run_smdebug_test(training, ec2_connection, region, docker_executable="nvidia-docker", container_name="smdebug-gpu")
+    run_smdebug_test(training, ec2_connection, region, docker_executable="nvidia-docker", container_name="smdebug-gpu",
+                     is_large_shm="p2.8xlarge" in SMDEBUG_EC2_GPU_INSTANCE_TYPE)
 
 
 @pytest.mark.flaky(reruns=0)
@@ -47,13 +48,15 @@ def run_smdebug_test(
     container_name="smdebug",
     test_script=SMDEBUG_SCRIPT,
     logfile="output.log",
+    is_large_shm=False
 ):
     framework = get_framework_from_image_uri(image_uri)
     container_test_local_dir = os.path.join("$HOME", "container_tests")
     ec2_connection.run(f"$(aws ecr get-login --no-include-email --region {region})", hide=True)
 
+    shm_setting = '--shm-size=1g' if is_large_shm else ""
     ec2_connection.run(
-        f"{docker_executable} run --shm-size=1g --name {container_name} -v "
+        f"{docker_executable} run {shm_setting} --name {container_name} -v "
         f"{container_test_local_dir}:{os.path.join(os.sep, 'test')} -itd {image_uri}",
         hide=True,
     )


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the tests I've run on the DLC image

*Description:*
 increasing the size of the /dev/shm in docker container since a lower amount of the shared memory leads to false failures of the smdebug tests
*Tests run:*
Executed locally for p2.8xl and p3.8xl



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

