### PR TITLE
return model metadata in HTTP headers of the inference response

### DIFF
--- a/tensorflow/inference/docker/build_artifacts/sagemaker/nginx.conf.template
+++ b/tensorflow/inference/docker/build_artifacts/sagemaker/nginx.conf.template
@@ -16,6 +16,7 @@ http {
   default_type application/json;
   access_log /dev/stdout combined;
   js_import tensorflowServing.js;
+  js_set $model_info_header tensorflowServing.model_info_header;
 
   proxy_read_timeout %PROXY_READ_TIMEOUT%;  
 
@@ -35,6 +36,8 @@ http {
 
     set $tfs_version %TFS_VERSION%;
     set $default_tfs_model %TFS_DEFAULT_MODEL_NAME%;
+    set $default_tfs_model_version %TFS_DEFAULT_MODEL_VERSION%;
+    add_header tensorflowModelInfo $model_info_header;
 
     location /tfs {
         rewrite ^/tfs/(.*) /$1  break;

--- a/tensorflow/inference/docker/build_artifacts/sagemaker/tensorflowServing.js
+++ b/tensorflow/inference/docker/build_artifacts/sagemaker/tensorflowServing.js
@@ -233,7 +233,20 @@ function csv_request(r) {
     tfs_json_request(r, builder.join(''))
 }
 
+function model_info_header(r) {
+    var attributes = parse_custom_attributes(r)
+    var model_version = 'DEFAULT'
+    var my_header = ''
+
+    model_version = r.variables.default_tfs_model_version
+    if ('tfs-model-version' in attributes) {
+            model_version = attributes['tfs-model-version']
+    }
+    my_header = '{ "modelId":"' + attributes['tfs-model-name'] + '","version":"' + model_version + '"}'
+    return my_header
+}
+
 export default {invocations, ping, ping_without_model, return_error,
     tfs_json_request, make_tfs_uri, parse_custom_attributes,
     json_request, is_tfs_json, is_json_lines, generic_json_request,
-    json_lines_request, csv_request};
+    json_lines_request, csv_request, model_info_header};


### PR DESCRIPTION
### Description
Return model name/model version used for inference in HTTP header.
This is in addition to `x-Amzn-Invoked-Production-Variant` header which identifies the Production Variant.
Note that Production Variants include operational parameters such as instance type, environment variables and etc. Production Variants are generally owned and maintained by MLOPS. It's possible that multiple Production Variants will serve the same model and model version. 

Model name/version is essential information for the Data Scientists. This PR abstracts it from the MLOPS.

### Tests run
**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

### DLC image/dockerfile

### Additional context

## Label Checklist
- [ ] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
