### PR TITLE
[pytorch][sagemaker] Decrease docker image size

### DIFF
--- a/pytorch/training/docker/1.8/py3/cu111/Dockerfile.gpu
+++ b/pytorch/training/docker/1.8/py3/cu111/Dockerfile.gpu
@@ -127,28 +127,8 @@ RUN conda install -c pytorch magma-cuda111==2.5.2 \
     h5py \
     requests \
     libgcc \
- && conda clean -ya
-
-# Install libboost from source. This package is needed for smdataparallel functionality [for networking asynchronous IO].
-RUN wget --quiet https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.gz \
-  && tar -xzf boost_1_73_0.tar.gz \
-  && cd boost_1_73_0 \
-  && ./bootstrap.sh \
-  && ./b2 threading=multi --prefix=${CONDA_PREFIX} -j 64 cxxflags=-fPIC cflags=-fPIC install || true \
-  && cd .. \
-  && rm -rf boost_1_73_0.tar.gz \
-  && rm -rf boost_1_73_0
-
-WORKDIR /opt/pytorch
-
-# Copy workaround script for incorrect hostname
-COPY changehostname.c /
-COPY start_with_right_hostname.sh /usr/local/bin/start_with_right_hostname.sh
-
-WORKDIR /root
-
-# Uninstall torch and torchvision before installing the custom versions from an S3 bucket
-RUN pip install --no-cache-dir -U \
+ && conda clean -ya \
+ && pip install --no-cache-dir -U \
     smdebug==${SMDEBUG_VERSION} \
     smclarify \
     "sagemaker>=2,<3" \
@@ -170,6 +150,24 @@ RUN pip install --no-cache-dir -U \
  && pip install --no-cache-dir -U ${PT_TRAINING_URL} \
  && pip uninstall -y torchvision \
  && pip install --no-deps --no-cache-dir -U ${PT_TORCHVISION_URL}
+
+# Install libboost from source. This package is needed for smdataparallel functionality [for networking asynchronous IO].
+RUN wget --quiet https://dl.bintray.com/boostorg/release/1.73.0/source/boost_1_73_0.tar.gz \
+  && tar -xzf boost_1_73_0.tar.gz \
+  && cd boost_1_73_0 \
+  && ./bootstrap.sh \
+  && ./b2 threading=multi --prefix=${CONDA_PREFIX} -j 64 cxxflags=-fPIC cflags=-fPIC install || true \
+  && cd .. \
+  && rm -rf boost_1_73_0.tar.gz \
+  && rm -rf boost_1_73_0
+
+WORKDIR /opt/pytorch
+
+# Copy workaround script for incorrect hostname
+COPY changehostname.c /
+COPY start_with_right_hostname.sh /usr/local/bin/start_with_right_hostname.sh
+
+WORKDIR /root
 
 # install metis
 RUN wget -nv http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/${METIS}.tar.gz \


### PR DESCRIPTION
The situation:
- layer 1 installs `conda install -c pytorch magma-cuda111==2.5.2` in order to pick up needed dependencies
- layer 2 removes torch and installs custom pytorch through pip: `pip uninstall -y torch && pip install --no-cache-dir -U ${PT_TRAINING_URL} `
Result: dependencies installed, custom PT installed, there is 1.5GB overhead in image size

Solution: remove the useless package within the same layer it was installed

*Issue #, if available:*
no issues 

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type


## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*

*Tests run:*

*DLC image/dockerfile:*
pytorch/training/docker/1.8/py3/cu111/Dockerfile.gpu

*Additional context:*
These images are too damn large

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

