### PR TITLE
[Tensorflow]|[build]|[test] Updating TF 2.5.1 training binaries

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -28,13 +28,13 @@ eks_tests = true
 ec2_tests = true
 
 ### Off by default
-efa_tests = false
-sagemaker_local_tests = false
+efa_tests = true
+sagemaker_local_tests = true
 
 # SM remote test valid values:
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
-sagemaker_remote_tests = "off"
+sagemaker_remote_tests = "standard"
 
 use_scheduler = false

--- a/tensorflow/buildspec.yml
+++ b/tensorflow/buildspec.yml
@@ -1,7 +1,7 @@
 account_id: &ACCOUNT_ID <set-$ACCOUNT_ID-in-environment>
 region: &REGION <set-$REGION-in-environment>
 framework: &FRAMEWORK tensorflow
-version: &VERSION 2.5.0
+version: &VERSION 2.5.1
 short_version: &SHORT_VERSION 2.5
 repository_info:
   training_repository: &TRAINING_REPOSITORY
@@ -37,7 +37,6 @@ context:
     deep_learning_container:
       source: ../../src/deep_learning_container.py
       target: deep_learning_container.py
-
 images:
   BuildTensorflowCpuPy37TrainingDockerImage:
     <<: *TRAINING_REPOSITORY
@@ -53,7 +52,7 @@ images:
       *DEVICE_TYPE ]
     context:
       <<: *TRAINING_CONTEXT
-  BuildTensorflowGpuPy37Cu112TrainingDockerImage:
+  BuildTensorflowGpuCu112Py37TrainingDockerImage:
     <<: *TRAINING_REPOSITORY
     build: &TENSORFLOW_GPU_TRAINING_PY3 false
     image_size_baseline: &IMAGE_SIZE_BASELINE 7738
@@ -68,11 +67,11 @@ images:
       /Dockerfile., *DEVICE_TYPE ]
     context:
       <<: *TRAINING_CONTEXT
-  BuildTensorflowExampleGpuPy37Cu112TrainingDockerImage:
+  BuildTensorflowExampleGpuCu112Py37TrainingDockerImage:
     <<: *TRAINING_REPOSITORY
     build: &TENSORFLOW_GPU_TRAINING_PY3 false
     image_size_baseline: &IMAGE_SIZE_BASELINE 7738
-    base_image_name: BuildTensorflowGpuPy37Cu112TrainingDockerImage
+    base_image_name: BuildTensorflowGpuCu112Py37TrainingDockerImage
     device_type: &DEVICE_TYPE gpu
     python_version: &DOCKER_PYTHON_VERSION py3
     tag_python_version: &TAG_PYTHON_VERSION py37
@@ -84,30 +83,3 @@ images:
       /Dockerfile., *DEVICE_TYPE ]
     context:
       <<: *TRAINING_CONTEXT
-  BuildTensorflowCPUInferencePy3DockerImage:
-    <<: *INFERENCE_REPOSITORY
-    build: &TENSORFLOW_CPU_INFERENCE_PY3 false
-    image_size_baseline: 4899
-    device_type: &DEVICE_TYPE cpu
-    python_version: &DOCKER_PYTHON_VERSION py3
-    tag_python_version: &TAG_PYTHON_VERSION py37
-    os_version: &OS_VERSION ubuntu18.04
-    # TODO: To be reverted once TF Training 2.5.1 is released
-    tag: !join [ "2.5.1", "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION ]
-    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
-    context:
-      <<: *INFERENCE_CONTEXT
-  BuildTensorflowGPUInferencePy3DockerImage:
-    <<: *INFERENCE_REPOSITORY
-    build: &TENSORFLOW_GPU_INFERENCE_PY3 false
-    image_size_baseline: 7738
-    device_type: &DEVICE_TYPE gpu
-    python_version: &DOCKER_PYTHON_VERSION py3
-    tag_python_version: &TAG_PYTHON_VERSION py37
-    cuda_version: &CUDA_VERSION cu112
-    os_version: &OS_VERSION ubuntu18.04
-    # TODO: To be reverted once TF Training 2.5.1 is released
-    tag: !join [ "2.5.1", "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION ]
-    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile., *DEVICE_TYPE ]
-    context:
-      <<: *INFERENCE_CONTEXT

--- a/tensorflow/training/docker/2.5/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.5/py3/Dockerfile.cpu
@@ -28,7 +28,7 @@ ARG PIP=pip3
 ARG PYTHON_VERSION=3.7.10
 ARG OPENSSL_VERSION=1.1.1g
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.5_aws/20210617_160451/cpu/py37/tensorflow_cpu-2.5.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.5_aws/20210812_232413/cpu/py38/tensorflow_cpu-2.5.1-cp38-cp38-manylinux2010_x86_64.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.
@@ -150,7 +150,7 @@ RUN ${PIP} install --no-cache-dir -U \
     scipy==1.7.0 \
     scikit-learn==0.24.2 \
     pandas==1.2.5 \
-    Pillow==8.3.1 \
+    Pillow \
     python-dateutil==2.8.1 \
     "pyYAML>=5.4,<5.5" \
     requests==2.24.0 \

--- a/tensorflow/training/docker/2.5/py3/cu112/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.5/py3/cu112/Dockerfile.gpu
@@ -32,7 +32,7 @@ ARG EFA_VERSION=1.11.2
 ARG OMPI_VERSION=4.1.1
 ARG BRANCH_OFI=1.1.3-aws
 
-ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.5_aws/20210617_160451/gpu/cu112/py37/tensorflow_gpu-2.5.0-cp37-cp37m-manylinux2010_x86_64.whl
+ARG TF_URL=https://aws-tensorflow-binaries.s3-us-west-2.amazonaws.com/tensorflow/r2.5_aws/20210812_232413/gpu/cu112/py38/tensorflow_gpu-2.5.1-cp38-cp38-manylinux2010_x86_64.whl
 
 # The smdebug pipeline relies for following format to perform string replace and trigger DLC pipeline for validating
 # the nightly builds. Therefore, while updating the smdebug version, please ensure that the format is not disturbed.
@@ -215,7 +215,7 @@ RUN ${PIP} install --no-cache-dir -U \
    scipy==1.7.0 \
    scikit-learn==0.24.2 \
    pandas==1.2.5 \
-   Pillow==8.3.1 \
+   Pillow \
    python-dateutil==2.8.1 \
    "pyYAML>=5.4,<5.5" \
    requests==2.25.1 \


### PR DESCRIPTION
This is similar to the automated PR created by the TF deployment pipeline for TF 2.5.1 security patch release. Since the automated PR was not created, creating this manually