### PR TITLE
Release tf2.6.2

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -298,20 +298,8 @@ release_images:
       # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
+
   23:
-    framework: "tensorflow"
-    version: "2.6.0"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py38" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu112"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-      # to images being published.
-      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
-  24:
     framework: "tensorflow"
     version: "2.6.2"
     training:
@@ -322,7 +310,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  25:
+  24:
     framework: "autogluon"
     version: "0.3.1"
     training:
@@ -333,7 +321,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  26:
+  25:
     framework: "autogluon"
     version: "0.3.1"
     inference:
@@ -343,12 +331,24 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  27:
+  26:
     framework: "huggingface_tensorflow"
     version: "2.5.1"
     hf_transformers: "4.12.3"
     training:
       device_types: [ "gpu" ]
+      python_versions: [ "py37" ]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu112"
+      example: False
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  27:
+    framework: "huggingface_tensorflow"
+    version: "2.5.1"
+    hf_transformers: "4.12.3"
+    inference:
+      device_types: [ "cpu", "gpu" ]
       python_versions: [ "py37" ]
       os_version: "ubuntu18.04"
       cuda_version: "cu112"
@@ -356,18 +356,6 @@ release_images:
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
   28:
-    framework: "huggingface_tensorflow"
-    version: "2.5.1"
-    hf_transformers: "4.12.3"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py37" ]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu112"
-      example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-  29:
     framework: "huggingface_pytorch"
     version: "1.9.1"
     hf_transformers: "4.12.3"
@@ -379,7 +367,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  30:
+  29:
     framework: "huggingface_pytorch"
     version: "1.9.1"
     hf_transformers: "4.12.3"
@@ -391,7 +379,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  31:
+  30:
     framework: "pytorch"
     version: "1.10.0"
     customer_type: "e3"
@@ -415,7 +403,7 @@ release_images:
       # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-  32:
+  31:
     framework: "pytorch"
     version: "1.10.0"
     customer_type: "e3"
@@ -428,7 +416,7 @@ release_images:
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
 
-  33:
+  32:
     framework: "mxnet"
     version: "1.8.0"
     inference:
@@ -440,7 +428,7 @@ release_images:
       disable_sm_tag: True
       force_release: False
 
-  34:
+  33:
     framework: "tensorflow"
     version: "2.5.1"
     inference:
@@ -452,7 +440,7 @@ release_images:
       disable_sm_tag: True
       force_release: False
 
-  35:
+  34:
     framework: "tensorflow"
     version: "1.15.5"
     inference:
@@ -463,7 +451,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  36:
+  35:
     framework: "tensorflow"
     version: "2.7.0"
     customer_type: "e3"
@@ -487,7 +475,7 @@ release_images:
       # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-  37:
+  36:
     framework: "tensorflow"
     version: "2.7.0"
     customer_type: "e3"

--- a/release_images.yml
+++ b/release_images.yml
@@ -287,18 +287,8 @@ release_images:
       force_release: False
   22:
     framework: "tensorflow"
-    version: "2.6.0"
+    version: "2.6.2"
     training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py38" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu112"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-      # to images being published.
-      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
-    inference:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py38" ]
       os_version: "ubuntu20.04"
@@ -311,6 +301,19 @@ release_images:
   23:
     framework: "tensorflow"
     version: "2.6.0"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py38" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu112"
+      example: False        # [Default: False] Set to True to denote that this image is an Example image
+      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
+      # to images being published.
+      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
+      # has already been published. Re-released image will have minor version incremented by 1.
+  24:
+    framework: "tensorflow"
+    version: "2.6.2"
     training:
       device_types: [ "gpu" ]
       python_versions: [ "py38" ]
@@ -319,7 +322,7 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  24:
+  25:
     framework: "autogluon"
     version: "0.3.1"
     training:
@@ -330,7 +333,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  25:
+  26:
     framework: "autogluon"
     version: "0.3.1"
     inference:
@@ -340,24 +343,12 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  26:
+  27:
     framework: "huggingface_tensorflow"
     version: "2.5.1"
     hf_transformers: "4.12.3"
     training:
       device_types: [ "gpu" ]
-      python_versions: [ "py37" ]
-      os_version: "ubuntu18.04"
-      cuda_version: "cu112"
-      example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-  27:
-    framework: "huggingface_tensorflow"
-    version: "2.5.1"
-    hf_transformers: "4.12.3"
-    inference:
-      device_types: [ "cpu", "gpu" ]
       python_versions: [ "py37" ]
       os_version: "ubuntu18.04"
       cuda_version: "cu112"
@@ -365,6 +356,18 @@ release_images:
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
   28:
+    framework: "huggingface_tensorflow"
+    version: "2.5.1"
+    hf_transformers: "4.12.3"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py37" ]
+      os_version: "ubuntu18.04"
+      cuda_version: "cu112"
+      example: False
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  29:
     framework: "huggingface_pytorch"
     version: "1.9.1"
     hf_transformers: "4.12.3"
@@ -376,7 +379,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  29:
+  30:
     framework: "huggingface_pytorch"
     version: "1.9.1"
     hf_transformers: "4.12.3"
@@ -388,7 +391,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  30:
+  31:
     framework: "pytorch"
     version: "1.10.0"
     customer_type: "e3"
@@ -412,7 +415,7 @@ release_images:
       # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-  31:
+  32:
     framework: "pytorch"
     version: "1.10.0"
     customer_type: "e3"
@@ -425,7 +428,7 @@ release_images:
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
 
-  32:
+  33:
     framework: "mxnet"
     version: "1.8.0"
     inference:
@@ -437,7 +440,7 @@ release_images:
       disable_sm_tag: True
       force_release: False
 
-  33:
+  34:
     framework: "tensorflow"
     version: "2.5.1"
     inference:
@@ -449,7 +452,7 @@ release_images:
       disable_sm_tag: True
       force_release: False
 
-  34:
+  35:
     framework: "tensorflow"
     version: "1.15.5"
     inference:
@@ -460,7 +463,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  35:
+  36:
     framework: "tensorflow"
     version: "2.7.0"
     customer_type: "e3"
@@ -484,7 +487,7 @@ release_images:
       # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-  36:
+  37:
     framework: "tensorflow"
     version: "2.7.0"
     customer_type: "e3"


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- Update release images yaml for TF 2.6.2 training release. Inference is currently set to TF2.6.0 - this will need to be added later when we build/release TF2.6.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
