### PR TITLE
[config] Remove efa_tests config option and include as sagemaker_remote_tests option

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Note: If merging this PR should also close the associated Issue, please also add
 
 - [ ] Revision A: `sagemaker_remote_tests = "standard"`
 - [ ] Revision B: `sagemaker_remote_tests = "rc"`
-- [ ] Revision C: `sagemaker_remote_tests = "standard"` & `efa_tests = true`
+- [ ] Revision C: `sagemaker_remote_tests = "efa"`
 
 **Additionally, please run the sagemaker local tests in at least one revision:**
 - [ ] `sagemaker_local_tests = true`

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -31,13 +31,13 @@ eks_tests = true
 ec2_tests = true
 
 ### Off by default
-efa_tests = false
 sagemaker_local_tests = false
 
 # SM remote test valid values:
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
+# "efa" --> run efa sagemaker tests
 sagemaker_remote_tests = "off"
 
 use_scheduler = false

--- a/release_images.yml
+++ b/release_images.yml
@@ -345,7 +345,7 @@ release_images:
   26:
     framework: "huggingface_pytorch"
     version: "1.8.1"
-    hf_transformers: "4.6.1"
+    hf_transformers: "4.10.2"
     training:
       device_types: ["gpu"]
       python_versions: [ "py36" ]
@@ -402,7 +402,7 @@ release_images:
   30:
     framework: "huggingface_pytorch"
     version: "1.8.1"
-    hf_transformers: "4.6.1"
+    hf_transformers: "4.10.2"
     inference:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py36" ]

--- a/src/config.py
+++ b/src/config.py
@@ -63,7 +63,8 @@ def is_sm_local_test_enabled():
 
 
 def are_efa_tests_enabled():
-    return parse_dlc_developer_configs("test", "efa_tests")
+    sm_remote_value = get_sagemaker_remote_tests_config_value()
+    return sm_remote_value == "efa"
 
 
 def is_scheduler_enabled():
@@ -74,6 +75,7 @@ class AllowedSMRemoteConfigValues(Enum):
     OFF = "off"
     RC = "rc"
     STANDARD = "standard"
+    EFA = "efa"
 
 
 def get_sagemaker_remote_tests_config_value():

--- a/src/config.py
+++ b/src/config.py
@@ -62,11 +62,6 @@ def is_sm_local_test_enabled():
     return parse_dlc_developer_configs("test", "sagemaker_local_tests")
 
 
-def are_efa_tests_enabled():
-    sm_remote_value = get_sagemaker_remote_tests_config_value()
-    return sm_remote_value == "efa"
-
-
 def is_scheduler_enabled():
     return parse_dlc_developer_configs("test", "use_scheduler")
 
@@ -100,6 +95,7 @@ def is_sm_remote_test_enabled():
         True,
         AllowedSMRemoteConfigValues.STANDARD.value,
         AllowedSMRemoteConfigValues.RC.value,
+        AllowedSMRemoteConfigValues.EFA.value,
     }:
         return True
 
@@ -109,3 +105,8 @@ def is_sm_remote_test_enabled():
             f"Please choose one of {allowed_values}. Disabling sagemaker remote tests."
         )
     return False
+
+
+def are_efa_tests_enabled():
+    sm_remote_value = get_sagemaker_remote_tests_config_value()
+    return sm_remote_value == AllowedSMRemoteConfigValues.EFA.value

--- a/test/dlc_tests/sanity/quick_checks/test_dlc_developer_config.py
+++ b/test/dlc_tests/sanity/quick_checks/test_dlc_developer_config.py
@@ -24,7 +24,6 @@ def test_developer_configuration():
     assert config.parse_dlc_developer_configs("build", "do_build") is True
 
     # Check test settings
-    assert config.parse_dlc_developer_configs("test", "efa_tests") is False
     assert config.parse_dlc_developer_configs("test", "sanity_tests") is True
     assert config.parse_dlc_developer_configs("test", "sagemaker_remote_tests") == "off"
     assert config.parse_dlc_developer_configs("test", "sagemaker_local_tests") is False


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- EFA tests are run on SM remote job in PR - so they should not be a separate option. Refactoring this to avoid confusion when it comes to the separate implementation of sm remote options and the efa option.
- Update PR template to indicate the changes, as well as the tests that should be run prior to new framework merge

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
