### PR TITLE
[release] Prepare release for HF PT1.9 and TF2.5 transformers 4.10.2

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -479,3 +479,51 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
+  36:
+    framework: "huggingface_tensorflow"
+    version: "2.5.1"
+    hf_transformers: "4.10.2"
+    training:
+      device_types: [ "gpu" ]
+      python_versions: [ "py37" ]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu112"
+      example: False
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  37:
+    framework: "huggingface_tensorflow"
+    version: "2.5.1"
+    hf_transformers: "4.10.2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py37" ]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu112"
+      example: False
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  38:
+    framework: "huggingface_pytorch"
+    version: "1.9.0"
+    hf_transformers: "4.10.2"
+    training:
+      device_types: [ "gpu" ]
+      python_versions: [ "py38" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu111"
+      example: False
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  39:
+    framework: "huggingface_pytorch"
+    version: "1.9.0"
+    hf_transformers: "4.10.2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py38" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu111"
+      example: False
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False


### PR DESCRIPTION
*GitHub Issue #, if available:*
#1355 

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- prep release for these two framework version releases

### DLC image/dockerfile
- HF PT1.9 gpu training, cpu and gpu inference
- HF TF2.5 gpu training, cpu and gpu inference

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
