### PR TITLE
[release] [tensorflow] Set TF 2.3.1 cuda version to 11.0

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -73,7 +73,7 @@ release_images:
     framework: "tensorflow"
     version: "2.3.1"
     training:
-      device_types: ["cpu", "gpu"]
+      device_types: ["gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
       cuda_version: "cu110"

--- a/release_images.yml
+++ b/release_images.yml
@@ -78,7 +78,7 @@ release_images:
       os_version: "ubuntu18.04"
       cuda_version: "cu110"
       example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: False  # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
+      disable_sm_tag: True  # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
       # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.

--- a/release_images.yml
+++ b/release_images.yml
@@ -76,7 +76,7 @@ release_images:
       device_types: ["cpu", "gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
-      cuda_version: "cu102"
+      cuda_version: "cu110"
       example: False        # [Default: False] Set to True to denote that this image is an Example image
       disable_sm_tag: False  # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
       # to images being published.
@@ -89,7 +89,7 @@ release_images:
       device_types: ["gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
-      cuda_version: "cu102"
+      cuda_version: "cu110"
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
Set the CUDA version for TF 2.3.1 images to 11.0 in release_images.yml

*Tests run:*
N/A

*DLC image/dockerfile:*
https://github.com/aws/deep-learning-containers/blob/master/tensorflow/training/docker/2.3.1/py3/cu110/Dockerfile.gpu

*Additional context:*
https://github.com/aws/deep-learning-containers/pull/635

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

