### PR TITLE
[WIP][PT-2.0][Inference][Benchmark][ec2]Add torch inductor benchmarks

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -9,7 +9,7 @@ ei_mode = false
 neuron_mode = false
 # Please only set it to true if you are preparing a GRAVITON related PR
 # Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = false
+graviton_mode = true
 # Please only set it to True if you are preparing a HABANA related PR
 # Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -9,7 +9,7 @@ ei_mode = false
 neuron_mode = false
 # Please only set it to true if you are preparing a GRAVITON related PR
 # Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = true
+graviton_mode = false
 # Please only set it to True if you are preparing a HABANA related PR
 # Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -23,7 +23,7 @@ huggingface_trcomp_mode = false
 trcomp_mode = false
 # Please only set it to True if you are preparing a Benchmark related PR
 # Do remember to revert it back to False before merging any PR (including Benchmark dedicated PR)
-benchmark_mode = false
+benchmark_mode = true
 
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -9,7 +9,7 @@ ei_mode = false
 neuron_mode = false
 # Please only set it to true if you are preparing a GRAVITON related PR
 # Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = true
+graviton_mode = false
 # Please only set it to True if you are preparing a HABANA related PR
 # Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false
@@ -38,7 +38,7 @@ build_inference = true
 datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
-do_build = true
+do_build = false
 
 [test]
 ### On by default

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -28,14 +28,14 @@ benchmark_mode = true
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
+build_training = false
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = true
+datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_pytorch_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_pytorch_inference.py
@@ -19,6 +19,8 @@ PT_PERFORMANCE_INFERENCE_CPU_CMD = f"{PT_PERFORMANCE_INFERENCE_SCRIPT} --iterati
 PT_PERFORMANCE_INFERENCE_GPU_CMD = f"{PT_PERFORMANCE_INFERENCE_SCRIPT} --iterations 1000 --gpu"
 
 
+#TODO remove before merge
+@pytest.mark.skip(reason="for testing")
 @pytest.mark.model("resnet18, VGG13, MobileNetV2, GoogleNet, DenseNet121, InceptionV3")
 @pytest.mark.parametrize("ec2_instance_type", ["p3.16xlarge"], indirect=True)
 def test_performance_ec2_pytorch_inference_gpu(pytorch_inference, ec2_connection, region, gpu_only):
@@ -28,7 +30,8 @@ def test_performance_ec2_pytorch_inference_gpu(pytorch_inference, ec2_connection
         pytorch_inference, "gpu", ec2_connection, region, PT_PERFORMANCE_INFERENCE_GPU_CMD, threshold,
     )
 
-
+#TODO remove before merge
+@pytest.mark.skip(reason="for testing")
 @pytest.mark.model("resnet18, VGG13, MobileNetV2, GoogleNet, DenseNet121, InceptionV3")
 @pytest.mark.parametrize("ec2_instance_type", ["c5.18xlarge"], indirect=True)
 def test_performance_ec2_pytorch_inference_cpu(pytorch_inference, ec2_connection, region, cpu_only):

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -168,8 +168,6 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     upload_metric(instance_type, precision, suite,
                   "PassRate", passrate, "Percent")
 
-    ec2_connection.run(
-        f"{docker_cmd} exec {container_name} " f"/bin/bash tar -cvzf /test/{log_file} $HOME/pytorch/benchmark_logs")
     ec2_connection.run(f"docker rm -f {container_name}")
     framework_version = re.search(r"\d+(\.\d+){2}", image_uri).group()
     s3_location = os.path.join(

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -146,7 +146,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
 
     # Run performance inference command, display benchmark results to console
     container_name = f"{repo_name}-performance-{image_tag}-ec2"
-    log_file = f"inductor_benchmarks_{instance_type}_{suite}.tar.gz"
+    log_file = f"inductor_benchmarks_{instance_type}_{suite}.log"
     ec2_connection.run(
         f"{docker_cmd} run -d --name {container_name}  -e OMP_NUM_THREADS=1 "
         f"-v {container_test_local_dir}:{os.path.join(os.sep, 'test')} {image_uri} "

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -192,6 +192,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
 
     ec2_connection.run(f"{docker_cmd} pull -q {image_uri} ")
     ec2_connection.run(f"mkdir -p /home/ubuntu/results")
+    log_file = f"inductor_benchmarks_{instance_type}_{suite}.log"
 
     test_cmd = f"python benchmarks/dynamo/runner.py"
     f" --suites = {suite}"
@@ -211,7 +212,6 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
         BENCHMARK_RESULTS_S3_BUCKET, "pytorch", framework_version, "ec2", "inference", instance_type, "py3",
     )
     container_name = f"{repo_name}-performance-{image_tag}-ec2"
-    log_file = f"inductor_benchmarks_{instance_type}_{suite}.log"
     ec2_connection.run(
         f"{docker_cmd} run -d --name {container_name}  -e OMP_NUM_THREADS=1 "
         f"-v /home/ubuntu/results:/root {image_uri} "

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -219,7 +219,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     clone_pytorch = (f"git clone --branch v2.0.0 --recursive --single-branch --depth 1 "
                      f"https://github.com/pytorch/pytorch.git")
     clone_torchbench = "git clone --branch main --recursive --single-branch --depth 1 --verbose https://github.com/pytorch/benchmark.git"
-    install_prereq = "apt-get install dialog apt-utils -y && pip install gitpython numpy==1.23"
+    install_prereq = "apt-get update && apt-get install dialog apt-utils -y && pip install gitpython numpy==1.23"
     increase_git_buffer_size = "git config --global http.postBuffer 1048576000"
 
     #if is_graviton:

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -109,11 +109,11 @@ def upload_metric(region, instance_type, precision, suite, metric_name, value, u
     )
 
 
-@pytest.mark.skip(reason="for testing")
-#@pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge", "m5.4xlarge"], indirect=True)
-#@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
-@pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge"], indirect=True)
-@pytest.mark.parametrize("suite", ["torchbench"])
+#@pytest.mark.skip(reason="for testing")
+@pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge", "m5.4xlarge"], indirect=True)
+@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
+#@pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge"], indirect=True)
+#@pytest.mark.parametrize("suite", ["torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
 def test_performance_ec2_pytorch_inference_cpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, cpu_only):
     _, image_framework_version = get_framework_and_version_from_tag(
@@ -130,11 +130,11 @@ def test_performance_ec2_pytorch_inference_cpu(ec2_instance_type, suite, precisi
     )
 
 
-@pytest.mark.skip(reason="for testing")
-#@pytest.mark.parametrize("ec2_instance_type", ["c6g.4xlarge", "c7g.4xlarge", "m7g.4xlarge"], indirect=True)
-#@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
-@pytest.mark.parametrize("ec2_instance_type", ["m7g.4xlarge"], indirect=True)
-@pytest.mark.parametrize("suite", ["torchbench"])
+@pytest.mark.xfail
+@pytest.mark.parametrize("ec2_instance_type", ["c6g.4xlarge", "c7g.4xlarge", "m7g.4xlarge"], indirect=True)
+@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
+#@pytest.mark.parametrize("ec2_instance_type", ["m7g.4xlarge"], indirect=True)
+#@pytest.mark.parametrize("suite", ["torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
 @pytest.mark.parametrize("ec2_instance_ami", [UL20_CPU_ARM64_US_WEST_2], indirect=True)
 def test_performance_ec2_pytorch_inference_graviton(ec2_instance_type, suite, precision, pytorch_inference_graviton, ec2_connection, region, cpu_only):
@@ -155,10 +155,10 @@ def test_performance_ec2_pytorch_inference_graviton(ec2_instance_type, suite, pr
 
 
 #@pytest.mark.skip(reason="Hangs indefinitely needs investigation")
-#@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
-#@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
-@pytest.mark.parametrize("ec2_instance_type", ["g4dn.4xlarge"], indirect=True)
-@pytest.mark.parametrize("suite", ["torchbench"])
+@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
+@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
+#@pytest.mark.parametrize("ec2_instance_type", ["g4dn.4xlarge"], indirect=True)
+#@pytest.mark.parametrize("suite", ["torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
 def test_performance_ec2_pytorch_inference_gpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, gpu_only):
     _, image_framework_version = get_framework_and_version_from_tag(

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -221,7 +221,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} " f"bash -c 'mkdir -p /root/pytorch/logs_{suite}'")
     ec2_connection.run(
-        f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} " f"bash -c 'python benchmarks/dynamo/runner.py --suites=torchbench --inference --dtypes={precision} --compilers=inductor --output-dir=/root/pytorch/logs_{suite} --extra-args=\"--output-directory=./\" --device {device} --no-update-archive --no-gh-comment' " f"2>&1 | tee {log_file}")
+        f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} " f"bash -c 'python benchmarks/dynamo/runner.py --suites=torchbench --inference --dtypes={precision} --compilers=inductor --output-dir=/root/pytorch/logs_{suite} --extra-args=\"--output-directory=./\" --device {device} --no-update-archive --quick --no-gh-comment' " f"2>&1 | tee {log_file}")
     ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root\" {container_name} " f"bash -c 'echo root contents'")
     ec2_connection.run(

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -211,7 +211,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
 
     clone_pytorch = (f"git clone --branch v2.0.0 --recursive --single-branch --depth 1 "
                      f"https://github.com/pytorch/pytorch.git")
-    clone_torchbench = "GIT_CURL_VERBOSE=1 GIT_TRACE=1 git clone --branch main --recursive --single-branch --depth 1 --verbose https://github.com/pytorch/benchmark.git"
+    clone_torchbench = "GIT_CURL_VERBOSE=1 git clone --branch main --recursive --single-branch --depth 1 --verbose https://github.com/pytorch/benchmark.git"
     install_prereq = "pip install -U numpy==1.23"
     increase_git_buffer_size = "git config --global http.postBuffer 1048576000"
 

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -211,7 +211,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
 
     clone_pytorch = (f"git clone --branch v2.0.0 --recursive --single-branch --depth 1 "
                      f"https://github.com/pytorch/pytorch.git")
-    clone_torchbench = "GIT_CURL_VERBOSE=1 GIT_TRACE=1 git clone --branch master --recursive --single-branch --depth 1 --verbose https://github.com/pytorch/benchmark.git"
+    clone_torchbench = "GIT_CURL_VERBOSE=1 GIT_TRACE=1 git clone --branch main --recursive --single-branch --depth 1 --verbose https://github.com/pytorch/benchmark.git"
     install_prereq = "pip install -U numpy==1.23"
     increase_git_buffer_size = "git config --global http.postBuffer 1048576000"
 

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -133,8 +133,6 @@ def test_performance_ec2_pytorch_inference_cpu(ec2_instance_type, suite, precisi
 @pytest.mark.xfail
 @pytest.mark.parametrize("ec2_instance_type", ["c6g.4xlarge", "c7g.4xlarge", "m7g.4xlarge"], indirect=True)
 @pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
-#@pytest.mark.parametrize("ec2_instance_type", ["m7g.4xlarge"], indirect=True)
-#@pytest.mark.parametrize("suite", ["torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
 @pytest.mark.parametrize("ec2_instance_ami", [UL20_CPU_ARM64_US_WEST_2], indirect=True)
 def test_performance_ec2_pytorch_inference_graviton(ec2_instance_type, suite, precision, pytorch_inference_graviton, ec2_connection, region, cpu_only):
@@ -154,11 +152,10 @@ def test_performance_ec2_pytorch_inference_graviton(ec2_instance_type, suite, pr
     )
 
 
-#@pytest.mark.skip(reason="Hangs indefinitely needs investigation")
-@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
-@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
-#@pytest.mark.parametrize("ec2_instance_type", ["g4dn.4xlarge"], indirect=True)
-#@pytest.mark.parametrize("suite", ["torchbench"])
+#@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
+#@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
+@pytest.mark.parametrize("ec2_instance_type", ["g4dn.4xlarge"], indirect=True)
+@pytest.mark.parametrize("suite", ["torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
 def test_performance_ec2_pytorch_inference_gpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, gpu_only):
     _, image_framework_version = get_framework_and_version_from_tag(

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -1,0 +1,55 @@
+import os
+import time
+import pytest
+from test.test_utils import (
+    CONTAINER_TESTS_PREFIX,
+    get_framework_and_version_from_tag,
+    LOGGER,
+    BENCHMARK_RESULTS_S3_BUCKET
+)
+
+SETUP_CMD = "cd $HOME &&
+             git clone --branch v2.0.0-rc3 --recursive https://github.com/pytorch/pytorch.git &&
+             git clone --recursive https://github.com/pytorch/benchmark.git &&
+             git checkout $(cat pytorch/.github/ci_commit_pins/benchmark.txt &&
+             cd $HOME/benchmark &&
+             python install.py;"
+
+@pytest.mark.parametrize("ec2_instance_type", ["p3.16xlarge"], indirect=True)
+@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+def test_performance_ec2_pytorch_inference(pytorch_inference, ec2_connection, region, gpu_only):
+    ec2_performance_pytorch_inference(
+        pytorch_inference, "gpu", ec2_connection, region, 
+        f"python benchmarks/dynamo/runner.py --suites={suite} --inference --dtypes=float32 --compilers=inductor --output-dir $HOME/pytorch/benchmark_logs --device {device}",
+    )
+
+def ec2_performance_pytorch_inference(image_uri, processor, ec2_connection, region, test_cmd, threshold):
+    docker_cmd = "nvidia-docker" if processor == "gpu" else "docker"
+    container_test_local_dir = os.path.join("$HOME", "container_tests")
+    repo_name, image_tag = image_uri.split("/")[-1].split(":")
+
+    # Make sure we are logged into ECR so we can pull the image
+    ec2_connection.run(f"$(aws ecr get-login --no-include-email --region {region})", hide=True)
+
+    ec2_connection.run(f"{docker_cmd} pull -q {image_uri} ")
+
+    time_str = time.strftime("%Y-%m-%d-%H-%M-%S")
+    commit_info = os.getenv("CODEBUILD_RESOLVED_SOURCE_VERSION")
+    # Run performance inference command, display benchmark results to console
+    container_name = f"{repo_name}-performance-{image_tag}-ec2"
+    log_file = f"inductor_benchmarks_{time_str}.tar.gz"
+    ec2_connection.run(
+        f"{docker_cmd} run -d --name {container_name}  -e OMP_NUM_THREADS=1 "
+        f"-v {container_test_local_dir}:{os.path.join(os.sep, 'test')} {image_uri} "
+    )
+    ec2_connection.run(f"{docker_cmd} exec {container_name} " f"/bin/bash {SETUP_CMD}")
+    ec2_connection.run(f"{docker_cmd} exec {container_name} " f"/bin/bash {test_cmd} " f"2>&1 | tee {log_file}")
+    ec2_connection.run(f"{docker_cmd} exec {container_name} " f"/bin/bash tar -cvzf /test/{log_file} $HOME/pytorch/benchmark_logs")
+    ec2_connection.run(f"docker rm -f {container_name}")
+    framework_version = re.search(r"\d+(\.\d+){2}", image_uri).group()
+    s3_location = os.path.join(
+        BENCHMARK_RESULTS_S3_BUCKET, "pytorch", framework_version, "ec2", "inference", processor, "py3", log_name,
+    )
+    ec2_connection.run(f"aws s3 cp {log_file} {s3_location}")
+    LOGGER.info(f"To retrieve complete benchmark log, check {s3_location}")

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -213,19 +213,18 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
         f"{docker_cmd} run -d --name {container_name}  -e OMP_NUM_THREADS=1 "
         f"-v {ec2_local_dir}:/root {image_uri} "
     )
-    print("=========================setting up instance=====================")
-    ec2_connection.run(f"{docker_cmd} exec {container_name} --workdir=\"/root\""
-                       f"bash -c 'git clone --branch v2.0.0 --recursive --single-branch --depth 1 https://github.com/pytorch/pytorch.git && git clone --branch v2.0.0 --recursive --single-branch --depth 1 https://github.com/pytorch/pytorch.git'")
+    ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
+                       f"bash -c 'git clone --branch v2.0.0 --recursive --single-branch --depth 1 https://github.com/pytorch/pytorch.git && git clone --recursive https://github.com/pytorch/benchmark.git'")
     ec2_connection.run(
-        f"{docker_cmd} exec {container_name} --workdir=\"/root/benchmark\"" f"bash -c 'python install.py'")
+        f"{docker_cmd} exec --workdir=\"/root/benchmark\" {container_name} " f"bash -c 'python install.py'")
     ec2_connection.run(
-        f"{docker_cmd} exec {container_name} --workdir=\"/root/pytorch\"" f"bash -c 'mkdir -p /root/pytorch/logs_{suite}'")
+        f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} " f"bash -c 'mkdir -p /root/pytorch/logs_{suite}'")
     ec2_connection.run(
-        f"{docker_cmd} exec {container_name} --workdir=\"/root/pytorch\"" f"bash -c 'python benchmarks/dynamo/runner.py --suites=torchbench --inference --dtypes={precision} --compilers=inductor --output-dir=/root/pytorch/logs_{suite} --extra-args=\"--output-directory=./\" --device {device} --no-update-archive --no-gh-comment'" f"2>&1 | tee {log_file}")
+        f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} " f"bash -c 'python benchmarks/dynamo/runner.py --suites=torchbench --inference --dtypes={precision} --compilers=inductor --output-dir=/root/pytorch/logs_{suite} --extra-args=\"--output-directory=./\" --device {device} --no-update-archive --no-gh-comment'" f" 2>&1 | tee {log_file}")
     ec2_connection.run(
-        f"{docker_cmd} exec {container_name} --workdir=\"/root\"" f"bash -c 'echo root contents'")
+        f"{docker_cmd} exec --workdir=\"/root\" {container_name} " f"bash -c 'echo root contents'")
     ec2_connection.run(
-        f"{docker_cmd} exec {container_name} --workdir=\"/root\"" f"bash -c 'ls -l'")
+        f"{docker_cmd} exec --workdir=\"/root\" {container_name} " f"bash -c 'ls -l'")
 #    ec2_connection.run(
 #        f"{docker_cmd} exec {container_name} "
 #        f"/bin/bash {test_cmd} " f"2>&1 | tee /root/pytorch/logs_{suite}/{log_file}")

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -20,6 +20,8 @@ from test.test_utils import (
     LOGGER,
     BENCHMARK_RESULTS_S3_BUCKET
 )
+import sys
+import logging
 import pytest
 import pandas as pd
 import boto3
@@ -27,8 +29,12 @@ from botocore.exceptions import ClientError
 from packaging.version import Version
 from packaging.specifiers import SpecifierSet
 
+LOGGER = logging.getLogger(__name__)
+LOGGER.addHandler(logging.StreamHandler(sys.stdout))
+LOGGER.setLevel(logging.INFO)
+
 SETUP_CMD = "cd /root && \
-             git clone --branch v2.0.0 --recursive --single-branch -depth 1 https://github.com/pytorch/pytorch.git && \
+             git clone --branch v2.0.0 --recursive --single-branch --depth 1 https://github.com/pytorch/pytorch.git && \
              git clone --recursive https://github.com/pytorch/benchmark.git && \
              git checkout $(cat pytorch/.github/ci_commit_pins/benchmark.txt && \
              cd /root/benchmark && \
@@ -45,12 +51,12 @@ def unique_metric_dims(instance_type, precision, model_suite):
     return dimensions
 
 
-def get_boto3_session(region="us-east-1"):
+def get_boto3_session(region="us-west-2"):
     """Get boto3 session with us-east-1 as default region used to connect to AWS services."""
     return boto3.session.Session(region_name=region)
 
 
-def get_cloudwatch_client(region="us-east-1"):
+def get_cloudwatch_client(region="us-west-2"):
     """Get AWS CloudWatch client object. Currently assume region is IAD (us-east-1)"""
     return get_boto3_session(region=region).client("cloudwatch")
 
@@ -106,7 +112,7 @@ def upload_metric(instance_type, precision, suite, metric_name, value, unit, reg
 @pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge", "m5.4xlarge"], indirect=True)
 @pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
-def test_performance_ec2_pytorch_inference_cpu(suite, precision, pytorch_inference, ec2_connection, region, cpu_only):
+def test_performance_ec2_pytorch_inference_cpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, cpu_only):
     _, image_framework_version = get_framework_and_version_from_tag(
         pytorch_inference)
     if Version(image_framework_version) in SpecifierSet("<2.0"):
@@ -124,12 +130,12 @@ def test_performance_ec2_pytorch_inference_cpu(suite, precision, pytorch_inferen
 @pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
 @pytest.mark.parametrize("ec2_instance_ami", [UL20_CPU_ARM64_US_WEST_2], indirect=True)
-def test_performance_ec2_pytorch_inference_graviton(suite, precision, pytorch_inference_graviton, ec2_connection, region, cpu_only):
+def test_performance_ec2_pytorch_inference_graviton(ec2_instance_type, suite, precision, pytorch_inference_graviton, ec2_connection, region, cpu_only):
     _, image_framework_version = get_framework_and_version_from_tag(
-        pytorch_inference)
+        pytorch_inference_graviton)
     if Version(image_framework_version) in SpecifierSet("<2.0"):
         ec2_performance_pytorch_inference(
-            pytorch_inference,
+            pytorch_inference_graviton,
             ec2_instance_type,
             ec2_connection,
             region,
@@ -141,7 +147,7 @@ def test_performance_ec2_pytorch_inference_graviton(suite, precision, pytorch_in
 @pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
 @pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
-def test_performance_ec2_pytorch_inference_gpu(suite, precision, pytorch_inference, ec2_connection, region, gpu_only):
+def test_performance_ec2_pytorch_inference_gpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, gpu_only):
     _, image_framework_version = get_framework_and_version_from_tag(
         pytorch_inference)
     if Version(image_framework_version) in SpecifierSet("<2.0"):
@@ -162,6 +168,15 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     ec2_local_dir = os.path.join("$HOME", "results")
     repo_name, image_tag = image_uri.split("/")[-1].split(":")
 
+    LOGGER.info(f"ec2_performance_pytorch_inference params "
+                f"image_uri:{image_uri}"
+                f"instance_type:{instance_type}"
+                f"ec2_connection:{ec2_connection}"
+                f"region:{region}"
+                f"suite{suite}"
+                f"precision:{precision}"
+                )
+
     # Make sure we are logged into ECR so we can pull the image
     ec2_connection.run(
         f"$(aws ecr get-login --no-include-email --region {region})", hide=True)
@@ -169,18 +184,18 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     ec2_connection.run(f"{docker_cmd} pull -q {image_uri} ")
     ec2_connection.run(f"mkdir -p $HOME/results")
 
-    test_cmd = f"cd /root/pytorch &&"
-    f" mkdir -p /root/pytorch/logs_{suite} &&"
-    f" python benchmarks/dynamo/runner.py"
-    f" --suites = {suite}"
-    f" --inference"
-    f" --dtypes = {precision}"
-    f" --compilers=inductor"
-    f" --output-dir=/root/pytorch/logs_{suite}"
-    f" --extra-args='--output-directory=./'"
-    f" --device {device}"
-    f" --no-update-archive"
-    f" --no-gh-comment"
+#    test_cmd = f"cd /root/pytorch &&"
+#    f" mkdir -p /root/pytorch/logs_{suite} &&"
+#    f" python benchmarks/dynamo/runner.py"
+#    f" --suites = {suite}"
+#    f" --inference"
+#    f" --dtypes = {precision}"
+#    f" --compilers=inductor"
+#    f" --output-dir=/root/pytorch/logs_{suite}"
+#    f" --extra-args='--output-directory=./'"
+#    f" --device {device}"
+#    f" --no-update-archive"
+#    f" --no-gh-comment"
 
     # Run performance inference command, display benchmark results to console
     framework_version = re.search(r"\d+(\.\d+){2}", image_uri).group()
@@ -191,30 +206,36 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     log_file = f"inductor_benchmarks_{instance_type}_{suite}.log"
     ec2_connection.run(
         f"{docker_cmd} run -d --name {container_name}  -e OMP_NUM_THREADS=1 "
-        f"-v {ec2_local_dir}:/root/pytorch/logs_{suite} {image_uri} "
+        f"-v {ec2_local_dir}:/root {image_uri} "
     )
     print("=========================setting up instance=====================")
+    ec2_connection.run(f"{docker_cmd} exec {container_name} --workdir=\"/root\""
+                       f"bash -c 'git clone --branch v2.0.0 --recursive --single-branch --depth 1 https://github.com/pytorch/pytorch.git && git clone --branch v2.0.0 --recursive --single-branch --depth 1 https://github.com/pytorch/pytorch.git'")
     ec2_connection.run(
-        f"{docker_cmd} exec {container_name} " f"/bin/bash {SETUP_CMD}")
-    print("=========================executing benchmarks=====================")
+        f"{docker_cmd} exec {container_name} --workdir=\"/root/benchmark\"" f"bash -c 'python install.py'")
     ec2_connection.run(
-        f"{docker_cmd} exec {container_name} " 
-        f"/bin/bash {test_cmd} " f"2>&1 | tee /root/pytorch/logs_{suite}/{log_file}")
-    print("=========================Upload all logs to S3=====================")
+        f"{docker_cmd} exec {container_name} --workdir=\"/root/pytorch\"" f"bash -c 'mkdir -p /root/pytorch/logs_{suite}'")
     ec2_connection.run(
-        f"{docker_cmd} exec {container_name} " f"/bin/bash ls -l")
+        f"{docker_cmd} exec {container_name} --workdir=\"/root/pytorch\"" f"bash -c 'python benchmarks/dynamo/runner.py --suites=torchbench --inference --dtypes={precision} --compilers=inductor --output-dir=/root/pytorch/logs_{suite} --extra-args=\"--output-directory=./\" --device {device} --no-update-archive --no-gh-comment'" f"2>&1 | tee {log_file}")
     ec2_connection.run(
-        f"{docker_cmd} exec {container_name} " f"/bin/bash ls -l $HOME/results")
+        f"{docker_cmd} exec {container_name} --workdir=\"/root\"" f"bash -c 'echo root contents'")
+    ec2_connection.run(
+        f"{docker_cmd} exec {container_name} --workdir=\"/root\"" f"bash -c 'ls -l'")
+#    ec2_connection.run(
+#        f"{docker_cmd} exec {container_name} "
+#        f"/bin/bash {test_cmd} " f"2>&1 | tee /root/pytorch/logs_{suite}/{log_file}")
 
     ec2_connection.run(
-        f"aws s3 cp {ec2_local_dir} {s3_location}/logs_{suite} --recursive")
-    speedup = read_metric(f"{ec2_local_dir}/geomean.csv")
+        f"aws s3 cp {ec2_local_dir}/pytorch/logs_{suite} {s3_location}/logs_{suite} --recursive")
+    speedup = read_metric(f"{ec2_local_dir}/pytorch/logs_{suite}/geomean.csv")
     LOGGER.info(f"Seedup = {speedup}")
-    comp_time = read_metric(f"{ec2_local_dir}/comp_time.csv")
+    comp_time = read_metric(
+        f"{ec2_local_dir}/pytorch/logs_{suite}/comp_time.csv")
     LOGGER.info(f"Compilation Time = {comp_time}")
-    memory = read_metric(f"{ec2_local_dir}/memory.csv")
+    memory = read_metric(f"{ec2_local_dir}/pytorch/logs_{suite}/memory.csv")
     LOGGER.info(f"Memory Footprint = {memory}")
-    passrate = read_metric(f"{ec2_local_dir}/passrate.csv")
+    passrate = read_metric(
+        f"{ec2_local_dir}/pytorch/logs_{suite}/passrate.csv")
     LOGGER.info(f"Pass Rate = {passrate}")
     upload_metric(region, instance_type, precision,
                   suite, "Speedup", speedup, "None")
@@ -226,5 +247,6 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
                   "PassRate", passrate, "Percent")
 
     ec2_connection.run(f"docker rm -f {container_name}")
-    ec2_connection.run(f"aws s3 cp {ec2_local_dir}/{log_file} {s3_location}/{log_file}")
+    ec2_connection.run(
+        f"aws s3 cp {ec2_local_dir}/{log_file} {s3_location}/{log_file}")
     LOGGER.info(f"To retrieve complete benchmark log, check {s3_location}")

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -223,7 +223,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} " f"bash -c 'mkdir -p /root/pytorch/logs_{suite}'")
     bench_output = ec2_connection.run(
-        f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} " f"bash -c 'python benchmarks/dynamo/runner.py --suites=torchbench --inference --dtypes={precision} --compilers=inductor --output-dir=/root/pytorch/logs_{suite} --extra-args=\"--output-directory=./\" --device {device} --no-update-archive --quick --no-gh-comment' " f"2>&1 | tee {log_file}").std.split("\n")
+        f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} " f"bash -c 'python benchmarks/dynamo/runner.py --suites=torchbench --inference --dtypes={precision} --compilers=inductor --output-dir=/root/pytorch/logs_{suite} --extra-args=\"--output-directory=./\" --device {device} --no-update-archive --quick --no-gh-comment' " f"2>&1 | tee {log_file}").stdout.split("\n")
     LOGGER.info(f"BENCHMARK OUTPUT ============================\n{bench_output}")
     ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root\" {container_name} " f"bash -c 'echo root contents'")

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -116,14 +116,15 @@ def test_performance_ec2_pytorch_inference_cpu(ec2_instance_type, suite, precisi
     _, image_framework_version = get_framework_and_version_from_tag(
         pytorch_inference)
     if Version(image_framework_version) in SpecifierSet("<2.0"):
-        ec2_performance_pytorch_inference(
-            pytorch_inference,
-            ec2_instance_type,
-            ec2_connection,
-            region,
-            suite,
-            precision,
-        )
+        pytest.skip("skip the test as torch.compile only supported after 2.0")
+    ec2_performance_pytorch_inference(
+        pytorch_inference,
+        ec2_instance_type,
+        ec2_connection,
+        region,
+        suite,
+        precision,
+    )
 
 
 @pytest.mark.parametrize("ec2_instance_type", ["c6g.4xlarge", "c7g.4xlarge", "m7g.4xlarge"], indirect=True)
@@ -134,14 +135,17 @@ def test_performance_ec2_pytorch_inference_graviton(ec2_instance_type, suite, pr
     _, image_framework_version = get_framework_and_version_from_tag(
         pytorch_inference_graviton)
     if Version(image_framework_version) in SpecifierSet("<2.0"):
-        ec2_performance_pytorch_inference(
-            pytorch_inference_graviton,
-            ec2_instance_type,
-            ec2_connection,
-            region,
-            suite,
-            precision,
-        )
+        pytest.skip("skip the test as torch.compile only supported after 2.0")
+    if "graviton" not in pytorch_inference_graviton:
+        pytest.skip("skip EC2 tests for inductor")
+    ec2_performance_pytorch_inference(
+        pytorch_inference_graviton,
+        ec2_instance_type,
+        ec2_connection,
+        region,
+        suite,
+        precision,
+    )
 
 
 @pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
@@ -151,14 +155,15 @@ def test_performance_ec2_pytorch_inference_gpu(ec2_instance_type, suite, precisi
     _, image_framework_version = get_framework_and_version_from_tag(
         pytorch_inference)
     if Version(image_framework_version) in SpecifierSet("<2.0"):
-        ec2_performance_pytorch_inference(
-            pytorch_inference,
-            ec2_instance_type,
-            ec2_connection,
-            region,
-            suite,
-            precision,
-        )
+        pytest.skip("skip the test as torch.compile only supported after 2.0")
+    ec2_performance_pytorch_inference(
+        pytorch_inference,
+        ec2_instance_type,
+        ec2_connection,
+        region,
+        suite,
+        precision,
+    )
 
 
 def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, region, suite, precision):

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -110,22 +110,22 @@ def upload_metric(instance_type, precision, suite, metric_name, value, unit, reg
 
 
 #@pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge", "m5.4xlarge"], indirect=True)
-@pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge"], indirect=True)
-@pytest.mark.parametrize("suite", ["torchbench"])
-@pytest.mark.parametrize("precision", ["float32"])
-def test_performance_ec2_pytorch_inference_cpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, cpu_only):
-    _, image_framework_version = get_framework_and_version_from_tag(
-        pytorch_inference)
-    if Version(image_framework_version) in SpecifierSet("<2.0"):
-        pytest.skip("skip the test as torch.compile only supported after 2.0")
-    ec2_performance_pytorch_inference(
-        pytorch_inference,
-        ec2_instance_type,
-        ec2_connection,
-        region,
-        suite,
-        precision,
-    )
+#@pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge"], indirect=True)
+#@pytest.mark.parametrize("suite", ["torchbench"])
+#@pytest.mark.parametrize("precision", ["float32"])
+#def test_performance_ec2_pytorch_inference_cpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, cpu_only):
+#    _, image_framework_version = get_framework_and_version_from_tag(
+#        pytorch_inference)
+#    if Version(image_framework_version) in SpecifierSet("<2.0"):
+#        pytest.skip("skip the test as torch.compile only supported after 2.0")
+#    ec2_performance_pytorch_inference(
+#        pytorch_inference,
+#        ec2_instance_type,
+#        ec2_connection,
+#        region,
+#        suite,
+#        precision,
+#    )
 
 
 #@pytest.mark.parametrize("ec2_instance_type", ["c6g.4xlarge", "c7g.4xlarge", "m7g.4xlarge"], indirect=True)
@@ -149,7 +149,8 @@ def test_performance_ec2_pytorch_inference_cpu(ec2_instance_type, suite, precisi
 #    )
 #
 #
-@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
+#@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
+@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge"], indirect=True)
 @pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
 def test_performance_ec2_pytorch_inference_gpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, gpu_only):

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -172,7 +172,7 @@ def test_performance_ec2_pytorch_inference_gpu(ec2_instance_type, suite, precisi
 def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, region, suite, precision):
     is_gpu = re.search(r"(p3|g4|g5)", instance_type)
     device = "cuda" if is_gpu else "cpu"
-    docker_cmd = "nvidia-docker" if is_gpu == "gpu" else "docker"
+    docker_cmd = "nvidia-docker" if is_gpu else "docker"
     ec2_local_dir = os.path.join("/home/ubuntu", "results")
     repo_name, image_tag = image_uri.split("/")[-1].split(":")
 

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -232,6 +232,8 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
 
     ec2_connection.run(
         f"aws s3 cp /home/ubuntu/results/pytorch/logs_{suite} {s3_location}/logs_{suite} --recursive")
+    ec2_connection.run(
+        f"aws s3 cp /home/ubuntu/results/pytorch/{log_file} {s3_location}/{log_file}")
     speedup = read_metric(f"/home/ubuntu/results/pytorch/logs_{suite}/geomean.csv")
     LOGGER.info(f"Seedup = {speedup}")
     comp_time = read_metric(

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -109,8 +109,9 @@ def upload_metric(instance_type, precision, suite, metric_name, value, unit, reg
     )
 
 
-@pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge", "m5.4xlarge"], indirect=True)
-@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
+#@pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge", "m5.4xlarge"], indirect=True)
+@pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge"], indirect=True)
+@pytest.mark.parametrize("suite", ["torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
 def test_performance_ec2_pytorch_inference_cpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, cpu_only):
     _, image_framework_version = get_framework_and_version_from_tag(
@@ -127,43 +128,43 @@ def test_performance_ec2_pytorch_inference_cpu(ec2_instance_type, suite, precisi
     )
 
 
-@pytest.mark.parametrize("ec2_instance_type", ["c6g.4xlarge", "c7g.4xlarge", "m7g.4xlarge"], indirect=True)
-@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
-@pytest.mark.parametrize("precision", ["float32"])
-@pytest.mark.parametrize("ec2_instance_ami", [UL20_CPU_ARM64_US_WEST_2], indirect=True)
-def test_performance_ec2_pytorch_inference_graviton(ec2_instance_type, suite, precision, pytorch_inference_graviton, ec2_connection, region, cpu_only):
-    _, image_framework_version = get_framework_and_version_from_tag(
-        pytorch_inference_graviton)
-    if Version(image_framework_version) in SpecifierSet("<2.0"):
-        pytest.skip("skip the test as torch.compile only supported after 2.0")
-    if "graviton" not in pytorch_inference_graviton:
-        pytest.skip("skip EC2 tests for inductor")
-    ec2_performance_pytorch_inference(
-        pytorch_inference_graviton,
-        ec2_instance_type,
-        ec2_connection,
-        region,
-        suite,
-        precision,
-    )
-
-
-@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
-@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
-@pytest.mark.parametrize("precision", ["float32"])
-def test_performance_ec2_pytorch_inference_gpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, gpu_only):
-    _, image_framework_version = get_framework_and_version_from_tag(
-        pytorch_inference)
-    if Version(image_framework_version) in SpecifierSet("<2.0"):
-        pytest.skip("skip the test as torch.compile only supported after 2.0")
-    ec2_performance_pytorch_inference(
-        pytorch_inference,
-        ec2_instance_type,
-        ec2_connection,
-        region,
-        suite,
-        precision,
-    )
+#@pytest.mark.parametrize("ec2_instance_type", ["c6g.4xlarge", "c7g.4xlarge", "m7g.4xlarge"], indirect=True)
+#@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
+#@pytest.mark.parametrize("precision", ["float32"])
+#@pytest.mark.parametrize("ec2_instance_ami", [UL20_CPU_ARM64_US_WEST_2], indirect=True)
+#def test_performance_ec2_pytorch_inference_graviton(ec2_instance_type, suite, precision, pytorch_inference_graviton, ec2_connection, region, cpu_only):
+#    _, image_framework_version = get_framework_and_version_from_tag(
+#        pytorch_inference_graviton)
+#    if Version(image_framework_version) in SpecifierSet("<2.0"):
+#        pytest.skip("skip the test as torch.compile only supported after 2.0")
+#    if "graviton" not in pytorch_inference_graviton:
+#        pytest.skip("skip EC2 tests for inductor")
+#    ec2_performance_pytorch_inference(
+#        pytorch_inference_graviton,
+#        ec2_instance_type,
+#        ec2_connection,
+#        region,
+#        suite,
+#        precision,
+#    )
+#
+#
+#@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
+#@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
+#@pytest.mark.parametrize("precision", ["float32"])
+#def test_performance_ec2_pytorch_inference_gpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, gpu_only):
+#    _, image_framework_version = get_framework_and_version_from_tag(
+#        pytorch_inference)
+#    if Version(image_framework_version) in SpecifierSet("<2.0"):
+#        pytest.skip("skip the test as torch.compile only supported after 2.0")
+#    ec2_performance_pytorch_inference(
+#        pytorch_inference,
+#        ec2_instance_type,
+#        ec2_connection,
+#        region,
+#        suite,
+#        precision,
+#    )
 
 
 def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, region, suite, precision):
@@ -220,7 +221,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} " f"bash -c 'mkdir -p /root/pytorch/logs_{suite}'")
     ec2_connection.run(
-        f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} " f"bash -c 'python benchmarks/dynamo/runner.py --suites=torchbench --inference --dtypes={precision} --compilers=inductor --output-dir=/root/pytorch/logs_{suite} --extra-args=\"--output-directory=./\" --device {device} --no-update-archive --no-gh-comment'" f" 2>&1 | tee {log_file}")
+        f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} " f"bash -c 'python benchmarks/dynamo/runner.py --suites=torchbench --inference --dtypes={precision} --compilers=inductor --output-dir=/root/pytorch/logs_{suite} --extra-args=\"--output-directory=./\" --device {device} --no-update-archive --no-gh-comment' " f"2>&1 | tee {log_file}")
     ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root\" {container_name} " f"bash -c 'echo root contents'")
     ec2_connection.run(

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -236,23 +236,26 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     prereq_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
                                             f"bash -c '{install_prereq}'").stdout.split("\n")
     LOGGER.info(f"Output install prereq ================================\n{prereq_output}")
+    pip_freezee_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
+                                            f"bash -c 'pip freeze'").stdout.split("\n")
+    LOGGER.info(f"Output pip freeze ================================\n{pip_freezee_output}")
     clone_pt_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
                        f"bash -c '{clone_pytorch}'").stdout.split("\n")
     LOGGER.info(f"Output git clone ================================\n{clone_pt_output}")
     clone_tb_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
                        f"bash -c '{clone_torchbench}'").stdout.split("\n")
     LOGGER.info(f"Output git clone ================================\n{clone_tb_output}")
-    pip_freezee_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
-                                            f"bash -c 'pip freeze'").stdout.split("\n")
-    LOGGER.info(f"Output pip freeze ================================\n{pip_freezee_output}")
     install_output = ec2_connection.run(
-        f"{docker_cmd} exec --workdir=\"/root/benchmark\" {container_name} " f"bash -c 'python install.py'").stdout.split("\n")
+        f"{docker_cmd} exec --workdir=\"/root/benchmark\" {container_name} "
+        f"bash -c 'python install.py'").stdout.split("\n")
     LOGGER.info(f"Output python install.py ================================\n{install_output}")
     mkdir_output = ec2_connection.run(
-        f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} " f"bash -c 'mkdir -p /root/pytorch/logs_{suite}'").stdout.split("\n")
+        f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} "
+        f"bash -c 'mkdir -p /root/pytorch/logs_{suite}'").stdout.split("\n")
     LOGGER.info(f"Output mkdir ================================\n{mkdir_output}")
     bench_output = ec2_connection.run(
-        f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} " f"bash -c '{test_cmd}'").stdout.split("\n")
+        f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} "
+        f"bash -c '{test_cmd}'").stdout.split("\n")
     LOGGER.info(f"Output benchmark command ================================\n{bench_output}")
 
     s3_cp_output = ec2_connection.run(

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -1,3 +1,16 @@
+# Copyright 2019-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import os
 import time
 import pytest

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -211,8 +211,9 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
 
     clone_pytorch = (f"git clone --branch v2.0.0 --recursive --single-branch --depth 1 "
                      f"https://github.com/pytorch/pytorch.git")
-    clone_torchbench = f"GIT_CURL_VERBOSE=1 GIT_TRACE=1 git clone --verbose https://github.com/pytorch/benchmark.git"
-    install_prereq = f"pip install -U numpy"
+    clone_torchbench = "GIT_CURL_VERBOSE=1 GIT_TRACE=1 git clone --verbose https://github.com/pytorch/benchmark.git"
+    install_prereq = "pip install -U numpy"
+    increase_git_buffer_size = "git config --global http.postBuffer 1048576000"
 
     #if is_graviton:
     #    git_clone = (f"rm -rf /root/benchmark/torchbenchmark/models/torchrec_dlrm && "
@@ -236,6 +237,9 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     prereq_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
                                             f"bash -c '{install_prereq}'").stdout.split("\n")
     LOGGER.info(f"Output install prereq ================================\n{prereq_output}")
+    buffersize_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
+                                            f"bash -c '{increase_git_buffer_size}'").stdout.split("\n")
+    LOGGER.info(f"Output buffersize ================================\n{buffersize_output}")
     pip_freezee_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
                                             f"bash -c 'pip freeze'").stdout.split("\n")
     LOGGER.info(f"Output pip freeze ================================\n{pip_freezee_output}")

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -260,7 +260,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     if suite == "torchbench":
         install_output = ec2_connection.run(
             f"{docker_cmd} exec --workdir=\"/root/benchmark\" {container_name} "
-            f"bash -c 'python install.py'").stdout.split("\n")
+            f"--user root bash -c 'python install.py'").stdout.split("\n")
         LOGGER.info(f"Output python install.py ================================\n{install_output}")
     mkdir_output = ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} "
@@ -268,7 +268,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     LOGGER.info(f"Output mkdir ================================\n{mkdir_output}")
     bench_output = ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} "
-        f"bash -c '{test_cmd}'").stdout.split("\n")
+        f"--user root bash -c '{test_cmd}'").stdout.split("\n")
     LOGGER.info(f"Output benchmark command ================================\n{bench_output}")
 
     s3_cp_output = ec2_connection.run(

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -105,7 +105,7 @@ def upload_metric(instance_type, precision, suite, metric_name, value, unit):
 @pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge", "m5.4xlarge"], indirect=True)
 @pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
-def test_performance_ec2_pytorch_inference_cpu(pytorch_inference, ec2_connection, region):
+def test_performance_ec2_pytorch_inference_cpu(suite, precision, pytorch_inference, ec2_connection, region):
     _, image_framework_version = get_framework_and_version_from_tag(
         pytorch_inference)
     if Version(image_framework_version) in SpecifierSet("<2.0"):
@@ -123,7 +123,7 @@ def test_performance_ec2_pytorch_inference_cpu(pytorch_inference, ec2_connection
 @pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
 @pytest.mark.parametrize("ec2_instance_ami", [UL20_CPU_ARM64_US_WEST_2], indirect=True)
-def test_performance_ec2_pytorch_inference_graviton(pytorch_inference, ec2_connection, region):
+def test_performance_ec2_pytorch_inference_graviton(suite, precision, pytorch_inference, ec2_connection, region):
     _, image_framework_version = get_framework_and_version_from_tag(
         pytorch_inference)
     if Version(image_framework_version) in SpecifierSet("<2.0"):
@@ -139,7 +139,7 @@ def test_performance_ec2_pytorch_inference_graviton(pytorch_inference, ec2_conne
 @pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
 @pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
-def test_performance_ec2_pytorch_inference_gpu(pytorch_inference, ec2_connection, region):
+def test_performance_ec2_pytorch_inference_gpu(suite, precision, pytorch_inference, ec2_connection, region):
     _, image_framework_version = get_framework_and_version_from_tag(
         pytorch_inference)
     if Version(image_framework_version) in SpecifierSet("<2.0"):

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -202,6 +202,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     f" --extra-args=\"--output-directory=./\""
     f" --device {device}"
     f" --no-update-archive"
+    f" --quick"
     f" --no-gh-comment 2>&1 | tee {log_file}"
 
     # Run performance inference command, display benchmark results to console

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -199,8 +199,9 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     ec2_connection.run(f"mkdir -p /home/ubuntu/results")
     ec2_connection.run(f"git clone https://github.com/pytorch/pytorch.git --branch v2.0.0"
                        f" --recursive --single-branch --depth 1 /home/ubuntu/results/pytorch")
-    ec2_connection.run(f"git clone --branch main --recursive --single-branch --depth 1"
-                       f" https://github.com/pytorch/benchmark.git /home/ubuntu/results/benchmark")
+    if suite == "torchbench":
+        ec2_connection.run(f"git clone --branch main --recursive --single-branch --depth 1"
+                           f" https://github.com/pytorch/benchmark.git /home/ubuntu/results/benchmark")
     log_file = f"inductor_benchmarks_{instance_type}_{suite}.log"
 
     test_cmd = (f"python benchmarks/dynamo/runner.py"
@@ -256,10 +257,11 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     #    clone_tb_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
     #                       f"bash -c '{clone_torchbench}'").stdout.split("\n")
     #    LOGGER.info(f"Output clone torchbench ================================\n{clone_tb_output}")
-    install_output = ec2_connection.run(
-        f"{docker_cmd} exec --workdir=\"/root/benchmark\" {container_name} "
-        f"bash -c 'python install.py'").stdout.split("\n")
-    LOGGER.info(f"Output python install.py ================================\n{install_output}")
+    if suite == "torchbench":
+        install_output = ec2_connection.run(
+            f"{docker_cmd} exec --workdir=\"/root/benchmark\" {container_name} "
+            f"bash -c 'python install.py'").stdout.split("\n")
+        LOGGER.info(f"Output python install.py ================================\n{install_output}")
     mkdir_output = ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} "
         f"bash -c 'mkdir -p /root/pytorch/logs_{suite}'").stdout.split("\n")

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -232,8 +232,18 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
 
     ec2_connection.run(
         f"aws s3 cp /home/ubuntu/results/pytorch/logs_{suite} {s3_location}/logs_{suite} --recursive")
-    ec2_connection.run(
-        f"aws s3 cp /home/ubuntu/results/pytorch/{log_file} {s3_location}/{log_file}")
+
+    output_list_logs_dir = ec2_connection.run(
+        f"ls -l /home/ubuntu/results/pytorch/logs_{suite}").stdout.split("\n")
+    LOGGER.info(f"CONTENTS OF LOGS DIR============================{output_list_logs_dir}")
+    output_list_pytorch = ec2_connection.run(
+        f"ls -l /home/ubuntu/results/pytorch").stdout.split("\n")
+    LOGGER.info(f"CONTENTS OF PYTORCH DIR========================={output_list_pytorch}")
+    output_geomean = ec2_connection.run(
+        f"ls -l /home/ubuntu/results/pytorch/logs_{suite}/geomean.csv").stdout.split("\n")
+    LOGGER.info(f"GEOMEAN =================={output_geomean}")
+
+
     speedup = read_metric(f"/home/ubuntu/results/pytorch/logs_{suite}/geomean.csv")
     LOGGER.info(f"Seedup = {speedup}")
     comp_time = read_metric(

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -240,6 +240,8 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     git_clone_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
                        f"bash -c '{git_clone}'").stdout.split("\n")
     LOGGER.info(f"Output git clone ================================\n{git_clone_output}")
+    pip_freezee_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
+                                            f"bash -c 'pip freeze'").stdout.split("\n")
     install_output = ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root/benchmark\" {container_name} " f"bash -c 'python install.py'").stdout.split("\n")
     LOGGER.info(f"Output python install.py ================================\n{install_output}")

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -211,7 +211,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
 
     clone_pytorch = (f"git clone --branch v2.0.0 --recursive --single-branch --depth 1 "
                      f"https://github.com/pytorch/pytorch.git")
-    clone_torchbench = f"git clone https://github.com/pytorch/benchmark.git"
+    clone_torchbench = f"git clone --verbose https://github.com/pytorch/benchmark.git"
     install_prereq = f"pip install -U numpy"
 
     #if is_graviton:

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -55,9 +55,9 @@ def get_cloudwatch_client(region="us-east-1"):
     return get_boto3_session(region=region).client("cloudwatch")
 
 
-def put_metric_data(metric_name, namespace, unit, value, dimensions):
+def put_metric_data(region, metric_name, namespace, unit, value, dimensions):
     """Puts data points to cloudwatch metrics"""
-    cloudwatch_client = get_cloudwatch_client()
+    cloudwatch_client = get_cloudwatch_client(region)
     current_timestamp = datetime.datetime.utcnow()
     try:
         response = cloudwatch_client.put_metric_data(
@@ -92,8 +92,9 @@ def read_metric(model_suite, csv_file):
     return float(value)
 
 
-def upload_metric(instance_type, precision, suite, metric_name, value, unit):
+def upload_metric(instance_type, precision, suite, metric_name, value, unit, region):
     put_metric_data(
+        region=region,
         metric_name=metric_name,
         namespace=f"PyTorch/EC2/Benchmarks/TorchDynamo/Inductor",
         unit=unit,
@@ -105,7 +106,7 @@ def upload_metric(instance_type, precision, suite, metric_name, value, unit):
 @pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge", "m5.4xlarge"], indirect=True)
 @pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
-def test_performance_ec2_pytorch_inference_cpu(suite, precision, pytorch_inference, ec2_connection, region):
+def test_performance_ec2_pytorch_inference_cpu(suite, precision, pytorch_inference, ec2_connection, region, cpu_only):
     _, image_framework_version = get_framework_and_version_from_tag(
         pytorch_inference)
     if Version(image_framework_version) in SpecifierSet("<2.0"):
@@ -123,7 +124,7 @@ def test_performance_ec2_pytorch_inference_cpu(suite, precision, pytorch_inferen
 @pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
 @pytest.mark.parametrize("ec2_instance_ami", [UL20_CPU_ARM64_US_WEST_2], indirect=True)
-def test_performance_ec2_pytorch_inference_graviton(suite, precision, pytorch_inference, ec2_connection, region):
+def test_performance_ec2_pytorch_inference_graviton(suite, precision, pytorch_inference_graviton, ec2_connection, region, cpu_only):
     _, image_framework_version = get_framework_and_version_from_tag(
         pytorch_inference)
     if Version(image_framework_version) in SpecifierSet("<2.0"):
@@ -136,10 +137,11 @@ def test_performance_ec2_pytorch_inference_graviton(suite, precision, pytorch_in
             precision,
         )
 
+
 @pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
 @pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
-def test_performance_ec2_pytorch_inference_gpu(suite, precision, pytorch_inference, ec2_connection, region):
+def test_performance_ec2_pytorch_inference_gpu(suite, precision, pytorch_inference, ec2_connection, region, gpu_only):
     _, image_framework_version = get_framework_and_version_from_tag(
         pytorch_inference)
     if Version(image_framework_version) in SpecifierSet("<2.0"):
@@ -178,6 +180,10 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     f" --no-gh-comment"
 
     # Run performance inference command, display benchmark results to console
+    framework_version = re.search(r"\d+(\.\d+){2}", image_uri).group()
+    s3_location = os.path.join(
+        BENCHMARK_RESULTS_S3_BUCKET, "pytorch", framework_version, "ec2", "inference", instance_type, "py3",
+    )
     container_name = f"{repo_name}-performance-{image_tag}-ec2"
     log_file = f"inductor_benchmarks_{instance_type}_{suite}.log"
     ec2_connection.run(
@@ -189,22 +195,24 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     ec2_connection.run(
         f"{docker_cmd} exec {container_name} " f"/bin/bash {test_cmd} " f"2>&1 | tee {log_file}")
 
+    ec2_connection.run(f"aws s3 cp ./logs_{suite} {s3_location}/logs_{suite}")
     speedup = read_metric(suite, "geomean.csv")
+    LOGGER.info(f"Seedup = {speedup}")
     comp_time = read_metric(suite, "comp_time.csv")
+    LOGGER.info(f"Compilation Time = {comp_time}")
     memory = read_metric(suite, "memory.csv")
+    LOGGER.info(f"Memory Footprint = {memory}")
     passrate = read_metric(suite, "passrate.csv")
-    upload_metric(instance_type, precision, suite, "Speedup", speedup, "None")
-    upload_metric(instance_type, precision, suite,
+    LOGGER.info(f"Pass Rate = {passrate}")
+    upload_metric(region, instance_type, precision,
+                  suite, "Speedup", speedup, "None")
+    upload_metric(region, instance_type, precision, suite,
                   "CompilationTime", comp_time, "Seconds")
-    upload_metric(instance_type, precision, suite,
+    upload_metric(region, instance_type, precision, suite,
                   "PeakMemoryFootprintCompressionRatio", memory, "None")
-    upload_metric(instance_type, precision, suite,
+    upload_metric(region, instance_type, precision, suite,
                   "PassRate", passrate, "Percent")
 
     ec2_connection.run(f"docker rm -f {container_name}")
-    framework_version = re.search(r"\d+(\.\d+){2}", image_uri).group()
-    s3_location = os.path.join(
-        BENCHMARK_RESULTS_S3_BUCKET, "pytorch", framework_version, "ec2", "inference", instance_type, "py3", log_file,
-    )
-    ec2_connection.run(f"aws s3 cp {log_file} {s3_location}")
+    ec2_connection.run(f"aws s3 cp {log_file} {s3_location}/{log_file}")
     LOGGER.info(f"To retrieve complete benchmark log, check {s3_location}")

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -195,9 +195,9 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     log_file = f"inductor_benchmarks_{instance_type}_{suite}.log"
 
     test_cmd = f"python benchmarks/dynamo/runner.py"
-    f" --suites = {suite}"
+    f" --suites={suite}"
     f" --inference"
-    f" --dtypes = {precision}"
+    f" --dtypes={precision}"
     f" --compilers=inductor"
     f" --output-dir=/root/pytorch/logs_{suite}"
     f" --extra-args=\"--output-directory=./\""

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -240,21 +240,21 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     import subprocess as sp
     sp.run(f"aws s3 cp {s3_location}/logs_{suite} /home/ubuntu/results/ --recursive", shell=True)
     output_list_logs_dir = ec2_connection.run(
-        f"ls -l /home/ubuntu/results/pytorch/logs_{suite}").stdout.split("\n")
+        f"ls -l /home/ubuntu/results/logs_{suite}").stdout.split("\n")
     LOGGER.info(f"CONTENTS OF LOGS DIR============================{output_list_logs_dir}")
     output_list_pytorch = ec2_connection.run(
         f"ls -l /home/ubuntu/results/pytorch").stdout.split("\n")
     LOGGER.info(f"CONTENTS OF PYTORCH DIR========================={output_list_pytorch}")
 
-    speedup = read_metric(f"/home/ubuntu/results/pytorch/logs_{suite}/geomean.csv")
+    speedup = read_metric(f"/home/ubuntu/results/logs_{suite}/geomean.csv")
     LOGGER.info(f"Seedup = {speedup}")
     comp_time = read_metric(
-        f"/home/ubuntu/results/pytorch/logs_{suite}/comp_time.csv")
+        f"/home/ubuntu/results/logs_{suite}/comp_time.csv")
     LOGGER.info(f"Compilation Time = {comp_time}")
-    memory = read_metric(f"/home/ubuntu/results/pytorch/logs_{suite}/memory.csv")
+    memory = read_metric(f"/home/ubuntu/results/logs_{suite}/memory.csv")
     LOGGER.info(f"Memory Footprint = {memory}")
     passrate = read_metric(
-        f"/home/ubuntu/results/pytorch/logs_{suite}/passrate.csv")
+        f"/home/ubuntu/results/logs_{suite}/passrate.csv")
     LOGGER.info(f"Pass Rate = {passrate}")
     upload_metric(region, instance_type, precision,
                   suite, "Speedup", speedup, "None")

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -218,8 +218,8 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
 
     clone_pytorch = (f"git clone --branch v2.0.0 --recursive --single-branch --depth 1 "
                      f"https://github.com/pytorch/pytorch.git")
-    clone_torchbench = "GIT_CURL_VERBOSE=1 git clone --branch main --recursive --single-branch --depth 1 --verbose https://github.com/pytorch/benchmark.git"
-    install_prereq = "pip install -U numpy==1.23"
+    clone_torchbench = "git clone --branch main --recursive --single-branch --depth 1 --verbose https://github.com/pytorch/benchmark.git"
+    install_prereq = "apt-get install dialog apt-utils -y && pip install gitpython numpy==1.23"
     increase_git_buffer_size = "git config --global http.postBuffer 1048576000"
 
     #if is_graviton:

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -157,7 +157,7 @@ def test_performance_ec2_pytorch_inference_graviton(ec2_instance_type, suite, pr
 #@pytest.mark.skip(reason="Hangs indefinitely needs investigation")
 #@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
 #@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
-@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge"], indirect=True)
+@pytest.mark.parametrize("ec2_instance_type", ["g4dn.4xlarge"], indirect=True)
 @pytest.mark.parametrize("suite", ["torchbench"])
 @pytest.mark.parametrize("precision", ["float32"])
 def test_performance_ec2_pytorch_inference_gpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, gpu_only):

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -268,7 +268,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     LOGGER.info(f"Output mkdir ================================\n{mkdir_output}")
     bench_output = ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} "
-        f"--user root bash -cex '{test_cmd}'").stdout.split("\n")
+        f"--user root {test_cmd}").stdout.split("\n")
     LOGGER.info(f"Output benchmark command ================================\n{bench_output}")
 
     s3_cp_output = ec2_connection.run(

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -211,7 +211,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
 
     clone_pytorch = (f"git clone --branch v2.0.0 --recursive --single-branch --depth 1 "
                      f"https://github.com/pytorch/pytorch.git")
-    clone_torchbench = f"git clone --verbose https://github.com/pytorch/benchmark.git"
+    clone_torchbench = f"GIT_CURL_VERBOSE=1 GIT_TRACE=1 git clone --verbose https://github.com/pytorch/benchmark.git"
     install_prereq = f"pip install -U numpy"
 
     #if is_graviton:

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -260,7 +260,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     if suite == "torchbench":
         install_output = ec2_connection.run(
             f"{docker_cmd} exec --workdir=\"/root/benchmark\" {container_name} "
-            f"--user root bash -cex 'python install.py'").stdout.split("\n")
+            f"bash -cex 'python install.py'").stdout.split("\n")
         LOGGER.info(f"Output python install.py ================================\n{install_output}")
     mkdir_output = ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} "
@@ -268,7 +268,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     LOGGER.info(f"Output mkdir ================================\n{mkdir_output}")
     bench_output = ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} "
-        f"--user root {test_cmd}").stdout.split("\n")
+        f"{test_cmd}").stdout.split("\n")
     LOGGER.info(f"Output benchmark command ================================\n{bench_output}")
 
     s3_cp_output = ec2_connection.run(

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -149,22 +149,22 @@ def test_performance_ec2_pytorch_inference_cpu(ec2_instance_type, suite, precisi
 #    )
 #
 #
-#@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
-#@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
-#@pytest.mark.parametrize("precision", ["float32"])
-#def test_performance_ec2_pytorch_inference_gpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, gpu_only):
-#    _, image_framework_version = get_framework_and_version_from_tag(
-#        pytorch_inference)
-#    if Version(image_framework_version) in SpecifierSet("<2.0"):
-#        pytest.skip("skip the test as torch.compile only supported after 2.0")
-#    ec2_performance_pytorch_inference(
-#        pytorch_inference,
-#        ec2_instance_type,
-#        ec2_connection,
-#        region,
-#        suite,
-#        precision,
-#    )
+@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
+@pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
+@pytest.mark.parametrize("precision", ["float32"])
+def test_performance_ec2_pytorch_inference_gpu(ec2_instance_type, suite, precision, pytorch_inference, ec2_connection, region, gpu_only):
+    _, image_framework_version = get_framework_and_version_from_tag(
+        pytorch_inference)
+    if Version(image_framework_version) in SpecifierSet("<2.0"):
+        pytest.skip("skip the test as torch.compile only supported after 2.0")
+    ec2_performance_pytorch_inference(
+        pytorch_inference,
+        ec2_instance_type,
+        ec2_connection,
+        region,
+        suite,
+        precision,
+    )
 
 
 def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, region, suite, precision):

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -194,7 +194,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     ec2_connection.run(f"mkdir -p /home/ubuntu/results")
     log_file = f"inductor_benchmarks_{instance_type}_{suite}.log"
 
-    test_cmd = f"python benchmarks/dynamo/runner.py"
+    test_cmd = (f"python benchmarks/dynamo/runner.py"
     f" --suites={suite}"
     f" --inference"
     f" --dtypes={precision}"
@@ -204,7 +204,7 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     f" --device {device}"
     f" --no-update-archive"
     f" --quick"
-    f" --no-gh-comment 2>&1 | tee {log_file}"
+    f" --no-gh-comment 2>&1 | tee {log_file}")
 
     # Run performance inference command, display benchmark results to console
     framework_version = re.search(r"\d+(\.\d+){2}", image_uri).group()

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -109,7 +109,7 @@ def upload_metric(region, instance_type, precision, suite, metric_name, value, u
     )
 
 
-#@pytest.mark.skip(reason="for testing")
+@pytest.mark.skip(reason="for testing")
 @pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge", "m5.4xlarge"], indirect=True)
 @pytest.mark.parametrize("suite", ["huggingface", "timm", "torchbench"])
 #@pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge"], indirect=True)

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -242,33 +242,33 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
     ).stdout.split("\n")
     LOGGER.info(f"Output docker run ================================\n{docker_run_output}")
     prereq_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
-                                            f"bash -c '{install_prereq}'").stdout.split("\n")
+                                            f"bash -cex '{install_prereq}'").stdout.split("\n")
     LOGGER.info(f"Output install prereq ================================\n{prereq_output}")
     buffersize_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
-                                            f"bash -c '{increase_git_buffer_size}'").stdout.split("\n")
+                                            f"bash -cex '{increase_git_buffer_size}'").stdout.split("\n")
     LOGGER.info(f"Output buffersize ================================\n{buffersize_output}")
     pip_freezee_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
-                                            f"bash -c 'pip freeze'").stdout.split("\n")
+                                            f"bash -cex 'pip freeze'").stdout.split("\n")
     LOGGER.info(f"Output pip freeze ================================\n{pip_freezee_output}")
     #clone_pt_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
-    #                   f"bash -c '{clone_pytorch}'").stdout.split("\n")
+    #                   f"bash -cex '{clone_pytorch}'").stdout.split("\n")
     #LOGGER.info(f"Output clone pytorch ================================\n{clone_pt_output}")
     #if suite == "torchbench":
     #    clone_tb_output = ec2_connection.run(f"{docker_cmd} exec --workdir=\"/root\" {container_name} "
-    #                       f"bash -c '{clone_torchbench}'").stdout.split("\n")
+    #                       f"bash -cex '{clone_torchbench}'").stdout.split("\n")
     #    LOGGER.info(f"Output clone torchbench ================================\n{clone_tb_output}")
     if suite == "torchbench":
         install_output = ec2_connection.run(
             f"{docker_cmd} exec --workdir=\"/root/benchmark\" {container_name} "
-            f"--user root bash -c 'python install.py'").stdout.split("\n")
+            f"--user root bash -cex 'python install.py'").stdout.split("\n")
         LOGGER.info(f"Output python install.py ================================\n{install_output}")
     mkdir_output = ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} "
-        f"bash -c 'mkdir -p /root/pytorch/logs_{suite}'").stdout.split("\n")
+        f"bash -cex 'mkdir -p /root/pytorch/logs_{suite}'").stdout.split("\n")
     LOGGER.info(f"Output mkdir ================================\n{mkdir_output}")
     bench_output = ec2_connection.run(
         f"{docker_cmd} exec --workdir=\"/root/pytorch\" {container_name} "
-        f"--user root bash -c '{test_cmd}'").stdout.split("\n")
+        f"--user root bash -cex '{test_cmd}'").stdout.split("\n")
     LOGGER.info(f"Output benchmark command ================================\n{bench_output}")
 
     s3_cp_output = ec2_connection.run(

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -109,7 +109,7 @@ def upload_metric(region, instance_type, precision, suite, metric_name, value, u
     )
 
 
-@pytest.mark.skip(reason="for testing")
+#@pytest.mark.skip(reason="for testing")
 @pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge", "m5.4xlarge"], indirect=True)
 @pytest.mark.parametrize("suite", ["huggingface", "timm_models", "torchbench"])
 #@pytest.mark.parametrize("ec2_instance_type", ["c5.4xlarge"], indirect=True)
@@ -152,6 +152,7 @@ def test_performance_ec2_pytorch_inference_graviton(ec2_instance_type, suite, pr
     )
 
 
+@pytest.mark.skip(reason="for testing")
 #@pytest.mark.parametrize("ec2_instance_type", ["p3.2xlarge", "g5.4xlarge", "g4dn.4xlarge"], indirect=True)
 #@pytest.mark.parametrize("suite", ["huggingface", "timm_models", "torchbench"])
 @pytest.mark.parametrize("ec2_instance_type", ["g4dn.4xlarge"], indirect=True)

--- a/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
+++ b/test/dlc_tests/benchmark/ec2/pytorch/inference/test_performance_torch_inductor_inference.py
@@ -231,9 +231,12 @@ def ec2_performance_pytorch_inference(image_uri, instance_type, ec2_connection, 
 #        f"{docker_cmd} exec {container_name} "
 #        f"/bin/bash {test_cmd} " f"2>&1 | tee /root/pytorch/logs_{suite}/{log_file}")
 
-    ec2_connection.run(
+    s3_outcome = ec2_connection.run(
         f"aws s3 cp /home/ubuntu/results/pytorch/logs_{suite} {s3_location}/logs_{suite} --recursive")
+    LOGGER.info(f"S3 upload logs============================{s3_outcome}")
 
+    import subprocess as sp
+    sp.run(f"aws s3 cp {s3_location}/logs_{suite} /home/ubuntu/results/ --recursive", shell=True)
     output_list_logs_dir = ec2_connection.run(
         f"ls -l /home/ubuntu/results/pytorch/logs_{suite}").stdout.split("\n")
     LOGGER.info(f"CONTENTS OF LOGS DIR============================{output_list_logs_dir}")

--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -318,6 +318,7 @@ def ec2_instance(
         "ImageId": ec2_instance_ami,
         "InstanceType": ec2_instance_type,
         "IamInstanceProfile": {"Name": ec2_instance_role_name},
+        "UserData": user_data,
         "TagSpecifications": [
             {"ResourceType": "instance", "Tags": [{"Key": "Name", "Value": f"CI-CD {ec2_key_name}"}]},
         ],

--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -311,7 +311,7 @@ def ec2_instance(
     request.addfinalizer(delete_ssh_keypair)
 
     user_data = """#!/bin/bash
-    sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y ec2-instance-connect"""
+    sudo apt-get update -y && sudo apt-get upgrade -y && sudo apt-get install -y ec2-instance-connect"""
 
     params = {
         "KeyName": ec2_key_name,

--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -356,7 +356,7 @@ def ec2_instance(
     ):
         params["BlockDeviceMappings"] = [{"DeviceName": volume_name, "Ebs": {"VolumeSize": 300,},}]
     else:
-        params["BlockDeviceMappings"] = [{"DeviceName": volume_name, "Ebs": {"VolumeSize": 150,},}]
+        params["BlockDeviceMappings"] = [{"DeviceName": volume_name, "Ebs": {"VolumeSize": 500,},}]
 
     # For TRN1 since we are using a private AMI that has some BERT data/tests, have a bifgger volume size
     # Once use DLAMI, this can be removed

--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -310,6 +310,9 @@ def ec2_instance(
 
     request.addfinalizer(delete_ssh_keypair)
 
+    user_data = """#!/bin/bash
+    sudo apt-get update && sudo apt-get upgrade && sudo apt-get install -y ec2-instance-connect"""
+
     params = {
         "KeyName": ec2_key_name,
         "ImageId": ec2_instance_ami,

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -356,7 +356,7 @@ def main():
                 raise Exception(f"EKS cluster {eks_cluster_name} is not in active state")
 
         # Execute dlc_tests pytest command
-        pytest_cmd = ["-s", "-rA", test_path, f"--junitxml={report}", "-n=auto"]
+        pytest_cmd = ["-s", "-rA", test_path, f"--junitxml={report}", "-n=auto", "--duration=0"]
 
         is_habana_image = any("habana" in image_uri for image_uri in all_image_list)
         if specific_test_type == "ec2":

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -356,7 +356,7 @@ def main():
                 raise Exception(f"EKS cluster {eks_cluster_name} is not in active state")
 
         # Execute dlc_tests pytest command
-        pytest_cmd = ["-s", "-rA", test_path, f"--junitxml={report}", "-n=auto", "--duration=0"]
+        pytest_cmd = ["-s", "-rA", test_path, f"--junitxml={report}", "-n=auto", "--durations=0"]
 
         is_habana_image = any("habana" in image_uri for image_uri in all_image_list)
         if specific_test_type == "ec2":


### PR DESCRIPTION
PR builds on https://github.com/aws/deep-learning-containers/pull/2802 to run torch dynamo benchmarks inside inference DLC containers

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`


### Additional context

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### Benchmark Testing Checklist
* When creating a PR:
- [x] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
