### PR TITLE
[test] Check approximate values in smclarify test

### DIFF
--- a/test/dlc_tests/container_tests/bin/test_smclarify_bias_metrics.py
+++ b/test/dlc_tests/container_tests/bin/test_smclarify_bias_metrics.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import copy
-import pytest
 import os
 import logging
 import sys
@@ -14,6 +13,11 @@ from typing import Dict, Optional
 import pandas as pd
 from smclarify.bias.report import FacetColumn, LabelColumn, bias_report, StageType
 from smclarify.util.dataset import Datasets
+
+# Install and import pytest
+import subprocess
+subprocess.call([sys.executable, "-m", "pip", "install", "pytest"])
+import pytest
 
 logger = logging.getLogger(__name__)
 

--- a/test/dlc_tests/container_tests/bin/test_smclarify_bias_metrics.py
+++ b/test/dlc_tests/container_tests/bin/test_smclarify_bias_metrics.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import copy
+import pytest
 import os
 import logging
 import sys
@@ -14,6 +16,42 @@ from smclarify.bias.report import FacetColumn, LabelColumn, bias_report, StageTy
 from smclarify.util.dataset import Datasets
 
 logger = logging.getLogger(__name__)
+
+def approximate(expected, rtol=None, atol=None):
+    """
+    An enhancement of pytest.approx to support complex composite objects like a nested dict (see [1]).
+    [1] https://github.com/pytest-dev/pytest/issues/3164
+
+    :param expected: the input, it is supposed to be a complex composite object like a nested dict or list.
+    :param rtol: relative tolerance
+    :param atol: absolute tolerance
+    :return: A copy of the input but with all floating number wrapped by pytest.approx.
+    """
+    expected_copy = copy.deepcopy(expected)
+    __approximate(expected_copy, rtol, atol)
+    return expected_copy
+
+
+def __approximate(data, rtol=None, atol=None):
+    t = type(data)
+    if t == dict:
+        for key, value in data.items():
+            if type(value) == float:
+                data[key] = pytest.approx(value, rel=rtol, abs=atol)
+            elif value:
+                __approximate(value, rtol, atol)
+            else:
+                logger.info(f"Cannot convert null value for {data['name']}")
+    elif t == list:
+        for i in range(len(data)):
+            value = data[i]
+            if type(value) == float:
+                data[i] = pytest.approx(value, rel=rtol, abs=atol)
+            elif value:
+                __approximate(value, rtol, atol)
+            else:
+                logger.info(f"Cannot convert null value for  index {data}[{i}]")
+
 
 def fetch_input_data() -> pd.DataFrame:
     dataset = Datasets()
@@ -98,9 +136,9 @@ def test_bias_metrics():
     pre_training_expected_result = expected_results.get("pre_training_bias_metrics")
     post_training_expected_result = expected_results.get("post_training_bias_metrics")
 
-    if not (pre_training_metrics == pre_training_expected_result):
+    if not (pre_training_metrics == approximate(pre_training_expected_result)):
         raise AssertionError("Pre_training Bias Metrics values differ from expected Metrics")
-    if not (post_training_metrics == post_training_expected_result):
+    if not (post_training_metrics == approximate(post_training_expected_result)):
         raise AssertionError("Post_training Bias Metrics values differ from expected Metrics")
     print("Test SMClarify Bias Metrics succeeded!")
 

--- a/test/dlc_tests/ec2/test_smclarify.py
+++ b/test/dlc_tests/ec2/test_smclarify.py
@@ -76,8 +76,8 @@ def run_smclarify_bias_metrics(
         ec2_connection.run(
             f"{docker_executable} run --name {container_name} -v "
             f"{container_test_local_dir}:{os.path.join(os.sep, 'test')} {image_uri} "
-            f"\"python3 -m pip install pytest && "
-            f"python3 {test_script}\"",
+            f"\"python -m pip install pytest && "
+            f"python {test_script}\"",
             hide=True,
             timeout=300,
         )

--- a/test/dlc_tests/ec2/test_smclarify.py
+++ b/test/dlc_tests/ec2/test_smclarify.py
@@ -76,8 +76,7 @@ def run_smclarify_bias_metrics(
         ec2_connection.run(
             f"{docker_executable} run --name {container_name} -v "
             f"{container_test_local_dir}:{os.path.join(os.sep, 'test')} {image_uri} "
-            f"\"python -m pip install pytest && "
-            f"python {test_script}\"",
+            f"python {test_script}",
             hide=True,
             timeout=300,
         )

--- a/test/dlc_tests/ec2/test_smclarify.py
+++ b/test/dlc_tests/ec2/test_smclarify.py
@@ -76,7 +76,8 @@ def run_smclarify_bias_metrics(
         ec2_connection.run(
             f"{docker_executable} run --name {container_name} -v "
             f"{container_test_local_dir}:{os.path.join(os.sep, 'test')} {image_uri} "
-            f"python {test_script}",
+            f"\"python3 -m pip install pytest && "
+            f"python3 {test_script}\"",
             hide=True,
             timeout=300,
         )


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
The current test checks for exact value match in smclarify tests. When run on different arch or OS, the values can be slightly different. We need to check for approximate values instead.

*Tests run:*
I ran the tests manually using @mansimane 's containers which used to fail this test.
```
PASSED ec2/test_smclarify.py::::test_smclarify_metrics_cpu[XXXXXXXX.dkr.ecr.us-west-2.amazonaws.com/pr-pytorch-training:1.9.0-cpu-py38-ubuntu20.04-pr-1132-2021-06-08-05-36-47-test_smclarify_metrics_cpu-pt-tr-1-9-0-cpu-py38-ubuntu20-04-pr-1132-2021-06-08-05-36-47-XXXXXXXX_test-0-c4.2xlarge]
PASSED ec2/test_smclarify.py::::test_smclarify_metrics_gpu[XXXXXXXX.dkr.ecr.us-west-2.amazonaws.com/pr-pytorch-training:1.9.0-gpu-py38-cu111-ubuntu20.04-pr-1132-2021-06-08-05-36-47-test_smclarify_metrics_gpu-pt-tr-1-9-0-gpu-py38-cu111-ubuntu20-04-pr-1132-2021-06-08-05-36-47-XXXXXXXX_test-0-p3.2xlarge]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

