### PR TITLE
[TensorFlow][Training] TF2.10.1 Release 

### DIFF
--- a/release_images_training.yml
+++ b/release_images_training.yml
@@ -1,41 +1,41 @@
 ---
 release_images:
   1:
-    framework: "pytorch"
-    version: "1.13.1"
+    framework: "tensorflow"
+    version: "2.10.1"
     customer_type: "ec2"
     arch_type: "x86"
     training:
       device_types: ["cpu", "gpu"]
       python_versions: ["py39"]
       os_version: "ubuntu20.04"
-      cuda_version: "cu117"
+      cuda_version: "cu112"
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
   2:
-    framework: "pytorch"
-    version: "1.13.1"
+    framework: "tensorflow"
+    version: "2.10.1"
+    customer_type: "sagemaker"
+    arch_type: "x86"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py39"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu112"
+      example: False
+      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      force_release: False
+  1:
+    framework: "tensorflow"
+    version: "2.10.1"
     customer_type: "ec2"
     arch_type: "x86"
     training:
       device_types: ["gpu"]
       python_versions: ["py39"]
       os_version: "ubuntu20.04"
-      cuda_version: "cu117"
+      cuda_version: "cu112"
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
-      force_release: False
-  3:
-    framework: "pytorch"
-    version: "1.13.1"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py39" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu117"
-      example: False
-      disable_sm_tag: False # [Default: False] This option is not used by Example images
       force_release: False

--- a/release_images_training.yml
+++ b/release_images_training.yml
@@ -26,7 +26,7 @@ release_images:
       example: False
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
-  1:
+  3:
     framework: "tensorflow"
     version: "2.10.1"
     customer_type: "ec2"

--- a/release_images_training.yml
+++ b/release_images_training.yml
@@ -39,3 +39,4 @@ release_images:
       example: True
       disable_sm_tag: False  # [Default: False] This option is not used by Example images
       force_release: False
+      


### PR DESCRIPTION
*GitHub Issue #, if available:*

## Description
Release schema update for TF2.10.1 to release CVE patching efforts for the images (CPU, GPU EC2 + SageMaker, GPU Example Image)

