### PR TITLE
[tensorflow] Narrow version pinning for bokeh package in TF2.6 training

### DIFF
--- a/tensorflow/training/docker/2.6/py3/Dockerfile.cpu
+++ b/tensorflow/training/docker/2.6/py3/Dockerfile.cpu
@@ -158,7 +158,7 @@ RUN ${PIP} install --no-cache-dir -U \
 
 # Install extra packages
 RUN pip install --no-cache-dir -U \
-    "bokeh>=2.3,<3" \
+    "bokeh>=2.3,<2.4" \
     "imageio>=2.9,<3" \
     "opencv-python>=4.3,<5" \
     "plotly>=5.1,<6" \

--- a/tensorflow/training/docker/2.6/py3/cu112/Dockerfile.gpu
+++ b/tensorflow/training/docker/2.6/py3/cu112/Dockerfile.gpu
@@ -237,7 +237,7 @@ RUN ${PIP} install --no-cache-dir -U \
 
 # Install extra packages
 RUN ${PIP} install --no-cache-dir -U \
-    "bokeh>=2.3,<3" \
+    "bokeh>=2.3,<2.4" \
     "imageio>=2.9,<3" \
     "opencv-python>=4.3,<5" \
     "plotly>=5.1,<6" \

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/sagemaker/test_mnist.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/sagemaker/test_mnist.py
@@ -222,7 +222,6 @@ def test_smdataparallel_smmodelparallel_mnist(sagemaker_session, instance_type, 
 def _assert_checkpoint_exists_v2(s3_model_dir):
     """
     s3_model_dir: S3 url of the checkpoint 
-        e.g. 's3://sagemaker-us-west-2-578276202366/tensorflow-training-2021-09-03-02-49-44-067/model'
     """
     bucket, *prefix = re.sub('s3://', '', s3_model_dir).split('/')
     prefix = '/'.join(prefix)


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- bokeh 2.4 brings in a typing-extensions dependency that conflicts with TF2.6 binary dependency requirements. Bokeh 2.4 was released today. If we narrow the pinning, we can take in the latest patch version of 2.3 to avoid any dependency breaking changes.

### Tests run
- Ran container locally, installed package, ensured that the pip check failures went away

### DLC image/dockerfile
- TF 2.6 training/inference cpu/gpu images

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
