### PR TITLE
[test] Fix after number of safety check json params increased

### DIFF
--- a/test/dlc_tests/sanity/test_safety_check.py
+++ b/test/dlc_tests/sanity/test_safety_check.py
@@ -98,9 +98,9 @@ def _get_latest_package_version(package):
 
 @pytest.mark.model("N/A")
 @pytest.mark.skipif(not is_dlc_cicd_context(), reason="Skipping test because it is not running in dlc cicd infra")
-# @pytest.mark.skipif(not is_mainline_context(),
-#                     reason="Skipping the test to decrease the number of calls to the Safety Check DB. "
-#                            "Test will be executed in the 'mainline' pipeline only")
+@pytest.mark.skipif(not is_mainline_context(),
+                    reason="Skipping the test to decrease the number of calls to the Safety Check DB. "
+                           "Test will be executed in the 'mainline' pipeline only")
 def test_safety(image):
     """
     Runs safety check on a container with the capability to ignore safety issues that cannot be fixed, and only raise

--- a/test/dlc_tests/sanity/test_safety_check.py
+++ b/test/dlc_tests/sanity/test_safety_check.py
@@ -127,7 +127,8 @@ def test_safety(image):
         run(f"{docker_exec_cmd} pip install safety yolk3k ", hide=True)
         json_str_safety_result = safety_check.run_safety_check_on_container(docker_exec_cmd)
         safety_result = json.loads(json_str_safety_result)
-        for package, affected_versions, curr_version, _, vulnerability_id in safety_result[:5]:
+        for vulnerability in safety_result:
+            package, affected_versions, curr_version, _, vulnerability_id = vulnerability[:5]
             # Get the latest version of the package with vulnerability
             latest_version = _get_latest_package_version(package)
             # If the latest version of the package is also affected, ignore this vulnerability

--- a/test/dlc_tests/sanity/test_safety_check.py
+++ b/test/dlc_tests/sanity/test_safety_check.py
@@ -98,9 +98,9 @@ def _get_latest_package_version(package):
 
 @pytest.mark.model("N/A")
 @pytest.mark.skipif(not is_dlc_cicd_context(), reason="Skipping test because it is not running in dlc cicd infra")
-@pytest.mark.skipif(not is_mainline_context(),
-                    reason="Skipping the test to decrease the number of calls to the Safety Check DB. "
-                           "Test will be executed in the 'mainline' pipeline only")
+# @pytest.mark.skipif(not is_mainline_context(),
+#                     reason="Skipping the test to decrease the number of calls to the Safety Check DB. "
+#                            "Test will be executed in the 'mainline' pipeline only")
 def test_safety(image):
     """
     Runs safety check on a container with the capability to ignore safety issues that cannot be fixed, and only raise
@@ -127,7 +127,7 @@ def test_safety(image):
         run(f"{docker_exec_cmd} pip install safety yolk3k ", hide=True)
         json_str_safety_result = safety_check.run_safety_check_on_container(docker_exec_cmd)
         safety_result = json.loads(json_str_safety_result)
-        for package, affected_versions, curr_version, _, vulnerability_id in safety_result:
+        for package, affected_versions, curr_version, _, vulnerability_id in safety_result[:5]:
             # Get the latest version of the package with vulnerability
             latest_version = _get_latest_package_version(package)
             # If the latest version of the package is also affected, ignore this vulnerability


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
`safety check --json` recently started producing more output values per CVE than it did before.

We only need the first 5 values, which represent "package name", "affected versions", "installed version", "explanation", and "safety-db vulnerability ID".

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

