### PR TITLE
[test][sagemaker] Adding smart retry to sagemaker remote tests

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -24,16 +24,16 @@ skip_frameworks = []
 datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
-do_build = true
+do_build = false
 
 [test]
 ### On by default
-sanity_tests = true
+sanity_tests = false
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = true
-eks_tests = true
-ec2_tests = true
+ecs_tests = false
+eks_tests = false
+ec2_tests = false
 
 ### SM specific tests
 ### Off by default

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -22,19 +22,19 @@ benchmark_mode = false
 # available farameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "tensorflow", "mxnet", "pytorch"]
 skip_frameworks = []
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = false
+datetime_tag = true
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
-do_build = false
+do_build = true
 
 [test]
 ### On by default
-sanity_tests = false
+sanity_tests = true
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = false
-eks_tests = false
-ec2_tests = false
+ecs_tests = true
+eks_tests = true
+ec2_tests = true
 
 ### SM specific tests
 ### Off by default
@@ -45,6 +45,6 @@ sagemaker_local_tests = false
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "standard"
+sagemaker_remote_tests = "off"
 
 use_scheduler = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -20,7 +20,7 @@ benchmark_mode = false
 [build]
 # Frameworks for which you want to disable both builds and tests
 # available farameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "tensorflow", "mxnet", "pytorch"]
-skip_frameworks = ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "tensorflow", "pytorch"]
+skip_frameworks = []
 # Set to false in order to remove datetime tag on PR builds
 datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -19,12 +19,13 @@ benchmark_mode = false
 
 [build]
 # Frameworks for which you want to disable both builds and tests
-skip_frameworks = []
+# available farameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "tensorflow", "mxnet", "pytorch"]
+skip_frameworks = ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "tensorflow", "pytorch"]
 # Set to false in order to remove datetime tag on PR builds
 datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
-do_build = true
+do_build = false
 
 [test]
 ### On by default

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -21,7 +21,7 @@ benchmark_mode = false
 # Frameworks for which you want to disable both builds and tests
 skip_frameworks = []
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = true
+datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -24,7 +24,7 @@ skip_frameworks = []
 datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
-do_build = false
+do_build = true
 
 [test]
 ### On by default

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -44,6 +44,6 @@ sagemaker_local_tests = false
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "off"
+sagemaker_remote_tests = "standard"
 
 use_scheduler = false

--- a/test/sagemaker_tests/autogluon/inference/conftest.py
+++ b/test/sagemaker_tests/autogluon/inference/conftest.py
@@ -95,6 +95,7 @@ def pytest_addoption(parser):
     parser.addoption(
         "--efa", action="store_true", default=False, help="Run only efa tests",
     )
+    parser.addoption('--sagemaker-regions', default='us-west-2')
 
 
 def pytest_configure(config):
@@ -123,6 +124,12 @@ def fixture_docker_base_name(request):
 @pytest.fixture(scope='session', name='region')
 def fixture_region(request):
     return request.config.getoption('--region')
+
+
+@pytest.fixture(scope='session', name='sagemaker_regions')
+def fixture_sagemaker_regions(request):
+    sagemaker_regions = request.config.getoption('--sagemaker-regions')
+    return sagemaker_regions.split(",")
 
 
 @pytest.fixture(scope='session', name='framework_version')

--- a/test/sagemaker_tests/autogluon/inference/conftest.py
+++ b/test/sagemaker_tests/autogluon/inference/conftest.py
@@ -323,3 +323,20 @@ def disable_test(request):
 
     if build_name and version and _is_test_disabled(test_name, build_name, version):
         pytest.skip(f"Skipping {test_name} test because it has been disabled.")
+
+
+@pytest.fixture(autouse=True)
+def skip_test_successfully_executed_before(request):
+    """
+    "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
+    So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
+    But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The method checks whether lastfailed file exists and the test name is not in it.
+    """
+    test_name = request.node.name
+    lastfailed = request.config.cache.get("cache/lastfailed", None)
+
+    if lastfailed is not None \
+            and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
+        pytest.skip(f"Skipping {test_name} because it was successfully executed for this commit")

--- a/test/sagemaker_tests/autogluon/training/conftest.py
+++ b/test/sagemaker_tests/autogluon/training/conftest.py
@@ -191,8 +191,8 @@ def fixture_sagemaker_session(region):
 
 
 @pytest.fixture(scope='session', name='sagemaker_regions')
-def sagemaker_regions(request):
-    fixture_sagemaker_regions = request.config.getoption('--sagemaker-regions')
+def fixture_sagemaker_regions(request):
+    sagemaker_regions = request.config.getoption('--sagemaker-regions')
     return sagemaker_regions.split(",")
 
 

--- a/test/sagemaker_tests/autogluon/training/conftest.py
+++ b/test/sagemaker_tests/autogluon/training/conftest.py
@@ -323,3 +323,20 @@ def disable_test(request):
 
     if build_name and version and _is_test_disabled(test_name, build_name, version):
         pytest.skip(f"Skipping {test_name} test because it has been disabled.")
+
+
+@pytest.fixture(autouse=True)
+def skip_test_successfully_executed_before(request):
+    """
+    "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
+    So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
+    But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The method checks whether lastfailed file exists and the test name is not in it.
+    """
+    test_name = request.node.name
+    lastfailed = request.config.cache.get("cache/lastfailed", None)
+
+    if lastfailed is not None \
+            and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
+        pytest.skip(f"Skipping {test_name} because it was successfully executed for this commit")

--- a/test/sagemaker_tests/huggingface/inference/conftest.py
+++ b/test/sagemaker_tests/huggingface/inference/conftest.py
@@ -356,3 +356,20 @@ def disable_test(request):
 
     if build_name and version and _is_test_disabled(test_name, build_name, version):
         pytest.skip(f"Skipping {test_name} test because it has been disabled.")
+
+
+@pytest.fixture(autouse=True)
+def skip_test_successfully_executed_before(request):
+    """
+    "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
+    So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
+    But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The method checks whether lastfailed file exists and the test name is not in it.
+    """
+    test_name = request.node.name
+    lastfailed = request.config.cache.get("cache/lastfailed", None)
+
+    if lastfailed is not None \
+            and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
+        pytest.skip(f"Skipping {test_name} because it was successfully executed for this commit")

--- a/test/sagemaker_tests/huggingface_pytorch/training/conftest.py
+++ b/test/sagemaker_tests/huggingface_pytorch/training/conftest.py
@@ -325,3 +325,20 @@ def disable_test(request):
 
     if build_name and version and _is_test_disabled(test_name, build_name, version):
         pytest.skip(f"Skipping {test_name} test because it has been disabled.")
+
+
+@pytest.fixture(autouse=True)
+def skip_test_successfully_executed_before(request):
+    """
+    "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
+    So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
+    But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The method checks whether lastfailed file exists and the test name is not in it.
+    """
+    test_name = request.node.name
+    lastfailed = request.config.cache.get("cache/lastfailed", None)
+
+    if lastfailed is not None \
+            and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
+        pytest.skip(f"Skipping {test_name} because it was successfully executed for this commit")

--- a/test/sagemaker_tests/huggingface_tensorflow/training/integration/conftest.py
+++ b/test/sagemaker_tests/huggingface_tensorflow/training/integration/conftest.py
@@ -219,3 +219,20 @@ def disable_test(request):
 
     if build_name and version and _is_test_disabled(test_name, build_name, version):
         pytest.skip(f"Skipping {test_name} test because it has been disabled.")
+
+
+@pytest.fixture(autouse=True)
+def skip_test_successfully_executed_before(request):
+    """
+    "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
+    So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
+    But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The method checks whether lastfailed file exists and the test name is not in it.
+    """
+    test_name = request.node.name
+    lastfailed = request.config.cache.get("cache/lastfailed", None)
+
+    if lastfailed is not None \
+            and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
+        pytest.skip(f"Skipping {test_name} because it was successfully executed for this commit")

--- a/test/sagemaker_tests/mxnet/inference/conftest.py
+++ b/test/sagemaker_tests/mxnet/inference/conftest.py
@@ -251,7 +251,7 @@ def disable_test(request):
 @pytest.fixture(autouse=True)
 def skip_successfully_executed_test(request):
     test_name = request.node.name
-    test_file_name = str(request.node.fspath)
+    test_file_name = os.path.basename(str(request.node.fspath))
     file_and_test_name = f"{test_file_name}::{test_name}"
     lastfailed = request.config.cache.get("cache/lastfailed", None)
     logger.warning(f"test_name - {test_name}, lastfailed - {lastfailed}")
@@ -259,4 +259,4 @@ def skip_successfully_executed_test(request):
 
     if lastfailed is not None \
             and not any(file_and_test_name in failed_test_name for failed_test_name in lastfailed.keys()):
-        pytest.skip(f"Skipping {test_name} test because it was already successfully executed for this commit.")
+        pytest.skip(f"Skipping {file_and_test_name} test because it is in {lastfailed.keys()}")

--- a/test/sagemaker_tests/mxnet/inference/conftest.py
+++ b/test/sagemaker_tests/mxnet/inference/conftest.py
@@ -246,3 +246,13 @@ def disable_test(request):
 
     if build_name and version and _is_test_disabled(test_name, build_name, version):
         pytest.skip(f"Skipping {test_name} test because it has been disabled.")
+
+
+@pytest.fixture(autouse=True)
+def skip_successfully_executed_test(request):
+    test_name = request.node.name
+    lastfailed = request.config.cache.get("cache/lastfailed", None)
+    logger.info(f"test_name - {test_name}, lastfailed - {lastfailed}")
+
+    if lastfailed is not None and test_name not in lastfailed.keys():
+        pytest.skip(f"Skipping {test_name} test because it was already successfully executed for this commit.")

--- a/test/sagemaker_tests/mxnet/inference/conftest.py
+++ b/test/sagemaker_tests/mxnet/inference/conftest.py
@@ -249,11 +249,17 @@ def disable_test(request):
 
 
 @pytest.fixture(autouse=True)
-def skip_successfully_executed_test(request):
+def skip_test_successfully_executed_before(request):
+    """
+    "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
+    So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
+    But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The method checks whether lastfailed file exists and the test name is not in it.
+    """
     test_name = request.node.name
     lastfailed = request.config.cache.get("cache/lastfailed", None)
-    logger.info(f"test_name - {test_name}, lastfailed - {lastfailed}")
 
     if lastfailed is not None \
             and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
-        pytest.skip(f"Skipping {test_name} because it's not in {lastfailed.keys()}")
+        pytest.skip(f"Skipping {test_name} because it was successfully executed for this commit")

--- a/test/sagemaker_tests/mxnet/inference/conftest.py
+++ b/test/sagemaker_tests/mxnet/inference/conftest.py
@@ -251,12 +251,9 @@ def disable_test(request):
 @pytest.fixture(autouse=True)
 def skip_successfully_executed_test(request):
     test_name = request.node.name
-    test_file_name = os.path.basename(str(request.node.fspath))
-    file_and_test_name = f"{test_file_name}::{test_name}"
     lastfailed = request.config.cache.get("cache/lastfailed", None)
-    logger.warning(f"test_name - {test_name}, lastfailed - {lastfailed}")
-    print(f"test_name - {test_name}, lastfailed - {lastfailed}")
+    logger.info(f"test_name - {test_name}, lastfailed - {lastfailed}")
 
     if lastfailed is not None \
-            and not any(file_and_test_name in failed_test_name for failed_test_name in lastfailed.keys()):
-        pytest.skip(f"Skipping {file_and_test_name} test because it is in {lastfailed.keys()}")
+            and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
+        pytest.skip(f"Skipping {test_name} because it's not in {lastfailed.keys()}")

--- a/test/sagemaker_tests/mxnet/inference/conftest.py
+++ b/test/sagemaker_tests/mxnet/inference/conftest.py
@@ -251,8 +251,12 @@ def disable_test(request):
 @pytest.fixture(autouse=True)
 def skip_successfully_executed_test(request):
     test_name = request.node.name
+    test_file_name = str(request.node.fspath)
+    file_and_test_name = f"{test_file_name}::{test_name}"
     lastfailed = request.config.cache.get("cache/lastfailed", None)
-    logger.info(f"test_name - {test_name}, lastfailed - {lastfailed}")
+    logger.warning(f"test_name - {test_name}, lastfailed - {lastfailed}")
+    print(f"test_name - {test_name}, lastfailed - {lastfailed}")
 
-    if lastfailed is not None and test_name not in lastfailed.keys():
+    if lastfailed is not None \
+            and not any(file_and_test_name in failed_test_name for failed_test_name in lastfailed.keys()):
         pytest.skip(f"Skipping {test_name} test because it was already successfully executed for this commit.")

--- a/test/sagemaker_tests/mxnet/training/conftest.py
+++ b/test/sagemaker_tests/mxnet/training/conftest.py
@@ -246,3 +246,13 @@ def disable_test(request):
 
     if build_name and version and _is_test_disabled(test_name, build_name, version):
         pytest.skip(f"Skipping {test_name} test because it has been disabled.")
+
+
+@pytest.fixture(autouse=True)
+def skip_successfully_executed_test(request):
+    test_name = request.node.name
+    lastfailed = request.config.cache.get("cache/lastfailed", None)
+    logger.info(f"test_name - {test_name}, lastfailed - {lastfailed}")
+
+    if lastfailed is not None and test_name not in lastfailed.keys():
+        pytest.skip(f"Skipping {test_name} test because it was already successfully executed for this commit.")

--- a/test/sagemaker_tests/mxnet/training/conftest.py
+++ b/test/sagemaker_tests/mxnet/training/conftest.py
@@ -249,11 +249,17 @@ def disable_test(request):
 
 
 @pytest.fixture(autouse=True)
-def skip_successfully_executed_test(request):
+def skip_test_successfully_executed_before(request):
+    """
+    "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
+    So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
+    But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The method checks whether lastfailed file exists and the test name is not in it.
+    """
     test_name = request.node.name
     lastfailed = request.config.cache.get("cache/lastfailed", None)
-    logger.info(f"test_name - {test_name}, lastfailed - {lastfailed}")
 
     if lastfailed is not None \
             and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
-        pytest.skip(f"Skipping {test_name} because it's not in {lastfailed.keys()}")
+        pytest.skip(f"Skipping {test_name} because it was successfully executed for this commit")

--- a/test/sagemaker_tests/mxnet/training/conftest.py
+++ b/test/sagemaker_tests/mxnet/training/conftest.py
@@ -254,5 +254,6 @@ def skip_successfully_executed_test(request):
     lastfailed = request.config.cache.get("cache/lastfailed", None)
     logger.info(f"test_name - {test_name}, lastfailed - {lastfailed}")
 
-    if lastfailed is not None and test_name not in lastfailed.keys():
-        pytest.skip(f"Skipping {test_name} test because it was already successfully executed for this commit.")
+    if lastfailed is not None \
+            and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
+        pytest.skip(f"Skipping {test_name} because it's not in {lastfailed.keys()}")

--- a/test/sagemaker_tests/pytorch/inference/conftest.py
+++ b/test/sagemaker_tests/pytorch/inference/conftest.py
@@ -344,3 +344,20 @@ def disable_test(request):
 
     if build_name and version and _is_test_disabled(test_name, build_name, version):
         pytest.skip(f"Skipping {test_name} test because it has been disabled.")
+
+
+@pytest.fixture(autouse=True)
+def skip_test_successfully_executed_before(request):
+    """
+    "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
+    So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
+    But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The method checks whether lastfailed file exists and the test name is not in it.
+    """
+    test_name = request.node.name
+    lastfailed = request.config.cache.get("cache/lastfailed", None)
+
+    if lastfailed is not None \
+            and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
+        pytest.skip(f"Skipping {test_name} because it was successfully executed for this commit")

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -348,3 +348,20 @@ def disable_test(request):
 
     if build_name and version and _is_test_disabled(test_name, build_name, version):
         pytest.skip(f"Skipping {test_name} test because it has been disabled.")
+
+
+@pytest.fixture(autouse=True)
+def skip_test_successfully_executed_before(request):
+    """
+    "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
+    So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
+    But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The method checks whether lastfailed file exists and the test name is not in it.
+    """
+    test_name = request.node.name
+    lastfailed = request.config.cache.get("cache/lastfailed", None)
+
+    if lastfailed is not None \
+            and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
+        pytest.skip(f"Skipping {test_name} because it was successfully executed for this commit")

--- a/test/sagemaker_tests/tensorflow/inference/test/integration/sagemaker/conftest.py
+++ b/test/sagemaker_tests/tensorflow/inference/test/integration/sagemaker/conftest.py
@@ -254,3 +254,20 @@ def disable_test(request):
 
     if build_name and version and _is_test_disabled(test_name, build_name, version):
         pytest.skip(f"Skipping {test_name} test because it has been disabled.")
+
+
+@pytest.fixture(autouse=True)
+def skip_test_successfully_executed_before(request):
+    """
+    "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
+    So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
+    But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The method checks whether lastfailed file exists and the test name is not in it.
+    """
+    test_name = request.node.name
+    lastfailed = request.config.cache.get("cache/lastfailed", None)
+
+    if lastfailed is not None \
+            and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
+        pytest.skip(f"Skipping {test_name} because it was successfully executed for this commit")

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/conftest.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/integration/conftest.py
@@ -225,3 +225,20 @@ def disable_test(request):
 
     if build_name and version and _is_test_disabled(test_name, build_name, version):
         pytest.skip(f"Skipping {test_name} test because it has been disabled.")
+
+
+@pytest.fixture(autouse=True)
+def skip_test_successfully_executed_before(request):
+    """
+    "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
+    So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
+    But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The method checks whether lastfailed file exists and the test name is not in it.
+    """
+    test_name = request.node.name
+    lastfailed = request.config.cache.get("cache/lastfailed", None)
+
+    if lastfailed is not None \
+            and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
+        pytest.skip(f"Skipping {test_name} because it was successfully executed for this commit")

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/conftest.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/conftest.py
@@ -225,3 +225,20 @@ def disable_test(request):
 
     if build_name and version and _is_test_disabled(test_name, build_name, version):
         pytest.skip(f"Skipping {test_name} test because it has been disabled.")
+
+
+@pytest.fixture(autouse=True)
+def skip_test_successfully_executed_before(request):
+    """
+    "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
+    So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
+    But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The method checks whether lastfailed file exists and the test name is not in it.
+    """
+    test_name = request.node.name
+    lastfailed = request.config.cache.get("cache/lastfailed", None)
+
+    if lastfailed is not None \
+            and not any(test_name in failed_test_name for failed_test_name in lastfailed.keys()):
+        pytest.skip(f"Skipping {test_name} because it was successfully executed for this commit")

--- a/test/test_utils/pytest_cache.py
+++ b/test/test_utils/pytest_cache.py
@@ -133,6 +133,35 @@ class PytestCache:
         s3_file_path = os.path.join(s3_file_dir, "lastfailed")
         self.__upload_cache_to_s3(local_file_path, s3_file_path)
 
+    def merge_cache_and_upload_from_local_to_s3(self,
+                                             current_dir,
+                                             commit_id,
+                                             framework,
+                                             version,
+                                             build_context,
+                                             test_type):
+        """
+        Copy pytest cache file from local box to directory in s3. .pytest_cache directory will be copied from 
+        :param current_dir ec2 directory to s3 directory generated from parameters.
+
+                Following parameters are required to create a path to cache file in s3:
+        :param current_dir: directory on ec2 instance
+        :param commit_id
+        :param framework
+        :param version
+        :param build_context
+        :param test_type
+        """
+        self.__merge_2_execution_caches_and_save("tmp", "lastfailed", "tmp")
+        local_file_dir = os.path.join(current_dir, ".pytest_cache", "v", "cache")
+        # tmp file contains full execution cache now so uploading tmp but now lastfailed
+        local_file_path = os.path.join(local_file_dir, "tmp")
+        s3_file_dir = self.__make_s3_path(commit_id, framework, version, build_context, test_type)
+        s3_file_path = os.path.join(s3_file_dir, "lastfailed")
+        self.__upload_cache_to_s3(local_file_path, s3_file_path)
+
+
+
     def __make_s3_path(self, commit_id, framework, version, build_context, test_type):
         return os.path.join(commit_id, framework, version, build_context, test_type)
 

--- a/test/test_utils/pytest_cache.py
+++ b/test/test_utils/pytest_cache.py
@@ -134,12 +134,12 @@ class PytestCache:
         self.__upload_cache_to_s3(local_file_path, s3_file_path)
 
     def merge_cache_and_upload_from_local_to_s3(self,
-                                             current_dir,
-                                             commit_id,
-                                             framework,
-                                             version,
-                                             build_context,
-                                             test_type):
+                                                current_dir,
+                                                commit_id,
+                                                framework,
+                                                version,
+                                                build_context,
+                                                test_type):
         """
         Copy pytest cache file from local box to directory in s3. .pytest_cache directory will be copied from 
         :param current_dir ec2 directory to s3 directory generated from parameters.
@@ -152,15 +152,13 @@ class PytestCache:
         :param build_context
         :param test_type
         """
-        self.__merge_2_execution_caches_and_save("tmp", "lastfailed", "tmp")
+        tmp_file_name = "tmp"
         local_file_dir = os.path.join(current_dir, ".pytest_cache", "v", "cache")
-        # tmp file contains full execution cache now so uploading tmp but now lastfailed
-        local_file_path = os.path.join(local_file_dir, "tmp")
+        self.__merge_2_execution_caches_and_save(tmp_file_name, f"{local_file_dir}/lastfailed", tmp_file_name)
+        # tmp file contains full execution cache now so uploading tmp instead of lastfailed
         s3_file_dir = self.__make_s3_path(commit_id, framework, version, build_context, test_type)
         s3_file_path = os.path.join(s3_file_dir, "lastfailed")
-        self.__upload_cache_to_s3(local_file_path, s3_file_path)
-
-
+        self.__upload_cache_to_s3(tmp_file_name, s3_file_path)
 
     def __make_s3_path(self, commit_id, framework, version, build_context, test_type):
         return os.path.join(commit_id, framework, version, build_context, test_type)
@@ -181,7 +179,7 @@ class PytestCache:
     def __merge_2_execution_caches_and_save(self, cache_file_1, cache_file_2, save_to):
         """
         Merges 2 JSON objects into one and safe on disk 
-        
+
         :param cache_file_1
         :param cache_file_2
         :param save_to: filename where to save result JSON

--- a/test/test_utils/sagemaker.py
+++ b/test/test_utils/sagemaker.py
@@ -357,6 +357,7 @@ def execute_sagemaker_remote_tests(image, pytest_cache_params):
                     f"{pytest_command} failed with error code: {res.return_code}\n"
                     f"Traceback:\n{res.stdout}"
                 )
+    return None
 
 
 def generate_empty_report(report, test_type, case):

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -145,7 +145,7 @@ def send_scheduler_requests(requester, image):
             break
 
 
-def run_sagemaker_remote_tests(images):
+def run_sagemaker_remote_tests(images, pytest_cache_params):
     """
     Function to set up multiprocessing for SageMaker tests
     :param images: <list> List of all images to be used in SageMaker tests
@@ -188,7 +188,7 @@ def run_sagemaker_remote_tests(images):
             return
         pool_number = len(images)
         with Pool(pool_number) as p:
-            p.map(sm_utils.execute_sagemaker_remote_tests, images)
+            p.starmap(sm_utils.execute_sagemaker_remote_tests, [[image, pytest_cache_params] for image in images])
 
 
 def pull_dlc_images(images):
@@ -389,7 +389,7 @@ def main():
                 for image in standard_images_list
                 if not (("tensorflow-inference" in image and "py2" in image) or is_e3_image(image))
             ]
-            run_sagemaker_remote_tests(sm_remote_images)
+            run_sagemaker_remote_tests(sm_remote_images, pytest_cache_params)
             if standard_images_list and not sm_remote_images:
                 report = os.path.join(os.getcwd(), "test", f"{test_type}.xml")
                 sm_utils.generate_empty_report(report, test_type, "sm_remote_unsupported")


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
Smart retry for sagemaker remote tests. We're executing SM remote tests in separate threads so we need additional handler for pytest cache


### Tests run
**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

### DLC image/dockerfile

### Additional context

## Label Checklist
- [ ] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron"/"graviton">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
