### PR TITLE
[graviton] Add arch_type-specific env variable for graviton EC2 tests

### DIFF
--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -648,7 +648,11 @@ def generate_unique_values_for_fixtures(metafunc_obj, images_to_parametrize, val
                     instance_tag = ""
                     for processor in allowed_processors:
                         if processor in image:
-                            instance_type = os.getenv(f"EC2_{processor.upper()}_INSTANCE_TYPE")
+                            if "graviton" in image:
+                                instance_type_env = f"EC2_{processor.upper()}_GRAVITON_INSTANCE_TYPE"
+                            else:
+                                instance_type_env = f"EC2_{processor.upper()}_INSTANCE_TYPE"
+                            instance_type = os.getenv(instance_type_env)
                             if instance_type:
                                 instance_tag = f"-{instance_type.replace('.', '-')}"
                                 break

--- a/test/dlc_tests/ec2/mxnet/inference/test_mxnet_inference.py
+++ b/test/dlc_tests/ec2/mxnet/inference/test_mxnet_inference.py
@@ -24,7 +24,7 @@ MX_EC2_SINGLE_GPU_INSTANCE_TYPE = get_ec2_instance_type(
     default="p3.2xlarge", processor="gpu", filter_function=ec2_utils.filter_only_single_gpu,
 )
 MX_EC2_NEURON_INSTANCE_TYPE = get_ec2_instance_type(default="inf1.xlarge", processor="neuron")
-MX_EC2_GRAVITON_INSTANCE_TYPE = get_ec2_instance_type(default="c6g.4xlarge", processor="cpu")
+MX_EC2_GRAVITON_INSTANCE_TYPE = get_ec2_instance_type(default="c6g.4xlarge", processor="cpu", arch_type="graviton")
 
 MX_TELEMETRY_CMD = os.path.join(CONTAINER_TESTS_PREFIX, "test_mx_dlc_telemetry_test")
 

--- a/test/dlc_tests/ec2/pytorch/inference/test_pytorch_inference.py
+++ b/test/dlc_tests/ec2/pytorch/inference/test_pytorch_inference.py
@@ -23,7 +23,7 @@ PT_EC2_NEURON_INSTANCE_TYPE = get_ec2_instance_type(default="inf1.xlarge", proce
 PT_EC2_SINGLE_GPU_INSTANCE_TYPE = get_ec2_instance_type(
     default="p3.2xlarge", processor="gpu", filter_function=ec2_utils.filter_only_single_gpu,
 )
-PT_EC2_GRAVITON_INSTANCE_TYPE = get_ec2_instance_type(default="c6g.4xlarge", processor="cpu")
+PT_EC2_GRAVITON_INSTANCE_TYPE = get_ec2_instance_type(default="c6g.4xlarge", processor="cpu", arch_type="graviton")
 
 PT_TELEMETRY_CMD = os.path.join(CONTAINER_TESTS_PREFIX, "pytorch_tests", "test_pt_dlc_telemetry_test")
 

--- a/test/dlc_tests/ec2/tensorflow/inference/test_tensorflow_inference.py
+++ b/test/dlc_tests/ec2/tensorflow/inference/test_tensorflow_inference.py
@@ -21,7 +21,7 @@ TF_EC2_NEURON_ACCELERATOR_TYPE = get_ec2_instance_type(default="inf1.xlarge", pr
 TF_EC2_SINGLE_GPU_INSTANCE_TYPE = get_ec2_instance_type(
     default="p3.2xlarge", processor="gpu", filter_function=ec2_utils.filter_only_single_gpu,
 )
-TF_EC2_GRAVITON_INSTANCE_TYPE = get_ec2_instance_type(default="c6g.4xlarge", processor="cpu")
+TF_EC2_GRAVITON_INSTANCE_TYPE = get_ec2_instance_type(default="c6g.4xlarge", processor="cpu", arch_type="graviton")
 
 
 @pytest.mark.model("mnist")

--- a/test/dlc_tests/eks/mxnet/inference/test_eks_mxnet_inference.py
+++ b/test/dlc_tests/eks/mxnet/inference/test_eks_mxnet_inference.py
@@ -56,6 +56,8 @@ def test_eks_mxnet_squeezenet_inference(mxnet_inference):
     __test_eks_mxnet_squeezenet_inference(mxnet_inference)
 
 
+# TODO: Enable after adding EKS infrastructure to support graviton
+@pytest.mark.skip(reason="EKS graviton tests require further development")
 @pytest.mark.model("squeezenet")
 def test_eks_mxnet_squeezenet_inference_graviton(mxnet_inference_graviton):
     __test_eks_mxnet_squeezenet_inference(mxnet_inference_graviton)
@@ -104,7 +106,8 @@ def __test_eks_mxnet_squeezenet_inference(mxnet_inference):
 
 
 @pytest.mark.skip(
-    "Flaky test. Same test passes on EC2. Fails for gpu-inference for mx1.7. Refer: https://github.com/aws/deep-learning-containers/issues/587"
+    "Flaky test. Same test passes on EC2. Fails for gpu-inference for mx1.7. "
+    "Refer: https://github.com/aws/deep-learning-containers/issues/587"
 )
 @pytest.mark.integration("gluonnlp")
 @pytest.mark.model("bert_sst")
@@ -113,7 +116,8 @@ def test_eks_mxnet_gluonnlp_inference(mxnet_inference, py3_only):
 
 
 @pytest.mark.skip(
-    "Flaky test. Same test passes on EC2. Fails for gpu-inference for mx1.7. Refer: https://github.com/aws/deep-learning-containers/issues/587"
+    "Flaky test. Same test passes on EC2. Fails for gpu-inference for mx1.7. "
+    "Refer: https://github.com/aws/deep-learning-containers/issues/587"
 )
 @pytest.mark.integration("gluonnlp")
 @pytest.mark.model("bert_sst")

--- a/test/dlc_tests/eks/pytorch/inference/test_eks_pytorch_inference.py
+++ b/test/dlc_tests/eks/pytorch/inference/test_eks_pytorch_inference.py
@@ -61,6 +61,8 @@ def test_eks_pytorch_densenet_inference(pytorch_inference):
     __test_eks_pytorch_densenet_inference(pytorch_inference)
 
 
+# TODO: Enable after adding EKS infrastructure to support graviton
+@pytest.mark.skip(reason="EKS graviton tests require further development")
 @pytest.mark.model("densenet")
 def test_eks_pytorch_densenet_inference_graviton(pytorch_inference_graviton):
     __test_eks_pytorch_densenet_inference(pytorch_inference_graviton)

--- a/test/dlc_tests/eks/tensorflow/inference/test_eks_tensorflow_inference.py
+++ b/test/dlc_tests/eks/tensorflow/inference/test_eks_tensorflow_inference.py
@@ -60,6 +60,8 @@ def test_eks_tensorflow_half_plus_two_inference(tensorflow_inference):
     __test_eks_tensorflow_half_plus_two_inference(tensorflow_inference)
 
 
+# TODO: Enable after adding EKS infrastructure to support graviton
+@pytest.mark.skip(reason="EKS graviton tests require further development")
 @pytest.mark.model("half_plus_two")
 def test_eks_tensorflow_half_plus_two_inference_graviton(tensorflow_inference_graviton):
     __test_eks_tensorflow_half_plus_two_inference(tensorflow_inference_graviton)
@@ -115,7 +117,8 @@ def test_eks_tensorflow_albert(tensorflow_inference):
     __test_eks_tensorflow_albert(tensorflow_inference)
 
 
-@pytest.mark.skipif(not test_utils.is_nightly_context(), reason="Running additional model in nightly context only")
+# TODO: Enable after adding EKS infrastructure to support graviton
+@pytest.mark.skip(reason="EKS graviton tests require further development")
 @pytest.mark.model("albert")
 def test_eks_tensorflow_albert_graviton(tensorflow_inference_graviton):
     __test_eks_tensorflow_albert(tensorflow_inference_graviton)

--- a/test/test_utils/ec2.py
+++ b/test/test_utils/ec2.py
@@ -42,7 +42,7 @@ def filter_not_heavy_instance_types(instance_type_list):
     return filtered_list
 
 
-def get_ec2_instance_type(default, processor, filter_function=lambda x: x, efa=False):
+def get_ec2_instance_type(default, processor, filter_function=lambda x: x, efa=False, arch_type=""):
     """
     Get EC2 instance type from associated EC2_[CPU|GPU]_INSTANCE_TYPE env variable, or set it to a default
     for contexts where the variable is not present (i.e. PR, Nightly, local testing)
@@ -65,6 +65,8 @@ def get_ec2_instance_type(default, processor, filter_function=lambda x: x, efa=F
     if default in HEAVY_INSTANCE_LIST and not efa:
         raise RuntimeError(f"Default instance type should never be one of {HEAVY_INSTANCE_LIST}, but it is {default}")
     instance_type = os.getenv(f"EC2_{processor.upper()}_INSTANCE_TYPE")
+    if arch_type == "graviton":
+        instance_type = os.getenv(f"EC2_{processor.upper()}_{arch_type.upper()}_INSTANCE_TYPE")
     if not instance_type and is_mainline_context():
         return []
 


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- Add special env variable for different arch types
- Skip EKS tests for now, since infra is not ready

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
