### PR TITLE
Make quick checks tests PR-only

### DIFF
--- a/test/dlc_tests/sanity/quick_checks/test_buildspecs.py
+++ b/test/dlc_tests/sanity/quick_checks/test_buildspecs.py
@@ -3,10 +3,16 @@ import re
 
 import pytest
 
+from test.test_utils import is_pr_context
+
 
 @pytest.mark.quick_checks
 @pytest.mark.model("N/A")
 @pytest.mark.integration("buildspecs")
+@pytest.mark.skipif(
+    not is_pr_context(),
+    reason="This tests to ensure train/inference buildspecs are set up as expected in PRs.",
+)
 def test_train_inference_buildspec():
     """
     Walk through all buildspecs. Ensure the following:


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- Ensure that buildspec quick checks test runs only in PR
- Test is not supported in mainline context

### Tests run
- Test runs regularly in quick_checks

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
