### PR TITLE
[doc] Add new TF and PT Neuron images to available_images

### DIFF
--- a/available_images.md
+++ b/available_images.md
@@ -123,7 +123,9 @@ Neuron Inference Containers
 
 | Framework 			                    |Job Type 	 |Python Version Options    |Example URL 			                                                                                    |
 |-------------------------------------------|------------|--------------------------|-----------------------------------------------------------------------------------------------------------|
-|TensorFlow 1.15 with Neuron Inference      |inference 	 |3.7 (py37) 	            |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-inference-neuron:1.15.4-neuron-py37-ubuntu18.04    |
+|PyTorch 1.5.1 with Neuron Inference        |inference 	 |3.7 (py37) 	            |763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference-neuron:1.5.1-neuron-py36-ubuntu16.04        |
+|TensorFlow 1.15.5 with Neuron Inference    |inference 	 |3.7 (py37) 	            |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-inference-neuron:1.15.5-neuron-py37-ubuntu18.04    |
+
 
 Prior General Framework Container Versions
 ==============
@@ -198,3 +200,10 @@ Prior Elastic Inference Container Versions
 |MXNet 1.5.1 with Elastic Inference           |inference     |No 			      |CPU 		   |3.6 (py36) 	   |763104351884.dkr.ecr.us-east-1.amazonaws.com/mxnet-inference-eia:1.5.1-cpu-py36-ubuntu16.04        |
 |PyTorch 1.3.1 with Elastic Inference 		  |inference 	 |No 			      |CPU 		   |3.6 (py36) 			       |763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference-eia:1.3.1-cpu-py36-ubuntu16.04      |
 |TensorFlow 1.14.0 with Elastic Inference 	  |inference 	 |No                      |CPU 	        |2.7 (py27), 3.6 (py36) 			      |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-inference-eia:1.14.0-cpu-py36-ubuntu16.04   |
+
+
+Prior Neuron Inference Container Versions
+==============
+| Framework 			                      |Job Type 	 |Python Version Options     |Example URL 			                                                                           |
+|---------------------------------------------|--------------|---------------------------|---------------------------------------------------------------------------------------------------|
+|TensorFlow 1.15.4 with Neuron Inference 	  |inference 	 |3.7 (py37) 			     |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-inference-neuron:1.15.4-neuron-py37-ubuntu18.04   |

--- a/available_images.md
+++ b/available_images.md
@@ -123,7 +123,7 @@ Neuron Inference Containers
 
 | Framework 			                    |Job Type 	 |Python Version Options    |Example URL 			                                                                                    |
 |-------------------------------------------|------------|--------------------------|-----------------------------------------------------------------------------------------------------------|
-|PyTorch 1.5.1 with Neuron Inference        |inference 	 |3.7 (py37) 	            |763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference-neuron:1.5.1-neuron-py36-ubuntu16.04        |
+|PyTorch 1.5.1 with Neuron Inference        |inference 	 |3.6 (py36) 	            |763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference-neuron:1.5.1-neuron-py36-ubuntu16.04        |
 |TensorFlow 1.15.5 with Neuron Inference    |inference 	 |3.7 (py37) 	            |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-inference-neuron:1.15.5-neuron-py37-ubuntu18.04    |
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description:*
Add newly released TF 1.15.5 and PT 1.5.1 Neuron DLC images to available_images.md

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*
- https://github.com/aws/deep-learning-containers/releases/tag/v1.3-tf-1.15.5-inf-neuron-py37
- https://github.com/aws/deep-learning-containers/releases/tag/v1.1-pt-1.5.1-inf-neuron-py36


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

