### PR TITLE
[test][sanity] whitelist openssl cve vulnerability installed using apt

### DIFF
--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -240,13 +240,14 @@ def _run_dependency_check_test(image, ec2_connection, processor):
     }
 
     # Whitelist CVE #CVE-2021-3711 for DLCs where openssl is installed using apt-get
-    framework, fw_version = get_framework_and_version_from_tag(image)
+    framework, _ = get_framework_and_version_from_tag(image)
+    short_fw_version = re.search(r"(\d+\.\d+)", image).group(1)
 
     references = { 
-        "tensorflow2": ["2.3.4", "2.4.3", "2.6.0"], 
-        "tensorflow1": ["1.15.5"], 
-        "mxnet": ["1.9.0"], 
-        "pytorch": ["1.5.1", "1.6.0", "1.7.1", "1.8.1", "1.9.0"]
+        "tensorflow2": ["2.3", "2.4", "2.6"], 
+        "tensorflow1": ["1.15"], 
+        "mxnet": ["1.9"], 
+        "pytorch": ["1.5", "1.6", "1.7", "1.8", "1.9"]
         }
 
     if is_tf_version("1", image):
@@ -256,7 +257,7 @@ def _run_dependency_check_test(image, ec2_connection, processor):
     else:
         reference_fw = framework
 
-    if (reference_fw in references and fw_version in references[reference_fw]):
+    if (reference_fw in references and short_fw_version in references[reference_fw]):
         allowed_vulnerabilities.add("CVE-2021-3711")
 
     container_name = f"dep_check_{processor}"

--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -247,7 +247,9 @@ def _run_dependency_check_test(image, ec2_connection, processor):
         "tensorflow2": ["2.3", "2.4", "2.6"], 
         "tensorflow1": ["1.15"], 
         "mxnet": ["1.9"], 
-        "pytorch": ["1.5", "1.6", "1.7", "1.8", "1.9"]
+        "pytorch": ["1.5", "1.6", "1.7", "1.8", "1.9"],
+        "huggingface_pytorch": ["1.6", "1.7", "1.8"],
+        "huggingface_tensorflow": ["2.3", "2.4"]
         }
 
     if is_tf_version("1", image):

--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -247,9 +247,9 @@ def _run_dependency_check_test(image, ec2_connection, processor):
         "tensorflow2": ["2.3", "2.4", "2.6"], 
         "tensorflow1": ["1.15"], 
         "mxnet": ["1.9"], 
-        "pytorch": ["1.5", "1.6", "1.7", "1.8", "1.9"],
-        "huggingface_pytorch": ["1.6", "1.7", "1.8"],
-        "huggingface_tensorflow": ["2.3", "2.4"]
+        "pytorch": [],
+        "huggingface_pytorch": [],
+        "huggingface_tensorflow": []
         }
 
     if is_tf_version("1", image):


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- whitelist openssl [CVE-2021-3711](https://nvd.nist.gov/vuln/detail/CVE-2021-3711) vulnerability installed on DLC using apt 

## Label Checklist
- [ ] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true` or `neuron_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
