### PR TITLE
Pin numpy to <1.20 in MX 1.9 images

### DIFF
--- a/mxnet/buildspec.yml
+++ b/mxnet/buildspec.yml
@@ -40,60 +40,60 @@ context:
       target: deep_learning_container.py
 
 images:
-  BuildE3MXNetCPUTrainPy3DockerImage:
-    <<: *TRAINING_REPOSITORY
-    build: &MXNET_CPU_TRAINING_PY3 false
-    image_size_baseline: 3000
-    device_type: &DEVICE_TYPE cpu
-    python_version: &DOCKER_PYTHON_VERSION py3
-    tag_python_version: &TAG_PYTHON_VERSION py38
-    os_version: &OS_VERSION ubuntu20.04
-    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-e3" ]
-    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
-    target: e3
-    context:
-      <<: *TRAINING_CONTEXT
-  BuildE3MXNetGPUTrainPy3DockerImage:
-    <<: *TRAINING_REPOSITORY
-    build: &MXNET_GPU_TRAINING_PY3 false
-    image_size_baseline: 7159
-    device_type: &DEVICE_TYPE gpu
-    python_version: &DOCKER_PYTHON_VERSION py3
-    tag_python_version: &TAG_PYTHON_VERSION py38
-    cuda_version: &CUDA_VERSION cu112
-    os_version: &OS_VERSION ubuntu20.04
-    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-e3" ]
-    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile., *DEVICE_TYPE ]
-    target: e3
-    context:
-      <<: *TRAINING_CONTEXT
-  BuildSMMXNetCPUTrainPy3DockerImage:
-    <<: *TRAINING_REPOSITORY
-    build: &MXNET_CPU_TRAINING_PY3 false
-    image_size_baseline: 3000
-    device_type: &DEVICE_TYPE cpu
-    python_version: &DOCKER_PYTHON_VERSION py3
-    tag_python_version: &TAG_PYTHON_VERSION py38
-    os_version: &OS_VERSION ubuntu20.04
-    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
-    target: sagemaker
-    context:
-      <<: *TRAINING_CONTEXT
-  BuildSMMXNetGPUTrainPy3DockerImage:
-    <<: *TRAINING_REPOSITORY
-    build: &MXNET_GPU_TRAINING_PY3 false
-    image_size_baseline: 7159
-    device_type: &DEVICE_TYPE gpu
-    python_version: &DOCKER_PYTHON_VERSION py3
-    tag_python_version: &TAG_PYTHON_VERSION py38
-    cuda_version: &CUDA_VERSION cu112
-    os_version: &OS_VERSION ubuntu20.04
-    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile., *DEVICE_TYPE ]
-    target: sagemaker
-    context:
-      <<: *TRAINING_CONTEXT
+  # BuildE3MXNetCPUTrainPy3DockerImage:
+  #   <<: *TRAINING_REPOSITORY
+  #   build: &MXNET_CPU_TRAINING_PY3 false
+  #   image_size_baseline: 3000
+  #   device_type: &DEVICE_TYPE cpu
+  #   python_version: &DOCKER_PYTHON_VERSION py3
+  #   tag_python_version: &TAG_PYTHON_VERSION py38
+  #   os_version: &OS_VERSION ubuntu20.04
+  #   tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-e3" ]
+  #   docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
+  #   target: e3
+  #   context:
+  #     <<: *TRAINING_CONTEXT
+  # BuildE3MXNetGPUTrainPy3DockerImage:
+  #   <<: *TRAINING_REPOSITORY
+  #   build: &MXNET_GPU_TRAINING_PY3 false
+  #   image_size_baseline: 7159
+  #   device_type: &DEVICE_TYPE gpu
+  #   python_version: &DOCKER_PYTHON_VERSION py3
+  #   tag_python_version: &TAG_PYTHON_VERSION py38
+  #   cuda_version: &CUDA_VERSION cu112
+  #   os_version: &OS_VERSION ubuntu20.04
+  #   tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-e3" ]
+  #   docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile., *DEVICE_TYPE ]
+  #   target: e3
+  #   context:
+  #     <<: *TRAINING_CONTEXT
+  # BuildSMMXNetCPUTrainPy3DockerImage:
+  #   <<: *TRAINING_REPOSITORY
+  #   build: &MXNET_CPU_TRAINING_PY3 false
+  #   image_size_baseline: 3000
+  #   device_type: &DEVICE_TYPE cpu
+  #   python_version: &DOCKER_PYTHON_VERSION py3
+  #   tag_python_version: &TAG_PYTHON_VERSION py38
+  #   os_version: &OS_VERSION ubuntu20.04
+  #   tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
+  #   docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
+  #   target: sagemaker
+  #   context:
+  #     <<: *TRAINING_CONTEXT
+  # BuildSMMXNetGPUTrainPy3DockerImage:
+  #   <<: *TRAINING_REPOSITORY
+  #   build: &MXNET_GPU_TRAINING_PY3 false
+  #   image_size_baseline: 7159
+  #   device_type: &DEVICE_TYPE gpu
+  #   python_version: &DOCKER_PYTHON_VERSION py3
+  #   tag_python_version: &TAG_PYTHON_VERSION py38
+  #   cuda_version: &CUDA_VERSION cu112
+  #   os_version: &OS_VERSION ubuntu20.04
+  #   tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
+  #   docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile., *DEVICE_TYPE ]
+  #   target: sagemaker
+  #   context:
+  #     <<: *TRAINING_CONTEXT
   BuildE3MXNetCPUInferencePy3DockerImage:
     <<: *INFERENCE_REPOSITORY
     build: &MXNET_CPU_INFERENCE_PY3 false

--- a/mxnet/buildspec.yml
+++ b/mxnet/buildspec.yml
@@ -148,18 +148,18 @@ images:
     target: sagemaker
     context:
       <<: *INFERENCE_CONTEXT
-  BuildMXNetExampleGPUTrainPy3DockerImage:
-    <<: *TRAINING_REPOSITORY
-    build: &MXNET_GPU_TRAINING_PY3 false
-    image_size_baseline: 7324
-    base_image_name: BuildE3MXNetGPUTrainPy3DockerImage
-    device_type: &DEVICE_TYPE gpu
-    python_version: &DOCKER_PYTHON_VERSION py3
-    tag_python_version: &TAG_PYTHON_VERSION py38
-    cuda_version: &CUDA_VERSION cu112
-    os_version: &OS_VERSION ubuntu20.04
-    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION,
-                 "-e3-example" ]
-    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /example, /Dockerfile., *DEVICE_TYPE ]
-    context:
-      <<: *TRAINING_CONTEXT
+  # BuildMXNetExampleGPUTrainPy3DockerImage:
+  #   <<: *TRAINING_REPOSITORY
+  #   build: &MXNET_GPU_TRAINING_PY3 false
+  #   image_size_baseline: 7324
+  #   base_image_name: BuildE3MXNetGPUTrainPy3DockerImage
+  #   device_type: &DEVICE_TYPE gpu
+  #   python_version: &DOCKER_PYTHON_VERSION py3
+  #   tag_python_version: &TAG_PYTHON_VERSION py38
+  #   cuda_version: &CUDA_VERSION cu112
+  #   os_version: &OS_VERSION ubuntu20.04
+  #   tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION,
+  #                "-e3-example" ]
+  #   docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /example, /Dockerfile., *DEVICE_TYPE ]
+  #   context:
+  #     <<: *TRAINING_CONTEXT

--- a/mxnet/inference/docker/1.9/py3/Dockerfile.cpu
+++ b/mxnet/inference/docker/1.9/py3/Dockerfile.cpu
@@ -70,7 +70,7 @@ RUN pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pytho
     gluonnlp==0.10.0 \
     gluoncv==0.8.0 \
     multi-model-server==$MMS_VERSION \
-    "numpy<2" \
+    "numpy<1.20" \
     onnx==1.8.1
 
 # This is here to make our installed version of OpenCV work.

--- a/mxnet/inference/docker/1.9/py3/cu112/Dockerfile.gpu
+++ b/mxnet/inference/docker/1.9/py3/cu112/Dockerfile.gpu
@@ -70,7 +70,7 @@ RUN pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pytho
     gluonnlp==0.10.0 \
     gluoncv==0.8.0 \
     multi-model-server==$MMS_VERSION \
-    "numpy<2" \
+    "numpy<1.20" \
     onnx==1.8.1
 
 # This is here to make our installed version of OpenCV work.

--- a/mxnet/training/docker/1.9/py3/Dockerfile.cpu
+++ b/mxnet/training/docker/1.9/py3/Dockerfile.cpu
@@ -93,7 +93,7 @@ RUN pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pytho
  && pip install --no-cache --upgrade \
     h5py==2.10.0 \
     onnx==1.8.1 \
-    "numpy<2" \
+    "numpy<1.20" \
     pandas==1.3.0 \
     "Pillow>=9.0,<10.0" \
     "requests<3" \

--- a/mxnet/training/docker/1.9/py3/cu112/Dockerfile.gpu
+++ b/mxnet/training/docker/1.9/py3/cu112/Dockerfile.gpu
@@ -119,7 +119,7 @@ RUN pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pytho
  && pip install --no-cache --upgrade \
     h5py==2.10.0 \
     onnx==1.8.1 \
-    "numpy<2" \
+    "numpy<1.20" \
     pandas==1.3.0 \
     "Pillow>=9.0,<10.0" \
     "requests<3" \


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- There are issues updating numpy to greater than or equal to 1.20 (see failed PR https://github.com/apache/incubator-mxnet/pull/20685)
- We cannot use <1.19, even though MX CI pins those requirements for v1.9; We are going to pin numpy to <1.20 for now, and follow up if decisions need to be made based on incompatibility

Test PR for numpy <1.20 in MX1.9: https://github.com/apache/incubator-mxnet/pull/20859/files

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
