### PR TITLE
[test] Skip ECR Scan on TF 2.4.1 images

### DIFF
--- a/test/dlc_tests/sanity/test_security_check.py
+++ b/test/dlc_tests/sanity/test_security_check.py
@@ -3,8 +3,11 @@ from time import sleep, time
 
 import pytest
 
+from packaging.version import Version
+
 from invoke import run
 
+from test.test_utils import get_framework_and_version_from_tag
 from test.test_utils import ecr as ecr_utils
 
 
@@ -47,6 +50,11 @@ def test_ecr_scan(image, ecr_client):
     :param image: str Image URI for image to be tested
     :param ecr_client: boto3 Client for ECR
     """
+    # TODO: Unskip this test for TF 2.4.1 images
+    framework, version = get_framework_and_version_from_tag(image)
+    if framework == "tensorflow" and Version(version) == Version("2.4.1"):
+        pytest.skip("Skip ECR Scan on TF 2.4.1 DLC images")
+
     scan_status = None
     start_time = time()
     ecr_utils.start_ecr_image_scan(ecr_client, image)


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [x] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
Skip the ECR Scan check on TF 2.4.1 docker images

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

