### PR TITLE
[test][ec2][pytorch] Run NCCL version test only on PT 1.7 or above DLCs

### DIFF
--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -342,6 +342,11 @@ def mx18_and_above_only():
 
 
 @pytest.fixture(scope="session")
+def pt17_and_above_only():
+    pass
+
+
+@pytest.fixture(scope="session")
 def pt16_and_above_only():
     pass
 
@@ -377,10 +382,11 @@ def framework_version_within_limit(metafunc_obj, image):
         if mx18_requirement_failed :
             return False
     if image_framework_name == "pytorch" :
+        pt17_requirement_failed = "pt17_and_above_only" in metafunc_obj.fixturenames and is_below_framework_version("1.7", image, "pytorch")
         pt16_requirement_failed = "pt16_and_above_only" in metafunc_obj.fixturenames and is_below_framework_version("1.6", image, "pytorch")
         pt15_requirement_failed = "pt15_and_above_only" in metafunc_obj.fixturenames and is_below_framework_version("1.5", image, "pytorch")
         pt14_requirement_failed = "pt14_and_above_only" in metafunc_obj.fixturenames and is_below_framework_version("1.4", image, "pytorch")
-        if pt16_requirement_failed or pt15_requirement_failed or pt14_requirement_failed:
+        if pt17_requirement_failed or pt16_requirement_failed or pt15_requirement_failed or pt14_requirement_failed:
             return False
     return True
 

--- a/test/dlc_tests/ec2/pytorch/training/test_pytorch_training.py
+++ b/test/dlc_tests/ec2/pytorch/training/test_pytorch_training.py
@@ -125,10 +125,13 @@ def test_pytorch_nccl(pytorch_training, ec2_connection, gpu_only, py3_only, ec2_
     test_cmd = os.path.join(CONTAINER_TESTS_PREFIX, "pytorch_tests", "testPyTorchNccl")
     execute_ec2_training_test(ec2_connection, pytorch_training, test_cmd)
 
+
 @pytest.mark.integration("nccl")
 @pytest.mark.model("N/A")
 @pytest.mark.parametrize("ec2_instance_type", PT_EC2_GPU_INSTANCE_TYPE, indirect=True)
-def test_pytorch_nccl_version(pytorch_training, ec2_connection, gpu_only, py3_only, ec2_instance_type):
+def test_pytorch_nccl_version(
+    pytorch_training, ec2_connection, gpu_only, py3_only, ec2_instance_type, pt17_and_above_only,
+):
     """
     Tests nccl version
     """
@@ -136,6 +139,7 @@ def test_pytorch_nccl_version(pytorch_training, ec2_connection, gpu_only, py3_on
         pytest.skip(f"Image {pytorch_training} is incompatible with instance type {ec2_instance_type}")
     test_cmd = os.path.join(CONTAINER_TESTS_PREFIX, "pytorch_tests", "testPyTorchNcclVersion")
     execute_ec2_training_test(ec2_connection, pytorch_training, test_cmd)
+
 
 @pytest.mark.integration("mpi")
 @pytest.mark.model("resnet18")


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
Skip PyTorch NCCL Version Test on DLCs PyTorch 1.6 and below

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

