### PR TITLE
[autogluon][test]Ag sanity fixes

### DIFF
--- a/autogluon/training/docker/0.2/py3/Dockerfile.cpu
+++ b/autogluon/training/docker/0.2/py3/Dockerfile.cpu
@@ -101,7 +101,7 @@ RUN pip install --no-cache-dir -U \
 && pip uninstall -y jupyter-client jupyter-core jupyter-packaging jupyter-server jupyter-server-proxy \
     jupyterlab jupyterlab-nvdashboard jupyterlab-pygments jupyterlab-server jupyterlab-widgets ipywidgets \
     widgetsnbextension traitlets pydeck panel nbformat nbconvert nbclient pyppeteer matplotlib-inline \
-    ipython-genutils ipython ipykernel torchvision bokeh plotly notebook datashader
+    ipython-genutils ipython ipykernel bokeh notebook datashader
 
 # Allow OpenSSH to talk to containers without asking for confirmation
 RUN cat /etc/ssh/ssh_config | grep -v StrictHostKeyChecking > /etc/ssh/ssh_config.new \

--- a/autogluon/training/docker/0.2/py3/cu102/Dockerfile.gpu
+++ b/autogluon/training/docker/0.2/py3/cu102/Dockerfile.gpu
@@ -50,7 +50,7 @@ RUN source activate rapids \
  && pip uninstall -y jupyter-client jupyter-core jupyter-packaging jupyter-server jupyter-server-proxy \
     jupyterlab jupyterlab-nvdashboard jupyterlab-pygments jupyterlab-server jupyterlab-widgets ipywidgets \
     widgetsnbextension traitlets pydeck panel nbformat nbconvert nbclient pyppeteer matplotlib-inline websockets \
-    ipython-genutils ipython ipykernel torchvision bokeh plotly notebook datashader
+    ipython-genutils ipython ipykernel bokeh notebook datashader
 
 WORKDIR /
 

--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -40,6 +40,7 @@ LOGGER.addHandler(logging.StreamHandler(sys.stderr))
 FRAMEWORK_FIXTURES = (
     "pytorch_inference",
     "pytorch_training",
+    "autogluon_training",
     "mxnet_inference",
     "mxnet_training",
     "tensorflow_inference",

--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -62,6 +62,7 @@ FRAMEWORK_FIXTURES = (
     "huggingface_tensorflow_inference",
     "huggingface_pytorch_inference",
     "huggingface_mxnet_inference",
+    "autogluon_training",
 )
 
 # Ignore container_tests collection, as they will be called separately from test functions
@@ -344,6 +345,11 @@ def non_huggingface_only():
 
 
 @pytest.fixture(scope="session")
+def non_autogluon_only():
+    pass
+
+
+@pytest.fixture(scope="session")
 def cpu_only():
     pass
 
@@ -617,6 +623,8 @@ def pytest_generate_tests(metafunc):
                     if not framework_version_within_limit(metafunc, image):
                         continue
                     if "non_huggingface_only" in metafunc.fixturenames and "huggingface" in image:
+                        continue
+                    if "non_autogluon_only" in metafunc.fixturenames and "autogluon" in image:
                         continue
                     if is_example_lookup or is_huggingface_lookup or is_standard_lookup:
                         if "cpu_only" in metafunc.fixturenames and "cpu" in image and "eia" not in image:

--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -210,8 +210,8 @@ def test_framework_and_cuda_version_gpu(gpu, ec2_connection):
     # CUDA Version Check #
     cuda_version = re.search(r"-cu(\d+)-", image).group(1)
 
-    # MXNet inference containers do not currently have nvcc in /usr/local/cuda/bin, so check symlink
-    if "mxnet-inference" in image:
+    # MXNet inference and Autogluon containers do not currently have nvcc in /usr/local/cuda/bin, so check symlink
+    if "mxnet-inference" in image or "autogluon" in image:
         cuda_cmd = "readlink /usr/local/cuda"
     else:
         cuda_cmd = "nvcc --version"

--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -149,7 +149,8 @@ def test_framework_version_cpu(image):
         image)
 
     # Framework name may include huggingface
-    tested_framework = tested_framework.lstrip("huggingface_")
+    if tested_framework.startswith('huggingface_'):
+        tested_framework = tested_framework[len("huggingface_"):]
     # Module name is torch
     if tested_framework == "pytorch":
         tested_framework = "torch"
@@ -183,7 +184,8 @@ def test_framework_and_cuda_version_gpu(gpu, ec2_connection):
     # Skip framework version test for tensorflow-inference, since it doesn't have core TF installed
     if "tensorflow-inference" not in image:
         # Framework name may include huggingface
-        tested_framework = tested_framework.lstrip("huggingface_")
+        if tested_framework.startswith('huggingface_'):
+            tested_framework = tested_framework[len("huggingface_"):]
         # Module name is "torch"
         if tested_framework == "pytorch":
             tested_framework = "torch"

--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -154,6 +154,8 @@ def test_framework_version_cpu(image):
     # Module name is torch
     if tested_framework == "pytorch":
         tested_framework = "torch"
+    elif tested_framework == "autogluon":
+        tested_framework = "autogluon.core"
     ctx = Context()
     container_name = get_container_name("framework-version", image)
     start_container(container_name, image, ctx)
@@ -163,7 +165,10 @@ def test_framework_version_cpu(image):
     if is_canary_context():
         assert tag_framework_version in output.stdout.strip()
     else:
-        assert tag_framework_version == output.stdout.strip()
+        if tested_framework == "autogluon.core":
+            assert output.stdout.strip().startswith(tag_framework_version)
+        else:
+            assert tag_framework_version == output.stdout.strip()
 
 
 # TODO: Enable as canary once resource cleaning lambda is added
@@ -189,14 +194,18 @@ def test_framework_and_cuda_version_gpu(gpu, ec2_connection):
         # Module name is "torch"
         if tested_framework == "pytorch":
             tested_framework = "torch"
+        elif tested_framework == "autogluon":
+            tested_framework = "autogluon.core"
         cmd = f"import {tested_framework}; print({tested_framework}.__version__)"
-        output = ec2.execute_ec2_training_test(
-            ec2_connection, image, cmd, executable="python")
+        output = ec2.execute_ec2_training_test(ec2_connection, image, cmd, executable="python")
 
         if is_canary_context():
             assert tag_framework_version in output.stdout.strip()
         else:
-            assert tag_framework_version == output.stdout.strip()
+            if tested_framework == "autogluon.core":
+                assert output.stdout.strip().startswith(tag_framework_version)
+            else:
+                assert tag_framework_version == output.stdout.strip()
 
     # CUDA Version Check #
     cuda_version = re.search(r"-cu(\d+)-", image).group(1)

--- a/test/dlc_tests/sanity/test_telemetry.py
+++ b/test/dlc_tests/sanity/test_telemetry.py
@@ -36,7 +36,7 @@ def test_telemetry_bad_instance_role_disabled_neuron(neuron, ec2_client, ec2_ins
 @pytest.mark.processor("gpu")
 @pytest.mark.integration("telemetry")
 @pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge"], indirect=True)
-def test_telemetry_instance_tag_success_gpu(gpu, ec2_client, ec2_instance, ec2_connection, non_huggingface_only):
+def test_telemetry_instance_tag_success_gpu(gpu, ec2_client, ec2_instance, ec2_connection, non_huggingface_only, non_autogluon_only):
     _run_tag_success(gpu, ec2_client, ec2_instance, ec2_connection)
 
 
@@ -44,7 +44,7 @@ def test_telemetry_instance_tag_success_gpu(gpu, ec2_client, ec2_instance, ec2_c
 @pytest.mark.processor("cpu")
 @pytest.mark.integration("telemetry")
 @pytest.mark.parametrize("ec2_instance_type", ["c4.4xlarge"], indirect=True)
-def test_telemetry_instance_tag_success_cpu(cpu, ec2_client, ec2_instance, ec2_connection, cpu_only, non_huggingface_only):
+def test_telemetry_instance_tag_success_cpu(cpu, ec2_client, ec2_instance, ec2_connection, cpu_only, non_huggingface_only, non_autogluon_only):
     _run_tag_success(cpu, ec2_client, ec2_instance, ec2_connection)
 
 
@@ -53,7 +53,7 @@ def test_telemetry_instance_tag_success_cpu(cpu, ec2_client, ec2_instance, ec2_c
 @pytest.mark.integration("telemetry")
 @pytest.mark.parametrize("ec2_instance_type", ["inf1.xlarge"], indirect=True)
 @pytest.mark.skip("Feature doesn't exist on Neuron DLCs")
-def test_telemetry_instance_tag_success_neuron(neuron, ec2_client, ec2_instance, ec2_connection, non_huggingface_only):
+def test_telemetry_instance_tag_success_neuron(neuron, ec2_client, ec2_instance, ec2_connection, non_huggingface_only, non_autogluon_only):
     _run_tag_success(neuron, ec2_client, ec2_instance, ec2_connection)
 
 


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description

### Tests run

### DLC image/dockerfile

### Additional context

## Label Checklist
- [ ] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true` or `neuron_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
