### PR TITLE
[pytorch][training] PT 1.9.1 Fix package versions 

### DIFF
--- a/pytorch/training/docker/1.9/py3/cu111/Dockerfile.gpu
+++ b/pytorch/training/docker/1.9/py3/cu111/Dockerfile.gpu
@@ -163,7 +163,7 @@ RUN ${CONDA_PREFIX}/bin/conda config --set ssl_verify False \
 
 RUN conda install -c pytorch magma-cuda111==2.5.2 \
  && conda install -y scikit-learn \
-    pandas \
+    pandas==1.2.4 \
     h5py \
     requests \
     libgcc \
@@ -216,12 +216,19 @@ RUN pip install --no-cache-dir -U \
 # numba 0.54 only works with numpy>=1.20. See https://github.com/numba/numba/issues/7339
 RUN pip install --no-cache-dir -U \
     "bokeh>=2.3,<3" \
-    "imageio>=2.9,<3" \
+    "imageio==2.10.3" \
     "opencv-python>=4.3,<5" \
-    "plotly>=5.1,<6" \
+    "plotly==5.3.1" \
     "seaborn>=0.11,<1" \
     "numba<0.54" \
-    "shap>=0.39,<1"
+    "shap>=0.39,<1" \
+    "jsii==1.43.0" \
+    "marshmallow==3.14.0" \
+    "matplotlib==3.4.3" \
+    "packaging==21.2" \
+    "pyarrow==6.0.0" \
+    "pyinstrument==4.0.4" \
+    "pyparsing==2.4.7"
 
 # install metis
 RUN rm /etc/apt/sources.list.d/* \


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
FOR PT1.9, getting below error and fix is added to PR

```
>           raise CommandTimedOut(result, timeout=timeout)
E           invoke.exceptions.CommandTimedOut: Command did not complete within 3000 seconds!

E           Command: "nvidia-docker exec --user root ec2_training_container /bin/bash -c '/test/bin/pytorch_tests/testPyTorchS3Plugin'"
E           Stdout:
E           INITIATING SHUFFLE TEST
E           [2021-11-23 19:19:20.529 0b52519bd68f:14 INFO utils.py:27] RULE_JOB_STOP_SIGNAL_FILENAME: None
E           [2021-11-23 19:19:20.572 0b52519bd68f:14 INFO profiler_config_parser.py:102] Unable to find config at /opt/ml/input/config/profilerconfig.json. Profiler is disabled.
E           Shuffle test passed for S3IterableDataset
E           ShuffleDataset test passes for 30 buffer_size & 0 workers 

E           ShuffleDataset test passes for 300 buffer_size & 0 workers 
E           ShuffleDataset test passes for 3000 buffer_size & 0 workers 
E           ShuffleDataset test passes for 30 buffer_size & 16 workers 
E           Stderr:
```


### Tests run
**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

### DLC image/dockerfile

### Additional context

## Label Checklist
- [ ] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
