### PR TITLE
Add reruns statement to canary tests

### DIFF
--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -382,6 +382,9 @@ def main():
             pytest_cmds = [
                 ["-s", "-rA", f"--junitxml={report}", "-n=auto", f"--{specific_test_type}", "--ignore=container_tests/"]
             ]
+            if specific_test_type == "canary":
+                # Add rerun flag to canaries to avoid flakiness
+                pytest_cmds = [pytest_cmd + ["--reruns=1", "--reruns-delay=10"] for pytest_cmd in pytest_cmds]
 
         pytest_cmds = [pytest_cmd + ["--last-failed", "--last-failed-no-failures", "all"] for pytest_cmd in pytest_cmds]
         pytest_cache_util.download_pytest_cache_from_s3_to_local(os.getcwd(), **pytest_cache_params)


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- Add reruns to canary pytest cmd to avoid flaky errors

### Tests run
- Tests will run in canary context

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
