### PR TITLE
[canary] Update python versions for TF canaries

### DIFF
--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -763,11 +763,13 @@ def get_canary_default_tag_py3_version(framework, version):
     :param version: fw major.minor version, i.e. 2.2
     :return: default tag python version
     """
-    if framework == "tensorflow2" or framework == "huggingface_tensorflow":
+    if framework == "tensorflow" or framework == "huggingface_tensorflow":
         if Version("2.2") <= Version(version) < Version("2.6"):
             return "py37"
-        if Version(version) >= Version("2.6"):
+        if Version("2.6") <= Version(version) < Version("2.8"):
             return "py38"
+        if Version(version) >= Version("2.8"):
+            return"py39"
 
     if framework == "mxnet":
         if Version(version) == Version("1.8"):


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- TF2.8 maps to python 3.9, so update canaries in advance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
