### PR TITLE
[tensorflow] [benchmark] [sagemaker] Adding XLA performance benchmarks for TF2.5+ Training on GPU instances

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -7,7 +7,9 @@ ei_mode = false
 # Please only set it to true if you are preparing a NEURON related PR
 # Do remember to revert it back to false before merging any PR (including NEURON dedicated PR)
 neuron_mode = false
-benchmark_mode = false
+# Please only set it to True if you are preparing a Benchmark related PR
+# Do remember to revert it back to False before merging any PR (including Benchmark dedicated PR)
+benchmark_mode = true
 
 [build]
 # Frameworks for which you want to disable both builds and tests

--- a/src/config/test_config.py
+++ b/src/config/test_config.py
@@ -1,7 +1,5 @@
 from . import parse_dlc_developer_configs
 
-# Please only set it to True if you are preparing a Benchmark related PR
-# Do remember to revert it back to False before merging any PR (including Benchmark dedicated PR)
 ENABLE_BENCHMARK_DEV_MODE = parse_dlc_developer_configs("dev", "benchmark_mode")
 
 # Disable the test codebuild jobs to be run

--- a/test/dlc_tests/benchmark/sagemaker/tensorflow/training/resources/tensorflow2/singletrain_gpu_without_xla.sh
+++ b/test/dlc_tests/benchmark/sagemaker/tensorflow/training/resources/tensorflow2/singletrain_gpu_without_xla.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: MIT-0
+
+# Ensure you have Horovod, OpenMPI, and Tensorflow installed on each machine
+# Specify hosts in the file `hosts`
+
+set -ex
+
+# p3 instances have larger GPU memory, so a higher batch size can be used
+GPU_MEM=`nvidia-smi --query-gpu=memory.total --format=csv,noheader -i 0 | awk '{print $1}'`
+if [ $GPU_MEM -gt 15000 ] ; then BATCH_SIZE=256; else BATCH_SIZE=128; fi
+
+# Training
+
+python -W ignore deep-learning-models/models/resnet/tensorflow2/train_tf2_resnet.py \
+--data_dir $SM_CHANNEL_TRAIN --synthetic --batch_size 128 --num_batches 1000 --clear_log 2 --xla-off

--- a/test/dlc_tests/benchmark/sagemaker/tensorflow/training/test_performance_hopper_sm_training.py
+++ b/test/dlc_tests/benchmark/sagemaker/tensorflow/training/test_performance_hopper_sm_training.py
@@ -1,0 +1,206 @@
+'''
+This testplan will currently testing XLA effectiveness for DLC TF containers.
+When Hopper containers are made available, this testplan should be skipped for DLC TF containers.
+'''
+import os
+import re
+import time
+
+from random import Random
+
+import pytest
+
+from invoke.context import Context
+
+from test.test_utils import (
+    BENCHMARK_RESULTS_S3_BUCKET, LOGGER, get_framework_and_version_from_tag, get_cuda_version_from_tag,
+)
+
+
+
+@pytest.mark.flaky(reruns=3)
+@pytest.mark.integration("imagenet dataset")
+@pytest.mark.multinode(4)
+@pytest.mark.model("resnet50")
+def test_hopper_tensorflow_sagemaker_training_performance_multinode(tensorflow_training, region, gpu_only, tf25_and_above_only):
+    throughput_without_xla = run_sm_perf_test(
+                                image_uri=tensorflow_training,
+                                xla=False,
+                                num_nodes=4,
+                                region=region,
+                                threshold=None
+                                )
+    throughput_with_xla = run_sm_perf_test(
+                                image_uri=tensorflow_training,
+                                xla=True,
+                                num_nodes=4,
+                                region=region,
+                                threshold=None
+                                )
+   
+    _, framework_version = get_framework_and_version_from_tag(tensorflow_training)
+    py_version = "py2" if "py2" in tensorflow_training else "py37" if "py37" in tensorflow_training else "py3"
+    '''
+    Uncomment when Hopper is active
+    There is enough variation in performance to warrant putting down a THRESHOLD in terms of performance ratio
+    assert throughput_with_xla > throughput_without_xla, (
+        f"tensorflow {framework_version} sagemaker training gpu {py_version} imagenet 4 nodes "
+        f"XLA Benchmark Result {throughput_with_xla} does not reach the threshold {throughput_without_xla}"
+    )
+    '''
+
+
+@pytest.mark.integration("imagenet dataset")
+@pytest.mark.model("resnet50")
+def test_hopper_tensorflow_sagemaker_training_performance_singlenode(tensorflow_training, region, gpu_only, tf25_and_above_only):
+    throughput_without_xla = run_sm_perf_test(
+                                image_uri=tensorflow_training,
+                                xla=False,
+                                num_nodes=1,
+                                region=region,
+                                threshold=None
+                                )
+    throughput_with_xla = run_sm_perf_test(
+                                image_uri=tensorflow_training,
+                                xla=True,
+                                num_nodes=1,
+                                region=region,
+                                threshold=None
+                                )
+   
+    _, framework_version = get_framework_and_version_from_tag(tensorflow_training)
+    py_version = "py2" if "py2" in tensorflow_training else "py37" if "py37" in tensorflow_training else "py3"
+    '''
+    Uncomment when Hopper is active.
+    There is enough variation in performance to warrant putting down a THRESHOLD in terms of performance ratio
+    assert throughput_with_xla > throughput_without_xla, (
+        f"tensorflow {framework_version} sagemaker training gpu {py_version} imagenet 1 nodes "
+        f"XLA Benchmark Result {throughput_with_xla} does not reach the threshold {throughput_without_xla}"
+    )
+    '''
+
+
+
+def run_sm_perf_test(image_uri, xla, num_nodes, region, threshold=None):
+    """
+    Run TF sagemaker training performance tests
+
+    Additional context: Setup for this function is performed by 'setup_sm_benchmark_tf_train_env' -- this installs
+    some prerequisite packages, clones some repos, and creates a virtualenv called sm_benchmark_venv.
+
+    TODO: Refactor the above setup function to be more obviously connected to this function,
+    TODO: and install requirements via a requirements.txt file
+
+    :param image_uri: ECR image URI
+    :param xla: [ True | False ] Enable XLA acceleration
+    :param num_nodes: Number of nodes to run on
+    :param region: AWS region
+
+    This function was inspired by deep-learning-containers/test/dlc_tests/benchmark/sagemaker/tensorflow/training/test_performance_tensorflow_sm_training.py
+
+    """
+    _, framework_version = get_framework_and_version_from_tag(image_uri)
+
+    processor = "xla" if xla else "gpu"
+    device_cuda_str = f"{processor}-{get_cuda_version_from_tag(image_uri)}"
+    ec2_instance_type = "p3.8xlarge"
+    py_version = "py2" if "py2" in image_uri else "py37" if "py37" in image_uri else "py3"
+
+    time_str = time.strftime("%Y-%m-%d-%H-%M-%S")
+    commit_info = os.getenv("CODEBUILD_RESOLVED_SOURCE_VERSION")
+    target_upload_location = os.path.join(
+        BENCHMARK_RESULTS_S3_BUCKET, "hopper", "tensorflow", framework_version, "sagemaker", "training", device_cuda_str, py_version
+    )
+    training_job_name = (
+        f"hpr-tf{framework_version[0]}-bench-{device_cuda_str}-{num_nodes}-node-{py_version}-{commit_info[:7]}-{time_str}"
+    )
+
+    if "hopper" in image_uri:
+        if xla:
+            LOGGER.info('Testing Hopper image with XLA enabled')
+        else:
+            LOGGER.info('Testing Hopper image with XLA disabled')
+    else:
+        if xla:
+            LOGGER.info('Testing non-Hopper image with XLA enabled')
+        else:
+            LOGGER.info('Testing non-Hopper image with XLA disabled')
+
+    # Inserting random sleep because this test starts multiple training jobs around the same time, resulting in
+    # a throttling error for SageMaker APIs.
+    time.sleep(Random(x=training_job_name).random() * 60)
+
+    test_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "resources")
+    venv_dir = os.path.join(test_dir, "sm_benchmark_venv")
+
+    ctx = Context()
+
+    with ctx.cd(test_dir), ctx.prefix(f"source {venv_dir}/bin/activate"):
+        log_file = (
+            f"results-{commit_info}-{time_str}-hopper-tf{framework_version}-{device_cuda_str}-{py_version}-{num_nodes}-node.txt"
+        )
+        run_out = ctx.run(
+            f"timeout 45m python tf_sm_benchmark.py "
+            f"--framework-version {framework_version} "
+            f"--image-uri {image_uri} "
+            f"--instance-type ml.{ec2_instance_type} "
+            f"--node-count {num_nodes} "
+            f"--python {py_version} "
+            f"--region {region} "
+            f"--job-name {training_job_name} "
+            f"--xla-{'on' if xla else 'off'} "
+            f"2>&1 | tee {log_file}",
+            warn=True,
+            echo=True,
+        )
+
+        if not (run_out.ok or run_out.return_code == 124):
+            target_upload_location = os.path.join(target_upload_location, "failure_log")
+
+    ctx.run(f"aws s3 cp {os.path.join(test_dir, log_file)} {os.path.join(target_upload_location, log_file)}")
+
+    LOGGER.info(f"Test results can be found at {os.path.join(target_upload_location, log_file)}")
+
+    result_statement, throughput = _print_results_of_test(os.path.join(test_dir, log_file))
+    throughput /= num_nodes
+
+    assert run_out.ok, (
+        f"Benchmark Test failed with return code {run_out.return_code}. "
+        f"Test results can be found at {os.path.join(target_upload_location, log_file)}"
+    )
+
+    LOGGER.info(
+        f"hopper-tensorflow {framework_version} sagemaker training {device_cuda_str} {py_version} "
+        f"imagenet {num_nodes} nodes Throughput: {throughput} images/sec, threshold: {threshold} images/sec"
+    )
+    if threshold:
+        assert throughput > threshold, (
+            f"hopper-tensorflow {framework_version} sagemaker training {processor} {py_version} imagenet {num_nodes} nodes "
+            f"Regression Benchmark Result {throughput} does not reach the threshold {threshold}"
+        )
+    return throughput
+
+
+def _print_results_of_test(file_path):
+    result = ""
+    throughput = 0
+    """calculate average throughput"""
+    result_list, throughput_list = [], []
+    with open(file_path, 'r') as f:
+        lines = f.readlines()
+        for line in lines:
+            if "images/sec: " in line:
+                result_list.append(line.strip("\n"))
+                throughput = float(
+                    re.search(r"(images/sec:[ ]*)(?P<throughput>[0-9]+\.?[0-9]+)", line).group("throughput")
+                )
+                throughput_list.append(throughput)
+    result = "\n".join(result_list[-100:])+ "\n"
+    if len(throughput_list) == 0:
+        raise Exception(
+            "Cannot find throughput lines. Looks like SageMaker job was not run successfully. Please check"
+        )
+    # Take average of last 100 throughput lines
+    throughput = sum(throughput_list[-100:])/len(throughput_list[-100:])
+    LOGGER.info(result)
+    return result, throughput

--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -565,7 +565,7 @@ def skip_efa_tests(request):
         pytest.skip('Skipping EFA tests as EFA tests are disabled.')
 
 
-#@pytest.fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def disable_test(request):
     test_name = request.node.name
     # We do not have a regex pattern to find CB name, which means we must resort to string splitting

--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -345,6 +345,9 @@ def tf23_and_above_only():
 def tf24_and_above_only():
     pass
 
+@pytest.fixture(scope="session")
+def tf25_and_above_only():
+    pass
 
 @pytest.fixture(scope="session")
 def tf21_and_above_only():
@@ -387,10 +390,11 @@ def framework_version_within_limit(metafunc_obj, image):
     image_framework_name, _ = get_framework_and_version_from_tag(image)
     if image_framework_name == "tensorflow" :
         tf2_requirement_failed = "tf2_only" in metafunc_obj.fixturenames and not is_tf_version("2", image)
+        tf25_requirement_failed = "tf25_and_above_only" in metafunc_obj.fixturenames and is_below_framework_version("2.5", image, "tensorflow")
         tf24_requirement_failed = "tf24_and_above_only" in metafunc_obj.fixturenames and is_below_framework_version("2.4", image, "tensorflow")
         tf23_requirement_failed = "tf23_and_above_only" in metafunc_obj.fixturenames and is_below_framework_version("2.3", image, "tensorflow")
         tf21_requirement_failed = "tf21_and_above_only" in metafunc_obj.fixturenames and is_below_framework_version("2.1", image, "tensorflow")
-        if tf2_requirement_failed or tf21_requirement_failed or tf24_requirement_failed or tf23_requirement_failed :
+        if tf2_requirement_failed or tf21_requirement_failed or tf24_requirement_failed or tf25_requirement_failed or tf23_requirement_failed :
             return False
     if image_framework_name == "mxnet" :
         mx18_requirement_failed = "mx18_and_above_only" in metafunc_obj.fixturenames and is_below_framework_version("1.8", image, "mxnet")
@@ -561,7 +565,7 @@ def skip_efa_tests(request):
         pytest.skip('Skipping EFA tests as EFA tests are disabled.')
 
 
-@pytest.fixture(autouse=True)
+#@pytest.fixture(autouse=True)
 def disable_test(request):
     test_name = request.node.name
     # We do not have a regex pattern to find CB name, which means we must resort to string splitting


### PR DESCRIPTION
## Intention
These benchmarks are intended to explore the performance improvement from enabling XLA.

## Overview
Adding 2 new SM benchmarks for TF2.5+ Training images for GPU instances only. These tests will **not** fail based on XLA performance and merely serve to collect performance data.

## Changelog
1. Added new TestPlan test_performance_optimized_sm_training.py
2 Created new fixture tf25_and_above_only
3. Added 2 new benchmarks to report performance with and without XLA on p3.8xl - single node and multi node

## Testing
### Local Setup
1. Built the TF 2.5 image for GPU Training.
2. Modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`
3. Used test/testrunner.py to test the Image built

### Test Results
Testplan | Instance | Nodes | Accelerator | Throughput (Trial 1)
-- | -- | -- | -- | --
New | p3.8xl | 1 | gpu-cu112 | 1845
New | p3.8xl | 1 | xla-cu112 | 1769
New | p3.8xl | 4 | gpu-cu112 | 1672
New | p3.8xl | 4 | xla-cu112 | 1620

The original TF2 single node test PASSed
The original TF2 multi node test FAILed due to p3.16xl availability

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

