### PR TITLE
[test][tensorflow] Add ECS Horovod test for TF

### DIFF
--- a/test/dlc_tests/container_tests/bin/testTF2HVDHelper
+++ b/test/dlc_tests/container_tests/bin/testTF2HVDHelper
@@ -45,7 +45,7 @@ if [ ${RETURN_VAL} -eq 0 ]; then
         -x HOROVOD_HIERARCHICAL_ALLREDUCE=1 -x HOROVOD_FUSION_THRESHOLD=16777216 \
         -x NCCL_MIN_NRINGS=4 -x LD_LIBRARY_PATH -x PATH -mca pml ob1 -mca btl ^openib \
         -x NCCL_SOCKET_IFNAME=$INTERFACE -mca btl_tcp_if_exclude lo,docker0 \
-        -x TF_CPP_MIN_LOG_LEVEL=0 -x RDMAV_FORK_SAFE\
+        -x TF_CPP_MIN_LOG_LEVEL=0 \
         python -W ignore ${HOVOROD_DIR}/tf2_train_imagenet_resnet_hvd.py \
         --synthetic --batch_size 64 --num_batches 100 --clear_log 2> ${TRAINING_LOG}
 else

--- a/test/dlc_tests/ecs/tensorflow/training/test_ecs_tensorflow_training.py
+++ b/test/dlc_tests/ecs/tensorflow/training/test_ecs_tensorflow_training.py
@@ -9,8 +9,10 @@ from test.test_utils import ec2 as ec2_utils
 
 TF_MNIST_TRAINING_SCRIPT = os.path.join(CONTAINER_TESTS_PREFIX, "testTensorFlow")
 TF_FasterRCNN_TRAINING_SCRIPT = os.path.join(CONTAINER_TESTS_PREFIX, "testFasterRCNN")
+TF_MPI_TRAINING_SCRIPT = os.path.join(CONTAINER_TESTS_PREFIX, "testTF2HVD")
 
 
+@pytest.mark.skip(reason="I can do what I want.")
 @pytest.mark.model("mnist")
 @pytest.mark.parametrize("training_script", [TF_MNIST_TRAINING_SCRIPT], indirect=True)
 @pytest.mark.parametrize("ecs_instance_type", ["c5.4xlarge"], indirect=True)
@@ -30,6 +32,7 @@ def test_ecs_tensorflow_training_mnist_cpu(cpu_only, ecs_container_instance, ten
     ecs_utils.ecs_training_test_executor(ecs_cluster_name, cluster_arn, training_cmd, tensorflow_training, instance_id)
 
 
+@pytest.mark.skip(reason="I can do what I want.")
 @pytest.mark.model("mnist")
 @pytest.mark.parametrize("training_script", [TF_MNIST_TRAINING_SCRIPT], indirect=True)
 @pytest.mark.parametrize("ecs_instance_type", ["p3.8xlarge"], indirect=True)
@@ -71,3 +74,27 @@ def test_ecs_tensorflow_training_fasterrcnn_gpu(gpu_only, ecs_container_instance
 
     ecs_utils.ecs_training_test_executor(ecs_cluster_name, cluster_arn, training_cmd, tensorflow_training, instance_id,
                                          num_gpus=num_gpus)
+
+
+@pytest.mark.model("FasterRCNN")
+@pytest.mark.parametrize("training_script", [TF_MPI_TRAINING_SCRIPT], indirect=True)
+@pytest.mark.parametrize("ecs_instance_type", ["p3dn.24xlarge"], indirect=True)
+@pytest.mark.parametrize("ecs_ami", [ECS_AML2_GPU_USWEST2], indirect=True)
+def test_ecs_tensorflow_training_mpi_gpu(
+    gpu_only, ecs_container_instance, tensorflow_training, training_cmd, ecs_cluster_name,
+):
+    """
+    GPU Faster RCNN test for TF Training
+
+    Instance Type - g3.8xlarge
+
+    Given above parameters, registers a task with family named after this test, runs the task, and waits for
+    the task to be stopped before doing teardown operations of instance and cluster.
+    """
+    instance_id, cluster_arn = ecs_container_instance
+
+    num_gpus = ec2_utils.get_instance_num_gpus(instance_id)
+
+    ecs_utils.ecs_training_test_executor(
+        ecs_cluster_name, cluster_arn, training_cmd, tensorflow_training, instance_id, num_gpus=num_gpus,
+    )

--- a/test/dlc_tests/ecs/tensorflow/training/test_ecs_tensorflow_training.py
+++ b/test/dlc_tests/ecs/tensorflow/training/test_ecs_tensorflow_training.py
@@ -75,8 +75,8 @@ def test_ecs_tensorflow_training_fasterrcnn_gpu(gpu_only, ecs_container_instance
                                          num_gpus=num_gpus)
 
 
-@pytest.mark.model("tf2mpi")
-@pytest.mark.skipif(not is_pr_context(), reason="Running additional model in nightly context only")
+@pytest.mark.model("tensorflow_mpi")
+@pytest.mark.skipif(not is_pr_context(), reason="Running additional model in pr context only")
 @pytest.mark.parametrize("training_script", [TF_MPI_TRAINING_SCRIPT], indirect=True)
 @pytest.mark.parametrize("ecs_instance_type", ["p3dn.24xlarge"], indirect=True)
 @pytest.mark.parametrize("ecs_ami", [ECS_AML2_GPU_USWEST2], indirect=True)

--- a/test/dlc_tests/ecs/tensorflow/training/test_ecs_tensorflow_training.py
+++ b/test/dlc_tests/ecs/tensorflow/training/test_ecs_tensorflow_training.py
@@ -75,13 +75,13 @@ def test_ecs_tensorflow_training_fasterrcnn_gpu(gpu_only, ecs_container_instance
                                          num_gpus=num_gpus)
 
 
-@pytest.mark.model("tensorflow_mpi")
+@pytest.mark.model("tensorflow2_mpi")
 @pytest.mark.skipif(not is_pr_context(), reason="Running additional model in pr context only")
 @pytest.mark.parametrize("training_script", [TF_MPI_TRAINING_SCRIPT], indirect=True)
 @pytest.mark.parametrize("ecs_instance_type", ["p3dn.24xlarge"], indirect=True)
 @pytest.mark.parametrize("ecs_ami", [ECS_AML2_GPU_USWEST2], indirect=True)
 def test_ecs_tensorflow_training_mpi_gpu(
-    gpu_only, ecs_container_instance, tensorflow_training, training_cmd, ecs_cluster_name,
+    gpu_only, ecs_container_instance, tensorflow_training, training_cmd, ecs_cluster_name, tf2_only
 ):
     """
     GPU MPI test for TF Training

--- a/test/dlc_tests/ecs/tensorflow/training/test_ecs_tensorflow_training.py
+++ b/test/dlc_tests/ecs/tensorflow/training/test_ecs_tensorflow_training.py
@@ -2,7 +2,8 @@ import os
 
 import pytest
 
-from test.test_utils import ECS_AML2_CPU_USWEST2, ECS_AML2_GPU_USWEST2, CONTAINER_TESTS_PREFIX, is_nightly_context
+from test.test_utils import ECS_AML2_CPU_USWEST2, ECS_AML2_GPU_USWEST2, CONTAINER_TESTS_PREFIX
+from test.test_utils import is_nightly_context, is_pr_context
 from test.test_utils import ecs as ecs_utils
 from test.test_utils import ec2 as ec2_utils
 
@@ -12,7 +13,6 @@ TF_FasterRCNN_TRAINING_SCRIPT = os.path.join(CONTAINER_TESTS_PREFIX, "testFaster
 TF_MPI_TRAINING_SCRIPT = os.path.join(CONTAINER_TESTS_PREFIX, "testTF2HVD")
 
 
-@pytest.mark.skip(reason="I can do what I want.")
 @pytest.mark.model("mnist")
 @pytest.mark.parametrize("training_script", [TF_MNIST_TRAINING_SCRIPT], indirect=True)
 @pytest.mark.parametrize("ecs_instance_type", ["c5.4xlarge"], indirect=True)
@@ -32,7 +32,6 @@ def test_ecs_tensorflow_training_mnist_cpu(cpu_only, ecs_container_instance, ten
     ecs_utils.ecs_training_test_executor(ecs_cluster_name, cluster_arn, training_cmd, tensorflow_training, instance_id)
 
 
-@pytest.mark.skip(reason="I can do what I want.")
 @pytest.mark.model("mnist")
 @pytest.mark.parametrize("training_script", [TF_MNIST_TRAINING_SCRIPT], indirect=True)
 @pytest.mark.parametrize("ecs_instance_type", ["p3.8xlarge"], indirect=True)
@@ -76,7 +75,8 @@ def test_ecs_tensorflow_training_fasterrcnn_gpu(gpu_only, ecs_container_instance
                                          num_gpus=num_gpus)
 
 
-@pytest.mark.model("FasterRCNN")
+@pytest.mark.model("tf2mpi")
+@pytest.mark.skipif(not is_pr_context(), reason="Running additional model in nightly context only")
 @pytest.mark.parametrize("training_script", [TF_MPI_TRAINING_SCRIPT], indirect=True)
 @pytest.mark.parametrize("ecs_instance_type", ["p3dn.24xlarge"], indirect=True)
 @pytest.mark.parametrize("ecs_ami", [ECS_AML2_GPU_USWEST2], indirect=True)
@@ -84,9 +84,9 @@ def test_ecs_tensorflow_training_mpi_gpu(
     gpu_only, ecs_container_instance, tensorflow_training, training_cmd, ecs_cluster_name,
 ):
     """
-    GPU Faster RCNN test for TF Training
+    GPU MPI test for TF Training
 
-    Instance Type - g3.8xlarge
+    Instance Type - p3dn.24xlarge
 
     Given above parameters, registers a task with family named after this test, runs the task, and waits for
     the task to be stopped before doing teardown operations of instance and cluster.


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [x] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [x] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [x] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [x] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
Add new test for TensorFlow Training with MPI on ECS

*Tests run:*
Successfully ran this test locally

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

