### PR TITLE
Fixing allowlist for HF PT 1.11 part 2

### DIFF
--- a/huggingface/pytorch/training/docker/1.11/py3/cu113/Dockerfile.trcomp.gpu.os_scan_allowlist.json
+++ b/huggingface/pytorch/training/docker/1.11/py3/cu113/Dockerfile.trcomp.gpu.os_scan_allowlist.json
@@ -30,37 +30,33 @@
             "reason_to_ignore": "Latest version of rdflib is being installed"
         },
         {
-            "rdflib": [
-                {
-                    "description": "[rdflib](https://pypi.org/project/rdflib/) is a Python library for working with RDF, a simple yet powerful language for representing information.\n\nAffected versions of this package are vulnerable to Server-Side Request Forgery (SSRF). `rdflib` provides no way to control how external references are resolved, nor a way to implement caching of external resources.\r\n\r\nIf a web service takes `POST`ed `JSON-LD` data, `rdflib` will attempt to resolve any URL in the `@context`.\r\nThis can lead to:\r\n1. attackers being able to probe internal networks, by having `rdflib` request potential non-public URLs\r\n2. reflection attacks, if the same or slightly-different URLs are repeated multiple times in the `@context`\r\n3. resource exhaustion, as the entire remote file is loaded into memory before JSON parsing is attempted\r\n4. Denial of Service, if web or task workers are tied up waiting for extended periods for HTTP requests to complete\r\n5. attackers being able to probe the local filesystem using `file://` URLs",
-                    "vulnerability_id": "SNYK-PYTHON-RDFLIB-1324490",
-                    "name": "SNYK-PYTHON-RDFLIB-1324490",
-                    "package_name": "rdflib",
-                    "package_details": {
-                        "file_path": "opt/conda/lib/python3.8/site-packages/rdflib-6.2.0.dist-info/METADATA",
-                        "name": "rdflib",
-                        "package_manager": "PYTHONPKG",
-                        "version": "6.2.0",
-                        "release": null
-                    },
-                    "remediation": {
-                        "recommendation": {
-                            "text": "None Provided"
-                        }
-                    },
-                    "cvss_v3_score": 8.6,
-                    "cvss_v30_score": 0.0,
-                    "cvss_v31_score": 8.6,
-                    "cvss_v2_score": 0.0,
-                    "cvss_v3_severity": "HIGH",
-                    "source_url": "https://snyk.io/vuln/SNYK-PYTHON-RDFLIB-1324490",
-                    "source": "SNYK",
-                    "severity": "HIGH",
-                    "status": "ACTIVE",
-                    "title": "IN1-PYTHON-RDFLIB-1324490 - rdflib",
-                    "reason_to_ignore": "Latest version of rdflib is being installed"
+            "description": "[rdflib](https://pypi.org/project/rdflib/) is a Python library for working with RDF, a simple yet powerful language for representing information.\n\nAffected versions of this package are vulnerable to Server-Side Request Forgery (SSRF). `rdflib` provides no way to control how external references are resolved, nor a way to implement caching of external resources.\r\n\r\nIf a web service takes `POST`ed `JSON-LD` data, `rdflib` will attempt to resolve any URL in the `@context`.\r\nThis can lead to:\r\n1. attackers being able to probe internal networks, by having `rdflib` request potential non-public URLs\r\n2. reflection attacks, if the same or slightly-different URLs are repeated multiple times in the `@context`\r\n3. resource exhaustion, as the entire remote file is loaded into memory before JSON parsing is attempted\r\n4. Denial of Service, if web or task workers are tied up waiting for extended periods for HTTP requests to complete\r\n5. attackers being able to probe the local filesystem using `file://` URLs",
+            "vulnerability_id": "SNYK-PYTHON-RDFLIB-1324490",
+            "name": "SNYK-PYTHON-RDFLIB-1324490",
+            "package_name": "rdflib",
+            "package_details": {
+                "file_path": "opt/conda/lib/python3.8/site-packages/rdflib-6.2.0.dist-info/METADATA",
+                "name": "rdflib",
+                "package_manager": "PYTHONPKG",
+                "version": "6.2.0",
+                "release": null
+            },
+            "remediation": {
+                "recommendation": {
+                    "text": "None Provided"
                 }
-            ]
+            },
+            "cvss_v3_score": 8.6,
+            "cvss_v30_score": 0.0,
+            "cvss_v31_score": 8.6,
+            "cvss_v2_score": 0.0,
+            "cvss_v3_severity": "HIGH",
+            "source_url": "https://snyk.io/vuln/SNYK-PYTHON-RDFLIB-1324490",
+            "source": "SNYK",
+            "severity": "HIGH",
+            "status": "ACTIVE",
+            "title": "IN1-PYTHON-RDFLIB-1324490 - rdflib",
+            "reason_to_ignore": "Latest version of rdflib is being installed"
         }
     ]
 }


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description

### Tests run
**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

### DLC image/dockerfile

### Additional context

## Label Checklist
- [ ] I have added the project label for this PR (*<project_name>* or "Improvement")

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
