### PR TITLE
[doc] Add MX 1.8 Neuron to available images

### DIFF
--- a/available_images.md
+++ b/available_images.md
@@ -134,8 +134,9 @@ Neuron Inference Containers
 
 |Framework                                  |Job Type   |Python Version Options |Example URL                                                                                                |
 |-------------------------------------------|-----------|-----------------------|-----------------------------------------------------------------------------------------------------------|
-|PyTorch 1.7.1 with Neuron Inference        |inference 	|3.6 (py36) 	        |763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference-neuron:1.7.1-neuron-py36-ubuntu16.04        |
+|PyTorch 1.7.1 with Neuron Inference        |inference 	|3.6 (py36) 	        |763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference-neuron:1.7.1-neuron-py36-ubuntu18.04        |
 |TensorFlow 1.15.5 with Neuron Inference    |inference 	|3.7 (py37) 	        |763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-inference-neuron:1.15.5-neuron-py37-ubuntu18.04    |
+|MXNet 1.8.0 with Neuron Inference          |inference 	|3.7 (py37) 	        |763104351884.dkr.ecr.us-east-1.amazonaws.com/mxnet-inference-neuron:1.8.0-neuron-py37-ubuntu18.04          |
 
 
 Prior General Framework Container Versions


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
1. Add MXNet 1.8 Neuron DLC to available_images.md:
```
763104351884.dkr.ecr.us-east-1.amazonaws.com/mxnet-inference-neuron:1.8.0-neuron-py37-ubuntu18.04
```
2. Fix URI for PyTorch 1.7.1 Neuron DLC on available_images.md
```
763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference-neuron:1.7.1-neuron-py36-ubuntu18.04
```

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*
https://github.com/aws/deep-learning-containers/releases/tag/v1.0-mx-1.8.0-inf-neuron-py37

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

