### PR TITLE
Re-release TF2.7 inference images as TF2.7.1

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -2,78 +2,32 @@
 release_images:
 # Check .release_images_template.yml for reference
   1:
-    framework: "huggingface_pytorch"
-    version: "1.10.2"
+    framework: "tensorflow"
+    version: "2.7.1"
     arch_type: "x86"
-    hf_transformers: "4.17.0"
-    training:
-      device_types: ["gpu"]
-      python_versions: ["py38"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu113"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-      # to images being published.
-      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
+    customer_type: "e3"
     inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py38" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu113"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-      # to images being published.
-      force_release: False   # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
-
-  2:
-    framework: "pytorch"
-    version: "1.10.2"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    training:
       device_types: ["cpu", "gpu"]
       python_versions: ["py38"]
       os_version: "ubuntu20.04"
-      cuda_version: "cu113"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-      # to images being published.
-      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py38" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu113"
+      cuda_version: "cu112"
       example: False        # [Default: False] Set to True to denote that this image is an Example image
       disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
       # to images being published.
       force_release: False   # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-
-  3:
+  2:
     framework: "tensorflow"
-    version: "2.6.3"
+    version: "2.7.1"
     arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py38" ]
+    customer_type: "sagemaker"
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py38"]
       os_version: "ubuntu20.04"
       cuda_version: "cu112"
       example: False        # [Default: False] Set to True to denote that this image is an Example image
       disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
       # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py38" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu112"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-      # to images being published.
-      force_release: False   # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
+      # has already been published. Re-released image will have minor version incremented by

--- a/release_images.yml
+++ b/release_images.yml
@@ -2,6 +2,32 @@
 release_images:
 # Check .release_images_template.yml for reference
   1:
+    framework: "huggingface_pytorch"
+    version: "1.10.2"
+    arch_type: "x86"
+    hf_transformers: "4.17.0"
+    training:
+      device_types: [ "gpu" ]
+      python_versions: [ "py38" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu113"
+      example: False        # [Default: False] Set to True to denote that this image is an Example image
+      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
+      # to images being published.
+      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
+      # has already been published. Re-released image will have minor version incremented by 1.
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py38" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu113"
+      example: False        # [Default: False] Set to True to denote that this image is an Example image
+      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
+      # to images being published.
+      force_release: False   # [Default: False] Set to True to force images to be published even if the same image
+      # has already been published. Re-released image will have minor version incremented by 1.
+
+  2:
     framework: "tensorflow"
     version: "2.7.1"
     arch_type: "x86"
@@ -16,7 +42,7 @@ release_images:
       # to images being published.
       force_release: False   # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-  2:
+  3:
     framework: "tensorflow"
     version: "2.7.1"
     arch_type: "x86"


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- re-release TF 2.7 inference images as TF2.7.1

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
