### PR TITLE
[release] Place TF 2.3.2 inference DLCs in release images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -75,28 +75,17 @@ release_images:
   6:
     framework: "tensorflow"
     version: "2.3.2"
-    training:
-      device_types: ["gpu"]
+    inference:
+      device_types: ["cpu", "gpu"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
-      cuda_version: "cu110"
+      cuda_version: "cu102"
       example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: True  # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
+      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
   7:
-    framework: "tensorflow"
-    version: "2.3.2"
-    training:
-      device_types: ["gpu"]
-      python_versions: ["py37"]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu110"
-      example: True
-      disable_sm_tag: False # [Default: False] This option is not used by Example images
-      force_release: False
-  8:
     framework: "tensorflow"
     version: "1.15.5"
     training:
@@ -115,7 +104,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  9:
+  8:
     framework: "tensorflow"
     version: "1.15.5"
     training:
@@ -128,7 +117,7 @@ release_images:
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-  10:
+  9:
     framework: "tensorflow"
     version: "1.15.0"
     inference:
@@ -140,7 +129,7 @@ release_images:
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
-  11:
+  10:
     framework: "mxnet"
     version: "1.8.0"
     training:
@@ -161,7 +150,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  12:
+  11:
     framework: "mxnet"
     version: "1.8.0"
     training:
@@ -172,7 +161,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  13:
+  12:
     framework: "mxnet"
     version: "1.7.0"
     training:
@@ -191,7 +180,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  14:
+  13:
     framework: "mxnet"
     version: "1.7.0"
     training:
@@ -200,31 +189,31 @@ release_images:
       os_version: "ubuntu16.04"
       cuda_version: "cu101"
       example: True
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  14:
+    framework: "mxnet"
+    version: "1.6.0"
+    training:
+      device_types: ["cpu","gpu"]
+      python_versions: ["py36"]
+      os_version: "ubuntu16.04"
+      cuda_version: "cu101"
+      example: False
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+    inference:
+      device_types: ["cpu","gpu"]
+      python_versions: ["py36"]
+      os_version: "ubuntu16.04"
+      cuda_version: "cu101"
+      example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
   15:
     framework: "mxnet"
     version: "1.6.0"
     training:
-      device_types: ["cpu","gpu"]
-      python_versions: ["py36"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu101"
-      example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-    inference:
-      device_types: ["cpu","gpu"]
-      python_versions: ["py36"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu101"
-      example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-  16:
-    framework: "mxnet"
-    version: "1.6.0"
-    training:
       device_types: ["gpu"]
       python_versions: ["py36"]
       os_version: "ubuntu16.04"
@@ -232,7 +221,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  17:
+  16:
     framework: "tensorflow"
     version: "2.2.2"
     training:
@@ -251,7 +240,7 @@ release_images:
       example: False
       disable_sm_tag: False # [Default: False] This option is not used by Example images
       force_release: False
-  18:
+  17:
     framework: "tensorflow"
     version: "2.2.2"
     training:
@@ -262,7 +251,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  19:
+  18:
     framework: "tensorflow"
     version: "2.0.0"
     inference:
@@ -272,7 +261,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  20:
+  19:
     framework: "tensorflow"
     version: "2.4.1"
     training:
@@ -291,7 +280,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  21:
+  20:
     framework: "tensorflow"
     version: "2.4.1"
     training:
@@ -302,7 +291,7 @@ release_images:
       example: True
       disable_sm_tag: False
       force_release: False
-  22:
+  21:
     framework: "tensorflow"
     version: "2.0.4"
     training:
@@ -321,7 +310,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  23:
+  22:
     framework: "tensorflow"
     version: "2.0.4"
     training:
@@ -332,7 +321,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  24:
+  23:
     framework: "tensorflow"
     version: "2.1.3"
     training:
@@ -351,7 +340,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  25:
+  24:
     framework: "tensorflow"
     version: "2.1.3"
     training:


### PR DESCRIPTION
*Issue #, if available:*

*Description:*
Replace TF 2.3.2 Training with Inference on release_images.yml

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

