### PR TITLE
[tensorflow] Set TF buildspec to TF 2.3 cu102

### DIFF
--- a/tensorflow/buildspec.yml
+++ b/tensorflow/buildspec.yml
@@ -2,8 +2,9 @@
   region: &REGION <set-$REGION-in-environment>
   framework: &FRAMEWORK tensorflow
   version: &VERSION 2.3.1
+  inference_version: &INFERENCE_VERSION 2.3.0
   short_version: &SHORT_VERSION 2.3
-  cuda_version: &CUDA_VERSION cu110
+  cuda_version: &CUDA_VERSION cu102
   os_version: &OS_VERSION ubuntu18.04
 
   repository_info:
@@ -70,3 +71,25 @@
       docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /example, /Dockerfile., *DEVICE_TYPE ]
       context:
         <<: *TRAINING_CONTEXT
+    BuildTensorflowCPUInferPy3DockerImage:
+      <<: *INFERENCE_REPOSITORY
+      build: &TENSORFLOW_CPU_INFERENCE_PY3 false
+      image_size_baseline: 4899
+      device_type: &DEVICE_TYPE cpu
+      python_version: &DOCKER_PYTHON_VERSION py3
+      tag_python_version: &TAG_PYTHON_VERSION py37
+      tag: !join [ *INFERENCE_VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION ]
+      docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
+      context:
+        <<: *INFERENCE_CONTEXT
+      BuildTensorflowGPUInferPy3DockerImage:
+        <<: *INFERENCE_REPOSITORY
+        build: &TENSORFLOW_GPU_INFERENCE_PY3 false
+        image_size_baseline: 7738
+        device_type: &DEVICE_TYPE gpu
+        python_version: &DOCKER_PYTHON_VERSION py3
+        tag_python_version: &TAG_PYTHON_VERSION py37
+        tag: !join [ *INFERENCE_VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION ]
+        docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile., *DEVICE_TYPE ]
+        context:
+          <<: *INFERENCE_CONTEXT


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
Reintroduce TensorFlow 2.3 cu102 dockerfiles and Inference dockerfiles into buildspec

*Tests run:*
N/A

*DLC image/dockerfile:*
N/A

*Additional context:*
N/A


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

