### PR TITLE
[tensorflow] [build,test] Fix python sdk repo localmode tfs tests failing issue

### DIFF
--- a/src/config/build_config.py
+++ b/src/config/build_config.py
@@ -5,9 +5,9 @@ ENABLE_EI_MODE = False
 # Do remember to revert it back to False before merging any PR (including NEURON dedicated PR)
 ENABLE_NEURON_MODE = False
 # Frameworks for which you want to disable both builds and tests
-DISABLE_FRAMEWORK_TESTS = ["mxnet", "pytorch"]
+DISABLE_FRAMEWORK_TESTS = []
 # Disable new builds or build without datetime tag
-DISABLE_DATETIME_TAG = True
+DISABLE_DATETIME_TAG = False
 # Note: Need to build the images at least once with DISABLE_DATETIME_TAG = True
 # before disabling new builds or tests will fail
 DISABLE_NEW_BUILDS = False

--- a/src/config/build_config.py
+++ b/src/config/build_config.py
@@ -5,9 +5,9 @@ ENABLE_EI_MODE = False
 # Do remember to revert it back to False before merging any PR (including NEURON dedicated PR)
 ENABLE_NEURON_MODE = False
 # Frameworks for which you want to disable both builds and tests
-DISABLE_FRAMEWORK_TESTS = []
+DISABLE_FRAMEWORK_TESTS = ["mxnet", "pytorch"]
 # Disable new builds or build without datetime tag
-DISABLE_DATETIME_TAG = False
+DISABLE_DATETIME_TAG = True
 # Note: Need to build the images at least once with DISABLE_DATETIME_TAG = True
 # before disabling new builds or tests will fail
 DISABLE_NEW_BUILDS = False

--- a/tensorflow/inference/docker/build_artifacts/sagemaker/serve.py
+++ b/tensorflow/inference/docker/build_artifacts/sagemaker/serve.py
@@ -94,9 +94,11 @@ class ServiceManager(object):
             # just use the standard default ports
             self._tfs_grpc_port = ["9000"]
             self._tfs_rest_port = ["8501"]
+            self._tfs_grpc_port_range = "9000-9000"
+            self._tfs_rest_port_range = "8501-8501"
             # set environment variable for python service
-            os.environ["TFS_GRPC_PORT_RANGE"] = "9000-9000"
-            os.environ["TFS_REST_PORT_RANGE"] = "8501-8501"
+            os.environ["TFS_GRPC_PORT_RANGE"] = self._tfs_grpc_port_range
+            os.environ["TFS_REST_PORT_RANGE"] = self._tfs_rest_port_range
 
     def _create_tfs_config(self):
         models = tfs_utils.find_models()


### PR DESCRIPTION
*Issue #, if available:*
#985 
## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
Sync https://github.com/aws/sagemaker-tensorflow-serving-container/pull/194

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

