### PR TITLE
[build] Revert smdebug version on PT 1.8

### DIFF
--- a/pytorch/training/docker/1.8/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/1.8/py3/Dockerfile.cpu
@@ -10,7 +10,7 @@ ARG OPEN_MPI_VERSION=4.0.1
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.
-ARG SMDEBUG_VERSION=1.0.10
+ARG SMDEBUG_VERSION=1.0.9
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging

--- a/pytorch/training/docker/1.8/py3/cu111/Dockerfile.gpu
+++ b/pytorch/training/docker/1.8/py3/cu111/Dockerfile.gpu
@@ -16,7 +16,7 @@ ARG RMM_VERSION=0.15.0
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.
-ARG SMDEBUG_VERSION=1.0.10
+ARG SMDEBUG_VERSION=1.0.9
 
 # Python won’t try to write .pyc or .pyo files on the import of source modules
 # Force stdin, stdout and stderr to be totally unbuffered. Good for logging


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to

## Reviewer Checklist
* For reviewer, before merging, please cross-check:
- [ ] I've verified the code change on the config file mentioned above has already been reverted

*Description:*
Set smdebug version on PT 1.8 DLCs back to 1.0.9

*Tests run:*

*DLC image/dockerfile:*
pytorch/training/docker/1.8/py3/Dockerfile.cpu
pytorch/training/docker/1.8/py3/cu111/Dockerfile.cpu

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

