### PR TITLE
[mxnet][eia][build]Add MXNet 1.7.0 for Elastic Inference

### DIFF
--- a/mxnet/buildspec-eia-1-5-1.yml
+++ b/mxnet/buildspec-eia-1-5-1.yml
@@ -1,7 +1,7 @@
   account_id: &ACCOUNT_ID <set-$ACCOUNT_ID-in-environment>
   region: &REGION <set-$REGION-in-environment>
   framework: &FRAMEWORK mxnet
-  version: &VERSION 1.7.0
+  version: &VERSION 1.5.1
   os_version: &OS_VERSION ubuntu16.04
 
   repository_info:
@@ -28,6 +28,17 @@
       device_type: &DEVICE_TYPE cpu
       python_version: &DOCKER_PYTHON_VERSION py3
       tag_python_version: &TAG_PYTHON_VERSION py36
+      tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION ]
+      docker_file: !join [ docker/, *VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., eia ]
+      context:
+        <<: *INFERENCE_CONTEXT
+    BuildEIAMXNetInferencePy2DockerImage:
+      <<: *INFERENCE_REPOSITORY
+      build: &MXNET_CPU_INFERENCE_PY2 false
+      image_size_baseline: 5000
+      device_type: &DEVICE_TYPE cpu
+      python_version: &DOCKER_PYTHON_VERSION py2
+      tag_python_version: &TAG_PYTHON_VERSION py27
       tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION ]
       docker_file: !join [ docker/, *VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., eia ]
       context:

--- a/mxnet/inference/docker/1.7.0/py3/Dockerfile.eia
+++ b/mxnet/inference/docker/1.7.0/py3/Dockerfile.eia
@@ -67,12 +67,12 @@ RUN pip install --no-cache-dir --upgrade \
     setuptools
 
 RUN pip install --no-cache-dir \
-    mxnet==1.7.0.post1 \
+    mxnet==1.7.0.post2 \
     https://amazonei-apachemxnet.s3.amazonaws.com/eimx-1.0-py2.py3-none-manylinux1_x86_64.whl \
     multi-model-server==$MMS_VERSION \
-    keras-mxnet==2.2.4.1 \
-    numpy==1.19.1 \
-    onnx==1.4.1 \
+    keras-mxnet==2.2.4.3 \
+    numpy==1.20.0 \
+    onnx==1.8.1 \
     "sagemaker-mxnet-inference<2"
 
 # Install openssl-1.1.1g to override default openssl-1.0.2g

--- a/mxnet/inference/docker/1.7.0/py3/Dockerfile.eia
+++ b/mxnet/inference/docker/1.7.0/py3/Dockerfile.eia
@@ -62,6 +62,8 @@ RUN wget https://amazonei-tools.s3.amazonaws.com/v${HEALTH_CHECK_VERSION}/ei_too
  && rm -rf /opt/ei_tools_${HEALTH_CHECK_VERSION}.tar.gz \
  && chmod a+x /opt/ei_tools/bin/health_check
 
+RUN pip install --upgrade pip
+
 RUN pip install --no-cache-dir --upgrade \
     pip \
     setuptools
@@ -71,7 +73,7 @@ RUN pip install --no-cache-dir \
     https://amazonei-apachemxnet.s3.amazonaws.com/eimx-1.0-py2.py3-none-manylinux1_x86_64.whl \
     multi-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.3 \
-    numpy==1.20.0 \
+    numpy==1.20.1 \
     onnx==1.8.1 \
     "sagemaker-mxnet-inference<2"
 

--- a/mxnet/inference/docker/1.7.0/py3/Dockerfile.eia
+++ b/mxnet/inference/docker/1.7.0/py3/Dockerfile.eia
@@ -73,7 +73,7 @@ RUN pip install --no-cache-dir \
     https://amazonei-apachemxnet.s3.amazonaws.com/eimx-1.0-py2.py3-none-manylinux1_x86_64.whl \
     multi-model-server==$MMS_VERSION \
     keras-mxnet==2.2.4.3 \
-    numpy==1.20.1 \
+    numpy==1.19.1 \
     onnx==1.8.1 \
     "sagemaker-mxnet-inference<2"
 

--- a/mxnet/inference/docker/1.7.0/py3/Dockerfile.eia
+++ b/mxnet/inference/docker/1.7.0/py3/Dockerfile.eia
@@ -1,0 +1,118 @@
+FROM ubuntu:16.04
+
+LABEL maintainer="Amazon AI"
+
+LABEL com.amazonaws.sagemaker.capabilities.accept-bind-to-port=true
+LABEL dlc_major_version="1"
+
+ARG MMS_VERSION=1.1.2
+ARG PYTHON=python3
+ARG PYTHON_VERSION=3.6.10
+ARG HEALTH_CHECK_VERSION=1.7.0
+
+RUN apt-get update \
+ && apt-get -y install --no-install-recommends \
+    build-essential \
+    ca-certificates \
+    curl \
+    emacs \
+    git \
+    libopencv-dev \
+    openjdk-8-jdk-headless \
+    vim \
+    wget \
+    zlib1g-dev \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# See http://bugs.python.org/issue19846
+ENV LANG=C.UTF-8 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib" \
+    PYTHONIOENCODING=UTF-8 \
+    LC_ALL=C.UTF-8
+
+RUN wget https://www.python.org/ftp/python/$PYTHON_VERSION/Python-$PYTHON_VERSION.tgz \
+ && tar -xvf Python-$PYTHON_VERSION.tgz \
+ && cd Python-$PYTHON_VERSION \
+ && ./configure \
+ && make \
+ && make install \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends \
+    libreadline-gplv2-dev \
+    libncursesw5-dev \
+    libssl-dev \
+    libsqlite3-dev \
+    tk-dev \
+    libgdbm-dev \
+    libc6-dev \
+    libbz2-dev \
+ && make \
+ && make install \
+ && rm -rf ../Python-$PYTHON_VERSION* \
+ && ln -s /usr/local/bin/pip3 /usr/bin/pip \
+ && ln -s $(which ${PYTHON}) /usr/local/bin/python
+
+WORKDIR /
+
+RUN wget https://amazonei-tools.s3.amazonaws.com/v${HEALTH_CHECK_VERSION}/ei_tools_${HEALTH_CHECK_VERSION}.tar.gz -O /opt/ei_tools_${HEALTH_CHECK_VERSION}.tar.gz \
+ && tar -xvf /opt/ei_tools_${HEALTH_CHECK_VERSION}.tar.gz -C /opt/ \
+ && rm -rf /opt/ei_tools_${HEALTH_CHECK_VERSION}.tar.gz \
+ && chmod a+x /opt/ei_tools/bin/health_check
+
+RUN pip install --no-cache-dir --upgrade \
+    pip \
+    setuptools
+
+RUN pip install --no-cache-dir \
+    mxnet==1.7.0.post1 \
+    https://amazonei-apachemxnet.s3.amazonaws.com/eimx-1.0-py2.py3-none-manylinux1_x86_64.whl \
+    multi-model-server==$MMS_VERSION \
+    keras-mxnet==2.2.4.1 \
+    numpy==1.19.1 \
+    onnx==1.4.1 \
+    "sagemaker-mxnet-inference<2"
+
+# Install openssl-1.1.1g to override default openssl-1.0.2g
+RUN wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz \
+ && apt-get remove --purge -y openssl \
+ && rm -rf /usr/include/openssl \
+ && apt-get update \
+ && apt-get install -y \
+    ca-certificates \
+    openjdk-8-jdk-headless \
+ && tar -xzvf openssl-1.1.1g.tar.gz \
+ && cd openssl-1.1.1g \
+ && ./config \
+ && make \
+ && make test \
+ && make install \
+ && cd ../ \
+ && rm -rf openssl-* \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/*
+
+# Purging default openssl in above command also prevents the new installation of openssl
+# from finding certificates at the pre-existing path. This env variable fixes the issue.
+ENV SSL_CERT_DIR=/etc/ssl/certs
+
+# This is here to make our installed version of OpenCV work.
+# https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394
+# TODO: Should we be installing OpenCV in our image like this? Is there another way we can fix this?
+RUN ln -s /dev/null /dev/raw1394
+
+RUN useradd -m model-server \
+ && mkdir -p /home/model-server/tmp \
+ && chown -R model-server /home/model-server
+
+COPY mms-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
+COPY config.properties /home/model-server
+
+RUN chmod +x /usr/local/bin/dockerd-entrypoint.py
+
+EXPOSE 8080 8081
+ENV TEMP=/home/model-server/tmp
+ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]
+CMD ["multi-model-server", "--start", "--mms-config", "/home/model-server/config.properties"]

--- a/src/config/build_config.py
+++ b/src/config/build_config.py
@@ -1,6 +1,6 @@
 # Please only set it to True if you are preparing an EI related PR
 # Do remember to revert it back to False before merging any PR (including EI dedicated PR)
-ENABLE_EI_MODE = True
+ENABLE_EI_MODE = False
 # Please only set it to True if you are preparing an NEURON related PR
 # Do remember to revert it back to False before merging any PR (including NEURON dedicated PR)
 ENABLE_NEURON_MODE = False

--- a/src/config/build_config.py
+++ b/src/config/build_config.py
@@ -1,6 +1,6 @@
 # Please only set it to True if you are preparing an EI related PR
 # Do remember to revert it back to False before merging any PR (including EI dedicated PR)
-ENABLE_EI_MODE = False
+ENABLE_EI_MODE = True
 # Please only set it to True if you are preparing an NEURON related PR
 # Do remember to revert it back to False before merging any PR (including NEURON dedicated PR)
 ENABLE_NEURON_MODE = False

--- a/test/dlc_tests/ec2/mxnet/inference/test_mxnet_inference.py
+++ b/test/dlc_tests/ec2/mxnet/inference/test_mxnet_inference.py
@@ -42,10 +42,11 @@ def test_ec2_mxnet_squeezenet_inference_cpu(mxnet_inference, ec2_connection, reg
 @pytest.mark.parametrize("ec2_instance_type", MX_EC2_CPU_INSTANCE_TYPE, indirect=True)
 @pytest.mark.parametrize("ei_accelerator_type", MX_EC2_EIA_ACCELERATOR_TYPE, indirect=True)
 def test_ec2_mxnet_resnet_inference_eia_cpu(mxnet_inference_eia, ec2_connection, region, eia_only):
+    model_name = RESNET_EIA_MODEL
     image_framework, image_framework_version = get_framework_and_version_from_tag(mxnet_inference_eia)
     if image_framework_version == "1.5.1":
         RESNET_EIA_MODEL = "resnet-152-eia-1-5-1"
-    run_ec2_mxnet_inference(mxnet_inference_eia, RESNET_EIA_MODEL, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
+    run_ec2_mxnet_inference(mxnet_inference_eia, model_name, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
 
 
 @pytest.mark.integration("elastic_inference")
@@ -54,10 +55,11 @@ def test_ec2_mxnet_resnet_inference_eia_cpu(mxnet_inference_eia, ec2_connection,
 @pytest.mark.parametrize("ei_accelerator_type", MX_EC2_EIA_ACCELERATOR_TYPE, indirect=True)
 @pytest.mark.skipif(MX_EC2_GPU_INSTANCE_TYPE == ["p3dn.24xlarge"], reason="Skipping EIA test on p3dn instances")
 def test_ec2_mxnet_resnet_inferencei_eia_gpu(mxnet_inference_eia, ec2_connection, region, eia_only):
+    model_name = RESNET_EIA_MODEL
     image_framework, image_framework_version = get_framework_and_version_from_tag(mxnet_inference_eia)
     if image_framework_version == "1.5.1":
         RESNET_EIA_MODEL = "resnet-152-eia-1-5-1"
-    run_ec2_mxnet_inference(mxnet_inference_eia, RESNET_EIA_MODEL, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
+    run_ec2_mxnet_inference(mxnet_inference_eia, model_name, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
 
 
 @pytest.mark.integration("gluonnlp")

--- a/test/dlc_tests/ec2/mxnet/inference/test_mxnet_inference.py
+++ b/test/dlc_tests/ec2/mxnet/inference/test_mxnet_inference.py
@@ -9,7 +9,7 @@ from test.dlc_tests.conftest import LOGGER
 
 SQUEEZENET_MODEL = "squeezenet"
 BERT_MODEL = "bert_sst"
-DEFAULT_RESNET_EIA_MODEL = "resnet-152-eia"
+RESNET_EIA_MODEL = "resnet-152-eia"
 
 
 MX_EC2_GPU_INSTANCE_TYPE = get_ec2_instance_type(default="g3.8xlarge", processor="gpu")
@@ -38,20 +38,26 @@ def test_ec2_mxnet_squeezenet_inference_cpu(mxnet_inference, ec2_connection, reg
 
 
 @pytest.mark.integration("elastic_inference")
-@pytest.mark.model(DEFAULT_RESNET_EIA_MODEL)
+@pytest.mark.model(RESNET_EIA_MODEL)
 @pytest.mark.parametrize("ec2_instance_type", MX_EC2_CPU_INSTANCE_TYPE, indirect=True)
 @pytest.mark.parametrize("ei_accelerator_type", MX_EC2_EIA_ACCELERATOR_TYPE, indirect=True)
 def test_ec2_mxnet_resnet_inference_eia_cpu(mxnet_inference_eia, ec2_connection, region, eia_only):
-    run_ec2_mxnet_inference(mxnet_inference_eia, DEFAULT_RESNET_EIA_MODEL, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
+    image_framework, image_framework_version = get_framework_and_version_from_tag(mxnet_inference_eia)
+    if image_framework_version == "1.5.1":
+        REANET_EIA_MODEL = "resnet-152-eia-1-5-1"
+    run_ec2_mxnet_inference(mxnet_inference_eia, RESNET_EIA_MODEL, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
 
 
 @pytest.mark.integration("elastic_inference")
-@pytest.mark.model(DEFAULT_RESNET_EIA_MODEL)
+@pytest.mark.model(RESNET_EIA_MODEL)
 @pytest.mark.parametrize("ec2_instance_type", MX_EC2_GPU_INSTANCE_TYPE, indirect=True)
 @pytest.mark.parametrize("ei_accelerator_type", MX_EC2_EIA_ACCELERATOR_TYPE, indirect=True)
 @pytest.mark.skipif(MX_EC2_GPU_INSTANCE_TYPE == ["p3dn.24xlarge"], reason="Skipping EIA test on p3dn instances")
-def test_ec2_mxnet_resnet_inference_eia_gpu(mxnet_inference_eia, ec2_connection, region, eia_only):
-    run_ec2_mxnet_inference(mxnet_inference_eia, DEFAULT_RESNET_EIA_MODEL, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
+def test_ec2_mxnet_resnet_inferencei_eia_gpu(mxnet_inference_eia, ec2_connection, region, eia_only):
+    image_framework, image_framework_version = get_framework_and_version_from_tag(mxnet_inference_eia)
+    if image_framework_version == "1.5.1":
+        REANET_EIA_MODEL = "resnet-152-eia-1-5-1"
+    run_ec2_mxnet_inference(mxnet_inference_eia, RESNET_EIA_MODEL, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
 
 
 @pytest.mark.integration("gluonnlp")
@@ -85,13 +91,9 @@ def run_ec2_mxnet_inference(image_uri, model_name, container_tag, ec2_connection
             inference_result = test_utils.request_mxnet_inference_gluonnlp(
                 port=target_port, connection=ec2_connection
             )
-        elif model_name == DEFAULT_RESNET_EIA_MODEL:
-            model = model_name
-            image_framework, image_framework_version = get_framework_and_version_from_tag(image_uri)
-            if image_framework_version == "1.5.1":
-                model = "resnet-152-eia-1-5-1"
+        elif model_name == RESNET_EIA_MODEL:
             inference_result = test_utils.request_mxnet_inference(
-                port=target_port, connection=ec2_connection, model=model
+                port=target_port, connection=ec2_connection, model=model_name
             )
         assert (
             inference_result

--- a/test/dlc_tests/ec2/mxnet/inference/test_mxnet_inference.py
+++ b/test/dlc_tests/ec2/mxnet/inference/test_mxnet_inference.py
@@ -45,7 +45,7 @@ def test_ec2_mxnet_resnet_inference_eia_cpu(mxnet_inference_eia, ec2_connection,
     model_name = RESNET_EIA_MODEL
     image_framework, image_framework_version = get_framework_and_version_from_tag(mxnet_inference_eia)
     if image_framework_version == "1.5.1":
-        RESNET_EIA_MODEL = "resnet-152-eia-1-5-1"
+        model_name = "resnet-152-eia-1-5-1"
     run_ec2_mxnet_inference(mxnet_inference_eia, model_name, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
 
 
@@ -58,7 +58,7 @@ def test_ec2_mxnet_resnet_inferencei_eia_gpu(mxnet_inference_eia, ec2_connection
     model_name = RESNET_EIA_MODEL
     image_framework, image_framework_version = get_framework_and_version_from_tag(mxnet_inference_eia)
     if image_framework_version == "1.5.1":
-        RESNET_EIA_MODEL = "resnet-152-eia-1-5-1"
+        model_name = "resnet-152-eia-1-5-1"
     run_ec2_mxnet_inference(mxnet_inference_eia, model_name, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
 
 

--- a/test/dlc_tests/ec2/mxnet/inference/test_mxnet_inference.py
+++ b/test/dlc_tests/ec2/mxnet/inference/test_mxnet_inference.py
@@ -2,14 +2,14 @@ import os
 import pytest
 
 from test import test_utils
-from test.test_utils import CONTAINER_TESTS_PREFIX
+from test.test_utils import CONTAINER_TESTS_PREFIX, get_framework_and_version_from_tag
 from test.test_utils.ec2 import get_ec2_instance_type, execute_ec2_inference_test, get_ec2_accelerator_type
 from test.dlc_tests.conftest import LOGGER
 
 
 SQUEEZENET_MODEL = "squeezenet"
 BERT_MODEL = "bert_sst"
-RESNET_EIA_MODEL = "resnet-152-eia"
+DEFAULT_RESNET_EIA_MODEL = "resnet-152-eia"
 
 
 MX_EC2_GPU_INSTANCE_TYPE = get_ec2_instance_type(default="g3.8xlarge", processor="gpu")
@@ -38,20 +38,20 @@ def test_ec2_mxnet_squeezenet_inference_cpu(mxnet_inference, ec2_connection, reg
 
 
 @pytest.mark.integration("elastic_inference")
-@pytest.mark.model(RESNET_EIA_MODEL)
+@pytest.mark.model(DEFAULT_RESNET_EIA_MODEL)
 @pytest.mark.parametrize("ec2_instance_type", MX_EC2_CPU_INSTANCE_TYPE, indirect=True)
 @pytest.mark.parametrize("ei_accelerator_type", MX_EC2_EIA_ACCELERATOR_TYPE, indirect=True)
 def test_ec2_mxnet_resnet_inference_eia_cpu(mxnet_inference_eia, ec2_connection, region, eia_only):
-    run_ec2_mxnet_inference(mxnet_inference_eia, RESNET_EIA_MODEL, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
+    run_ec2_mxnet_inference(mxnet_inference_eia, DEFAULT_RESNET_EIA_MODEL, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
 
 
 @pytest.mark.integration("elastic_inference")
-@pytest.mark.model(RESNET_EIA_MODEL)
+@pytest.mark.model(DEFAULT_RESNET_EIA_MODEL)
 @pytest.mark.parametrize("ec2_instance_type", MX_EC2_GPU_INSTANCE_TYPE, indirect=True)
 @pytest.mark.parametrize("ei_accelerator_type", MX_EC2_EIA_ACCELERATOR_TYPE, indirect=True)
 @pytest.mark.skipif(MX_EC2_GPU_INSTANCE_TYPE == ["p3dn.24xlarge"], reason="Skipping EIA test on p3dn instances")
 def test_ec2_mxnet_resnet_inference_eia_gpu(mxnet_inference_eia, ec2_connection, region, eia_only):
-    run_ec2_mxnet_inference(mxnet_inference_eia, RESNET_EIA_MODEL, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
+    run_ec2_mxnet_inference(mxnet_inference_eia, DEFAULT_RESNET_EIA_MODEL, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
 
 
 @pytest.mark.integration("gluonnlp")
@@ -85,9 +85,13 @@ def run_ec2_mxnet_inference(image_uri, model_name, container_tag, ec2_connection
             inference_result = test_utils.request_mxnet_inference_gluonnlp(
                 port=target_port, connection=ec2_connection
             )
-        elif model_name == RESNET_EIA_MODEL:
+        elif model_name == DEFAULT_RESNET_EIA_MODEL:
+            model = model_name
+            image_framework, image_framework_version = get_framework_and_version_from_tag(image_uri)
+            if image_framework_version == "1.5.1":
+                model = "resnet-152-eia-1-5-1"
             inference_result = test_utils.request_mxnet_inference(
-                port=target_port, connection=ec2_connection, model="resnet-152-eia"
+                port=target_port, connection=ec2_connection, model=model
             )
         assert (
             inference_result

--- a/test/dlc_tests/ec2/mxnet/inference/test_mxnet_inference.py
+++ b/test/dlc_tests/ec2/mxnet/inference/test_mxnet_inference.py
@@ -44,7 +44,7 @@ def test_ec2_mxnet_squeezenet_inference_cpu(mxnet_inference, ec2_connection, reg
 def test_ec2_mxnet_resnet_inference_eia_cpu(mxnet_inference_eia, ec2_connection, region, eia_only):
     image_framework, image_framework_version = get_framework_and_version_from_tag(mxnet_inference_eia)
     if image_framework_version == "1.5.1":
-        REANET_EIA_MODEL = "resnet-152-eia-1-5-1"
+        RESNET_EIA_MODEL = "resnet-152-eia-1-5-1"
     run_ec2_mxnet_inference(mxnet_inference_eia, RESNET_EIA_MODEL, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
 
 
@@ -56,7 +56,7 @@ def test_ec2_mxnet_resnet_inference_eia_cpu(mxnet_inference_eia, ec2_connection,
 def test_ec2_mxnet_resnet_inferencei_eia_gpu(mxnet_inference_eia, ec2_connection, region, eia_only):
     image_framework, image_framework_version = get_framework_and_version_from_tag(mxnet_inference_eia)
     if image_framework_version == "1.5.1":
-        REANET_EIA_MODEL = "resnet-152-eia-1-5-1"
+        RESNET_EIA_MODEL = "resnet-152-eia-1-5-1"
     run_ec2_mxnet_inference(mxnet_inference_eia, RESNET_EIA_MODEL, "resnet-152-eia", ec2_connection, "eia", region, 80, 8081)
 
 

--- a/test/dlc_tests/ecs/mxnet/inference/test_ecs_mxnet_inference.py
+++ b/test/dlc_tests/ecs/mxnet/inference/test_ecs_mxnet_inference.py
@@ -2,6 +2,7 @@ import pytest
 
 import test.test_utils.ecs as ecs_utils
 import test.test_utils.ec2 as ec2_utils
+from test.test_utils import get_framework_and_version_from_tag
 from test.test_utils import request_mxnet_inference, request_mxnet_inference_gluonnlp
 from test.test_utils import ECS_AML2_CPU_USWEST2, ECS_AML2_GPU_USWEST2
 

--- a/test/dlc_tests/ecs/mxnet/inference/test_ecs_mxnet_inference.py
+++ b/test/dlc_tests/ecs/mxnet/inference/test_ecs_mxnet_inference.py
@@ -36,12 +36,15 @@ def test_ecs_mxnet_inference_eia(mxnet_inference_eia, ecs_container_instance, ei
     public_ip_address = ec2_utils.get_public_ip(worker_instance_id, region=region)
 
     model_name = "resnet-152-eia"
+    image_framework, image_framework_version = get_framework_and_version_from_tag(mxnet_inference_eia)
+    if image_framework_version == "1.5.1":
+        model_name = "resnet-152-eia-1-5-1"
     service_name = task_family = revision = None
     try:
         service_name, task_family, revision = ecs_utils.setup_ecs_inference_service(
             mxnet_inference_eia, "mxnet", ecs_cluster_arn, model_name, worker_instance_id, ei_accelerator_type, region=region,
         )
-        inference_result = request_mxnet_inference(public_ip_address, model="resnet-152-eia")
+        inference_result = request_mxnet_inference(public_ip_address, model=model_name)
         assert inference_result, f"Failed to perform inference at IP address: {public_ip_address}"
 
     finally:

--- a/test/sagemaker_tests/mxnet/inference/integration/sagemaker/test_elastic_inference.py
+++ b/test/sagemaker_tests/mxnet/inference/integration/sagemaker/test_elastic_inference.py
@@ -18,12 +18,15 @@ import pytest
 from sagemaker import utils
 from sagemaker.mxnet import MXNetModel
 
+from test.test_utils import get_framework_and_version_from_tag
+
 from ...integration import EI_SUPPORTED_REGIONS, RESOURCE_PATH
 from ...integration.sagemaker.timeout import timeout_and_delete_endpoint_by_name
 
+
 DEFAULT_HANDLER_PATH = os.path.join(RESOURCE_PATH, 'default_handlers')
 MODEL_PATH = os.path.join(DEFAULT_HANDLER_PATH, 'model.tar.gz')
-SCRIPT_PATH = os.path.join(DEFAULT_HANDLER_PATH, 'model', 'code', 'eia_module.py')
+DEFAULT_SCRIPT_PATH = os.path.join(DEFAULT_HANDLER_PATH, 'model', 'code', 'eia_module.py')
 
 
 @pytest.fixture(autouse=True)
@@ -44,6 +47,11 @@ def skip_if_non_supported_ei_region(region):
 @pytest.mark.skip_if_non_supported_ei_region()
 @pytest.mark.skip_if_no_accelerator()
 def test_elastic_inference(ecr_image, sagemaker_session, instance_type, accelerator_type, framework_version):
+    entry_point = DEFAULT_SCRIPT_PATH
+    image_framework, image_framework_version = get_framework_and_version_from_tag(ecr_image)
+    if image_framework_version == "1.5.1":
+        entry_point = os.path.join(DEFAULT_HANDLER_PATH, 'model', 'code', 'empty_module.py')
+        
     endpoint_name = utils.unique_name_from_base('test-mxnet-ei')
 
     with timeout_and_delete_endpoint_by_name(endpoint_name=endpoint_name,
@@ -52,7 +60,7 @@ def test_elastic_inference(ecr_image, sagemaker_session, instance_type, accelera
         prefix = 'mxnet-serving/default-handlers'
         model_data = sagemaker_session.upload_data(path=MODEL_PATH, key_prefix=prefix)
         model = MXNetModel(model_data=model_data,
-                           entry_point=SCRIPT_PATH,
+                           entry_point=entry_point,
                            role='SageMakerRole',
                            image_uri=ecr_image,
                            framework_version=framework_version,

--- a/test/sagemaker_tests/mxnet/inference/integration/sagemaker/test_elastic_inference.py
+++ b/test/sagemaker_tests/mxnet/inference/integration/sagemaker/test_elastic_inference.py
@@ -23,7 +23,7 @@ from ...integration.sagemaker.timeout import timeout_and_delete_endpoint_by_name
 
 DEFAULT_HANDLER_PATH = os.path.join(RESOURCE_PATH, 'default_handlers')
 MODEL_PATH = os.path.join(DEFAULT_HANDLER_PATH, 'model.tar.gz')
-SCRIPT_PATH = os.path.join(DEFAULT_HANDLER_PATH, 'model', 'code', 'empty_module.py')
+SCRIPT_PATH = os.path.join(DEFAULT_HANDLER_PATH, 'model', 'code', 'eia_module.py')
 
 
 @pytest.fixture(autouse=True)

--- a/test/sagemaker_tests/mxnet/inference/resources/default_handlers/model/code/eia_module.py
+++ b/test/sagemaker_tests/mxnet/inference/resources/default_handlers/model/code/eia_module.py
@@ -13,6 +13,7 @@
 
 import mxnet as mx
 import eimx
+import os
 
 def model_fn(model_dir):
     logging.info('Invoking user-defined model_fn')

--- a/test/sagemaker_tests/mxnet/inference/resources/default_handlers/model/code/eia_module.py
+++ b/test/sagemaker_tests/mxnet/inference/resources/default_handlers/model/code/eia_module.py
@@ -25,7 +25,7 @@ def model_fn(model_dir):
     mod = mx.mod.Module(symbol=sym, context=mx.cpu(), label_names=None)
     exe = mod.bind(for_training=False,
                data_shapes=[('data', (1,2))],
-               label_shapes=None)
+               label_shapes=mod._label_shapes)
     mod.set_params(arg_params, aux_params, allow_missing=True)
 
     return mod

--- a/test/sagemaker_tests/mxnet/inference/resources/default_handlers/model/code/eia_module.py
+++ b/test/sagemaker_tests/mxnet/inference/resources/default_handlers/model/code/eia_module.py
@@ -13,7 +13,9 @@
 
 import mxnet as mx
 import eimx
+import logging
 import os
+
 
 def model_fn(model_dir):
     logging.info('Invoking user-defined model_fn')

--- a/test/sagemaker_tests/mxnet/inference/resources/default_handlers/model/code/eia_module.py
+++ b/test/sagemaker_tests/mxnet/inference/resources/default_handlers/model/code/eia_module.py
@@ -1,0 +1,28 @@
+#  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License").
+#  You may not use this file except in compliance with the License.
+#  A copy of the License is located at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  or in the "license" file accompanying this file. This file is distributed
+#  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+#  express or implied. See the License for the specific language governing
+#  permissions and limitations under the License.
+
+import mxnet as mx
+import eimx
+
+def model_fn(model_dir):
+    logging.info('Invoking user-defined model_fn')
+    # The compiled model artifacts are saved with the prefix 'compiled'
+    sym, arg_params, aux_params = mx.model.load_checkpoint(os.path.join(model_dir, 'compiled'), 0)
+    sym = sym.optimize_for('EIA')
+    mod = mx.mod.Module(symbol=sym, context=mx.cpu(), label_names=None)
+    exe = mod.bind(for_training=False,
+               data_shapes=[('data', (1,2))],
+               label_shapes=None)
+    mod.set_params(arg_params, aux_params, allow_missing=True)
+
+    return mod

--- a/test/sagemaker_tests/mxnet/inference/resources/default_handlers/model/code/eia_module.py
+++ b/test/sagemaker_tests/mxnet/inference/resources/default_handlers/model/code/eia_module.py
@@ -20,7 +20,7 @@ import os
 def model_fn(model_dir):
     logging.info('Invoking user-defined model_fn')
     # The compiled model artifacts are saved with the prefix 'compiled'
-    sym, arg_params, aux_params = mx.model.load_checkpoint(os.path.join(model_dir, 'compiled'), 0)
+    sym, arg_params, aux_params = mx.model.load_checkpoint(os.path.join(model_dir, 'model'), 0)
     sym = sym.optimize_for('EIA')
     mod = mx.mod.Module(symbol=sym, context=mx.cpu(), label_names=None)
     exe = mod.bind(for_training=False,

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -321,7 +321,8 @@ def get_inference_run_command(image_uri, model_names, processor="cpu"):
     server_type = get_inference_server_type(image_uri)
     if processor == "eia":
         multi_model_location = {
-            "resnet-152-eia": "https://s3.amazonaws.com/model-server/model_archive_1.0/resnet-152-eia.mar",
+            "resnet-152-eia": "https://s3.amazonaws.com/model-server/model_archive_1.0/resnet-152-eia-1-7-0.mar",
+            "resnet-152-eia-1-5-1": "https://s3.amazonaws.com/model-server/model_archive_1.0/resnet-152-eia-1-5-1.mar",
             "pytorch-densenet": "https://aws-dlc-sample-models.s3.amazonaws.com/pytorch/densenet_eia/densenet_eia_v1_5_1.mar",
             "pytorch-densenet-v1-3-1": "https://aws-dlc-sample-models.s3.amazonaws.com/pytorch/densenet_eia/densenet_eia_v1_3_1.mar",
         }


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet] | [ei] | [build]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON Checklist
* When creating a PR:
- [x] I've modified `src/config/build_config.py` in my PR branch by setting `ENABLE_EI_MODE = True` or `ENABLE_NEURON_MODE = True`
* When PR is reviewed and ready to be merged:
- [ ] I've reverted the code change on the config file mentioned above

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
Added MXNet 1.5.1 Dockerfile for Elastic Inference, and related test modifications to allow the use of `eimx` accelerator library.
Default framework version on buildspec-eia.yml is now 1.7.0.

*Tests run:*
GitHub Repo PR tests.
*DLC image/dockerfile:*
MXNet 1.7.0 Elastic Inference Dockerfile: `Dockerfile.eia`
*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

