### PR TITLE
[pytorch] Update cryptography to latest version in pytorch containers

### DIFF
--- a/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
+++ b/pytorch/inference/docker/1.6.0/py3/Dockerfile.cpu
@@ -94,6 +94,7 @@ RUN conda install -c \
  && ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
  && pip install packaging==20.4 \
     enum-compat==0.0.3 \
+    "cryptography>3.2" \
  && conda install -y -c pytorch torchserve=$TS_VERSION \
  && conda install -y -c pytorch torch-model-archiver=$TS_VERSION
 

--- a/pytorch/training/docker/1.6.0/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/1.6.0/py3/Dockerfile.cpu
@@ -100,6 +100,7 @@ RUN pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pytho
     fastai==1.0.59 \
     scipy==1.2.2 \
     click \
+    "cryptography>3.2" \
     smdebug==${SMDEBUG_VERSION} \
     "sagemaker>=2,<3" \
     sagemaker-experiments==0.* \

--- a/pytorch/training/docker/1.6.0/py3/cu110/Dockerfile.gpu
+++ b/pytorch/training/docker/1.6.0/py3/cu110/Dockerfile.gpu
@@ -141,6 +141,7 @@ RUN pip install \
     Pillow \
     scipy \
     click \
+    "cryptography>3.2" \
  && pip install --no-cache-dir -U ${PT_TRAINING_URL} \
  && pip uninstall -y torchvision \
  && pip install --no-deps --no-cache-dir -U ${PT_TORCHVISION_URL}


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
<3.2 versions of cryptography have a CVE (CVE-2020-25659) associated with it. For pytorch containers, the cryptography dependency comes from conda packages. However, the cryptography package has not been updated on conda (https://anaconda.org/anaconda/cryptography). Introducing this pip install to ensure that we get the latest version of cryptography and thus a package which mitigates the issue.

*Tests run:*
Built locally, ensured that no dependencies were broken.

*DLC image/dockerfile:*
PT 1.6 cu11 gpu/cpu training images, cpu inference images

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

