### PR TITLE
[pytorch][neuron][build] - fix the ps command that checks for torchserve running.

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -6,7 +6,7 @@ partner_developer = ""
 ei_mode = false
 # Please only set it to true if you are preparing a NEURON related PR
 # Do remember to revert it back to false before merging any PR (including NEURON dedicated PR)
-neuron_mode = false
+neuron_mode = true
 # Please only set it to True if you are preparing a Benchmark related PR
 # Do remember to revert it back to False before merging any PR (including Benchmark dedicated PR)
 benchmark_mode = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -6,7 +6,7 @@ partner_developer = ""
 ei_mode = false
 # Please only set it to true if you are preparing a NEURON related PR
 # Do remember to revert it back to false before merging any PR (including NEURON dedicated PR)
-neuron_mode = true
+neuron_mode = false
 # Please only set it to True if you are preparing a Benchmark related PR
 # Do remember to revert it back to False before merging any PR (including Benchmark dedicated PR)
 benchmark_mode = false

--- a/pytorch/buildspec-neuron.yml
+++ b/pytorch/buildspec-neuron.yml
@@ -18,7 +18,7 @@ context:
       source: docker/build_artifacts/torchserve-entrypoint.py
       target: torchserve-entrypoint.py
     dockerd-entrypoint:
-      source: docker/build_artifacts/entrypoint.sh
+      source: docker/build_artifacts/neuron_entrypoint.sh
       target: entrypoint.sh
     config:
       source: docker/build_artifacts/config.properties

--- a/pytorch/inference/docker/build_artifacts/neuron_entrypoint.sh
+++ b/pytorch/inference/docker/build_artifacts/neuron_entrypoint.sh
@@ -62,11 +62,12 @@ printf "Model path: %s\n" "$MODEL_PATH"
 printf "TS_CONFIG: %s\n" "$TS_CONFIG"
 # Start the Model Server
 if [[ -z "$MODEL_PATH" ]]; then
-  torchserve --start --ts-config /home/model-server/config.properties --model-store /opt/ml/model &
+  torchserve --start --ts-config /home/model-server/config.properties --model-store /opt/ml/model
 else
-  torchserve --start --ts-config $TS_CONFIG --models $MODEL_PATH &
+  torchserve --start --ts-config $TS_CONFIG --models $MODEL_PATH
 fi
 status=$?
+ts_pid=$(<"/home/model-server/tmp/.model_server.pid")
 if [ $status -ne 0 ]; then
   echo "Failed to start TF Model Server: $status"
   exit $status
@@ -86,10 +87,10 @@ while sleep 60; do
       exit 1
     fi
   fi
-  ps aux |grep torchserve |grep -q -v grep
+  ps -p $ts_pid >/dev/null 2>&1
   MODEL_SERVER_STATUS=$?
-  # If the greps above find anything, they exit with 0 status
-  # If they are not both 0, then something is wrong
+  # If the torchserve pid exists then status would be 0
+  # If not 0, then something is wrong
   if [ $MODEL_SERVER_STATUS -ne 0 ]; then
     echo "torchserve  has already exited."
     exit 1


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
For the pytorch DLC users have an option of running the provided the entrypoint function in /usr/loca/bin. This function starts the torchserve and also every 60 secs makes sure that the torchserve process is not dead. There was an bug in the way it was getting checked and so the container was getting killed after 6 secs.. torchserve when started properly saves the pid in a file and the fix is to use that pid to make sure that the process is running.

### Tests run
All the neuron related tests were run.

### DLC image/dockerfile

### Additional context

## Label Checklist
- [ ] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [x ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON Testing Checklist
* When creating a PR:
- [ x] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true` or `neuron_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
