### PR TITLE
[tensorflow][build] Tf 1 15 5 patching

### DIFF
--- a/tensorflow/training/docker/1.15/py3/cu110/Dockerfile.gpu
+++ b/tensorflow/training/docker/1.15/py3/cu110/Dockerfile.gpu
@@ -171,7 +171,7 @@ RUN ${PIP} install --no-cache-dir -U \
     scipy==1.5.2 \
     scikit-learn==0.23 \
     pandas==1.1 \
-    Pillow==8.2.0 \
+    Pillow \
     python-dateutil==2.8.1 \
     # install PyYAML>=5.4,<5.5 to avoid conflict with latest awscli
     "pyYAML>=5.4,<5.5" \

--- a/test/dlc_tests/sanity/test_safety_check.py
+++ b/test/dlc_tests/sanity/test_safety_check.py
@@ -147,14 +147,14 @@ def _get_latest_package_version(package):
 
 @pytest.mark.model("N/A")
 @pytest.mark.canary("Run safety tests regularly on production images")
-@pytest.mark.skipif(not is_dlc_cicd_context(), reason="Skipping test because it is not running in dlc cicd infra")
-@pytest.mark.skipif(
-    not (is_mainline_context() or (is_canary_context() and is_time_for_canary_safety_scan())),
-    reason=(
-        "Skipping the test to decrease the number of calls to the Safety Check DB. "
-        "Test will be executed in the 'mainline' pipeline and canaries pipeline."
-    )
-)
+# @pytest.mark.skipif(not is_dlc_cicd_context(), reason="Skipping test because it is not running in dlc cicd infra")
+# @pytest.mark.skipif(
+#     not (is_mainline_context() or (is_canary_context() and is_time_for_canary_safety_scan())),
+#     reason=(
+#         "Skipping the test to decrease the number of calls to the Safety Check DB. "
+#         "Test will be executed in the 'mainline' pipeline and canaries pipeline."
+#     )
+# )
 def test_safety(image):
     """
     Runs safety check on a container with the capability to ignore safety issues that cannot be fixed, and only raise


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description

### Tests run

### DLC image/dockerfile

### Additional context

## Label Checklist
- [ ] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true` or `neuron_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
