### PR TITLE
[release] Remove PyTorch 1.5.1 CPU and GPU images from release_images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -37,18 +37,8 @@ release_images:
   3:
     framework: "pytorch"
     version: "1.5.1"
-    training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py36"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu101"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-                            # to images being published.
-      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
-                            # has already been published. Re-released image will have minor version incremented by 1.
     inference:
-      device_types: ["cpu", "gpu", "eia"]
+      device_types: ["eia"]
       python_versions: ["py36"]
       os_version: "ubuntu16.04"
       cuda_version: "cu101"
@@ -58,19 +48,6 @@ release_images:
       force_release: False   # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
   4:
-    framework: "pytorch"
-    version: "1.5.1"
-    training:
-      device_types: ["gpu"]
-      python_versions: ["py36"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu101"
-      example: True         # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-                            # to images being published.
-      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
-                            # has already been published. Re-released image will have minor version incremented by 1.
-  5:
     framework: "tensorflow"
     version: "2.2.1"
     training:
@@ -83,7 +60,7 @@ release_images:
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
-  6:
+  5:
     framework: "tensorflow"
     version: "2.2.1"
     training:
@@ -106,7 +83,7 @@ release_images:
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
-  7:
+  6:
     framework: "tensorflow"
     version: "2.2.1"
     training:
@@ -117,7 +94,7 @@ release_images:
       example: True
       disable_sm_tag: False # [Default: False] This option is not used by Example images
       force_release: False
-  8:
+  7:
     framework: "tensorflow"
     version: "2.3.1"
     training:
@@ -140,7 +117,7 @@ release_images:
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
-  9:
+  8:
     framework: "tensorflow"
     version: "2.3.1"
     training:
@@ -151,7 +128,7 @@ release_images:
       example: True
       disable_sm_tag: False # [Default: False] This option is not used by Example images
       force_release: False
-  10:
+  9:
     framework: "tensorflow"
     version: "2.3.1"
     training:
@@ -164,7 +141,7 @@ release_images:
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
-  11:
+  10:
     framework: "tensorflow"
     version: "1.15.4"
     inference:
@@ -177,7 +154,7 @@ release_images:
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
-  12:
+  11:
     framework: "tensorflow"
     version: "2.1.2"
     training:
@@ -196,7 +173,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  13:
+  12:
     framework: "tensorflow"
     version: "2.1.2"
     training:
@@ -206,30 +183,30 @@ release_images:
       cuda_version: "cu101"
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  13:
+    framework: "tensorflow"
+    version: "2.0.3"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py36"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu100"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py36"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu100"
+      example: False
+      disable_sm_tag: False
       force_release: False
   14:
     framework: "tensorflow"
     version: "2.0.3"
     training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py36"]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu100"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-    inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py36"]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu100"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  15:
-    framework: "tensorflow"
-    version: "2.0.3"
-    training:
       device_types: ["gpu"]
       python_versions: ["py36"]
       os_version: "ubuntu18.04"
@@ -237,7 +214,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  16:
+  15:
     framework: "mxnet"
     version: "1.6.0"
     training:
@@ -258,7 +235,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  17:
+  16:
     framework: "mxnet"
     version: "1.6.0"
     training:
@@ -269,7 +246,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  18:
+  17:
     framework: "mxnet"
     version: "1.7.0"
     training:
@@ -290,7 +267,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  19:
+  18:
     framework: "mxnet"
     version: "1.7.0"
     training:


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [x] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [x] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [x] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [x] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

*Description:*
Release validation code validates images if they are mentioned in the `release_images.yml` file regardless of whether they have actually been published in the current execution. This means that older images which followed older tagging conventions can no longer be validated correctly.

This is a short-term fix to enable the current release to proceed correctly.

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

