### PR TITLE
[tensorflow] [sagemaker] Add nginx timeout

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -38,13 +38,13 @@ ec2_tests = true
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = false
+sagemaker_local_tests = true
 
 # SM remote test valid values:
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "off"
+sagemaker_remote_tests = "standard"
 
 use_scheduler = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -38,13 +38,13 @@ ec2_tests = true
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = true
+sagemaker_local_tests = false
 
 # SM remote test valid values:
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "standard"
+sagemaker_remote_tests = "off"
 
 use_scheduler = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -20,7 +20,7 @@ benchmark_mode = false
 [build]
 # Frameworks for which you want to disable both builds and tests
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "tensorflow", "mxnet", "pytorch"]
-skip_frameworks = []
+skip_frameworks = ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "mxnet", "pytorch"]
 # Set to false in order to remove datetime tag on PR builds
 datetime_tag = true
 # Note: Need to build the images at least once with datetime_tag = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -20,7 +20,7 @@ benchmark_mode = false
 [build]
 # Frameworks for which you want to disable both builds and tests
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "tensorflow", "mxnet", "pytorch"]
-skip_frameworks = ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "mxnet", "pytorch"]
+skip_frameworks = []
 # Set to false in order to remove datetime tag on PR builds
 datetime_tag = true
 # Note: Need to build the images at least once with datetime_tag = false

--- a/tensorflow/inference/docker/build_artifacts/sagemaker/nginx.conf.template
+++ b/tensorflow/inference/docker/build_artifacts/sagemaker/nginx.conf.template
@@ -17,6 +17,8 @@ http {
   access_log /dev/stdout combined;
   js_import tensorflowServing.js;
 
+  proxy_read_timeout %PROXY_READ_TIMEOUT%;  
+
   upstream tfs_upstream {
     %TFS_UPSTREAM%;
   }
@@ -62,3 +64,4 @@ http {
     keepalive_timeout 3;
   }
 }
+  

--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -406,6 +406,9 @@ def _run_dependency_check_test(image, ec2_connection):
             "1.10": ["gpu"],
             "1.11": ["gpu", "cpu"],
         },
+        "tensorflow": {
+            "2.8": ["cpu", "gpu"],
+        }
     }
 
     if processor in allow_openssl_cve_2021_3711_fw_versions.get(framework, {}).get(short_fw_version, []):

--- a/test/sagemaker_tests/tensorflow/inference/test/integration/local/test_nginx_config.py
+++ b/test/sagemaker_tests/tensorflow/inference/test/integration/local/test_nginx_config.py
@@ -1,0 +1,123 @@
+# Copyright 2019-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import os
+import subprocess
+
+import pytest
+
+
+@pytest.fixture(scope="session", autouse=True)
+def volume():
+    try:
+        model_dir = os.path.abspath("test/resources/models")
+        subprocess.check_call(
+            "docker volume create --name nginx_model_volume --opt type=none "
+            "--opt device={} --opt o=bind".format(model_dir).split()
+        )
+        yield model_dir
+    finally:
+        subprocess.check_call("docker volume rm nginx_model_volume".split())
+
+@pytest.mark.model("N/A")
+@pytest.mark.integration("nginx-config")
+def test_run_nginx_with_default_parameters(docker_base_name, tag, runtime_config):
+    try:
+        command = (
+            "docker run {}--name sagemaker-tensorflow-serving-test -p 8080:8080"
+            " --mount type=volume,source=nginx_model_volume,target=/opt/ml/model,readonly"
+            " {}:{} serve"
+        ).format(runtime_config, docker_base_name, tag)
+
+        proc = subprocess.Popen(command.split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+        lines_seen = {
+            "error_log  /dev/stderr error;": 0,
+            "proxy_read_timeout 60;": 0,
+        }
+
+        for stdout_line in iter(proc.stdout.readline, ""):
+            stdout_line = str(stdout_line)
+            for line in lines_seen.keys():
+                if line in stdout_line:
+                    lines_seen[line] += 1
+            if "started nginx" in stdout_line:
+                for value in lines_seen.values():
+                    assert value == 1
+                break
+
+    finally:
+        subprocess.check_call("docker rm -f sagemaker-tensorflow-serving-test".split())
+
+@pytest.mark.model("N/A")
+@pytest.mark.integration("nginx-config")
+def test_run_nginx_with_env_var_parameters(docker_base_name, tag, runtime_config):
+    try:
+        command = (
+            "docker run {}--name sagemaker-tensorflow-serving-test -p 8080:8080"
+            " --mount type=volume,source=nginx_model_volume,target=/opt/ml/model,readonly"
+            " -e SAGEMAKER_TFS_NGINX_LOGLEVEL=info"
+            " -e SAGEMAKER_NGINX_PROXY_READ_TIMEOUT_SECONDS=63"
+            " {}:{} serve"
+        ).format(runtime_config, docker_base_name, tag)
+
+        proc = subprocess.Popen(command.split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+        lines_seen = {
+            "error_log  /dev/stderr info;": 0,
+            "proxy_read_timeout 63;": 0,
+        }
+
+        for stdout_line in iter(proc.stdout.readline, ""):
+            stdout_line = str(stdout_line)
+            for line in lines_seen.keys():
+                if line in stdout_line:
+                    lines_seen[line] += 1
+            if "started nginx" in stdout_line:
+                for value in lines_seen.values():
+                    assert value == 1
+                break
+
+    finally:
+        subprocess.check_call("docker rm -f sagemaker-tensorflow-serving-test".split())
+
+@pytest.mark.model("N/A")
+@pytest.mark.integration("nginx-config")
+def test_run_nginx_with_higher_gunicorn_parameter(docker_base_name, tag, runtime_config):
+    try:
+        command = (
+            "docker run {}--name sagemaker-tensorflow-serving-test -p 8080:8080"
+            " --mount type=volume,source=nginx_model_volume,target=/opt/ml/model,readonly"
+            " -e SAGEMAKER_NGINX_PROXY_READ_TIMEOUT_SECONDS=60"
+            " -e SAGEMAKER_GUNICORN_TIMEOUT_SECONDS=120"
+            " {}:{} serve"
+        ).format(runtime_config, docker_base_name, tag)
+
+        proc = subprocess.Popen(command.split(), stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+        lines_seen = {
+            "proxy_read_timeout 120;": 0, # When GUnicorn is higher, set timeout to match.
+        }
+
+        for stdout_line in iter(proc.stdout.readline, ""):
+            stdout_line = str(stdout_line)
+            for line in lines_seen.keys():
+                if line in stdout_line:
+                    lines_seen[line] += 1
+            if "started nginx" in stdout_line:
+                for value in lines_seen.values():
+                    assert value == 1
+                break
+
+    finally:
+        subprocess.check_call("docker rm -f sagemaker-tensorflow-serving-test".split())

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/local/test_training.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/local/test_training.py
@@ -32,6 +32,8 @@ def py_full_version(py_version):  # noqa: F811
         return '3.7'
     elif py_version == '38':
         return '3.8'
+    elif py_version == '39':
+        return '3.9'
     else:
         return '3.6'
 


### PR DESCRIPTION
### Description
This adds support for the user to modify this NGINX [config variable](http://nginx.org/en/docs/http/ngx_http_proxy_module.html#proxy_read_timeout) in the TF SM inference images via an environment variable. 

### Tests run
**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [x] `sagemaker_local_tests = true`

### DLC image/dockerfile

### Additional context

## Label Checklist
- [x] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [x] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [x] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [x] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [x] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [x] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


I've tested the local TF inference SM tests.
