### PR TITLE
[test] Retry requirements install on failure

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -28,7 +28,7 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch"]
-build_frameworks = ['pytorch']
+build_frameworks = ['tensorflow']
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -28,7 +28,7 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch"]
-build_frameworks = ['tensorflow']
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -28,7 +28,7 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch"]
-build_frameworks = []
+build_frameworks = ['pytorch']
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true

--- a/testspec.yml
+++ b/testspec.yml
@@ -8,7 +8,7 @@ phases:
   pre_build:
     commands:
       - start-dockerd
-      - pip install -r src/requirements.txt
+      - for i in {1..3}; do pip install -r src/requirements.txt && break || sleep 15; done
       - python src/send_status.py --status 2
       - python src/parse_partner_developers.py
   build:

--- a/testspec.yml
+++ b/testspec.yml
@@ -8,7 +8,7 @@ phases:
   pre_build:
     commands:
       - start-dockerd
-      - for i in {1..3}; do pip install -r src/requirements.txt && break || sleep 15; done
+      - for i in {1..3}; do pip install -r src/requirements.txt && break || sleep 30; done
       - python src/send_status.py --status 2
       - python src/parse_partner_developers.py
   build:


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
- Sometimes we get unexpected failures due to hiccups with pypi installation. Instead of failing the whole build, try to install requirements again.

### Tests run
- [ ] Test pt that requirements get installed as expected [60a66d5](https://github.com/aws/deep-learning-containers/pull/2786/commits/60a66d5753173d860a97b646d38e8a4c82f89d2b)
- [ ] Same test as above for TF [98cadda](https://github.com/aws/deep-learning-containers/pull/2786/commits/98cadda414b5ffa91379d5adab6f3f1ef9a3da3e)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
