### PR TITLE
[pytorch][test][sagemaker] Fix PyTorch SM test retry logic

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -13,9 +13,9 @@ benchmark_mode = false
 
 [build]
 # Frameworks for which you want to disable both builds and tests
-skip_frameworks = ["mxnet", "tensorflow", "huggingface_pytorch", "huggingface_tensorflow", "autogluon"]
+skip_frameworks = []
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = false
+datetime_tag = true
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true
@@ -23,12 +23,12 @@ do_build = true
 [test]
 # On by default
 sanity_tests = true
-ecs_tests = false
-eks_tests = false
-ec2_tests = false
+ecs_tests = true
+eks_tests = true
+ec2_tests = true
 
 # Off by default
-sagemaker_tests = true
+sagemaker_tests = false
 efa_tests = false
 
 use_scheduler = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -13,9 +13,9 @@ benchmark_mode = false
 
 [build]
 # Frameworks for which you want to disable both builds and tests
-skip_frameworks = []
+skip_frameworks = ["mxnet", "tensorflow", "huggingface_pytorch", "huggingface_tensorflow", "autogluon"]
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = true
+datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true
@@ -23,12 +23,12 @@ do_build = true
 [test]
 # On by default
 sanity_tests = true
-ecs_tests = true
-eks_tests = true
-ec2_tests = true
+ecs_tests = false
+eks_tests = false
+ec2_tests = false
 
 # Off by default
-sagemaker_tests = false
+sagemaker_tests = true
 efa_tests = false
 
 use_scheduler = false


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

### Description
PyTorch Training and Inference SageMaker Test logic was written to reupload images to other regions to get around ICE errors. However, this is run whenever the test region is not `"us-west-2"`.

This means that if the list of regions I want to test in is just `["eu-west-1"]`, and the input image I provide exists in ECR in "eu-west-1", the test logic still attempts to reupload the image.

This PR changes the logic so that it only reuploads the image when the region where the test is run is not the same as the region where the ECR image exists.

### Tests run
CI

### DLC image/dockerfile

### Additional context

## Label Checklist
- [x] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [x] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
