### PR TITLE
[test] fix mnist dataset download for smdebug test

### DIFF
--- a/test/sagemaker_tests/pytorch/training/resources/mnist/smdebug_mnist.py
+++ b/test/sagemaker_tests/pytorch/training/resources/mnist/smdebug_mnist.py
@@ -12,13 +12,12 @@
 # language governing permissions and limitations under the License.
 
 # Workaround for https://github.com/pytorch/vision/issues/1938
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 from six.moves import urllib
 opener = urllib.request.build_opener()
 opener.addheaders = [('User-agent', 'Mozilla/5.0')]
 urllib.request.install_opener(opener)
 
-from __future__ import absolute_import
 import argparse
 import logging
 import sys

--- a/test/sagemaker_tests/pytorch/training/resources/mnist/smdebug_mnist.py
+++ b/test/sagemaker_tests/pytorch/training/resources/mnist/smdebug_mnist.py
@@ -10,6 +10,14 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
+# Workaround for https://github.com/pytorch/vision/issues/1938
+from __future__ import print_function
+from six.moves import urllib
+opener = urllib.request.build_opener()
+opener.addheaders = [('User-agent', 'Mozilla/5.0')]
+urllib.request.install_opener(opener)
+
 from __future__ import absolute_import
 import argparse
 import logging


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
- Workaround to fix 403 errors while downloading MNIST dataset. For context, refer https://github.com/pytorch/vision/issues/1938



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

