### PR TITLE
[test][sanity] fix sm utility import test

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -26,9 +26,9 @@ do_build = true
 [test]
 ### On by default
 sanity_tests = true
-ecs_tests = true
-eks_tests = true
-ec2_tests = true
+ecs_tests = false
+eks_tests = false
+ec2_tests = false
 
 ### Off by default
 efa_tests = false

--- a/src/start_testbuilds.py
+++ b/src/start_testbuilds.py
@@ -85,7 +85,7 @@ def is_test_job_enabled(test_type):
             return True
         if test_type == constants.EKS_TESTS and config.is_eks_test_enabled():
             return True
-        if test_type == constants.SANITY_TESTS and config.is_eks_test_enabled():
+        if test_type == constants.SANITY_TESTS and config.is_sanity_test_enabled():
             return True
 
     return False

--- a/test/dlc_tests/sanity/test_utility_installation.py
+++ b/test/dlc_tests/sanity/test_utility_installation.py
@@ -55,14 +55,16 @@ def test_utility_packages_using_import(training):
         "tensorflow1": "1.15",
     }
 
-    framework = "tensorflow1" if framework == "tensorflow" and framework_version.startswith("1.") else "tensorflow2"
+    if framework == "tensorflow":
+        framework = "tensorflow1" if framework_version.startswith("1.") else "tensorflow2"
+
     if Version(framework_version) < Version(utility_package_minimum_framework_version[framework]):
         pytest.skip("Extra utility packages will be added going forward.")
     
     for package in UTILITY_PACKAGES_IMPORT:
         version = test_utils.run_cmd_on_container(container_name, ctx, f"import {package}; print({package}.__version__)", executable="python").stdout.strip()
         if package == "sagemaker":
-            assert Version(version) > Version("2"), f"Sagemaker version should be > 2.0. Found version {sm_version}"
+            assert Version(version) > Version("2"), f"Sagemaker version should be > 2.0. Found version {version}"
 
 
 @pytest.mark.model("N/A")


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description

### Tests run

### DLC image/dockerfile

### Additional context

## Label Checklist
- [ ] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true` or `neuron_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
