### PR TITLE
[release] Update release images for HF PT1.8.1 transformers 4.10.2

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -345,7 +345,7 @@ release_images:
   26:
     framework: "huggingface_pytorch"
     version: "1.8.1"
-    hf_transformers: "4.6.1"
+    hf_transformers: "4.10.2"
     training:
       device_types: ["gpu"]
       python_versions: [ "py36" ]
@@ -402,7 +402,7 @@ release_images:
   30:
     framework: "huggingface_pytorch"
     version: "1.8.1"
-    hf_transformers: "4.6.1"
+    hf_transformers: "4.10.2"
     inference:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py36" ]


### PR DESCRIPTION
*GitHub Issue #, if available:*
#1326 

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- Update release images iml for new HF release

### DLC image/dockerfile
- HF PT 1.8.1 transformers 4.10.2 (training gpu, inference cpu/gpu)

### Additional context

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
