### PR TITLE
[tensorflow] [eks] [test] Temp fix for keras examples

### DIFF
--- a/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_training.py
+++ b/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_training.py
@@ -25,7 +25,7 @@ def test_eks_tensorflow_single_node_training(tensorflow_training):
     yaml_path = os.path.join(os.sep, "tmp", f"tensorflow_single_node_training_{rand_int}.yaml")
     pod_name = f"tensorflow-single-node-training-{rand_int}"
 
-    args = ("git clone https://github.com/keras-team/keras "
+    args = ("git clone --branch tf-2 https://github.com/keras-team/keras "
             "&& sed -i 's/import keras/from tensorflow import keras/g; "
             "s/from keras/from tensorflow.keras/g' /keras/examples/mnist_cnn.py "
             "&& python /keras/examples/mnist_cnn.py")


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [ x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
examples were deleted from keras repository. Using different branch temporary

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

