### PR TITLE
[tensorflow-1] Skip TF1 PR builds by default

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import argparse
 import os
+import re
 
 import utils
 import constants
@@ -36,12 +37,13 @@ def main():
     # Write empty dict to JSON file, so subsequent buildspec steps do not fail in case we skip this build
     utils.write_to_json_file(constants.TEST_TYPE_IMAGES_PATH, {})
 
-    # Add ability to skip tensorflow-1 or tensorflow-2
+    # Skip tensorflow-1 PR jobs, as there are no longer patch releases being added for TF1
+    # Purposefully not including this in developer config to make this difficult to enable
+    # TODO: Remove when we remove these jobs completely
     build_arn = utils.get_codebuild_build_arn()
     if build_context == "PR":
-        if "tensorflow-1" in build_arn and "tensorflow-1" in frameworks_to_skip:
-            return
-        if "tensorflow-2" in build_arn and "tensorflow-2" in frameworks_to_skip:
+        tf_1_build_regex = re.compile(r"dlc-pr-tensorflow-1:")
+        if tf_1_build_regex.search(build_arn):
             return
 
     # A general will work if in non-EI, non-NEURON and non-GRAVITON mode and its framework not been disabled


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- remove from dev config, so that it's difficult to start TF1 builds by accident
- disabling TF1 builds, as there are no new patch releases planned for TF1 https://github.com/tensorflow/tensorflow/releases/tag/v1.15.5

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
