### PR TITLE
[test][sagemaker] Updated requests version in tests/sagemaker_tests

### DIFF
--- a/test/sagemaker_tests/mxnet/inference/requirements.txt
+++ b/test/sagemaker_tests/mxnet/inference/requirements.txt
@@ -6,11 +6,12 @@ pytest==5.3.5
 pytest-cov
 pytest-rerunfailures==9.0
 pytest-xdist
+requests==2.24
 mock
 sagemaker<2
 docker-compose
 mxnet==1.7.0.post1
 awslogs
-requests_mock
+requests_mock==1.7.0
 fabric
 gitpython

--- a/test/sagemaker_tests/mxnet/inference/requirements.txt
+++ b/test/sagemaker_tests/mxnet/inference/requirements.txt
@@ -7,6 +7,7 @@ pytest-cov
 pytest-rerunfailures==9.0
 pytest-xdist
 requests==2.24
+urllib3>=1.25.10,<1.26.0
 mock
 sagemaker<2
 docker-compose

--- a/test/sagemaker_tests/mxnet/training/requirements.txt
+++ b/test/sagemaker_tests/mxnet/training/requirements.txt
@@ -5,6 +5,7 @@ pytest==5.3.5
 pytest-cov
 pytest-rerunfailures==9.0
 pytest-xdist
+requests==2.24
 mock
 sagemaker<2
 docker-compose

--- a/test/sagemaker_tests/mxnet/training/requirements.txt
+++ b/test/sagemaker_tests/mxnet/training/requirements.txt
@@ -6,6 +6,7 @@ pytest-cov
 pytest-rerunfailures==9.0
 pytest-xdist
 requests==2.24
+urllib3>=1.25.10,<1.26.0
 mock
 sagemaker<2
 docker-compose

--- a/test/sagemaker_tests/tensorflow/inference/requirements.txt
+++ b/test/sagemaker_tests/tensorflow/inference/requirements.txt
@@ -3,7 +3,7 @@ pytest==5.3.5
 pytest-rerunfailures==9.0
 pytest-timeout==1.3.4
 pytest-xdist==1.31.0
-requests
+requests==2.24
 fabric
 retrying
 gitpython

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/requirements.txt
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/requirements.txt
@@ -10,6 +10,7 @@ pytest==5.3.5
 pytest-cov
 pytest-rerunfailures==9.0
 pytest-xdist
+requests==2.24
 mock
 sagemaker<2
 docker-compose

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/requirements.txt
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/requirements.txt
@@ -10,6 +10,7 @@ pytest==5.3.5
 pytest-cov
 pytest-rerunfailures==9.0
 pytest-xdist
+requests==2.24
 mock
 sagemaker<2
 docker-compose


### PR DESCRIPTION

*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
Tests fail because of libraries incompatibility. Updated requests version to the one requiring urllib2 > 1.25

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

