### PR TITLE
Add release info for DJL; Fix AG buildspec

### DIFF
--- a/autogluon/buildspec.yml
+++ b/autogluon/buildspec.yml
@@ -11,27 +11,12 @@ repository_info:
     root: !join [ *FRAMEWORK, "/", *TRAINING_IMAGE_TYPE ]
     repository_name: &REPOSITORY_NAME !join [pr, "-", *FRAMEWORK, "-", *TRAINING_IMAGE_TYPE]
     repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ]
-  inference_repository: &INFERENCE_REPOSITORY
-    image_type: &INFERENCE_IMAGE_TYPE inference
-    root: !join [ *FRAMEWORK, "/", *INFERENCE_IMAGE_TYPE ]
-    repository_name: &REPOSITORY_NAME !join [pr, "-", *FRAMEWORK, "-", *INFERENCE_IMAGE_TYPE]
-    repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ]
 
 context:
   training_context: &TRAINING_CONTEXT
     entrypoint:
       source: docker/artifacts/dockerd-entrypoint.py
       target: dockerd-entrypoint.py
-    deep_learning_container:
-      source: ../../src/deep_learning_container.py
-      target: deep_learning_container.py
-  inference_context: &INFERENCE_CONTEXT
-    mms-entrypoint:
-      source: ../build_artifacts/inference/mms-entrypoint.py
-      target: mms-entrypoint.py
-    config:
-      source: ../build_artifacts/inference/config.properties
-      target: config.properties
     deep_learning_container:
       source: ../../src/deep_learning_container.py
       target: deep_learning_container.py
@@ -63,30 +48,3 @@ images:
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile., *DEVICE_TYPE ]
     context:
       <<: *TRAINING_CONTEXT
-
-  BuildAutogluonCPUInferencePy3DockerImage:
-    <<: *INFERENCE_REPOSITORY
-    build: &AUTOGLUON_CPU_INFERENCE_PY3 false
-    image_size_baseline: 6293
-    device_type: &DEVICE_TYPE cpu
-    python_version: &DOCKER_PYTHON_VERSION py3
-    tag_python_version: &TAG_PYTHON_VERSION py38
-    os_version: &OS_VERSION ubuntu20.04
-    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION ]
-    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
-    context:
-      <<: *INFERENCE_CONTEXT
-
-  BuildAutogluonGPUInferencePy3DockerImage:
-    <<: *INFERENCE_REPOSITORY
-    build: &AUTOGLUON_GPU_INFERENCE_PY3 false
-    image_size_baseline: 14325
-    device_type: &DEVICE_TYPE gpu
-    python_version: &DOCKER_PYTHON_VERSION py3
-    tag_python_version: &TAG_PYTHON_VERSION py38
-    cuda_version: &CUDA_VERSION cu113
-    os_version: &OS_VERSION ubuntu20.04
-    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION ]
-    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile., *DEVICE_TYPE ]
-    context:
-      <<: *INFERENCE_CONTEXT

--- a/available_images.md
+++ b/available_images.md
@@ -169,6 +169,7 @@ Large Model Inference Containers
 ===============================
 | Framework                                     |Job Type	|CPU/GPU 	|Python Version Options	|Example URL																						|
 |-----------------------------------------------|-----------|-----------|-----------------------|---------------------------------------------------------------------------------------------------|
+|DJLServing 0.20.0 with DeepSpeed 0.7.5, HuggingFace Transformers 4.23.1, and HuggingFace Accelerate 0.13.2    |inference	|GPU 		| 3.8 (py38)			|763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.20.0-deepspeed0.7.5-cu116		|
 |DJLServing 0.19.0 with DeepSpeed 0.7.3, HuggingFace Transformers 4.22.1, and HuggingFace Accelerate 0.13.2    |inference	|GPU 		| 3.8 (py38)			|763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.19.0-deepspeed0.7.3-cu113		|
 
 Habana Training Containers

--- a/release_images.yml
+++ b/release_images.yml
@@ -27,21 +27,6 @@ release_images:
       disable_sm_tag: False
       force_release: False
   3:
-    framework: "djl"
-    version: "0.20.0"
-    arch_type: "x86"
-    inference:
-      device_types: [ "gpu" ]
-      python_versions: [ "py38" ]
-      os_version: "ubuntu20.04"
-      deepspeed_version: "0.7.5"
-      cuda_version: "cu116"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: True # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-      # to images being published.
-      force_release: False   # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
-  4:
     framework: "mxnet"
     version: "1.9.0"
     customer_type: "ec2"
@@ -54,7 +39,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  5:
+  4:
     framework: "mxnet"
     version: "1.9.0"
     customer_type: "sagemaker"
@@ -67,7 +52,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  6:
+  5:
     framework: "pytorch"
     version: "1.13.0"
     arch_type: "x86"
@@ -80,7 +65,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  7:
+  6:
     framework: "pytorch"
     version: "1.13.0"
     arch_type: "x86"
@@ -93,7 +78,7 @@ release_images:
       example: True
       disable_sm_tag: False
       force_release: False
-  8:
+  7:
     framework: "pytorch"
     version: "1.12.1"
     arch_type: "x86"
@@ -106,7 +91,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  9:
+  8:
     framework: "pytorch"
     version: "1.12.1"
     arch_type: "x86"
@@ -119,7 +104,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  10:
+  9:
     framework: "pytorch"
     version: "1.12.1"
     arch_type: "x86"
@@ -132,7 +117,7 @@ release_images:
       example: True
       disable_sm_tag: False
       force_release: False
-  11:
+  10:
     framework: "tensorflow"
     version: "2.10.1"
     customer_type: "ec2"
@@ -145,7 +130,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  12:
+  11:
     framework: "tensorflow"
     version: "2.10.1"
     customer_type: "sagemaker"


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- Remove AG inference images from buildspec - these are now defined under "inference" specific buildspecs
- Add release info for DJL

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
