### PR TITLE
[release] Add std MX 1.8 back to release images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -331,14 +331,6 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-    inference:
-      device_types: ["cpu","gpu"]
-      python_versions: ["py37"]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu112"
-      example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
   25:
     framework: "tensorflow"
     version: "2.5.0"
@@ -351,6 +343,17 @@ release_images:
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
   26:
+    framework: "tensorflow"
+    version: "2.5.1"
+    inference:
+      device_types: ["cpu","gpu"]
+      python_versions: ["py37"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu112"
+      example: False
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  27:
     framework: "mxnet"
     version: "1.8.0"
     inference:

--- a/release_images.yml
+++ b/release_images.yml
@@ -108,15 +108,34 @@ release_images:
   8:
     framework: "mxnet"
     version: "1.8.0"
-    inference:
-      device_types: ["neuron"]
+    training:
+      device_types: ["cpu", "gpu"]
       python_versions: ["py37"]
-      os_version: "ubuntu18.04"
+      os_version: "ubuntu16.04"
       cuda_version: "cu110"
       example: False
-      disable_sm_tag: True
+      disable_sm_tag: False
+      force_release: False
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py37"]
+      os_version: "ubuntu16.04"
+      cuda_version: "cu110"
+      example: False
+      disable_sm_tag: False
       force_release: False
   9:
+    framework: "mxnet"
+    version: "1.8.0"
+    training:
+      device_types: ["gpu"]
+      python_versions: ["py37"]
+      os_version: "ubuntu16.04"
+      cuda_version: "cu110"
+      example: True
+      disable_sm_tag: False
+      force_release: False
+  10:
     framework: "mxnet"
     version: "1.7.0"
     training:
@@ -135,7 +154,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  10:
+  11:
     framework: "mxnet"
     version: "1.7.0"
     training:
@@ -145,17 +164,6 @@ release_images:
       cuda_version: "cu101"
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-  11:
-    framework: "tensorflow"
-    version: "2.4.1"
-    training:
-      device_types: ["gpu"]
-      python_versions: ["py37"]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu110"
-      example: False
-      disable_sm_tag: False
       force_release: False
   12:
     framework: "tensorflow"
@@ -165,10 +173,21 @@ release_images:
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
       cuda_version: "cu110"
-      example: True
+      example: False
       disable_sm_tag: False
       force_release: False
   13:
+    framework: "tensorflow"
+    version: "2.4.1"
+    training:
+      device_types: ["gpu"]
+      python_versions: ["py37"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu110"
+      example: True
+      disable_sm_tag: False
+      force_release: False
+  14:
     framework: "pytorch"
     version: "1.8.1"
     training:
@@ -191,7 +210,7 @@ release_images:
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
-  14:
+  15:
     framework: "pytorch"
     version: "1.8.1"
     training:
@@ -200,31 +219,31 @@ release_images:
       os_version: "ubuntu18.04"
       cuda_version: "cu111"
       example: True
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-  15:
-    framework: "pytorch"
-    version: "1.5.1"
-    training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py36"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu101"
-      example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-    inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py36"]
-      os_version: "ubuntu16.04"
-      cuda_version: "cu101"
-      example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
   16:
     framework: "pytorch"
     version: "1.5.1"
     training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py36"]
+      os_version: "ubuntu16.04"
+      cuda_version: "cu101"
+      example: False
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py36"]
+      os_version: "ubuntu16.04"
+      cuda_version: "cu101"
+      example: False
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  17:
+    framework: "pytorch"
+    version: "1.5.1"
+    training:
       device_types: ["gpu"]
       python_versions: ["py36"]
       os_version: "ubuntu16.04"
@@ -232,7 +251,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  17:
+  18:
     framework: "huggingface_tensorflow"
     version: "2.4.1"
     hf_transformers: "4.6.1"
@@ -244,7 +263,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  18:
+  19:
     framework: "huggingface_pytorch"
     version: "1.7.1"
     hf_transformers: "4.6.1"
@@ -256,7 +275,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  19:
+  20:
     framework: "pytorch"
     version: "1.5.0"
     inference:
@@ -267,7 +286,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  20:
+  21:
     framework: "pytorch"
     version: "1.6.0"
     training:
@@ -278,7 +297,7 @@ release_images:
       example: False
       disable_sm_tag: True  # [Default: False] This option is not used by Example images
       force_release: False
-  21:
+  22:
     framework: "pytorch"
     version: "1.6.0"
     training:
@@ -289,7 +308,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  22:
+  23:
     framework: "huggingface_pytorch"
     version: "1.6.0"
     hf_transformers: "4.6.1"
@@ -301,7 +320,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  23:
+  24:
     framework: "tensorflow"
     version: "2.5.0"
     training:
@@ -312,7 +331,15 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  24:
+    inference:
+      device_types: ["cpu","gpu"]
+      python_versions: ["py37"]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu112"
+      example: False
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  25:
     framework: "tensorflow"
     version: "2.5.0"
     training:
@@ -323,14 +350,14 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  25:
-    framework: "tensorflow"
-    version: "2.5.1"
+  26:
+    framework: "mxnet"
+    version: "1.8.0"
     inference:
-      device_types: ["cpu","gpu"]
+      device_types: ["neuron"]
       python_versions: ["py37"]
       os_version: "ubuntu18.04"
-      cuda_version: "cu112"
+      cuda_version: "cu110"
       example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      disable_sm_tag: True
       force_release: False


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
Add MXNet 1.8 CPU, GPU, Training, Inference images back to release_images.yml

*Tests run:*

*DLC image/dockerfile:*

*Additional context:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

