### PR TITLE
[test] use pytest feature to check for current test execution 

### DIFF
--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -342,6 +342,15 @@ def pt14_and_above_only():
     pass
 
 
+@pytest.fixture(autouse=True)
+def log_current_test():
+    """
+    Log the name of the test currently being executed by pytest
+    """
+    test_name = f"{os.environ.get('PYTEST_CURRENT_TEST').split(':')[-1].split(' ')[0]}"
+    LOGGER.info(f"============================= Executing test :: {test_name} :: =============================")
+
+
 def framework_version_within_limit(metafunc_obj, image):
     """
     Test all pytest fixtures for TensorFlow version limits, and return True if all requirements are satisfied

--- a/test/sagemaker_tests/mxnet/inference/conftest.py
+++ b/test/sagemaker_tests/mxnet/inference/conftest.py
@@ -149,3 +149,12 @@ def skip_eia_containers(request, docker_base_name):
     if request.node.get_closest_marker('skip_eia_containers'):
         if 'eia' in docker_base_name:
             pytest.skip('Skipping eia container with tag {}'.format(docker_base_name))
+
+
+@pytest.fixture(autouse=True)
+def log_current_test():
+    """
+    Log the name of the test currently being executed by pytest
+    """
+    test_name = f"{os.environ.get('PYTEST_CURRENT_TEST').split(':')[-1].split(' ')[0]}"
+    logger.info(f"============================= Executing test :: {test_name} :: =============================")

--- a/test/sagemaker_tests/mxnet/training/conftest.py
+++ b/test/sagemaker_tests/mxnet/training/conftest.py
@@ -164,3 +164,12 @@ def skip_py2_containers(request, tag):
     if request.node.get_closest_marker('skip_py2_containers'):
         if 'py2' in tag:
             pytest.skip('Skipping python2 container with tag {}'.format(tag))
+
+
+@pytest.fixture(autouse=True)
+def log_current_test():
+    """
+    Log the name of the test currently being executed by pytest
+    """
+    test_name = f"{os.environ.get('PYTEST_CURRENT_TEST').split(':')[-1].split(' ')[0]}"
+    logger.info(f"============================= Executing test :: {test_name} :: =============================")

--- a/test/sagemaker_tests/pytorch/inference/conftest.py
+++ b/test/sagemaker_tests/pytorch/inference/conftest.py
@@ -243,3 +243,12 @@ def skip_gpu_py2(request, use_gpu, instance_type, py_version, framework_version)
     if request.node.get_closest_marker('skip_gpu_py2') and is_gpu and py_version != 'py3' \
             and framework_version == '1.4.0':
         pytest.skip('Skipping the test until mms issue resolved.')
+
+
+@pytest.fixture(autouse=True)
+def log_current_test():
+    """
+    Log the name of the test currently being executed by pytest
+    """
+    test_name = f"{os.environ.get('PYTEST_CURRENT_TEST').split(':')[-1].split(' ')[0]}"
+    logger.info(f"============================= Executing test :: {test_name} :: =============================")

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -247,3 +247,12 @@ def skip_py2_containers(request, tag):
     if request.node.get_closest_marker('skip_py2_containers'):
         if 'py2' in tag:
             pytest.skip('Skipping python2 container with tag {}'.format(tag))
+
+
+@pytest.fixture(autouse=True)
+def log_current_test():
+    """
+    Log the name of the test currently being executed by pytest
+    """
+    test_name = f"{os.environ.get('PYTEST_CURRENT_TEST').split(':')[-1].split(' ')[0]}"
+    logger.info(f"============================= Executing test :: {test_name} :: =============================")

--- a/test/sagemaker_tests/tensorflow/inference/test/conftest.py
+++ b/test/sagemaker_tests/tensorflow/inference/test/conftest.py
@@ -10,3 +10,21 @@
 # distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
+
+import os
+import sys
+import pytest
+import logging
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.INFO)
+LOGGER.addHandler(logging.StreamHandler(sys.stderr))
+
+
+@pytest.fixture(autouse=True)
+def log_current_test():
+    """
+    Log the name of the test currently being executed by pytest
+    """
+    test_name = f"{os.environ.get('PYTEST_CURRENT_TEST').split(':')[-1].split(' ')[0]}"
+    LOGGER.info(f"============================= Executing test :: {test_name} :: =============================")

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/conftest.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/conftest.py
@@ -146,3 +146,12 @@ def skip_py2_containers(request, tag):
 def ecr_image(account_id, docker_base_name, tag, region):
     registry = get_ecr_registry(account_id, region)
     return '{}/{}:{}'.format(registry, docker_base_name, tag)
+
+
+@pytest.fixture(autouse=True)
+def log_current_test():
+    """
+    Log the name of the test currently being executed by pytest
+    """
+    test_name = f"{os.environ.get('PYTEST_CURRENT_TEST').split(':')[-1].split(' ')[0]}"
+    logger.info(f"============================= Executing test :: {test_name} :: =============================")

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/conftest.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/conftest.py
@@ -146,3 +146,12 @@ def skip_py2_containers(request, tag):
     if request.node.get_closest_marker('skip_py2_containers'):
         if 'py2' in tag:
             pytest.skip('Skipping python2 container with tag {}'.format(tag))
+
+
+@pytest.fixture(autouse=True)
+def log_current_test():
+    """
+    Log the name of the test currently being executed by pytest
+    """
+    test_name = f"{os.environ.get('PYTEST_CURRENT_TEST').split(':')[-1].split(' ')[0]}"
+    logger.info(f"============================= Executing test :: {test_name} :: =============================")


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON Checklist
* When creating a PR:
- [ ] I've modified `src/config/build_config.py` in my PR branch by setting `ENABLE_EI_MODE = True` or `ENABLE_NEURON_MODE = True`
* When PR is reviewed and ready to be merged:
- [ ] I've reverted the code change on the config file mentioned above
#### Benchmark Checklist
* When creating a PR:
- [ ] I've modified `src/config/test_config.py` in my PR branch by setting `ENABLE_BENCHMARK_DEV_MODE = True`
* When PR is reviewed and ready to be merged:
- [ ] I've reverted the code change on the config file mentioned above

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
- Occasionally, the test codebuild job timesout and it is difficult to find out the test that led to the timeout. Adding this feature will log the name of the test currently being executed by pytest.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

