### PR TITLE
[pytorch][eia][release] Add PT 1.5.1 EI image to release_images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -48,7 +48,7 @@ release_images:
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
     inference:
-      device_types: ["cpu", "gpu"]
+      device_types: ["cpu", "gpu", "eia"]
       python_versions: ["py36"]
       os_version: "ubuntu16.04"
       cuda_version: "cu101"


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
Add PyTorch 1.5.1 EIA image to the image variants to be released on release_images.yml

*Tests run:*
N/A

*DLC image/dockerfile:*
https://github.com/aws/deep-learning-containers/blob/master/pytorch/inference/docker/1.5.1/py3/Dockerfile.eia

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

