### PR TITLE
[tests][sagemaker] Disable SM tests (also EFA) by default on PR

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
 *GitHub Issue #, if available:*
 
-Note: 
-- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 
-- By default SageMaker and EFA tests are disabled on PR, request you to enable them if PR needs those tests by using dlc_developer_config.toml
+Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 
+
+
 
 ### Description
 
@@ -17,6 +17,7 @@ Note:
 
 ## PR Checklist
 - [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
+- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
 - [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
 - [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
 - [ ] (If applicable) I've documented below the tests I've run on the DLC image

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 Note: 
 - If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 
-- By default SageMaker and EFA tests are disabled, request you to enable them if PR needs those tests by using dlc_developer_config.toml
+- By default SageMaker and EFA tests are disabled on PR, request you to enable them if PR needs those tests by using dlc_developer_config.toml
 
 ### Description
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,8 @@
 *GitHub Issue #, if available:*
 
-Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 
+Note: 
+- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 
+- By default SageMaker and EFA tests are disabled, request you to enable them if PR needs those tests by using dlc_developer_config.toml
 
 ### Description
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -19,9 +19,9 @@ datetime_tag = true
 do_build = true
 
 [test]
-efa_tests = true
+efa_tests = false
 sanity_tests = true
-sagemaker_tests = true
+sagemaker_tests = false
 ecs_tests = true
 eks_tests = true
 ec2_tests = true

--- a/test/dlc_tests/sanity/test_dlc_developer_config.py
+++ b/test/dlc_tests/sanity/test_dlc_developer_config.py
@@ -30,9 +30,9 @@ def test_developer_configuration():
     assert _get_option(dev_config_contents, "build", "do_build") is True
 
     # Check test settings
-    assert _get_option(dev_config_contents, "test", "efa_tests") is True
+    assert _get_option(dev_config_contents, "test", "efa_tests") is False
     assert _get_option(dev_config_contents, "test", "sanity_tests") is True
-    assert _get_option(dev_config_contents, "test", "sagemaker_tests") is True
+    assert _get_option(dev_config_contents, "test", "sagemaker_tests") is False
     assert _get_option(dev_config_contents, "test", "ecs_tests") is True
     assert _get_option(dev_config_contents, "test", "eks_tests") is True
     assert _get_option(dev_config_contents, "test", "ec2_tests") is True


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

### Description

### Tests run

### DLC image/dockerfile

### Additional context

## Label Checklist
- [ ] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true` or `neuron_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
