### PR TITLE
[autogluon][test][sagemaker] Add support for py38 version in tests

### DIFF
--- a/test/sagemaker_tests/autogluon/inference/conftest.py
+++ b/test/sagemaker_tests/autogluon/inference/conftest.py
@@ -85,7 +85,7 @@ def pytest_addoption(parser):
     parser.addoption('--docker-base-name', default='autogluon')
     parser.addoption('--region', default='us-west-2')
     parser.addoption('--framework-version', default='')
-    parser.addoption('--py-version', choices=['37'], default='37')
+    parser.addoption('--py-version', choices=['37', '38'], default='38')
     parser.addoption('--processor', choices=['gpu', 'cpu'], default='cpu')
 
     # If not specified, will default to {framework-version}-{processor}-py{py-version}
@@ -331,7 +331,7 @@ def skip_test_successfully_executed_before(request):
     "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
     So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
     But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
-    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.
     The method checks whether lastfailed file exists and the test name is not in it.
     """
     test_name = request.node.name

--- a/test/sagemaker_tests/autogluon/training/conftest.py
+++ b/test/sagemaker_tests/autogluon/training/conftest.py
@@ -85,7 +85,7 @@ def pytest_addoption(parser):
     parser.addoption('--docker-base-name', default='autogluon')
     parser.addoption('--region', default='us-west-2')
     parser.addoption('--framework-version', default='')
-    parser.addoption('--py-version', choices=['37'], default='37')
+    parser.addoption('--py-version', choices=['37', '38'], default='38')
     parser.addoption('--processor', choices=['gpu', 'cpu'], default='cpu')
 
     # If not specified, will default to {framework-version}-{processor}-py{py-version}
@@ -331,7 +331,7 @@ def skip_test_successfully_executed_before(request):
     "cache/lastfailed" contains information about failed tests only. We're running SM tests in separate threads for each image.
     So when we retry SM tests, successfully executed tests executed again because pytest doesn't have that info in /.cache.
     But the flag "--last-failed-no-failures all" requires pytest to execute all the available tests.
-    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.  
+    The only sign that a test passed last time - lastfailed file exists and the test name isn't in that file.
     The method checks whether lastfailed file exists and the test name is not in it.
     """
     test_name = request.node.name


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

### Description
Add py38 as an option on autogluon SM test args

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
