### PR TITLE
[release] Fix release_images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -182,7 +182,7 @@ release_images:
       cuda_version: "cu100"
       example: False
       disable_sm_tag: False
-      force_release: True
+      force_release: False
   12:
     framework: "tensorflow"
     version: "1.15.4"

--- a/release_images.yml
+++ b/release_images.yml
@@ -174,10 +174,10 @@ release_images:
       cuda_version: "cu100"
       example: False
       disable_sm_tag: False
-      force_release: True
+      force_release: False
     inference:
       device_types: ["cpu", "gpu"]
-      python_versions: ["py36", "py37"]
+      python_versions: ["py36"]
       os_version: "ubuntu18.04"
       cuda_version: "cu100"
       example: False
@@ -193,7 +193,7 @@ release_images:
       cuda_version: "cu100"
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: True
+      force_release: False
   13:
     framework: "tensorflow"
     version: "2.1.2"


### PR DESCRIPTION
*Issue #, if available:*

*Description:*
release_images.yml for TF 1.15.4 includes py37 in inference images to be released. This is wrong, as there are no inference py37 images for TF 1.15

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

