### PR TITLE
add an env var to collect the number of cores

### DIFF
--- a/pytorch/inference/docker/build_artifacts/mms-entrypoint.py
+++ b/pytorch/inference/docker/build_artifacts/mms-entrypoint.py
@@ -15,14 +15,17 @@ from __future__ import absolute_import
 import shlex
 import subprocess
 import sys
+import os
+import multiprocessing
 
+os.environ["SAGEMAKER_MODEL_SERVER_WORKERS"] = str(multiprocessing.cpu_count())
 
-if sys.argv[1] == 'serve':
+if sys.argv[1] == "serve":
     from sagemaker_pytorch_serving_container import serving
+
     serving.main()
 else:
-    subprocess.check_call(shlex.split(' '.join(sys.argv[1:])))
+    subprocess.check_call(shlex.split(" ".join(sys.argv[1:])))
 
 # prevent docker exit
-subprocess.call(['tail', '-f', '/dev/null'])
-
+subprocess.call(["tail", "-f", "/dev/null"])

--- a/pytorch/inference/docker/build_artifacts/torchserve-entrypoint.py
+++ b/pytorch/inference/docker/build_artifacts/torchserve-entrypoint.py
@@ -15,13 +15,18 @@ from __future__ import absolute_import
 import shlex
 import subprocess
 import sys
+import os
+import multiprocessing
+
+os.environ["SAGEMAKER_MODEL_SERVER_WORKERS"] = str(multiprocessing.cpu_count())
 
 
-if sys.argv[1] == 'serve':
+if sys.argv[1] == "serve":
     from sagemaker_pytorch_serving_container import serving
+
     serving.main()
 else:
-    subprocess.check_call(shlex.split(' '.join(sys.argv[1:])))
+    subprocess.check_call(shlex.split(" ".join(sys.argv[1:])))
 
 # prevent docker exit
-subprocess.call(['tail', '-f', '/dev/null'])
+subprocess.call(["tail", "-f", "/dev/null"])


### PR DESCRIPTION
related to the Case ID 7825958121

as discussed the PyTorch images was using only one worker, and on instances like a **g4dn-xlarge**, for example, the GPU was heavily underused.
 the workaround to fix this was adding an env var to the **entrypoint** file.

to avoid having to build one docker for each instance here I check first the number of cores and add the variable **SAGEMAKER_MODEL_SERVER_WORKERS** to the number of cores available on the machine.