### PR TITLE
[sagemaker] Write blank report if sm remote images are filtered

### DIFF
--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -248,8 +248,8 @@ def main():
     efa_dedicated = os.getenv("EFA_DEDICATED", "False").lower() == "true"
     executor_mode = os.getenv("EXECUTOR_MODE", "False").lower() == "true"
     dlc_images = os.getenv("DLC_IMAGE") if executor_mode else get_dlc_images()
-    # Executing locally ona can provide commit_id or may ommit it. Assigning default value for local executions:  
-    commit_id = os.getenv('CODEBUILD_RESOLVED_SOURCE_VERSION', default="unrecognised_commit_id")
+    # Executing locally ona can provide commit_id or may ommit it. Assigning default value for local executions:
+    commit_id = os.getenv("CODEBUILD_RESOLVED_SOURCE_VERSION", default="unrecognised_commit_id")
     LOGGER.info(f"Images tested: {dlc_images}")
     all_image_list = dlc_images.split(" ")
     standard_images_list = [image_uri for image_uri in all_image_list if "example" not in image_uri]
@@ -384,16 +384,15 @@ def main():
             sys.exit(pytest.main(pytest_cmd))
 
         else:
-            run_sagemaker_remote_tests(
-                [
-                    image
-                    for image in standard_images_list
-                    if not (
-                        ("tensorflow-inference" in image and "py2" in image)
-                        or is_diy_image(image)
-                    )
-                ]
-            )
+            sm_remote_images = [
+                image
+                for image in standard_images_list
+                if not (("tensorflow-inference" in image and "py2" in image) or is_diy_image(image))
+            ]
+            run_sagemaker_remote_tests(sm_remote_images)
+            if standard_images_list and not sm_remote_images:
+                report = os.path.join(os.getcwd(), "test", f"{test_type}.xml")
+                sm_utils.generate_empty_report(report, test_type, "sm_remote_unsupported")
         metrics_utils.send_test_duration_metrics(start_time)
 
     elif specific_test_type == "sagemaker-local":


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- in conditions where sm remote tests get filtered, we need to write empty report

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
