### PR TITLE
[test][pytorch][ec2] Fix flakiness in NCCL Version test

### DIFF
--- a/test/dlc_tests/container_tests/bin/pytorch_tests/testPyTorchNcclVersion.py
+++ b/test/dlc_tests/container_tests/bin/pytorch_tests/testPyTorchNcclVersion.py
@@ -9,11 +9,13 @@ import torch
 LOGGER = logging.getLogger(__name__)
 logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 
+
 def test_nccl_version():
     try:
         pt_nccl = torch.cuda.nccl.version()
         find = subprocess.Popen(['find', '/usr', '-name', 'libnccl.so*'], stdout=PIPE)
-        tail = subprocess.Popen(['head', '-n1'], stdin=find.stdout, stdout=PIPE)
+        sort = subprocess.Popen(['sort', '-r'], stdin=find.stdout, stdout=PIPE)
+        tail = subprocess.Popen(['head', '-n1'], stdin=sort.stdout, stdout=PIPE)
         result = subprocess.Popen(['sed', '-r', 's/^.*\.so\.//'], stdin=tail.stdout, stdout=PIPE)
         output, error = result.communicate()
         numbers = [int(x, 10) for x in output.decode("utf-8").strip().split('.')]
@@ -26,6 +28,7 @@ def test_nccl_version():
         LOGGER.debug("Error: check_pytorch test failed.")
         LOGGER.debug("Exception: {}".format(excp))
         raise
+
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
The results of `find /usr -name libnccl.so.*` could be printed in any order. This caused the test script for NCCL version to sometimes fail based on chance.

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

