### PR TITLE
[release] Add MX 1.8 Neuron to release_images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -108,37 +108,16 @@ release_images:
   8:
     framework: "mxnet"
     version: "1.8.0"
-    training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py37"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu110"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-                            # to images being published.
-      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
-                            # has already been published. Re-released image will have minor version incremented by 1.
     inference:
-      device_types: ["cpu", "gpu"]
+      device_types: ["neuron"]
       python_versions: ["py37"]
-      os_version: "ubuntu16.04"
+      os_version: "ubuntu18.04"
       cuda_version: "cu110"
       example: False
       disable_sm_tag: False
       force_release: False
   9:
     framework: "mxnet"
-    version: "1.8.0"
-    training:
-      device_types: ["gpu"]
-      python_versions: ["py37"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu110"
-      example: True
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-  10:
-    framework: "mxnet"
     version: "1.7.0"
     training:
       device_types: ["cpu","gpu"]
@@ -156,7 +135,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  11:
+  10:
     framework: "mxnet"
     version: "1.7.0"
     training:
@@ -166,6 +145,17 @@ release_images:
       cuda_version: "cu101"
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  11:
+    framework: "tensorflow"
+    version: "2.4.1"
+    training:
+      device_types: ["gpu"]
+      python_versions: ["py37"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu110"
+      example: False
+      disable_sm_tag: False
       force_release: False
   12:
     framework: "tensorflow"
@@ -175,21 +165,10 @@ release_images:
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
       cuda_version: "cu110"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  13:
-    framework: "tensorflow"
-    version: "2.4.1"
-    training:
-      device_types: ["gpu"]
-      python_versions: ["py37"]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu110"
       example: True
       disable_sm_tag: False
       force_release: False
-  14:
+  13:
     framework: "pytorch"
     version: "1.8.1"
     training:
@@ -212,7 +191,7 @@ release_images:
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
-  15:
+  14:
     framework: "pytorch"
     version: "1.8.1"
     training:
@@ -221,31 +200,31 @@ release_images:
       os_version: "ubuntu18.04"
       cuda_version: "cu111"
       example: True
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  15:
+    framework: "pytorch"
+    version: "1.5.1"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py36"]
+      os_version: "ubuntu16.04"
+      cuda_version: "cu101"
+      example: False
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py36"]
+      os_version: "ubuntu16.04"
+      cuda_version: "cu101"
+      example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
   16:
     framework: "pytorch"
     version: "1.5.1"
     training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py36"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu101"
-      example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-    inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py36"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu101"
-      example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-  17:
-    framework: "pytorch"
-    version: "1.5.1"
-    training:
       device_types: ["gpu"]
       python_versions: ["py36"]
       os_version: "ubuntu16.04"
@@ -253,7 +232,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  18:
+  17:
     framework: "huggingface_tensorflow"
     version: "2.4.1"
     hf_transformers: "4.6.1"
@@ -265,7 +244,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  19:
+  18:
     framework: "huggingface_pytorch"
     version: "1.7.1"
     hf_transformers: "4.6.1"
@@ -277,7 +256,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  20:
+  19:
     framework: "pytorch"
     version: "1.5.0"
     inference:
@@ -288,7 +267,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  21:
+  20:
     framework: "pytorch"
     version: "1.6.0"
     training:
@@ -299,7 +278,7 @@ release_images:
       example: False
       disable_sm_tag: True  # [Default: False] This option is not used by Example images
       force_release: False
-  22:
+  21:
     framework: "pytorch"
     version: "1.6.0"
     training:
@@ -310,7 +289,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  23:
+  22:
     framework: "huggingface_pytorch"
     version: "1.6.0"
     hf_transformers: "4.6.1"


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

*Description:*
Add MXNet 1.8.0 Neuron DLC to release_images.yml

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

