### PR TITLE
Patch MX 1.9 inference images

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -28,14 +28,14 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch"]
-build_frameworks = []
+build_frameworks = ['mxnet']
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = true
+datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true
@@ -58,7 +58,7 @@ sagemaker_local_tests = false
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "off"
+sagemaker_remote_tests = "standard"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -28,14 +28,14 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch"]
-build_frameworks = ['mxnet']
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = false
+datetime_tag = true
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true
@@ -58,7 +58,7 @@ sagemaker_local_tests = false
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "standard"
+sagemaker_remote_tests = "off"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/mxnet/inference/docker/1.9/py3/Dockerfile.cpu
+++ b/mxnet/inference/docker/1.9/py3/Dockerfile.cpu
@@ -113,7 +113,9 @@ RUN pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pytho
     "protobuf>=3.20.2,<3.21" \
     "wheel>=0.38.0" \
     # setuptools is installed while the installation of python
-    "setuptools>=66.0.0"
+    "setuptools>=66.0.0" \
+    # Upper bound pin matplotlib, as it creates dependency conflict with numpy
+    "matplotlib<3.7"
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394

--- a/mxnet/inference/docker/1.9/py3/cu112/Dockerfile.gpu
+++ b/mxnet/inference/docker/1.9/py3/cu112/Dockerfile.gpu
@@ -95,7 +95,9 @@ RUN pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pytho
     "protobuf>=3.20.2,<3.21" \
     "wheel>=0.38.0" \
     # setuptools is installed while the installation of python
-    "setuptools>=66.0.0"
+    "setuptools>=66.0.0" \
+    # Upper bound pin matplotlib, as it creates dependency conflict with numpy
+    "matplotlib<3.7"
 
 # This is here to make our installed version of OpenCV work.
 # https://stackoverflow.com/questions/29274638/opencv-libdc1394-error-failed-to-initialize-libdc1394


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- Patch MXNet dockerfiles
- Upper bound pin matplotlib which has pip check issue with numpy version required for 1.9 images

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] Running sagemaker/sanity/ec2/ecs/eks on [e4b8c8f](https://github.com/aws/deep-learning-containers/pull/2736/commits/e4b8c8f607f061d56434a7a63b2b480185e93257) - no RC tests for MXNet

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
