### PR TITLE
[test] Force boto version upgrades on build/test envs

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -10,6 +10,7 @@ phases:
       - start-dockerd
       - echo Logging in to Amazon ECR...
       - $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION)
+      - pip install -U awscli boto3 botocore
       - pip install -r src/requirements.txt
       - bash src/setup.sh $FRAMEWORK
       - python src/parse_partner_developers.py

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -4,7 +4,7 @@ fabric==2.5.0
 pyfiglet==0.8.post1
 reprint==0.5.2
 ruamel.yaml==0.16.7
-boto3==1.11.11
+boto3
 black==19.10b0
 junit-xml==1.9
 toml==0.10.2

--- a/testspec.yml
+++ b/testspec.yml
@@ -19,6 +19,7 @@ phases:
           $(aws ecr get-login --no-include-email --region $AWS_DEFAULT_REGION --registry-ids 763104351884)
         fi
       - pip install -r test/requirements.txt
+      - pip install -U awscli boto3 botocore
       - pip install scheduler/.
       - echo Running pytest $TEST_TYPE tests on $DLC_IMAGES...
       - export PYTHONPATH=$PYTHONPATH:$(pwd)/src


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

### Description
Force awscli, boto3, and botocore to be upgraded to the latest available versions in order to prevent conflicts in their versions. These conflicts in versions cause long delays in package installations when one of the boto packages is in the requirements for any tests, due to the hundreds of available versions of these packages, which pip tries to iterate through to resolve package dependencies.

### Tests run
Locally tested to see if dependencies result in delays in env setup by replicating build/test env

### DLC image/dockerfile

### Additional context

## Label Checklist
- [x] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
