### PR TITLE
[test][pytorch][ec2] Fix test nccl version

### DIFF
--- a/test/dlc_tests/container_tests/bin/pytorch_tests/testPyTorchNcclVersion.py
+++ b/test/dlc_tests/container_tests/bin/pytorch_tests/testPyTorchNcclVersion.py
@@ -13,15 +13,20 @@ logging.basicConfig(stream=sys.stdout, level=logging.DEBUG)
 def test_nccl_version():
     try:
         pt_nccl = torch.cuda.nccl.version()
+        assert isinstance(pt_nccl, int) or isinstance(pt_nccl, tuple), \
+            "Error: PT NCCL version should be either int or tuple"
         find = subprocess.Popen(['find', '/usr', '-name', 'libnccl.so*'], stdout=PIPE)
         sort = subprocess.Popen(['sort', '-r'], stdin=find.stdout, stdout=PIPE)
         tail = subprocess.Popen(['head', '-n1'], stdin=sort.stdout, stdout=PIPE)
         result = subprocess.Popen(['sed', '-r', 's/^.*\.so\.//'], stdin=tail.stdout, stdout=PIPE)
         output, error = result.communicate()
-        numbers = [int(x, 10) for x in output.decode("utf-8").strip().split('.')]
-        assert len(numbers) == 3, \
+        system_nccl = [int(x, 10) for x in output.decode("utf-8").strip().split('.')]
+        assert len(system_nccl) == 3, \
             "Error: failed to parse system nccl version"
-        system_nccl = numbers[0] * 1000 + numbers[1] * 100 + numbers[2]
+        if isinstance(pt_nccl, int):
+            system_nccl = system_nccl[0] * 1000 + system_nccl[1] * 100 + system_nccl[2]
+        else:
+            pt_nccl = list(pt_nccl)
         assert pt_nccl == system_nccl, \
             "Error: PT NCCL version does not match system NCCL: {} vs {}".format(pt_nccl, system_nccl)
     except Exception as excp:


### PR DESCRIPTION
Previously `torch.cuda.nccl.version()` returns nccl version as `int`. In recent PT 1.10 build, it returns as `tuple`. This change corrupted the version parsing in `test_nccl_version()` and failed the test in https://github.com/aws/deep-learning-containers/pull/1392. This PR attempts to fix the issue.

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description

### Tests run
**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

### DLC image/dockerfile

### Additional context

## Label Checklist
- [ ] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron"/"graviton">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
