### PR TITLE
[pytorch][test][sagemaker] Allow py38 option on PT SM tests

### DIFF
--- a/test/sagemaker_tests/pytorch/inference/conftest.py
+++ b/test/sagemaker_tests/pytorch/inference/conftest.py
@@ -105,7 +105,7 @@ def pytest_addoption(parser):
     parser.addoption('--docker-base-name', default='pytorch')
     parser.addoption('--region', default='us-west-2')
     parser.addoption('--framework-version', default='')
-    parser.addoption('--py-version', choices=['2', '3'], default=str(sys.version_info.major))
+    parser.addoption('--py-version', choices=['2', '3', '37', '38'], default=str(sys.version_info.major))
     # Processor is still "cpu" for EIA tests
     parser.addoption('--processor', choices=['gpu', 'cpu', 'eia'], default='cpu')
     # If not specified, will default to {framework-version}-{processor}-py{py-version}
@@ -268,7 +268,7 @@ def skip_by_device_type(request, use_gpu, instance_type, accelerator_type):
 
 @pytest.fixture(autouse=True)
 def skip_by_py_version(request, py_version):
-    if request.node.get_closest_marker('skip_py2') and py_version != 'py3':
+    if request.node.get_closest_marker('skip_py2') and 'py2' in py_version:
         pytest.skip('Skipping the test because Python 2 is not supported.')
 
 
@@ -283,7 +283,7 @@ def skip_gpu_instance_restricted_regions(region, instance_type):
 @pytest.fixture(autouse=True)
 def skip_gpu_py2(request, use_gpu, instance_type, py_version, framework_version):
     is_gpu = use_gpu or instance_type[3] in ['g', 'p']
-    if request.node.get_closest_marker('skip_gpu_py2') and is_gpu and py_version != 'py3' \
+    if request.node.get_closest_marker('skip_gpu_py2') and is_gpu and 'py2' in py_version \
             and framework_version == '1.4.0':
         pytest.skip('Skipping the test until mms issue resolved.')
 

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -105,7 +105,7 @@ def pytest_addoption(parser):
     parser.addoption('--docker-base-name', default='pytorch')
     parser.addoption('--region', default='us-west-2')
     parser.addoption('--framework-version', default='')
-    parser.addoption('--py-version', choices=['2', '3'], default=str(sys.version_info.major))
+    parser.addoption('--py-version', choices=['2', '3', '37', '38'], default=str(sys.version_info.major))
     parser.addoption('--processor', choices=['gpu', 'cpu'], default='cpu')
     # If not specified, will default to {framework-version}-{processor}-py{py-version}
     parser.addoption('--tag', default=None)
@@ -293,7 +293,7 @@ def skip_by_py_version(request, py_version):
     and pytest is running from py2. We can rely on this when py2 is deprecated, but for now
     we must use "skip_py2_containers"
     """
-    if request.node.get_closest_marker('skip_py2') and py_version != 'py3':
+    if request.node.get_closest_marker('skip_py2') and 'py2' in py_version:
         pytest.skip('Skipping the test because Python 2 is not supported.')
 
 


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

### Description
Allow `py38` as input python version on SM Tests for PT Training and PT Inference

### Tests run

### DLC image/dockerfile

### Additional context

## Label Checklist
- [x] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [x] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
