### PR TITLE
[graviton][release] TF 2.9.1 Graviton patch release

### DIFF
--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -1,28 +1,26 @@
 ---
 release_images:
   1:
-    framework: "pytorch"
-    version: "1.13.1"
-    arch_type: "x86"
+    framework: "tensorflow"
+    version: "2.9.1"
     customer_type: "ec2"
+    arch_type: "graviton"
     inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py39" ]
+      device_types: ["cpu"]
+      python_versions: ["py38"]
       os_version: "ubuntu20.04"
-      cuda_version: "cu117"
       example: False
-      disable_sm_tag: False 
+      disable_sm_tag: False
       force_release: False
   2:
-    framework: "pytorch"
-    version: "1.13.1"
-    arch_type: "x86"
+    framework: "tensorflow"
+    version: "2.9.1"
     customer_type: "sagemaker"
+    arch_type: "graviton"
     inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py39" ]
+      device_types: ["cpu"]
+      python_versions: ["py38"]
       os_version: "ubuntu20.04"
-      cuda_version: "cu117"
       example: False
       disable_sm_tag: False
       force_release: False


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

### Description
Update release_images_inference.yml for re-release of TensorFlow 2.9.1 Graviton

### Tests run
quick PR test for release on first commit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
