### PR TITLE
[Release] Release TF2.11 + AG 0.6.1

### DIFF
--- a/release_images.yml
+++ b/release_images.yml
@@ -13,57 +13,57 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  2:
-    framework: "pytorch"
-    version: "1.11.0"
-    arch_type: "x86"
-    customer_type: "sagemaker"
     inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py38" ]
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py39"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu112"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  2:
+    framework: "tensorflow"
+    version: "2.11.0"
+    customer_type: "ec2"
+    arch_type: "x86"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py39"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu112"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py39"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu112"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  3:
+    framework: "tensorflow"
+    version: "2.11.0"
+    customer_type: "ec2"
+    arch_type: "x86"
+    training:
+      device_types: ["gpu"]
+      python_versions: ["py39"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu112"
+      example: True
+      disable_sm_tag: False
+      force_release: False
+  4:
+    framework: "autogluon"
+    version: "0.6.1"
+    arch_type: "x86"
+    training:
+      device_types: ["cpu","gpu"]
+      python_versions: ["py38"]
       os_version: "ubuntu20.04"
       cuda_version: "cu113"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-      # to images being published.
-      force_release: False   # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
-  3:
-    framework: "pytorch"
-    version: "1.11.0"
-    arch_type: "x86"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py38" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu115"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-      # to images being published.
-      force_release: False   # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
-  4:
-    framework: "pytorch"
-    version: "1.12.1"
-    arch_type: "graviton"
-    customer_type: "ec2"
-    inference:
-      device_types: ["cpu"]
-      python_versions: ["py38"]
-      os_version: "ubuntu20.04"
       example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-  5:
-    framework: "pytorch"
-    version: "1.12.1"
-    arch_type: "graviton"
-    customer_type: "sagemaker"
-    inference:
-      device_types: ["cpu"]
-      python_versions: ["py38"]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      disable_sm_tag: False
       force_release: False


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description

This PR updates the release images file in order to release TF2.11 Training and Inference images for SM + EC2, along with AutoGluon Training images for version 0.6.1

