### PR TITLE
[tensorflow]|[test] Addressing the comments in PR 1343

### DIFF
--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/sagemaker/test_mnist.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/sagemaker/test_mnist.py
@@ -27,6 +27,7 @@ from test.test_utils import get_framework_and_version_from_tag, get_cuda_version
 from ...integration.utils import processor, py_version, unique_name_from_base  # noqa: F401
 from .timeout import timeout
 
+
 def can_run_mnist_estimator(ecr_image):
     _, image_framework_version = get_framework_and_version_from_tag(ecr_image)
     return Version(image_framework_version) in SpecifierSet("<2.6")
@@ -36,28 +37,32 @@ def validate_or_skip_test(ecr_image):
     if not can_run_mnist_estimator(ecr_image):
         pytest.skip("Mnist Estimator related scripts can only run for versions < 2.6")
 
-RESOURCE_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
+
+RESOURCE_PATH = os.path.join(os.path.dirname(__file__), "..", "..", "resources")
+
 
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
 @pytest.mark.model("mnist")
 @pytest.mark.deploy_test
 def test_mnist(sagemaker_session, ecr_image, instance_type, framework_version):
-    resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
-    script = os.path.join(resource_path, 'mnist', 'mnist.py')
-    estimator = TensorFlow(entry_point=script,
-                           role='SageMakerRole',
-                           instance_type=instance_type,
-                           instance_count=1,
-                           sagemaker_session=sagemaker_session,
-                           image_uri=ecr_image,
-                           framework_version=framework_version)
+    resource_path = os.path.join(os.path.dirname(__file__), "..", "..", "resources")
+    script = os.path.join(resource_path, "mnist", "mnist.py")
+    estimator = TensorFlow(
+        entry_point=script,
+        role="SageMakerRole",
+        instance_type=instance_type,
+        instance_count=1,
+        sagemaker_session=sagemaker_session,
+        image_uri=ecr_image,
+        framework_version=framework_version,
+    )
 
     estimator = _disable_sm_profiler(sagemaker_session.boto_region_name, estimator)
 
     inputs = estimator.sagemaker_session.upload_data(
-        path=os.path.join(resource_path, 'mnist', 'data'),
-        key_prefix='scriptmode/mnist')
-    estimator.fit(inputs, job_name=unique_name_from_base('test-sagemaker-mnist'))
+        path=os.path.join(resource_path, "mnist", "data"), key_prefix="scriptmode/mnist"
+    )
+    estimator.fit(inputs, job_name=unique_name_from_base("test-sagemaker-mnist"))
     _assert_s3_file_exists(sagemaker_session.boto_region_name, estimator.model_data)
 
 
@@ -66,19 +71,21 @@ def test_mnist(sagemaker_session, ecr_image, instance_type, framework_version):
 @pytest.mark.multinode(2)
 @pytest.mark.integration("no parameter server")
 def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type, framework_version):
-    resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
-    script = os.path.join(resource_path, 'mnist', 'mnist.py')
-    estimator = TensorFlow(entry_point=script,
-                           role='SageMakerRole',
-                           instance_count=2,
-                           instance_type=instance_type,
-                           sagemaker_session=sagemaker_session,
-                           image_uri=ecr_image,
-                           framework_version=framework_version)
+    resource_path = os.path.join(os.path.dirname(__file__), "..", "..", "resources")
+    script = os.path.join(resource_path, "mnist", "mnist.py")
+    estimator = TensorFlow(
+        entry_point=script,
+        role="SageMakerRole",
+        instance_count=2,
+        instance_type=instance_type,
+        sagemaker_session=sagemaker_session,
+        image_uri=ecr_image,
+        framework_version=framework_version,
+    )
     inputs = estimator.sagemaker_session.upload_data(
-        path=os.path.join(resource_path, 'mnist', 'data'),
-        key_prefix='scriptmode/mnist')
-    estimator.fit(inputs, job_name=unique_name_from_base('test-tf-sm-distributed-mnist'))
+        path=os.path.join(resource_path, "mnist", "data"), key_prefix="scriptmode/mnist"
+    )
+    estimator.fit(inputs, job_name=unique_name_from_base("test-tf-sm-distributed-mnist"))
     _assert_s3_file_exists(sagemaker_session.boto_region_name, estimator.model_data)
 
 
@@ -87,115 +94,116 @@ def test_distributed_mnist_no_ps(sagemaker_session, ecr_image, instance_type, fr
 @pytest.mark.integration("parameter server")
 def test_distributed_mnist_ps(sagemaker_session, ecr_image, instance_type, framework_version):
     validate_or_skip_test(ecr_image=ecr_image)
-    print('ecr image used for training', ecr_image)
-    resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
-    script = os.path.join(resource_path, 'mnist', 'mnist_estimator.py')
-    estimator = TensorFlow(entry_point=script,
-                           role='SageMakerRole',
-                           hyperparameters={'sagemaker_parameter_server_enabled': True},
-                           instance_count=2,
-                           instance_type=instance_type,
-                           sagemaker_session=sagemaker_session,
-                           image_uri=ecr_image,
-                           framework_version=framework_version)
+    resource_path = os.path.join(os.path.dirname(__file__), "..", "..", "resources")
+    script = os.path.join(resource_path, "mnist", "mnist_estimator.py")
+    estimator = TensorFlow(
+        entry_point=script,
+        role="SageMakerRole",
+        hyperparameters={"sagemaker_parameter_server_enabled": True},
+        instance_count=2,
+        instance_type=instance_type,
+        sagemaker_session=sagemaker_session,
+        image_uri=ecr_image,
+        framework_version=framework_version,
+    )
     inputs = estimator.sagemaker_session.upload_data(
-        path=os.path.join(resource_path, 'mnist', 'data-distributed'),
-        key_prefix='scriptmode/mnist-distributed')
-    estimator.fit(inputs, job_name=unique_name_from_base('test-tf-sm-distributed-mnist'))
+        path=os.path.join(resource_path, "mnist", "data-distributed"), key_prefix="scriptmode/mnist-distributed"
+    )
+    estimator.fit(inputs, job_name=unique_name_from_base("test-tf-sm-distributed-mnist"))
     _assert_checkpoint_exists(sagemaker_session.boto_region_name, estimator.model_dir, 200)
+
 
 @pytest.mark.model("mnist")
 @pytest.mark.multinode(2)
 @pytest.mark.integration("parameter server")
 def test_distributed_mnist_custom_ps(sagemaker_session, ecr_image, instance_type, framework_version):
-    print('ecr image used for training', ecr_image)
-    resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
-    script = os.path.join(resource_path, 'mnist', 'mnist_custom.py')
-    estimator = TensorFlow(entry_point=script,
-                           role='SageMakerRole',
-                           hyperparameters={'sagemaker_parameter_server_enabled': True},
-                           instance_count=2,
-                           instance_type=instance_type,
-                           sagemaker_session=sagemaker_session,
-                           image_uri=ecr_image,
-                           framework_version=framework_version)
+    resource_path = os.path.join(os.path.dirname(__file__), "..", "..", "resources")
+    script = os.path.join(resource_path, "mnist", "mnist_custom.py")
+    estimator = TensorFlow(
+        entry_point=script,
+        role="SageMakerRole",
+        hyperparameters={"sagemaker_parameter_server_enabled": True},
+        instance_count=2,
+        instance_type=instance_type,
+        sagemaker_session=sagemaker_session,
+        image_uri=ecr_image,
+        framework_version=framework_version,
+    )
     inputs = estimator.sagemaker_session.upload_data(
-        path=os.path.join(resource_path, 'mnist', 'data-distributed'),
-        key_prefix='scriptmode/mnist-distributed')
-    estimator.fit(inputs, job_name=unique_name_from_base('test-tf-sm-distributed-mnist'))
-    _assert_checkpoint_exists_v2(sagemaker_session.boto_region_name, estimator.model_dir, 10)
+        path=os.path.join(resource_path, "mnist", "data-distributed"), key_prefix="scriptmode/mnist-distributed"
+    )
+    estimator.fit(inputs, job_name=unique_name_from_base("test-tf-sm-distributed-mnist"))
+    _assert_checkpoint_exists_v1(sagemaker_session.boto_region_name, estimator.model_dir, 10)
 
 
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
 @pytest.mark.model("mnist")
 @pytest.mark.integration("s3 plugin")
 def test_s3_plugin(sagemaker_session, ecr_image, instance_type, region, framework_version):
-    resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
-    script = os.path.join(resource_path, 'mnist', 'mnist_custom.py')
-    estimator = TensorFlow(entry_point=script,
-                           role='SageMakerRole',
-                           hyperparameters={
-                               # Saving a checkpoint after every 5 steps to hammer the S3 plugin
-                               'save-checkpoint-steps': 10,
-                               # Reducing throttling for checkpoint and model saving
-                               'throttle-secs': 1,
-                               # Without the patch training jobs would fail around 100th to
-                               # 150th step
-                               'max-steps': 200,
-                               # Large batch size would result in a larger checkpoint file
-                               'batch-size': 1024,
-                               # This makes the training job exporting model during training.
-                               # Stale model garbage collection will also be performed.
-                               'export-model-during-training': True
-                           },
-                           instance_count=1,
-                           instance_type=instance_type,
-                           sagemaker_session=sagemaker_session,
-                           image_uri=ecr_image,
-                           framework_version=framework_version)
+    resource_path = os.path.join(os.path.dirname(__file__), "..", "..", "resources")
+    script = os.path.join(resource_path, "mnist", "mnist_custom.py")
+    estimator = TensorFlow(
+        entry_point=script,
+        role="SageMakerRole",
+        hyperparameters={
+            # Saving a checkpoint after every 5 steps to hammer the S3 plugin
+            "save-checkpoint-steps": 10,
+            # Reducing throttling for checkpoint and model saving
+            "throttle-secs": 1,
+            # Without the patch training jobs would fail around 100th to
+            # 150th step
+            "max-steps": 200,
+            # Large batch size would result in a larger checkpoint file
+            "batch-size": 1024,
+            # This makes the training job exporting model during training.
+            # Stale model garbage collection will also be performed.
+            "export-model-during-training": True,
+        },
+        instance_count=1,
+        instance_type=instance_type,
+        sagemaker_session=sagemaker_session,
+        image_uri=ecr_image,
+        framework_version=framework_version,
+    )
 
     inputs = estimator.sagemaker_session.upload_data(
-        path=os.path.join(resource_path, 'mnist', 'data-distributed'),
-        key_prefix='scriptmode/mnist-distributed')
-    estimator.fit(inputs,job_name=unique_name_from_base('test-tf-sm-s3-mnist'))
-    print("=========== Model data location ===============")
-    print(estimator.model_data)
-    print("=========== Model dir           ===============")
-    print(estimator.model_dir)
-    _assert_checkpoint_exists_v2(sagemaker_session.boto_region_name, estimator.model_dir, 10)
+        path=os.path.join(resource_path, "mnist", "data-distributed"), key_prefix="scriptmode/mnist-distributed"
+    )
+    estimator.fit(inputs, job_name=unique_name_from_base("test-tf-sm-s3-mnist"))
+    _assert_checkpoint_exists_v1(sagemaker_session.boto_region_name, estimator.model_dir, 10)
+
 
 @pytest.mark.skipif(is_pr_context(), reason=SKIP_PR_REASON)
 @pytest.mark.model("mnist")
 @pytest.mark.integration("hpo")
 def test_tuning(sagemaker_session, ecr_image, instance_type, framework_version):
-    resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
-    script = os.path.join(resource_path, 'mnist', 'mnist.py')
+    resource_path = os.path.join(os.path.dirname(__file__), "..", "..", "resources")
+    script = os.path.join(resource_path, "mnist", "mnist.py")
 
-    estimator = TensorFlow(entry_point=script,
-                           role='SageMakerRole',
-                           instance_type=instance_type,
-                           instance_count=1,
-                           sagemaker_session=sagemaker_session,
-                           image_uri=ecr_image,
-                           framework_version=framework_version)
+    estimator = TensorFlow(
+        entry_point=script,
+        role="SageMakerRole",
+        instance_type=instance_type,
+        instance_count=1,
+        sagemaker_session=sagemaker_session,
+        image_uri=ecr_image,
+        framework_version=framework_version,
+    )
 
-    hyperparameter_ranges = {'epochs': IntegerParameter(1, 2)}
-    objective_metric_name = 'accuracy'
-    metric_definitions = [{'Name': objective_metric_name, 'Regex': 'accuracy = ([0-9\\.]+)'}]
+    hyperparameter_ranges = {"epochs": IntegerParameter(1, 2)}
+    objective_metric_name = "accuracy"
+    metric_definitions = [{"Name": objective_metric_name, "Regex": "accuracy = ([0-9\\.]+)"}]
 
-    tuner = HyperparameterTuner(estimator,
-                                objective_metric_name,
-                                hyperparameter_ranges,
-                                metric_definitions,
-                                max_jobs=2,
-                                max_parallel_jobs=2)
+    tuner = HyperparameterTuner(
+        estimator, objective_metric_name, hyperparameter_ranges, metric_definitions, max_jobs=2, max_parallel_jobs=2
+    )
 
     with timeout(minutes=20):
         inputs = estimator.sagemaker_session.upload_data(
-            path=os.path.join(resource_path, 'mnist', 'data'),
-            key_prefix='scriptmode/mnist')
+            path=os.path.join(resource_path, "mnist", "data"), key_prefix="scriptmode/mnist"
+        )
 
-        tuning_job_name = unique_name_from_base('test-tf-sm-tuning', max_length=32)
+        tuning_job_name = unique_name_from_base("test-tf-sm-tuning", max_length=32)
         tuner.fit(inputs, job_name=tuning_job_name)
         tuner.wait()
 
@@ -205,21 +213,23 @@ def test_tuning(sagemaker_session, ecr_image, instance_type, framework_version):
 @pytest.mark.integration("smdebug")
 @pytest.mark.skip_py2_containers
 def test_smdebug(sagemaker_session, ecr_image, instance_type, framework_version):
-    resource_path = os.path.join(os.path.dirname(__file__), '..', '..', 'resources')
-    script = os.path.join(resource_path, 'mnist', 'mnist_smdebug.py')
-    hyperparameters = {'smdebug_path': '/tmp/ml/output/tensors'}
-    estimator = TensorFlow(entry_point=script,
-                           role='SageMakerRole',
-                           instance_type=instance_type,
-                           instance_count=1,
-                           sagemaker_session=sagemaker_session,
-                           image_uri=ecr_image,
-                           framework_version=framework_version,
-                           hyperparameters=hyperparameters)
+    resource_path = os.path.join(os.path.dirname(__file__), "..", "..", "resources")
+    script = os.path.join(resource_path, "mnist", "mnist_smdebug.py")
+    hyperparameters = {"smdebug_path": "/tmp/ml/output/tensors"}
+    estimator = TensorFlow(
+        entry_point=script,
+        role="SageMakerRole",
+        instance_type=instance_type,
+        instance_count=1,
+        sagemaker_session=sagemaker_session,
+        image_uri=ecr_image,
+        framework_version=framework_version,
+        hyperparameters=hyperparameters,
+    )
     inputs = estimator.sagemaker_session.upload_data(
-        path=os.path.join(resource_path, 'mnist', 'data'),
-        key_prefix='scriptmode/mnist_smdebug')
-    estimator.fit(inputs, job_name=unique_name_from_base('test-sagemaker-mnist-smdebug'))
+        path=os.path.join(resource_path, "mnist", "data"), key_prefix="scriptmode/mnist_smdebug"
+    )
+    estimator.fit(inputs, job_name=unique_name_from_base("test-sagemaker-mnist-smdebug"))
     _assert_s3_file_exists(sagemaker_session.boto_region_name, estimator.model_data)
 
 
@@ -239,52 +249,51 @@ def test_smdataparallel_smmodelparallel_mnist(sagemaker_session, instance_type, 
     image_cuda_version = get_cuda_version_from_tag(ecr_image)
     if Version(image_framework_version) < Version("2.3.1") or image_cuda_version != "cu110":
         pytest.skip("SMD Model and Data Parallelism are only supported on CUDA 11, and on TensorFlow 2.3.1 or higher")
-    smmodelparallel_path = os.path.join(RESOURCE_PATH, 'smmodelparallel')
+    smmodelparallel_path = os.path.join(RESOURCE_PATH, "smmodelparallel")
     test_script = "smdataparallel_smmodelparallel_mnist_script_mode.sh"
-    estimator = TensorFlow(entry_point=test_script,
-                           role='SageMakerRole',
-                           instance_count=1,
-                           instance_type=instance_type,
-                           source_dir=smmodelparallel_path,
-                           sagemaker_session=sagemaker_session,
-                           image_uri=ecr_image,
-                           framework_version=framework_version,
-                           py_version='py3')
+    estimator = TensorFlow(
+        entry_point=test_script,
+        role="SageMakerRole",
+        instance_count=1,
+        instance_type=instance_type,
+        source_dir=smmodelparallel_path,
+        sagemaker_session=sagemaker_session,
+        image_uri=ecr_image,
+        framework_version=framework_version,
+        py_version="py3",
+    )
 
     estimator = _disable_sm_profiler(sagemaker_session.boto_region_name, estimator)
 
     estimator.fit()
 
 
-def _assert_checkpoint_exists_v2(region, model_dir, checkpoint_number):
+def _assert_checkpoint_exists_v1(region, model_dir, checkpoint_number):
     """
-    Checking for v2 style checkpoints i.e. checkpoint and .index files
+    Checking for new style checkpoints i.e. checkpoint and .index files
     """
-    _assert_s3_file_exists(region, os.path.join(model_dir, 'checkpoint'))
-    _assert_s3_file_exists(region,
-                           os.path.join(model_dir, 'model.ckpt-{}.index'.format(checkpoint_number)))
+    _assert_s3_file_exists(region, os.path.join(model_dir, "checkpoint"))
+    _assert_s3_file_exists(region, os.path.join(model_dir, "model.ckpt-{}.index".format(checkpoint_number)))
 
 
 def _assert_checkpoint_exists(region, model_dir, checkpoint_number):
     """
-    Checking for v1 style checkpoints i.e. graph.pbtxt, .index files and meta
+    Checking for old style checkpoints i.e. graph.pbtxt, .index files and meta
     """
-    _assert_s3_file_exists(region, os.path.join(model_dir, 'graph.pbtxt'))
-    _assert_s3_file_exists(region,
-                           os.path.join(model_dir, 'model.ckpt-{}.index'.format(checkpoint_number)))
-    _assert_s3_file_exists(region,
-                           os.path.join(model_dir, 'model.ckpt-{}.meta'.format(checkpoint_number)))
+    _assert_s3_file_exists(region, os.path.join(model_dir, "graph.pbtxt"))
+    _assert_s3_file_exists(region, os.path.join(model_dir, "model.ckpt-{}.index".format(checkpoint_number)))
+    _assert_s3_file_exists(region, os.path.join(model_dir, "model.ckpt-{}.meta".format(checkpoint_number)))
 
 
 def _assert_s3_file_exists(region, s3_url):
     parsed_url = urlparse(s3_url)
-    s3 = boto3.resource('s3', region_name=region)
-    s3.Object(parsed_url.netloc, parsed_url.path.lstrip('/')).load()
+    s3 = boto3.resource("s3", region_name=region)
+    s3.Object(parsed_url.netloc, parsed_url.path.lstrip("/")).load()
+
 
 def _disable_sm_profiler(region, estimator):
-    """Disable SMProfiler feature for China regions
-    """
+    """Disable SMProfiler feature for China regions"""
 
-    if region in ('cn-north-1', 'cn-northwest-1'):
+    if region in ("cn-north-1", "cn-northwest-1"):
         estimator.disable_profiler = True
     return estimator

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/resources/mnist/mnist_custom.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/resources/mnist/mnist_custom.py
@@ -16,8 +16,10 @@ import os
 import json
 import tensorflow as tf
 
+from packaging.version import Version 
+
 tf_major, tf_minor, _ = tf.__version__.split('.')
-if int(tf_major) > 2 or (int(tf_major) == 2 and int(tf_minor) >= 6):
+if Version(tf.__version__) >= Version("2.6.0"):
     import tensorflow_io as tfio
 from tensorflow.keras.layers import Conv2D, BatchNormalization, Dense, Flatten
 


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 


### Description
This PR has been made to address the comments in [PR 1343](https://github.com/aws/deep-learning-containers/pull/1343).


## Label Checklist
- [x] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true` or `neuron_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
