### PR TITLE
[release] Fix release buildspec testing after src config changes

### DIFF
--- a/release_buildspec.yml
+++ b/release_buildspec.yml
@@ -10,5 +10,6 @@ phases:
         fi
   build:
     commands:
+      - export PYTHONPATH=$PYTHONPATH:$(pwd)/src
       - publish_dlc_images --release-spec $(pwd)/release_images.yml
       - generate_release_information


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

### Description
After https://github.com/aws/deep-learning-containers/pull/1939 modified the `src/config.py` file to import functions from the local script `codebuild_environment`, the tests work fine, but release buildspec fails to import `src.config` because the PYTHONPATH for release_buildspec.yml is not the same as testspec.yml.

This PR now adds `export PYTHONPATH=$PYTHONPATH:$(pwd)/src` to the `release_buildspec.yml` file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
