### PR TITLE
[test][tensorflow][benchmark][ec2] Skip TF1 ec2 benchmarks temporarily

### DIFF
--- a/test/dlc_tests/benchmark/ec2/tensorflow/training/test_performance_tensorflow_training.py
+++ b/test/dlc_tests/benchmark/ec2/tensorflow/training/test_performance_tensorflow_training.py
@@ -46,10 +46,11 @@ def test_performance_tensorflow_cpu(tensorflow_training, ec2_connection, cpu_onl
     )
 
 
+# TODO: Enable TF1 by removing "tf2_only" fixture once infrastructure issues have been resolved.
 @pytest.mark.integration("synthetic dataset")
 @pytest.mark.model("resnet50")
 @pytest.mark.parametrize("ec2_instance_type", [TF_EC2_GPU_INSTANCE_TYPE], indirect=True)
-def test_performance_tensorflow_gpu_synthetic(tensorflow_training, ec2_connection, gpu_only):
+def test_performance_tensorflow_gpu_synthetic(tensorflow_training, ec2_connection, gpu_only, tf2_only):
     threshold = (
         TENSORFLOW2_TRAINING_GPU_SYNTHETIC_THRESHOLD
         if is_tf_version("2", tensorflow_training)
@@ -65,10 +66,11 @@ def test_performance_tensorflow_gpu_synthetic(tensorflow_training, ec2_connectio
     )
 
 
+# TODO: Enable TF1 by removing "tf2_only" fixture once infrastructure issues have been resolved.
 @pytest.mark.integration("imagenet dataset")
 @pytest.mark.model("resnet50")
 @pytest.mark.parametrize("ec2_instance_type", [TF_EC2_GPU_INSTANCE_TYPE], indirect=True)
-def test_performance_tensorflow_gpu_imagenet(tensorflow_training, ec2_connection, gpu_only):
+def test_performance_tensorflow_gpu_imagenet(tensorflow_training, ec2_connection, gpu_only, tf2_only):
     threshold = (
         TENSORFLOW2_TRAINING_GPU_IMAGENET_THRESHOLD
         if is_tf_version("2", tensorflow_training)


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
Skip TF1 benchmark tests temporarily due to infrastructure issues


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

