### PR TITLE
[test] Add huggingface parametrization

### DIFF
--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -429,25 +429,6 @@ def pytest_collection_modifyitems(session, config, items):
         report_generator.generate_sagemaker_reports()
 
 
-def generate_tests_exceptions(lookup_keyword, image_uri):
-    """
-    Given that a lookup_keyword exists within image_uri, ensure that the image_uri is not one of the exceptions
-    for images that match the keyword. For example, EIA images have "cpu" in the image uri, but are not meant to
-    be tested with functions that test CPU images.
-
-    :param lookup_keyword: Lookup term that has a match in the image URI
-    :param image_uri: ECR Image URI for image
-    :return: bool True if image_uri is one of the exceptions for lookup_keyword, and False otherwise
-    """
-    if lookup_keyword not in image_uri:
-        return False
-
-    exception_keywords = {
-        "cpu": ["eia"],
-        "tensorflow-training": ""
-    }
-
-
 def generate_unique_values_for_fixtures(metafunc_obj, images_to_parametrize, values_to_generate_for_fixture):
     """
     Take a dictionary (values_to_generate_for_fixture), that maps a fixture name used in a test function to another

--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -323,6 +323,11 @@ def example_only():
 
 
 @pytest.fixture(scope="session")
+def huggingface_only():
+    pass
+
+
+@pytest.fixture(scope="session")
 def tf2_only():
     pass
 


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [x] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [x] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [x] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [x] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
Added parametrization for "huggingface" keyword and associated DLC images

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

