### PR TITLE
[bug] Fix bugs in dependency check test

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -18,16 +18,16 @@ benchmark_mode = false
 # Frameworks for which you want to disable both builds and tests
 skip_frameworks = []
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = false
+datetime_tag = true
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
-do_build = false
+do_build = true
 
 [test]
 ### On by default
 sanity_tests = true
-ecs_tests = false
-eks_tests = false
+ecs_tests = true
+eks_tests = true
 ec2_tests = true
 
 ### Off by default

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -18,7 +18,7 @@ benchmark_mode = false
 # Frameworks for which you want to disable both builds and tests
 skip_frameworks = []
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = true
+datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true
@@ -26,9 +26,9 @@ do_build = true
 [test]
 ### On by default
 sanity_tests = true
-ecs_tests = true
-eks_tests = true
-ec2_tests = true
+ecs_tests = false
+eks_tests = false
+ec2_tests = false
 
 ### Off by default
 sagemaker_local_tests = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -21,14 +21,14 @@ skip_frameworks = []
 datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
-do_build = true
+do_build = false
 
 [test]
 ### On by default
 sanity_tests = true
 ecs_tests = false
 eks_tests = false
-ec2_tests = false
+ec2_tests = true
 
 ### Off by default
 sagemaker_local_tests = false

--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -312,8 +312,6 @@ def _run_dependency_check_test(image, ec2_connection, processor):
                 LOGGER.exception(
                     f"Failed to load NIST data for CVE {vulnerability}")
 
-
-
         # TODO: Remove this once we have whitelisted appropriate LOW/MEDIUM vulnerabilities
         if not (vulnerability_severity.get("CRITICAL") or vulnerability_severity.get("HIGH")):
             return

--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -267,7 +267,8 @@ def _run_dependency_check_test(image, ec2_connection, processor):
 
     # Execute test, copy results to s3
     ec2.execute_ec2_training_test(
-        ec2_connection, image, test_script, container_name=container_name)
+        ec2_connection, image, test_script, container_name=container_name, bin_bash_entrypoint=True
+    )
     ec2_connection.run(f"docker cp {html_file} ~/{dependency_check_report}")
     ec2_connection.run(
         f"aws s3 cp ~/{dependency_check_report} s3://dlc-dependency-check")
@@ -303,14 +304,15 @@ def _run_dependency_check_test(image, ec2_connection, processor):
                         .get("baseMetricV2", {})
                         .get("severity", "UNKNOWN")
                     )
+                    if vulnerability_severity.get(severity):
+                        vulnerability_severity[severity].append(vulnerability)
+                    else:
+                        vulnerability_severity[severity] = [vulnerability]
             except ConnectionError:
                 LOGGER.exception(
                     f"Failed to load NIST data for CVE {vulnerability}")
 
-            if vulnerability_severity.get(severity):
-                vulnerability_severity[severity].append(vulnerability)
-            else:
-                vulnerability_severity[severity] = [vulnerability]
+
 
         # TODO: Remove this once we have whitelisted appropriate LOW/MEDIUM vulnerabilities
         if not (vulnerability_severity.get("CRITICAL") or vulnerability_severity.get("HIGH")):
@@ -332,9 +334,6 @@ def _run_dependency_check_test(image, ec2_connection, processor):
     reason="Executing test in canaries pipeline during only a limited period of time.",
 )
 def test_dependency_check_cpu(cpu, ec2_connection):
-    # TODO: Fix test on HF inference
-    if "huggingface-tensorflow-inference" in cpu or "huggingface-pytorch-inference" in cpu:
-        pytest.skip("Temporarily skipping HF inference images due to test flakiness")
     _run_dependency_check_test(cpu, ec2_connection, "cpu")
 
 
@@ -347,9 +346,6 @@ def test_dependency_check_cpu(cpu, ec2_connection):
     reason="Executing test in canaries pipeline during only a limited period of time.",
 )
 def test_dependency_check_gpu(gpu, ec2_connection):
-    # TODO: Fix test on HF inference
-    if "huggingface-tensorflow-inference" in gpu or "huggingface-pytorch-inference" in gpu:
-        pytest.skip("Temporarily skipping HF inference images due to test flakiness")
     _run_dependency_check_test(gpu, ec2_connection, "gpu")
 
 

--- a/test/test_utils/ec2.py
+++ b/test/test_utils/ec2.py
@@ -444,6 +444,7 @@ def execute_ec2_training_test(
     host_network=False,
     container_name="ec2_training_container",
     timeout=3000,
+    bin_bash_entrypoint=False,
 ):
     if executable not in ("bash", "python"):
         raise RuntimeError(f"This function only supports executing bash or python commands on containers")
@@ -458,9 +459,10 @@ def execute_ec2_training_test(
     # Run training command
     shm_setting = '--shm-size="1g"' if large_shm else ""
     network = '--network="host" ' if host_network else ""
+    bin_bash_cmd = "--entrypoint /bin/bash " if bin_bash_entrypoint else ""
     connection.run(
         f"{docker_cmd} run --name {container_name} {network}-v {container_test_local_dir}:{os.path.join(os.sep, 'test')}"
-        f" {shm_setting} -itd {ecr_uri}",
+        f" {shm_setting} -itd {bin_bash_cmd}{ecr_uri}",
         hide=True,
     )
     return connection.run(


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description

- There are unbound variables in the dependency check test, so fixed this issue
- Add optional arg for setting entry point to /bin/bash in ec2 training tests - since we are running these on inference images as well, sometimes the entrypoint does not get appropriately overwritten
- This affects both HF inference and autogluon inference containers

### Tests run
- Running sanity tests on all images to verify success

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
