### PR TITLE
[dev][test] Add a config option to run RC integration tests & SM local tests in PR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@ mxnet/ @aws/dlc-mxnet-reviewers
 
 # Any PR with a file with "smdebug" in it will be assigned to the smdebug reviewer team
 *smdebug* @aws/dlc-smdebug-reviewers
+test_sm_profiler.py @aws/dlc-smdebug-reviewers
 
 # Any PR with a file with "neuron" in it will be assigned to the neuron reviewer team
 *neuron* @aws/dlc-neuron-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,16 +11,18 @@
 sagemaker_tests/ @aws/sagemaker-ml-frameworks
 
 # Any files modified under tensorflow/ or tensorflow_serving/ will be assigned to the tf reviewer team
-tensorflow/ @dlc-tf-reviewers
+tensorflow/ @aws/dlc-tf-reviewers
 tensorflow_serving/ @aws/dlc-tf-reviewers
 
 # Any PR with testTF* or testTensor* file change will be assigned to the tf reviewer team
-testTF* @dlc-tf-reviewers
+testTF* @aws/dlc-tf-reviewers
 testTensor* @aws/dlc-tf-reviewers
+huggingface_tensorflow/ @aws/dlc-tf-reviewers
 
 # Any files modified under pytorch/ or pytorch_tests/ dir will require review from pytorch reviewer team
-pytorch/ @dlc-pytorch-reviewers
+pytorch/ @aws/dlc-pytorch-reviewers
 pytorch_tests/ @aws/dlc-pytorch-reviewers
+huggingface_pytorch/ @aws/dlc-pytorch-reviewers
 
 # Any files modified under mxnet/ dir will require review from the mxnet reviewer team
 mxnet/ @aws/dlc-mxnet-reviewers

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -32,9 +32,9 @@ efa_tests = false
 sagemaker_local_tests = false
 
 # SM remote test valid values:
-# "off" --> do not trigger sagemaker remote tests
-# "default --> run default sagemaker remote tests
+# "off" --> do not trigger sagemaker remote tests (default)
+# "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
-sagemaker_remote_tests = "default"
+sagemaker_remote_tests = "standard"
 
 use_scheduler = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -13,7 +13,7 @@ benchmark_mode = false
 
 [build]
 # Frameworks for which you want to disable both builds and tests
-skip_frameworks = ["huggingface_pytorch", "huggingface_tensorflow", "mxnet"]
+skip_frameworks = []
 # Set to false in order to remove datetime tag on PR builds
 datetime_tag = true
 # Note: Need to build the images at least once with datetime_tag = false
@@ -28,9 +28,8 @@ eks_tests = true
 ec2_tests = true
 
 ### Off by default
-sagemaker_local_tests = true
-# valid values are "off", "default", "release_candidate"
-# if you place any value `val` where `bool(val) == True`, we will warn you, but assume default
+sagemaker_local_tests = false
+# valid values are "off", "default", "rc"
 sagemaker_remote_tests = "off"
 
 efa_tests = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -30,7 +30,11 @@ ec2_tests = true
 ### Off by default
 efa_tests = false
 sagemaker_local_tests = false
-# valid values are "off", "default", "rc"
-sagemaker_remote_tests = "off"
+
+# SM remote test valid values:
+# "off" --> do not trigger sagemaker remote tests
+# "default --> run default sagemaker remote tests
+# "rc" --> run release_candidate_integration tests
+sagemaker_remote_tests = "default"
 
 use_scheduler = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -28,10 +28,10 @@ eks_tests = true
 ec2_tests = true
 
 ### Off by default
-sagemaker_local_tests = false
-# valid values are "", "default", "release_candidate"
+sagemaker_local_tests = true
+# valid values are "off", "default", "release_candidate"
 # if you place any value `val` where `bool(val) == True`, we will warn you, but assume default
-sagemaker_remote_tests = "release_candidate"
+sagemaker_remote_tests = "off"
 
 efa_tests = false
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -21,14 +21,19 @@ datetime_tag = true
 do_build = true
 
 [test]
-# On by default
+### On by default
 sanity_tests = true
 ecs_tests = true
 eks_tests = true
 ec2_tests = true
 
-# Off by default
+### Off by default
 sagemaker_tests = false
+  # Setting release_candidate_tests to `true` will disable SM tests and run RC tests in SM test jobs.
+  # SM local tests will still run.
+  # *sagemaker_tests must be set to `true` if setting release_candidate_tests to `true`.*
+  release_candidate_tests = false
+
 efa_tests = false
 
 use_scheduler = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -35,6 +35,6 @@ sagemaker_local_tests = false
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
-sagemaker_remote_tests = "rc"
+sagemaker_remote_tests = "off"
 
 use_scheduler = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -13,7 +13,7 @@ benchmark_mode = false
 
 [build]
 # Frameworks for which you want to disable both builds and tests
-skip_frameworks = []
+skip_frameworks = ["huggingface_pytorch", "huggingface_tensorflow", "mxnet"]
 # Set to false in order to remove datetime tag on PR builds
 datetime_tag = true
 # Note: Need to build the images at least once with datetime_tag = false
@@ -28,11 +28,10 @@ eks_tests = true
 ec2_tests = true
 
 ### Off by default
-sagemaker_tests = true
-  # Setting release_candidate_tests to `true` will disable SM tests and run RC tests in SM test jobs.
-  # SM local tests will still run.
-  # *sagemaker_tests must be set to `true` if setting release_candidate_tests to `true`.*
-  release_candidate_tests = true
+sagemaker_local_tests = false
+# valid values are "", "default", "release_candidate"
+# if you place any value `val` where `bool(val) == True`, we will warn you, but assume default
+sagemaker_remote_tests = "release_candidate"
 
 efa_tests = false
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -28,11 +28,11 @@ eks_tests = true
 ec2_tests = true
 
 ### Off by default
-sagemaker_tests = false
+sagemaker_tests = true
   # Setting release_candidate_tests to `true` will disable SM tests and run RC tests in SM test jobs.
   # SM local tests will still run.
   # *sagemaker_tests must be set to `true` if setting release_candidate_tests to `true`.*
-  release_candidate_tests = false
+  release_candidate_tests = true
 
 efa_tests = false
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -35,6 +35,6 @@ sagemaker_local_tests = false
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
-sagemaker_remote_tests = "standard"
+sagemaker_remote_tests = "rc"
 
 use_scheduler = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -28,10 +28,9 @@ eks_tests = true
 ec2_tests = true
 
 ### Off by default
+efa_tests = false
 sagemaker_local_tests = false
 # valid values are "off", "default", "rc"
 sagemaker_remote_tests = "off"
-
-efa_tests = false
 
 use_scheduler = false

--- a/src/config.py
+++ b/src/config.py
@@ -14,7 +14,7 @@ LOGGER.addHandler(logging.StreamHandler(sys.stderr))
 
 
 def get_dlc_developer_config_path():
-    root_dir_pattern = re.compile(r'^(\S+deep-learning-containers)')
+    root_dir_pattern = re.compile(r"^(\S+deep-learning-containers)")
     pwd = os.getcwd()
     dev_config_parent_dir = os.getenv("CODEBUILD_SRC_DIR")
 
@@ -73,7 +73,7 @@ def is_scheduler_enabled():
 class AllowedSMRemoteConfigValues(Enum):
     OFF = "off"
     RC = "rc"
-    DEFAULT = "default"
+    STANDARD = "standard"
 
 
 def get_sagemaker_remote_tests_config_value():
@@ -94,7 +94,11 @@ def is_sm_remote_test_enabled():
     if isinstance(sm_remote_tests_value, str):
         sm_remote_tests_value = sm_remote_tests_value.lower().strip()
 
-    if sm_remote_tests_value in {True, AllowedSMRemoteConfigValues.DEFAULT.value, AllowedSMRemoteConfigValues.RC.value}:
+    if sm_remote_tests_value in {
+        True,
+        AllowedSMRemoteConfigValues.STANDARD.value,
+        AllowedSMRemoteConfigValues.RC.value,
+    }:
         return True
 
     if sm_remote_tests_value != AllowedSMRemoteConfigValues.OFF.value:

--- a/src/config.py
+++ b/src/config.py
@@ -94,15 +94,12 @@ def is_sm_remote_test_enabled():
     if isinstance(sm_remote_tests_value, str):
         sm_remote_tests_value = sm_remote_tests_value.lower().strip()
 
-    if sm_remote_tests_value == AllowedSMRemoteConfigValues.OFF.value:
-        return False
-    # Support "true" so as not to break existing workflows
-    if sm_remote_tests_value is True:
+    if sm_remote_tests_value in {True, AllowedSMRemoteConfigValues.DEFAULT.value, AllowedSMRemoteConfigValues.RC.value}:
         return True
-    if sm_remote_tests_value in (AllowedSMRemoteConfigValues.DEFAULT.value, AllowedSMRemoteConfigValues.RC.value):
-        return True
-    LOGGER.warning(
-        f"Unrecognized sagemaker_remote_tests setting {sm_remote_tests_value}. Please choose one of {allowed_values}. "
-        f"Disabling sagemaker remote tests."
-    )
+
+    if sm_remote_tests_value != AllowedSMRemoteConfigValues.OFF.value:
+        LOGGER.warning(
+            f"Unrecognized sagemaker_remote_tests setting {sm_remote_tests_value}. "
+            f"Please choose one of {allowed_values}. Disabling sagemaker remote tests."
+        )
     return False

--- a/src/config.py
+++ b/src/config.py
@@ -1,7 +1,14 @@
 import os
 import re
+import logging
+import sys
 
 import toml
+
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(logging.DEBUG)
+LOGGER.addHandler(logging.StreamHandler(sys.stdout))
+LOGGER.addHandler(logging.StreamHandler(sys.stderr))
 
 
 def get_dlc_developer_config_path():
@@ -29,9 +36,23 @@ def is_benchmark_mode_enabled():
     return parse_dlc_developer_configs("dev", "benchmark_mode")
 
 
-def is_rc_test_mode_enabled():
-    return parse_dlc_developer_configs("test", "release_candidate_tests")
-
-
 def is_build_enabled():
     return parse_dlc_developer_configs("build", "do_build")
+
+
+def get_allowed_sagemaker_remote_tests_config_values():
+    """
+    Retrieve allowed SM remote tests config values
+    """
+    return "", "default", "release_candidate"
+
+
+def get_sagemaker_remote_tests_config_value():
+    sm_config_value = parse_dlc_developer_configs("test", "sagemaker_remote_tests")
+    allowed_config_values = get_allowed_sagemaker_remote_tests_config_values()
+    if sm_config_value not in allowed_config_values:
+        LOGGER.warning(
+            f"Unrecognized sagemaker_remote_tests config {sm_config_value}. "
+            f"Please ensure it is one of {allowed_config_values}, or your tests may not get triggered as expected."
+        )
+    return sm_config_value

--- a/src/config.py
+++ b/src/config.py
@@ -29,5 +29,9 @@ def is_benchmark_mode_enabled():
     return parse_dlc_developer_configs("dev", "benchmark_mode")
 
 
+def is_rc_test_mode_enabled():
+    return parse_dlc_developer_configs("test", "release_candidate_tests")
+
+
 def is_build_enabled():
     return parse_dlc_developer_configs("build", "do_build")

--- a/src/config.py
+++ b/src/config.py
@@ -73,7 +73,7 @@ def get_allowed_sagemaker_remote_tests_config_values(disabled_only=False, enable
     Retrieve allowed SM remote tests config values
     """
     disabled = ("off", "", False)
-    enabled = ("default", "release_candidate")
+    enabled = ("default", "release_candidate", "rc")
     if disabled_only:
         return disabled
     if enabled_only:
@@ -82,6 +82,9 @@ def get_allowed_sagemaker_remote_tests_config_values(disabled_only=False, enable
 
 
 def get_sagemaker_remote_tests_config_value():
+    """
+    Get the actual config option for sm remote tests
+    """
     sm_config_value = parse_dlc_developer_configs("test", "sagemaker_remote_tests")
     allowed_config_values = get_allowed_sagemaker_remote_tests_config_values()
     if sm_config_value not in allowed_config_values:
@@ -93,7 +96,12 @@ def get_sagemaker_remote_tests_config_value():
 
 
 def is_sm_remote_test_enabled():
+    """
+    Check to see if sm remote test is enabled by config
+    """
     sm_remote_tests_value = get_sagemaker_remote_tests_config_value()
+    if isinstance(sm_remote_tests_value, str):
+        sm_remote_tests_value = sm_remote_tests_value.lower().strip()
     # disable SM tests if the sm_remote_tests_value is one of our 'disable' values
     if sm_remote_tests_value in get_allowed_sagemaker_remote_tests_config_values(disabled_only=True):
         return False

--- a/src/config.py
+++ b/src/config.py
@@ -61,11 +61,11 @@ def is_sm_local_test_enabled():
 
 
 def are_efa_tests_enabled():
-    parse_dlc_developer_configs("test", "efa_tests")
+    return parse_dlc_developer_configs("test", "efa_tests")
 
 
 def is_scheduler_enabled():
-    parse_dlc_developer_configs("test", "use_scheduler")
+    return parse_dlc_developer_configs("test", "use_scheduler")
 
 
 def get_allowed_sagemaker_remote_tests_config_values(disabled_only=False, enabled_only=False):

--- a/src/start_testbuilds.py
+++ b/src/start_testbuilds.py
@@ -20,7 +20,7 @@ import sys
 import boto3
 
 import constants
-from config import parse_dlc_developer_configs, is_benchmark_mode_enabled, get_sagemaker_remote_tests_config_value
+import config
 
 
 LOGGER = logging.getLogger(__name__)
@@ -49,12 +49,12 @@ def run_test_job(commit, codebuild_project, images_str=""):
             # dlc_developer_config, compared to having another config file under dlc/tests/.
             {
                 "name": "USE_SCHEDULER",
-                "value": str(parse_dlc_developer_configs("test", "use_scheduler")),
+                "value": str(config.is_scheduler_enabled()),
                 "type": "PLAINTEXT",
             },
             {
                 "name": "DISABLE_EFA_TESTS",
-                "value": str(not parse_dlc_developer_configs("test", "efa_tests")),
+                "value": str(not config.are_efa_tests_enabled()),
                 "type": "PLAINTEXT",
             },
         ]
@@ -70,28 +70,22 @@ def run_test_job(commit, codebuild_project, images_str=""):
 
 
 def is_test_job_enabled(test_type):
-    # For SM remote, we consider "enabled" as long as bool(config_value) == True
-    sm_remote_tests_enabled = get_sagemaker_remote_tests_config_value()
-    ec2_tests_enabled = parse_dlc_developer_configs("test", "ec2_tests")
-    ecs_tests_enabled = parse_dlc_developer_configs("test", "ecs_tests")
-    eks_tests_enabled = parse_dlc_developer_configs("test", "eks_tests")
-    sanity_tests_enabled = parse_dlc_developer_configs("test", "sanity_tests")
-
-    benchmark_mode = is_benchmark_mode_enabled()
-
-    # For each test type, see if we should run the tests.
-    if test_type == constants.SAGEMAKER_TESTS and sm_remote_tests_enabled:
+    """
+    Check to see if a test job is enabled
+    See if we should run the tests based on test types and config options.
+    """
+    if test_type == constants.SAGEMAKER_TESTS and config.is_sm_remote_test_enabled():
         return True
-    if test_type == constants.EC2_TESTS and ec2_tests_enabled:
+    if test_type == constants.EC2_TESTS and config.is_ec2_test_enabled():
         return True
 
     # We have no ECS/EKS/SANITY benchmark tests
-    if not benchmark_mode:
-        if test_type == constants.ECS_TESTS and ecs_tests_enabled:
+    if not config.is_benchmark_mode_enabled():
+        if test_type == constants.ECS_TESTS and config.is_ecs_test_enabled():
             return True
-        if test_type == constants.EKS_TESTS and eks_tests_enabled:
+        if test_type == constants.EKS_TESTS and config.is_eks_test_enabled():
             return True
-        if test_type == constants.SANITY_TESTS and sanity_tests_enabled:
+        if test_type == constants.SANITY_TESTS and config.is_eks_test_enabled():
             return True
 
     return False
@@ -109,8 +103,6 @@ def main():
 
     # Run necessary PR test jobs
     commit = os.getenv("CODEBUILD_RESOLVED_SOURCE_VERSION")
-
-    sm_local_tests_enabled = parse_dlc_developer_configs("test", "sagemaker_local_tests")
 
     for test_type, images in test_images.items():
         # only run the code build test jobs when the images are present
@@ -131,7 +123,11 @@ def main():
 
             # Trigger sagemaker local test jobs when there are changes in sagemaker_tests
             # sagemaker local test is not supported in benchmark dev mode
-            if test_type == "sagemaker" and not is_benchmark_mode_enabled() and sm_local_tests_enabled:
+            if (
+                test_type == "sagemaker"
+                and not config.is_benchmark_mode_enabled()
+                and config.is_sm_local_test_enabled()
+            ):
                 test_job = f"dlc-pr-{test_type}-local-test"
                 run_test_job(commit, test_job, images_str)
 

--- a/src/utils.py
+++ b/src/utils.py
@@ -20,7 +20,7 @@ import sys
 import boto3
 import constants
 
-from config import parse_dlc_developer_configs, is_build_enabled
+from config import is_build_enabled
 from invoke.context import Context
 from botocore.exceptions import ClientError
 

--- a/test/dlc_tests/release_candidate_integration/test_sm_profiler.py
+++ b/test/dlc_tests/release_candidate_integration/test_sm_profiler.py
@@ -1,7 +1,8 @@
 import os
 import json
-import yaml
 import time
+
+from packaging.version import Version
 
 import pytest
 
@@ -10,8 +11,8 @@ from invoke.exceptions import UnexpectedExit
 
 from test.test_utils import (
     is_mainline_context,
-    get_container_name,
     get_framework_and_version_from_tag,
+    get_container_name,
     get_processor_from_image_uri,
     is_tf_version,
     LOGGER,
@@ -76,7 +77,10 @@ def test_sm_profiler_tf(tensorflow_training):
 
     # Download sagemaker-tests zip
     sm_tests_zip = "sagemaker-tests.zip"
-    ctx.run(f"aws s3 cp s3://smprofiler-test-artifacts/{sm_tests_zip} {profiler_tests_dir}/{sm_tests_zip}", hide=True)
+    ctx.run(
+        f"aws s3 cp {os.getenv('SMPROFILER_TESTS_BUCKET')}/{sm_tests_zip} {profiler_tests_dir}/{sm_tests_zip}",
+        hide=True
+    )
     ctx.run(f"cd {profiler_tests_dir} && unzip {sm_tests_zip}", hide=True)
 
     # Install tf datasets
@@ -112,26 +116,28 @@ def run_sm_profiler_tests(image, profiler_tests_dir, test_file, processor):
     except UnexpectedExit:
         # Wait a minute and a half if we get an invoke failure - since smprofiler test requirements can be flaky
         time.sleep(90)
-    # Collect env variables for tests
+
     framework, version = get_framework_and_version_from_tag(image)
 
-    # TODO: remove when SMDebug adds a 1.9.0 pytorch specfile
-    if framework == "pytorch" and version == "1.9.0":
-        version = "1.8.0"
-    spec_file = f"buildspec_profiler_sagemaker_{framework}_{version.replace('.', '_')}_integration_tests.yml"
+    # Conditionally set sm data parallel tests, based on config file rules from link below:
+    # https://github.com/awslabs/sagemaker-debugger/tree/master/config/profiler
+    enable_sm_data_parallel_tests = "true"
+    if framework == "pytorch" and Version(version) < Version("1.6"):
+        enable_sm_data_parallel_tests = "false"
+    if framework == "tensorflow" and Version(version) < Version("2.3"):
+        enable_sm_data_parallel_tests = "false"
 
-    # Get buildspec file from GitHub
-    # Note: SMDebug seems to update these in master, not necessarily in feature branches, hence using master branch
-    ctx.run(
-        f"wget https://raw.githubusercontent.com/awslabs/sagemaker-debugger/master/config/profiler/{spec_file}",
-        hide=True,
-    )
-    with open(spec_file, "r") as sf:
-        yml_envs = yaml.safe_load(sf)
-        spec_file_envs = yml_envs.get("env", {}).get("variables")
+    # Set SMProfiler specific environment variables
+    smprof_configs = {
+        "use_current_branch": "false",
+        "enable_smdataparallel_tests": enable_sm_data_parallel_tests,
+        "force_run_tests": "false",
+        "framework": framework,
+        "build_type": "release"
+    }
 
     # Command to set all necessary environment variables
-    export_cmd = " && ".join(f"export {key}={val}" for key, val in spec_file_envs.items())
+    export_cmd = " && ".join(f"export {key}={val}" for key, val in smprof_configs.items())
     export_cmd = f"{export_cmd} && export ENV_CPU_TRAIN_IMAGE=test && export ENV_GPU_TRAIN_IMAGE=test && " \
                  f"export ENV_{processor.upper()}_TRAIN_IMAGE={image}"
 

--- a/test/dlc_tests/release_candidate_integration/test_sm_profiler.py
+++ b/test/dlc_tests/release_candidate_integration/test_sm_profiler.py
@@ -11,6 +11,7 @@ from invoke.exceptions import UnexpectedExit
 
 from test.test_utils import (
     is_mainline_context,
+    is_rc_test_context,
     get_framework_and_version_from_tag,
     get_container_name,
     get_processor_from_image_uri,
@@ -21,7 +22,7 @@ from test.test_utils import (
 
 @pytest.mark.integration("smprofiler")
 @pytest.mark.model("N/A")
-@pytest.mark.skipif(not is_mainline_context(), reason="Mainline only test")
+@pytest.mark.skipif(not is_mainline_context() and not is_rc_test_context(), reason="Mainline only test")
 def test_sm_profiler_pt(pytorch_training):
     processor = get_processor_from_image_uri(pytorch_training)
     if processor not in ("cpu", "gpu"):
@@ -60,7 +61,7 @@ def test_sm_profiler_pt(pytorch_training):
 
 @pytest.mark.integration("smprofiler")
 @pytest.mark.model("N/A")
-@pytest.mark.skipif(not is_mainline_context(), reason="Mainline only test")
+@pytest.mark.skipif(not is_mainline_context() and not is_rc_test_context(), reason="Mainline only test")
 def test_sm_profiler_tf(tensorflow_training):
     if is_tf_version("1", tensorflow_training):
         pytest.skip("Skipping test on TF1, since there are no smprofiler config files for TF1")

--- a/test/dlc_tests/sanity/quick_checks/test_dlc_developer_config.py
+++ b/test/dlc_tests/sanity/quick_checks/test_dlc_developer_config.py
@@ -33,12 +33,12 @@ def test_developer_configuration():
     # Check test settings
     assert _get_option(dev_config_contents, "test", "efa_tests") is False
     assert _get_option(dev_config_contents, "test", "sanity_tests") is True
-    assert _get_option(dev_config_contents, "test", "sagemaker_tests") is False
+    assert _get_option(dev_config_contents, "test", "sagemaker_remote_tests") == ""
+    assert _get_option(dev_config_contents, "test", "sagemaker_local_tests") is False
     assert _get_option(dev_config_contents, "test", "ecs_tests") is True
     assert _get_option(dev_config_contents, "test", "eks_tests") is True
     assert _get_option(dev_config_contents, "test", "ec2_tests") is True
     assert _get_option(dev_config_contents, "test", "use_scheduler") is False
-    assert _get_option(dev_config_contents, "test", "release_candidate_tests") is False
 
 
 def _get_option(toml_contents, section, option):

--- a/test/dlc_tests/sanity/quick_checks/test_dlc_developer_config.py
+++ b/test/dlc_tests/sanity/quick_checks/test_dlc_developer_config.py
@@ -44,6 +44,7 @@ def test_developer_config_wrappers_defaults():
     assert config.are_efa_tests_enabled() is False
     assert config.is_sanity_test_enabled() is True
     assert config.is_sm_local_test_enabled() is False
+    assert config.is_sm_remote_test_enabled() is False
     assert config.is_ecs_test_enabled() is True
     assert config.is_eks_test_enabled() is True
     assert config.is_ec2_test_enabled() is True

--- a/test/dlc_tests/sanity/quick_checks/test_dlc_developer_config.py
+++ b/test/dlc_tests/sanity/quick_checks/test_dlc_developer_config.py
@@ -1,45 +1,50 @@
-import os
-
 import pytest
-import toml
 
 
-from test.test_utils import is_dlc_cicd_context
+from src import config
 
 
 @pytest.mark.quick_checks
 @pytest.mark.model("N/A")
 @pytest.mark.integration("dlc_developer_config")
-@pytest.mark.skipif(not is_dlc_cicd_context(), reason="Test relies on CB env variables and should be run on CB")
 def test_developer_configuration():
     """
     Ensure that defaults are set back to normal before merge
     """
-    root_dir = os.getenv("CODEBUILD_SRC_DIR")
-    dev_config = os.path.join(root_dir, "dlc_developer_config.toml")
-    dev_config_contents = toml.load(dev_config)
-
     # Check dev settings
-    assert _get_option(dev_config_contents, "dev", "partner_developer") == ""
-    assert _get_option(dev_config_contents, "dev", "ei_mode") is False
-    assert _get_option(dev_config_contents, "dev", "neuron_mode") is False
-    assert _get_option(dev_config_contents, "dev", "benchmark_mode") is False
+    assert config.parse_dlc_developer_configs("dev", "partner_developer") == ""
+    assert config.parse_dlc_developer_configs("dev", "ei_mode") is False
+    assert config.parse_dlc_developer_configs("dev", "neuron_mode") is False
+    assert config.parse_dlc_developer_configs("dev", "benchmark_mode") is False
 
     # Check build settings
-    assert _get_option(dev_config_contents, "build", "skip_frameworks") == []
-    assert _get_option(dev_config_contents, "build", "datetime_tag") is True
-    assert _get_option(dev_config_contents, "build", "do_build") is True
+    assert config.parse_dlc_developer_configs("build", "skip_frameworks") == []
+    assert config.parse_dlc_developer_configs("build", "datetime_tag") is True
+    assert config.parse_dlc_developer_configs("build", "do_build") is True
 
     # Check test settings
-    assert _get_option(dev_config_contents, "test", "efa_tests") is False
-    assert _get_option(dev_config_contents, "test", "sanity_tests") is True
-    assert _get_option(dev_config_contents, "test", "sagemaker_remote_tests") == ""
-    assert _get_option(dev_config_contents, "test", "sagemaker_local_tests") is False
-    assert _get_option(dev_config_contents, "test", "ecs_tests") is True
-    assert _get_option(dev_config_contents, "test", "eks_tests") is True
-    assert _get_option(dev_config_contents, "test", "ec2_tests") is True
-    assert _get_option(dev_config_contents, "test", "use_scheduler") is False
+    assert config.parse_dlc_developer_configs("test", "efa_tests") is False
+    assert config.parse_dlc_developer_configs("test", "sanity_tests") is True
+    assert config.parse_dlc_developer_configs("test", "sagemaker_remote_tests") == "off"
+    assert config.parse_dlc_developer_configs("test", "sagemaker_local_tests") is False
+    assert config.parse_dlc_developer_configs("test", "ecs_tests") is True
+    assert config.parse_dlc_developer_configs("test", "eks_tests") is True
+    assert config.parse_dlc_developer_configs("test", "ec2_tests") is True
+    assert config.parse_dlc_developer_configs("test", "use_scheduler") is False
 
 
-def _get_option(toml_contents, section, option):
-    return toml_contents.get(section, {}).get(option)
+@pytest.mark.quick_checks
+@pytest.mark.model("N/A")
+@pytest.mark.integration("dlc_developer_config")
+def test_developer_config_wrappers_defaults():
+    """
+    Test defaults of config file wrappers
+    """
+    # Check test settings
+    assert config.are_efa_tests_enabled() is False
+    assert config.is_sanity_test_enabled() is True
+    assert config.is_sm_local_test_enabled() is False
+    assert config.is_ecs_test_enabled() is True
+    assert config.is_eks_test_enabled() is True
+    assert config.is_ec2_test_enabled() is True
+    assert config.is_scheduler_enabled() is False

--- a/test/dlc_tests/sanity/quick_checks/test_dlc_developer_config.py
+++ b/test/dlc_tests/sanity/quick_checks/test_dlc_developer_config.py
@@ -38,6 +38,7 @@ def test_developer_configuration():
     assert _get_option(dev_config_contents, "test", "eks_tests") is True
     assert _get_option(dev_config_contents, "test", "ec2_tests") is True
     assert _get_option(dev_config_contents, "test", "use_scheduler") is False
+    assert _get_option(dev_config_contents, "test", "release_candidate_tests") is False
 
 
 def _get_option(toml_contents, section, option):

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -244,7 +244,8 @@ def is_benchmark_dev_context():
 
 
 def is_rc_test_context():
-    return get_sagemaker_remote_tests_config_value() == "release_candidate"
+    sm_remote_tests_val = get_sagemaker_remote_tests_config_value()
+    return sm_remote_tests_val == "release_candidate" or sm_remote_tests_val == "rc"
 
 
 def is_time_for_canary_safety_scan():

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -18,7 +18,7 @@ from packaging.version import LegacyVersion, Version, parse
 from packaging.specifiers import SpecifierSet
 from retrying import retry
 
-from src.config import is_benchmark_mode_enabled
+from src.config import is_benchmark_mode_enabled, is_rc_test_mode_enabled
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
@@ -241,6 +241,10 @@ def is_dlc_cicd_context():
 
 def is_benchmark_dev_context():
     return is_benchmark_mode_enabled()
+
+
+def is_rc_test_context():
+    return is_rc_test_mode_enabled()
 
 
 def is_time_for_canary_safety_scan():

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -18,7 +18,7 @@ from packaging.version import LegacyVersion, Version, parse
 from packaging.specifiers import SpecifierSet
 from retrying import retry
 
-from src.config import is_benchmark_mode_enabled, get_sagemaker_remote_tests_config_value
+from src.config import is_benchmark_mode_enabled, get_sagemaker_remote_tests_config_value, AllowedSMRemoteConfigValues
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
@@ -76,6 +76,7 @@ SAGEMAKER_REMOTE_TEST_TYPE = "sagemaker"
 PUBLIC_DLC_REGISTRY = "763104351884"
 
 SAGEMAKER_EXECUTION_REGIONS = ["us-west-2", "us-east-1", "eu-west-1"]
+
 
 class MissingPythonVersionException(Exception):
     """
@@ -245,7 +246,7 @@ def is_benchmark_dev_context():
 
 def is_rc_test_context():
     sm_remote_tests_val = get_sagemaker_remote_tests_config_value()
-    return sm_remote_tests_val == "release_candidate" or sm_remote_tests_val == "rc"
+    return sm_remote_tests_val == AllowedSMRemoteConfigValues.RC.value
 
 
 def is_time_for_canary_safety_scan():

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -18,7 +18,7 @@ from packaging.version import LegacyVersion, Version, parse
 from packaging.specifiers import SpecifierSet
 from retrying import retry
 
-from src.config import is_benchmark_mode_enabled, is_rc_test_mode_enabled
+from src.config import is_benchmark_mode_enabled, get_sagemaker_remote_tests_config_value
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
@@ -244,7 +244,7 @@ def is_benchmark_dev_context():
 
 
 def is_rc_test_context():
-    return is_rc_test_mode_enabled()
+    return get_sagemaker_remote_tests_config_value() == "release_candidate"
 
 
 def is_time_for_canary_safety_scan():

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -314,9 +314,7 @@ def main():
     # Skipping non HuggingFace/AG specific tests to execute only sagemaker tests
     is_hf_image_present = any("huggingface" in image_uri for image_uri in all_image_list)
     is_ag_image_present = any("autogluon" in image_uri for image_uri in all_image_list)
-    if (is_hf_image_present or is_ag_image_present) and specific_test_type in (
-            "ecs", "ec2", "eks", "bai", "release_candidate_integration"
-    ):
+    if (is_hf_image_present or is_ag_image_present) and specific_test_type in ("ecs", "ec2", "eks", "bai"):
         # Creating an empty file for because codebuild job fails without it
         LOGGER.info(f"NOTE: {specific_test_type} tests not supported on HF or AG. Skipping...")
         report = os.path.join(os.getcwd(), "test", f"{test_type}.xml")

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -303,6 +303,12 @@ def main():
     eks_cluster_name = None
     benchmark_mode = "benchmark" in test_type or is_benchmark_dev_context()
     specific_test_type = re.sub("benchmark-", "", test_type) if "benchmark" in test_type else test_type
+
+    # In PR context, allow us to switch sagemaker tests to RC tests.
+    # Do not allow them to be both enabled due to capacity issues.
+    if specific_test_type == "sagemaker" and is_rc_test_context() and is_pr_context():
+        specific_test_type = "release_candidate_integration"
+
     test_path = os.path.join("benchmark", specific_test_type) if benchmark_mode else specific_test_type
 
     # Skipping non HuggingFace specific tests to execute only sagemaker tests
@@ -319,11 +325,6 @@ def main():
         report = os.path.join(os.getcwd(), "test", f"{test_type}.xml")
         sm_utils.generate_empty_report(report, test_type, "huggingface")
         return
-
-    # In PR context, allow us to switch sagemaker tests to RC tests.
-    # Do not allow them to be both enabled due to capacity issues.
-    if specific_test_type == "sagemaker" and is_rc_test_context() and is_pr_context():
-        specific_test_type = "release_candidate_integration"
 
     if specific_test_type in (
             "sanity", "ecs", "ec2", "eks", "canary", "bai", "quick_checks", "release_candidate_integration"

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -311,17 +311,14 @@ def main():
 
     test_path = os.path.join("benchmark", specific_test_type) if benchmark_mode else specific_test_type
 
-    # Skipping non HuggingFace specific tests to execute only sagemaker tests
-    if any("huggingface" in image_uri for image_uri in all_image_list) or \
-            any("autogluon" in image_uri for image_uri in all_image_list) \
-            and specific_test_type in (
-            "ecs",
-            "ec2",
-            "eks",
-            "bai",
-            "release_candidate_integration"
+    # Skipping non HuggingFace/AG specific tests to execute only sagemaker tests
+    is_hf_image_present = any("huggingface" in image_uri for image_uri in all_image_list)
+    is_ag_image_present = any("autogluon" in image_uri for image_uri in all_image_list)
+    if (is_hf_image_present or is_ag_image_present) and specific_test_type in (
+            "ecs", "ec2", "eks", "bai", "release_candidate_integration"
     ):
         # Creating an empty file for because codebuild job fails without it
+        LOGGER.info(f"NOTE: {specific_test_type} tests not supported on HF or AG. Skipping...")
         report = os.path.join(os.getcwd(), "test", f"{test_type}.xml")
         sm_utils.generate_empty_report(report, test_type, "huggingface")
         return

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -21,6 +21,7 @@ from test_utils import (
     get_dlc_images,
     is_pr_context,
     is_benchmark_dev_context,
+    is_rc_test_context,
     destroy_ssh_keypair,
     setup_sm_benchmark_tf_train_env,
     setup_sm_benchmark_mx_train_env,
@@ -318,6 +319,11 @@ def main():
         report = os.path.join(os.getcwd(), "test", f"{test_type}.xml")
         sm_utils.generate_empty_report(report, test_type, "huggingface")
         return
+
+    # In PR context, allow us to switch sagemaker tests to RC tests.
+    # Do not allow them to be both enabled due to capacity issues.
+    if specific_test_type == "sagemaker" and is_rc_test_context() and is_pr_context():
+        specific_test_type = "release_candidate_integration"
 
     if specific_test_type in (
             "sanity", "ecs", "ec2", "eks", "canary", "bai", "quick_checks", "release_candidate_integration"


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- Split "sagemaker_tests" config option into "sagemaker_remote_tests" and "sagemaker_local_tests"
- Provide option to run RC tests on "sagemaker_remote_tests"
 
### Tests run
Ran tests in CI to ensure that RC tests can run in the sagemaker jobs

### DLC image/dockerfile
N/A

### Additional context
This provides option for developers to run RC integration tests in CI before merge, or when updating RC integration tests. It also allows devs to switch on/off sagemaker-local tests independent of the remote tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
