### PR TITLE
[tensorflow][test]Add non safe port set test and integration test for multi-tfs

### DIFF
--- a/test/sagemaker_tests/tensorflow/inference/test/integration/local/test_container.py
+++ b/test/sagemaker_tests/tensorflow/inference/test/integration/local/test_container.py
@@ -40,17 +40,19 @@ def container(request, docker_base_name, tag, runtime_config):
     try:
         if request.param:
             batching_config = ' -e SAGEMAKER_TFS_ENABLE_BATCHING=true'
+            port_config = ' -e SAGEMAKER_SAFE_PORT_RANGE=9000-9999'            
         else:
             batching_config = ''
+            port_config = ''            
         command = (
             'docker run {}--name sagemaker-tensorflow-serving-test -p 8080:8080'
             ' --mount type=volume,source=model_volume,target=/opt/ml/model,readonly'
             ' -e SAGEMAKER_TFS_NGINX_LOGLEVEL=info'
             ' -e SAGEMAKER_BIND_TO_PORT=8080'
-            ' -e SAGEMAKER_SAFE_PORT_RANGE=9000-9999'
+            ' {}'
             ' {}'
             ' {}:{} serve'
-        ).format(runtime_config, batching_config, docker_base_name, tag)
+        ).format(runtime_config, batching_config, port_config, docker_base_name, tag)
 
         proc = subprocess.Popen(command.split(), stdout=sys.stdout, stderr=subprocess.STDOUT)
 

--- a/test/sagemaker_tests/tensorflow/inference/test/integration/local/test_multi_tfs.py
+++ b/test/sagemaker_tests/tensorflow/inference/test/integration/local/test_multi_tfs.py
@@ -1,0 +1,97 @@
+# Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+import requests
+
+BASE_URL = "http://localhost:8080/invocations"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def volume():
+    try:
+        model_dir = os.path.abspath("test/resources/models")
+        subprocess.check_call(
+            "docker volume create --name multi_tfs_model_volume --opt type=none "
+            "--opt device={} --opt o=bind".format(model_dir).split())
+        yield model_dir
+    finally:
+        subprocess.check_call("docker volume rm multi_tfs_model_volume".split())
+
+
+@pytest.fixture(scope="module", autouse=True, params=[True, False])
+def container(request, docker_base_name, tag, runtime_config):
+    try:
+        if request.param:
+            batching_config = " -e SAGEMAKER_TFS_ENABLE_BATCHING=true"
+        else:
+            batching_config = ""
+        command = (
+            "docker run {}--name sagemaker-tensorflow-serving-test -p 8080:8080"
+            " --mount type=volume,source=multi_tfs_model_volume,target=/opt/ml/model,readonly"
+            " -e SAGEMAKER_TFS_NGINX_LOGLEVEL=info"
+            " -e SAGEMAKER_BIND_TO_PORT=8080"
+            " -e SAGEMAKER_SAFE_PORT_RANGE=9000-9999"
+            " -e SAGEMAKER_TFS_INSTANCE_COUNT=2"
+            " -e SAGEMAKER_GUNICORN_WORKERS=4"
+            " -e SAGEMAKER_TFS_INTER_OP_PARALLELISM=1"
+            " -e SAGEMAKER_TFS_INTRA_OP_PARALLELISM=1"          
+            " {}"
+            " {}:{} serve"
+        ).format(runtime_config, batching_config, docker_base_name, tag)
+
+        proc = subprocess.Popen(command.split(), stdout=sys.stdout, stderr=subprocess.STDOUT)
+
+        attempts = 0
+
+        while attempts < 40:
+            time.sleep(3)
+            try:
+                res_code = requests.get("http://localhost:8080/ping").status_code
+                if res_code == 200:
+                    break
+            except:
+                attempts += 1
+                pass
+
+        yield proc.pid
+    finally:
+        subprocess.check_call("docker rm -f sagemaker-tensorflow-serving-test".split())
+
+
+def make_request(data, content_type="application/json", method="predict", version=None):
+    custom_attributes = "tfs-model-name=half_plus_three,tfs-method={}".format(method)
+    if version:
+        custom_attributes += ",tfs-model-version={}".format(version)
+
+    headers = {
+        "Content-Type": content_type,
+        "X-Amzn-SageMaker-Custom-Attributes": custom_attributes,
+    }
+    response = requests.post(BASE_URL, data=data, headers=headers)
+    return json.loads(response.content.decode("utf-8"))
+
+
+def test_predict():
+    x = {
+        "instances": [1.0, 2.0, 5.0]
+    }
+
+    y = make_request(json.dumps(x))
+    assert y == {"predictions": [3.5, 4.0, 5.5]}

--- a/test/sagemaker_tests/tensorflow/inference/test/integration/local/test_multi_tfs.py
+++ b/test/sagemaker_tests/tensorflow/inference/test/integration/local/test_multi_tfs.py
@@ -88,6 +88,8 @@ def make_request(data, content_type="application/json", method="predict", versio
     return json.loads(response.content.decode("utf-8"))
 
 
+@pytest.mark.flaky(reruns=5, reruns_delay=25)
+@pytest.mark.model("half_plus_three")
 def test_predict():
     x = {
         "instances": [1.0, 2.0, 5.0]


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/deep-learning-containers/issues/985

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON Checklist
* When creating a PR:
- [ ] I've modified `src/config/build_config.py` in my PR branch by setting `ENABLE_EI_MODE = True` or `ENABLE_NEURON_MODE = True`
* When PR is reviewed and ready to be merged:
- [ ] I've reverted the code change on the config file mentioned above
#### Benchmark Checklist
* When creating a PR:
- [ ] I've modified `src/config/test_config.py` in my PR branch by setting `ENABLE_BENCHMARK_DEV_MODE = True`
* When PR is reviewed and ready to be merged:
- [ ] I've reverted the code change on the config file mentioned above

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
We need to cover the test for not setting up SAGE_PORT ENV var scenario and multi-tfs.
Synced from TFS repo:
https://github.com/aws/sagemaker-tensorflow-serving-container/pull/201
https://github.com/aws/sagemaker-tensorflow-serving-container/pull/205

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

