### PR TITLE
[release] Add TF 2.6 to release_images

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -2,71 +2,6 @@
 release_images:
 # Check .release_images_template.yml for reference
   1:
-    framework: "tensorflow"
-    version: "2.7.1"
-    customer_type: "e3"
-    arch_type: "x86"
-    training:
-      device_types: ["cpu","gpu"]
-      python_versions: ["py38"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu112"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  2:
-    framework: "tensorflow"
-    version: "2.7.1"
-    customer_type: "e3"
-    arch_type: "x86"
-    training:
-      device_types: ["gpu"]
-      python_versions: ["py38"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu112"
-      example: True
-      disable_sm_tag: False
-      force_release: False
-  3:
-    framework: "tensorflow"
-    version: "2.7.1"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu","gpu" ]
-      python_versions: [ "py38" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu112"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  4:
-    framework: "tensorflow"
-    version: "2.7.0"
-    customer_type: "e3"
-    arch_type: "x86"
-    inference:
-      device_types: [ "cpu","gpu" ]
-      python_versions: [ "py38" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu112"
-      example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-  5:
-    framework: "tensorflow"
-    version: "2.7.0"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    inference:
-      device_types: [ "cpu","gpu" ]
-      python_versions: [ "py38" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu112"
-      example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-  6:
     framework: "huggingface_pytorch"
     version: "1.9.1"
     arch_type: "x86"
@@ -81,7 +16,7 @@ release_images:
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
-  7:
+  2:
     framework: "pytorch"
     version: "1.10.0"
     arch_type: "graviton"
@@ -93,7 +28,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  8:
+  3:
     framework: "pytorch"
     version: "1.9.1"
     arch_type: "x86"
@@ -105,7 +40,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  9:
+  4:
     framework: "pytorch"
     version: "1.9.1"
     arch_type: "x86"
@@ -117,7 +52,7 @@ release_images:
       example: True
       disable_sm_tag: False
       force_release: False
-  10:
+  5:
     framework: "autogluon"
     version: "0.4.2"
     arch_type: "x86"
@@ -141,3 +76,27 @@ release_images:
                             # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
                             # has already been published. Re-released image will have minor version incremented by 1.
+  6:
+    framework: "tensorflow"
+    version: "2.6.3"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py38" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu112"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  7:
+    framework: "tensorflow"
+    version: "2.6.3"
+    arch_type: "x86"
+    training:
+      device_types: [ "gpu" ]
+      python_versions: [ "py38" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu112"
+      example: True
+      disable_sm_tag: False
+      force_release: False


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

### Description
Add TF 2.6 Training DLCs to release_images.yml

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
