### PR TITLE
[test][sagemaker] Add ap-northeast-2 to NO_PR_REGIONS

### DIFF
--- a/test/sagemaker_tests/huggingface_pytorch/inference/conftest.py
+++ b/test/sagemaker_tests/huggingface_pytorch/inference/conftest.py
@@ -59,6 +59,7 @@ NO_P2_REGIONS = [
 NO_P3_REGIONS = [
     "af-south-1",
     "ap-east-1",
+    "ap-northeast-2",
     "ap-northeast-3",
     "ap-southeast-1",
     "ap-southeast-2",

--- a/test/sagemaker_tests/huggingface_pytorch/training/conftest.py
+++ b/test/sagemaker_tests/huggingface_pytorch/training/conftest.py
@@ -59,6 +59,7 @@ NO_P2_REGIONS = [
 ]
 NO_P3_REGIONS = [
     "ap-east-1",
+    "ap-northeast-2",
     "ap-northeast-3",
     "ap-southeast-1",
     "ap-southeast-2",

--- a/test/sagemaker_tests/huggingface_tensorflow/inference/integration/sagemaker/conftest.py
+++ b/test/sagemaker_tests/huggingface_tensorflow/inference/integration/sagemaker/conftest.py
@@ -38,6 +38,7 @@ NO_P2_REGIONS = [
     "af-south-1",
 ]
 NO_P3_REGIONS = [
+    "ap-northeast-2",
     "ap-southeast-1",
     "ap-southeast-2",
     "ap-south-1",

--- a/test/sagemaker_tests/huggingface_tensorflow/training/integration/__init__.py
+++ b/test/sagemaker_tests/huggingface_tensorflow/training/integration/__init__.py
@@ -40,6 +40,7 @@ NO_P2_REGIONS = [
     "af-south-1",
 ]
 NO_P3_REGIONS = [
+    "ap-northeast-2",
     "ap-southeast-1",
     "ap-southeast-2",
     "ap-south-1",

--- a/test/sagemaker_tests/mxnet/inference/integration/__init__.py
+++ b/test/sagemaker_tests/mxnet/inference/integration/__init__.py
@@ -39,6 +39,7 @@ NO_P2_REGIONS = [
     "af-south-1",
 ]
 NO_P3_REGIONS = [
+    "ap-northeast-2",
     "ap-southeast-1",
     "ap-southeast-2",
     "ap-south-1",

--- a/test/sagemaker_tests/mxnet/training/integration/__init__.py
+++ b/test/sagemaker_tests/mxnet/training/integration/__init__.py
@@ -32,6 +32,7 @@ NO_P2_REGIONS = [
     "af-south-1",
 ]
 NO_P3_REGIONS = [
+    "ap-northeast-2",
     "ap-southeast-1",
     "ap-southeast-2",
     "ap-south-1",

--- a/test/sagemaker_tests/pytorch/inference/conftest.py
+++ b/test/sagemaker_tests/pytorch/inference/conftest.py
@@ -59,6 +59,7 @@ NO_P2_REGIONS = [
 NO_P3_REGIONS = [
     "af-south-1",
     "ap-east-1",
+    "ap-northeast-2",
     "ap-northeast-3",
     "ap-southeast-1",
     "ap-southeast-2",

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -58,6 +58,7 @@ NO_P2_REGIONS = [
 ]
 NO_P3_REGIONS = [
     "ap-east-1",
+    "ap-northeast-2",
     "ap-northeast-3",
     "ap-southeast-1",
     "ap-southeast-2",

--- a/test/sagemaker_tests/tensorflow/inference/test/integration/sagemaker/conftest.py
+++ b/test/sagemaker_tests/tensorflow/inference/test/integration/sagemaker/conftest.py
@@ -38,6 +38,7 @@ NO_P2_REGIONS = [
     "af-south-1",
 ]
 NO_P3_REGIONS = [
+    "ap-northeast-2",
     "ap-southeast-1",
     "ap-southeast-2",
     "ap-south-1",

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/__init__.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/__init__.py
@@ -42,6 +42,7 @@ NO_P2_REGIONS = [
     "af-south-1",
 ]
 NO_P3_REGIONS = [
+    "ap-northeast-2",
     "ap-southeast-1",
     "ap-southeast-2",
     "ap-south-1",
@@ -176,7 +177,7 @@ def get_account_id_from_image_uri(image_uri):
     :return: <str> AWS Account ID
     """
     return image_uri.split(".")[0]
-    
+
 
 def reupload_image_to_test_ecr(source_image_uri, target_image_repo_name, target_region):
     """

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/__init__.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/__init__.py
@@ -46,6 +46,7 @@ NO_P2_REGIONS = [
     "af-south-1",
 ]
 NO_P3_REGIONS = [
+    "ap-northeast-2",
     "ap-southeast-1",
     "ap-southeast-2",
     "ap-south-1",
@@ -171,7 +172,7 @@ def get_unique_name_from_tag(image_uri):
     :return: unique name
     """
     return re.sub('[^A-Za-z0-9]+', '', image_uri)
-    
+
 
 def get_account_id_from_image_uri(image_uri):
     """
@@ -181,7 +182,7 @@ def get_account_id_from_image_uri(image_uri):
     :return: <str> AWS Account ID
     """
     return image_uri.split(".")[0]
-    
+
 
 def reupload_image_to_test_ecr(source_image_uri, target_image_repo_name, target_region):
     """


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
Add ap-northeast-2 to NO_P3_REGIONS lists, due to ICE errors for p3 instances

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

