### PR TITLE
[test] remove efa marker from pytest command

### DIFF
--- a/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
+++ b/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
@@ -14,7 +14,7 @@ from test.test_utils import is_pr_context, SKIP_PR_REASON
 
 
 # Test only runs in region us-west-2, on instance type p3.16xlarge, on PR_EKS_CLUSTER_NAME_TEMPLATE cluster
-@pytest.mark.skipif(not is_pr_context(), reason=SKIP_PR_REASON)
+@pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
 @pytest.mark.integration("horovod")
 @pytest.mark.model("resnet")
 @pytest.mark.multinode(3)

--- a/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
+++ b/test/dlc_tests/eks/tensorflow/training/test_eks_tensorflow_multi_node_training.py
@@ -14,7 +14,7 @@ from test.test_utils import is_pr_context, SKIP_PR_REASON
 
 
 # Test only runs in region us-west-2, on instance type p3.16xlarge, on PR_EKS_CLUSTER_NAME_TEMPLATE cluster
-@pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
+@pytest.mark.skipif(not is_pr_context(), reason=SKIP_PR_REASON)
 @pytest.mark.integration("horovod")
 @pytest.mark.model("resnet")
 @pytest.mark.multinode(3)

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -387,9 +387,6 @@ def main():
             # Note:- Running multiple pytest_cmds in a sequence will result in the execution log having two
             #        separate pytest reports, both of which must be examined in case of a manual review of results.
 
-            for pytest_cmd in pytest_cmds:
-                if not is_pr_context():
-                    pytest_cmd += ["--efa"] if efa_dedicated else ["-m", "not efa"]
 
             cmd_exit_statuses = [pytest.main(pytest_cmd) for pytest_cmd in pytest_cmds]
             if all([status == 0 for status in cmd_exit_statuses]):


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON Checklist
* When creating a PR:
- [ ] I've modified `src/config/build_config.py` in my PR branch by setting `ENABLE_EI_MODE = True` or `ENABLE_NEURON_MODE = True`
* When PR is reviewed and ready to be merged:
- [ ] I've reverted the code change on the config file mentioned above
#### Benchmark Checklist
* When creating a PR:
- [ ] I've modified `src/config/test_config.py` in my PR branch by setting `ENABLE_BENCHMARK_DEV_MODE = True`
* When PR is reviewed and ready to be merged:
- [ ] I've reverted the code change on the config file mentioned above

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
- remove efa marker from pytest command as the efa marker is not used for tests except sagemaker and pytest does not filter test based on multiple markers (-m) passed using command line (need to find a way to combine in a single -m flag).



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

