### PR TITLE
[partner_devs]Add PR number for builds via github webhook env variable

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -1,6 +1,6 @@
 [dev]
 # Set to "huggingface", for example, if you are a huggingface developer. Default is ""
-partner_developer = ""
+partner_developer = "huggingface"
 # Please only set it to true if you are preparing an EI related PR
 # Do remember to revert it back to false before merging any PR (including EI dedicated PR)
 ei_mode = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -1,6 +1,6 @@
 [dev]
 # Set to "huggingface", for example, if you are a huggingface developer. Default is ""
-partner_developer = "huggingface"
+partner_developer = ""
 # Please only set it to true if you are preparing an EI related PR
 # Do remember to revert it back to false before merging any PR (including EI dedicated PR)
 ei_mode = false

--- a/src/parse_partner_developers.py
+++ b/src/parse_partner_developers.py
@@ -31,7 +31,7 @@ def main():
 
     if partner_dev:
         LOGGER.info(f"PARTNER_DEVELOPER: {partner_dev.upper()}")
-        LOGGER.info(f"PR_NUMBER: {os.getenv('PR_NUMBER', '').replace('/', '-')}")
+        LOGGER.info(f"PR_NUMBER: {os.getenv('PR_NUMBER', os.getenv('CODEBUILD_SOURCE_VERSION', '')).replace('/', '-')}")
         LOGGER.info(f"COMMIT_ID: {os.getenv('CODEBUILD_RESOLVED_SOURCE_VERSION')}")
 
 

--- a/src/parse_partner_developers.py
+++ b/src/parse_partner_developers.py
@@ -33,6 +33,9 @@ def main():
         LOGGER.info(f"PARTNER_DEVELOPER: {partner_dev.upper()}")
         LOGGER.info(f"PR_NUMBER: {os.getenv('PR_NUMBER', os.getenv('CODEBUILD_SOURCE_VERSION', '')).replace('/', '-')}")
         LOGGER.info(f"COMMIT_ID: {os.getenv('CODEBUILD_RESOLVED_SOURCE_VERSION')}")
+        test_trigger = os.getenv("TEST_TRIGGER")
+        if test_trigger:
+            LOGGER.info(f"TEST_TRIGGER: {test_trigger}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
*Issue #, if available:*

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

*Description:*
Add some additional useful info to logs for partner dev experience



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

