### PR TITLE
[test][tensorflow][ecs, eks] Enable BERT/FasterRCNN tests in nightly

### DIFF
--- a/test/dlc_tests/ecs/tensorflow/training/test_ecs_tensorflow_training.py
+++ b/test/dlc_tests/ecs/tensorflow/training/test_ecs_tensorflow_training.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 
-from test.test_utils import ECS_AML2_CPU_USWEST2, ECS_AML2_GPU_USWEST2, CONTAINER_TESTS_PREFIX
+from test.test_utils import ECS_AML2_CPU_USWEST2, ECS_AML2_GPU_USWEST2, CONTAINER_TESTS_PREFIX, is_nightly_context
 from test.test_utils import ecs as ecs_utils
 from test.test_utils import ec2 as ec2_utils
 
@@ -50,7 +50,7 @@ def test_ecs_tensorflow_training_mnist_gpu(gpu_only, ecs_container_instance, ten
                                          num_gpus=num_gpus)
 
 
-@pytest.mark.skip(reason="Skip this test on PR and Mainline")
+@pytest.mark.skipif(not is_nightly_context(), reason="Running additional model in nightly context only")
 @pytest.mark.model("FasterRCNN")
 @pytest.mark.parametrize("training_script", [TF_FasterRCNN_TRAINING_SCRIPT], indirect=True)
 @pytest.mark.parametrize("ecs_instance_type", ["g3.8xlarge"], indirect=True)

--- a/test/dlc_tests/eks/tensorflow/inference/test_eks_tensorflow_inference.py
+++ b/test/dlc_tests/eks/tensorflow/inference/test_eks_tensorflow_inference.py
@@ -55,7 +55,7 @@ def test_eks_tensorflow_half_plus_two_inference(tensorflow_inference):
         run(f"kubectl delete service {selector_name}")
 
 
-@pytest.mark.skip(reason="Skip this test on PR and Mainline")
+@pytest.mark.skipif(not test_utils.is_nightly_context(), reason="Running additional model in nightly context only")
 @pytest.mark.model("albert")
 def test_eks_tensorflow_albert(tensorflow_inference):
     if "eia" in tensorflow_inference:

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -118,6 +118,10 @@ def is_mainline_context():
     return os.getenv("BUILD_CONTEXT") == "MAINLINE"
 
 
+def is_nightly_context():
+    return os.getenv("BUILD_CONTEXT") == "NIGHTLY"
+
+
 def is_empty_build_context():
     return not os.getenv("BUILD_CONTEXT")
 


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
- Add function for is_nightly_context
- Remove complete skips and add conditional skips for nightly tests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

