### PR TITLE
[gitops] Add code owners for new frameworks

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,9 @@
 # Any modification to sagemaker_tests will require review from SageMaker MLF team
 sagemaker_tests/ @aws/sagemaker-ml-frameworks
 
+# Any files modified under autogluon/ will be assigned to the autogluon reviewer team
+autogluon/ @aws/dlc-autogluon-reviewers
+
 # Any files modified under tensorflow/ or tensorflow_serving/ will be assigned to the tf reviewer team
 tensorflow/ @dlc-tf-reviewers
 tensorflow_serving/ @aws/dlc-tf-reviewers


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

### Description
Update CODEOWNERS with team ID for AutoGluon DLC images

### Tests run

### DLC image/dockerfile

### Additional context

## Label Checklist
- [x] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
