### PR TITLE
[release] Add PT 1.6 GPU cu110 and PT 1.8 to release_images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -193,7 +193,17 @@ release_images:
     framework: "pytorch"
     version: "1.8.1"
     training:
-      device_types: ["gpu"]
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py36"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu111"
+      example: False        # [Default: False] Set to True to denote that this image is an Example image
+      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
+                            # to images being published.
+      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
+                            # has already been published. Re-released image will have minor version incremented by 1.
+    inference:
+      device_types: ["cpu", "gpu"]
       python_versions: ["py36"]
       os_version: "ubuntu18.04"
       cuda_version: "cu111"
@@ -282,18 +292,21 @@ release_images:
     framework: "pytorch"
     version: "1.6.0"
     training:
-      device_types: ["cpu"]
+      device_types: ["gpu"]
       python_versions: ["py36"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu101"
+      os_version: "ubuntu18.04"
+      cuda_version: "cu110"
       example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      disable_sm_tag: True  # [Default: False] This option is not used by Example images
       force_release: False
-    inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py36"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu101"
-      example: False
+  22:
+    framework: "pytorch"
+    version: "1.6.0"
+    training:
+      device_types: [ "gpu" ]
+      python_versions: [ "py36" ]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu110"
+      example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
Add PT 1.6 cu110 Training DLC and PT 1.8 CPU/GPU Training/Inference DLCs to release_images.yml

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

