### PR TITLE
[test] Add back safety check skip conditions

### DIFF
--- a/test/dlc_tests/sanity/test_safety_check.py
+++ b/test/dlc_tests/sanity/test_safety_check.py
@@ -188,13 +188,15 @@ def _get_latest_package_version(package):
 @pytest.mark.model("N/A")
 @pytest.mark.canary("Run safety tests regularly on production images")
 @pytest.mark.skipif(not is_dlc_cicd_context(), reason="Skipping test because it is not running in dlc cicd infra")
-# @pytest.mark.skipif(
-#     not (is_mainline_context() or (is_canary_context() and is_time_for_canary_safety_scan())),
-#     reason=(
-#         "Skipping the test to decrease the number of calls to the Safety Check DB. "
-#         "Test will be executed in the 'mainline' pipeline and canaries pipeline."
-#     )
-# )
+@pytest.mark.skipif(
+    not (
+        is_mainline_context() or is_safety_test_context() or (is_canary_context() and is_time_for_canary_safety_scan())
+    ),
+    reason=(
+        "Skipping the test to decrease the number of calls to the Safety Check DB. "
+        "Test will be executed in the 'mainline' pipeline and canaries pipeline."
+    ),
+)
 def test_safety(image):
     """
     Runs safety check on a container with the capability to ignore safety issues that cannot be fixed, and only raise


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- Safety checks seem to have been mistakenly enabled everywhere by #1352 - this also negates the safety mode config option. Adding back the logic in this PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
