### PR TITLE
[release] Add TF 1.15.5 inference to release images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -98,7 +98,7 @@ release_images:
       force_release: False
   8:
     framework: "tensorflow"
-    version: "1.15.4"
+    version: "1.15.5"
     training:
       device_types: ["gpu"]
       python_versions: ["py37"]
@@ -107,9 +107,17 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py36"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu100"
+      example: False
+      disable_sm_tag: False
+      force_release: False
   9:
     framework: "tensorflow"
-    version: "1.15.4"
+    version: "1.15.5"
     training:
       device_types: ["gpu"]
       python_versions: ["py37"]
@@ -296,28 +304,6 @@ release_images:
       force_release: False
   22:
     framework: "tensorflow"
-    version: "1.15.5"
-    training:
-      device_types: [ "gpu" ]
-      python_versions: [ "py37" ]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu110"
-      example: False
-      disable_sm_tag: True  # [Default: False] This option is not used by Example images
-      force_release: False
-  23:
-    framework: "tensorflow"
-    version: "1.15.5"
-    training:
-      device_types: [ "gpu" ]
-      python_versions: [ "py37" ]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu110"
-      example: True
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-  24:
-    framework: "tensorflow"
     version: "2.0.4"
     training:
       device_types: ["cpu", "gpu"]
@@ -335,7 +321,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  25:
+  23:
     framework: "tensorflow"
     version: "2.0.4"
     training:
@@ -346,7 +332,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  26:
+  24:
     framework: "tensorflow"
     version: "2.1.3"
     training:
@@ -365,7 +351,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  27:
+  25:
     framework: "tensorflow"
     version: "2.1.3"
     training:


### PR DESCRIPTION
*Issue #, if available:*

*Description:*
Add TF 1.15.5 inference DLCs to release_images.yml

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

