### PR TITLE
[tests][ec2][eks] Change tests instance from p3.16x to g4dn 

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -9,22 +9,22 @@ ei_mode = false
 neuron_mode = false
 # Please only set it to True if you are preparing a Benchmark related PR
 # Do remember to revert it back to False before merging any PR (including Benchmark dedicated PR)
-benchmark_mode = false
+benchmark_mode = true
 
 [build]
 # Frameworks for which you want to disable both builds and tests
-skip_frameworks = []
+skip_frameworks = ["huggingface_pytorch", "huggingface_tensorflow"]
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = true
+datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true
 
 [test]
 efa_tests = false
-sanity_tests = true
+sanity_tests = false
 sagemaker_tests = false
-ecs_tests = true
+ecs_tests = false
 eks_tests = true
 ec2_tests = true
 use_scheduler = false

--- a/test/dlc_tests/benchmark/ec2/mxnet/test_performance_mxnet_inference.py
+++ b/test/dlc_tests/benchmark/ec2/mxnet/test_performance_mxnet_inference.py
@@ -20,7 +20,7 @@ MX_PERFORMANCE_INFERENCE_CPU_CMD = os.path.join(
     CONTAINER_TESTS_PREFIX, "benchmark", "run_mxnet_inference_performance_cpu"
 )
 
-MX_EC2_GPU_INSTANCE_TYPE = "p3.16xlarge"
+MX_EC2_GPU_INSTANCE_TYPE = "g4dn.12xlarge"
 MX_EC2_CPU_INSTANCE_TYPE = "c5.18xlarge"
 
 

--- a/test/dlc_tests/benchmark/ec2/mxnet/test_performance_mxnet_training.py
+++ b/test/dlc_tests/benchmark/ec2/mxnet/test_performance_mxnet_training.py
@@ -20,7 +20,7 @@ MX_PERFORMANCE_TRAINING_CPU_CMD = os.path.join(
     CONTAINER_TESTS_PREFIX, "benchmark", "run_mxnet_training_performance_cpu"
 )
 
-MX_EC2_GPU_INSTANCE_TYPE = "p3.16xlarge"
+MX_EC2_GPU_INSTANCE_TYPE = "g4dn.12xlarge"
 MX_EC2_CPU_INSTANCE_TYPE = "c5.18xlarge"
 
 

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_pytorch_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_pytorch_inference.py
@@ -20,7 +20,7 @@ PT_PERFORMANCE_INFERENCE_GPU_CMD = f"{PT_PERFORMANCE_INFERENCE_SCRIPT}  --iterat
 
 
 @pytest.mark.model("resnet18, VGG13, MobileNetV2, GoogleNet, DenseNet121, InceptionV3")
-@pytest.mark.parametrize("ec2_instance_type", ["p3.16xlarge"], indirect=True)
+@pytest.mark.parametrize("ec2_instance_type", ["g4dn.12xlarge"], indirect=True)
 def test_performance_ec2_pytorch_inference_gpu(pytorch_inference, ec2_connection, region, gpu_only):
     _, framework_version = get_framework_and_version_from_tag(pytorch_inference)
     threshold = get_threshold_for_image(framework_version, PYTORCH_INFERENCE_GPU_THRESHOLD)

--- a/test/dlc_tests/benchmark/ec2/pytorch/training/test_performance_pytorch_training.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/training/test_performance_pytorch_training.py
@@ -27,8 +27,8 @@ PT_PERFORMANCE_TRAINING_GPU_IMAGENET_CMD = os.path.join(
     CONTAINER_TESTS_PREFIX, "benchmark", "run_pytorch_training_performance_gpu_imagenet"
 )
 
-PT_EC2_GPU_SYNTHETIC_INSTANCE_TYPE = "p3.16xlarge"
-PT_EC2_GPU_IMAGENET_INSTANCE_TYPE = "p3.16xlarge"
+PT_EC2_GPU_SYNTHETIC_INSTANCE_TYPE = "g4dn.12xlarge"
+PT_EC2_GPU_IMAGENET_INSTANCE_TYPE = "g4dn.12xlarge"
 
 
 @pytest.mark.model("resnet50")

--- a/test/dlc_tests/benchmark/ec2/tensorflow/inference/test_performance_tensorflow_inference.py
+++ b/test/dlc_tests/benchmark/ec2/tensorflow/inference/test_performance_tensorflow_inference.py
@@ -22,7 +22,7 @@ from test.test_utils.ec2 import (
 
 
 @pytest.mark.model("inception, RCNN-Resnet101-kitti, resnet50_v2, mnist, SSDResnet50Coco")
-@pytest.mark.parametrize("ec2_instance_type", ["p3.16xlarge"], indirect=True)
+@pytest.mark.parametrize("ec2_instance_type", ["g4dn.12xlarge"], indirect=True)
 def test_performance_ec2_tensorflow_inference_gpu(tensorflow_inference, ec2_connection, ec2_instance_ami, region, gpu_only):
     _, framework_version = get_framework_and_version_from_tag(tensorflow_inference)
     threshold = get_threshold_for_image(framework_version, TENSORFLOW_INFERENCE_GPU_THRESHOLD)

--- a/test/dlc_tests/benchmark/ec2/tensorflow/training/test_performance_tensorflow_training.py
+++ b/test/dlc_tests/benchmark/ec2/tensorflow/training/test_performance_tensorflow_training.py
@@ -21,7 +21,7 @@ TF_PERFORMANCE_TRAINING_GPU_IMAGENET_CMD = os.path.join(
     CONTAINER_TESTS_PREFIX, "benchmark", "run_tensorflow_training_performance_gpu_imagenet",
 )
 
-TF_EC2_GPU_INSTANCE_TYPE = "p3.16xlarge"
+TF_EC2_GPU_INSTANCE_TYPE = "g4dn.12xlarge"
 TF_EC2_CPU_INSTANCE_TYPE = "c5.18xlarge"
 
 

--- a/test/dlc_tests/benchmark/sagemaker/mxnet/training/test_performance_mxnet_sm_training.py
+++ b/test/dlc_tests/benchmark/sagemaker/mxnet/training/test_performance_mxnet_sm_training.py
@@ -39,7 +39,7 @@ def test_mxnet_sagemaker_training_performance(mxnet_training, num_nodes, region,
     _, framework_version = get_framework_and_version_from_tag(mxnet_training)
     device_cuda_str = f"gpu-{get_cuda_version_from_tag(mxnet_training)}"
     py_version = "py37" if "py37" in mxnet_training else "py2" if "py2" in mxnet_training else "py3"
-    ec2_instance_type = "p3.16xlarge"
+    ec2_instance_type = "g4dn.12xlarge"
 
     time_str = time.strftime('%Y-%m-%d-%H-%M-%S')
     commit_info = os.getenv("CODEBUILD_RESOLVED_SOURCE_VERSION", "manual")

--- a/test/dlc_tests/eks/mxnet/training/test_eks_mxnet_multinode_training.py
+++ b/test/dlc_tests/eks/mxnet/training/test_eks_mxnet_multinode_training.py
@@ -26,7 +26,7 @@ def test_eks_mxnet_multi_node_training_horovod_mnist(mxnet_training, example_onl
     Run MXNet distributed training on EKS using docker images with MNIST dataset (horovod)
     """
     eks_cluster_size = "3"
-    ec2_instance_type = "p3.16xlarge"
+    ec2_instance_type = "g4dn.12xlarge"
 
     eks_gpus_per_worker = ec2_utils.get_instance_num_gpus(instance_type=ec2_instance_type)
     


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description

### Tests run

### DLC image/dockerfile

### Additional context

## Label Checklist
- [ ] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true` or `neuron_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
