### PR TITLE
Updated dockerfile for fetching vulnerabilities of updated images [mxnet, tensorflow, pytorch] 

### DIFF
--- a/mxnet/training/docker/1.8.0/py3/Dockerfile.cpu
+++ b/mxnet/training/docker/1.8.0/py3/Dockerfile.cpu
@@ -13,6 +13,11 @@ ARG MX_URL=https://aws-mx-pypi.s3-us-west-2.amazonaws.com/1.8.0/aws_mx-1.8.0-py2
 ARG SMDEBUG_VERSION=0.9.4
 ARG OPENSSL_VERSION=1.1.1k
 
+RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/
+
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:/usr/local/lib" \

--- a/pytorch/training/docker/1.8/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/1.8/py3/Dockerfile.cpu
@@ -32,6 +32,11 @@ ARG PT_S3_WHL=https://aws-s3-plugin.s3-us-west-2.amazonaws.com/binaries/0.0.1/93
 WORKDIR /
 
 RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/
+ 
+RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     build-essential \
     ca-certificates \

--- a/src/config/test_config.py
+++ b/src/config/test_config.py
@@ -7,9 +7,9 @@ ENABLE_BENCHMARK_DEV_MODE = False
 # It is recommended to set DISABLE_EFA_TESTS to True to disable EFA tests if there is no change to EFA installer version or Frameworks.
 DISABLE_EFA_TESTS = False
 
-DISABLE_SANITY_TESTS = False
-DISABLE_SAGEMAKER_TESTS = False
-DISABLE_ECS_TESTS = False
-DISABLE_EKS_TESTS = False
-DISABLE_EC2_TESTS = False
+DISABLE_SANITY_TESTS = True
+DISABLE_SAGEMAKER_TESTS = True
+DISABLE_ECS_TESTS = True
+DISABLE_EKS_TESTS = True
+DISABLE_EC2_TESTS = True
 USE_SCHEDULER = False

--- a/tensorflow/training/docker/2.4/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.4/py3/Dockerfile.cpu
@@ -36,6 +36,11 @@ ARG ESTIMATOR_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/est
 ARG SMDEBUG_VERSION=1.0.9
 
 RUN apt-get update \
+ && apt-get upgrade -y \
+ && apt-get clean \
+ && rm -rf /var/lib/apt/lists/
+
+RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     build-essential \
     openssh-client \


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON Checklist
* When creating a PR:
- [ ] I've modified `src/config/build_config.py` in my PR branch by setting `ENABLE_EI_MODE = True` or `ENABLE_NEURON_MODE = True`
* When PR is reviewed and ready to be merged:
- [ ] I've reverted the code change on the config file mentioned above

#### Benchmark Checklist
* When creating a PR:
- [ ] I've modified `src/config/test_config.py` in my PR branch by setting `ENABLE_BENCHMARK_DEV_MODE = True`
* When PR is reviewed and ready to be merged:
- [ ] I've reverted the code change on the config file mentioned above

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
A PR to allow CI to build the images that can be used for fetching the vulnerabilities. 

*Tests run:*

*DLC image/dockerfile:*
mxnet/training/docker/1.8.0/py3/Dockerfile.cpu
pytorch/training/docker/1.8/py3/Dockerfile.cpu
tensorflow/training/docker/2.4/py3/Dockerfile.cpu

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

