### PR TITLE
Update HF TF images to TF 2.11.1

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -41,7 +41,7 @@ build_inference = true
 datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
-do_build = false
+do_build = true
 
 [test]
 ### On by default

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -28,14 +28,14 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch"]
-build_frameworks = []
+build_frameworks = ["huggingface_tensorflow"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
+build_training = false
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = true
+datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true
@@ -58,7 +58,7 @@ sagemaker_local_tests = false
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "off"
+sagemaker_remote_tests = "standard"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -41,7 +41,7 @@ build_inference = true
 datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
-do_build = true
+do_build = false
 
 [test]
 ### On by default

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -38,7 +38,7 @@ build_inference = true
 datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
-do_build = true
+do_build = false
 
 [test]
 ### On by default
@@ -58,7 +58,7 @@ sagemaker_local_tests = false
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "standard"
+sagemaker_remote_tests = "off"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -31,17 +31,17 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch"]
-build_frameworks = ["huggingface_tensorflow"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = false
+build_training = true
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = false
+datetime_tag = true
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
-do_build = false
+do_build = true
 
 [test]
 ### On by default

--- a/huggingface/tensorflow/inference/buildspec.yml
+++ b/huggingface/tensorflow/inference/buildspec.yml
@@ -2,7 +2,7 @@ account_id: &ACCOUNT_ID <set-$ACCOUNT_ID-in-environment>
 region: &REGION <set-$REGION-in-environment>
 base_framework: &BASE_FRAMEWORK tensorflow
 framework: &FRAMEWORK !join [ "huggingface_", *BASE_FRAMEWORK]
-version: &VERSION 2.11.0
+version: &VERSION 2.11.1
 short_version: &SHORT_VERSION 2.11
 contributor: huggingface
 arch_type: x86

--- a/huggingface/tensorflow/inference/docker/2.11/py3/Dockerfile.cpu
+++ b/huggingface/tensorflow/inference/docker/2.11/py3/Dockerfile.cpu
@@ -16,7 +16,7 @@ ARG PYTHON_VERSION=3.9.10
 ARG OPEN_MPI_VERSION=4.1.4
 ARG MAMBA_VERSION=22.9.0-1
 # HF ARGS
-ARG TF_URL=https://framework-binaries.s3.us-west-2.amazonaws.com/tensorflow/r2.11_aws/cpu/2023-03-21-01-32/tensorflow_cpu-2.11.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+ARG TF_URL=https://framework-binaries.s3.us-west-2.amazonaws.com/tensorflow/r2.11_aws/cpu/2023-03-28-20-33/tensorflow_cpu-2.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 ARG TRANSFORMERS_VERSION
 
 ENV DLC_CONTAINER_TYPE=inference

--- a/huggingface/tensorflow/inference/docker/2.11/py3/cu112/Dockerfile.gpu
+++ b/huggingface/tensorflow/inference/docker/2.11/py3/cu112/Dockerfile.gpu
@@ -13,7 +13,7 @@ ARG PYTHON_VERSION=3.9.10
 ARG OPEN_MPI_VERSION=4.1.4
 ARG MAMBA_VERSION=22.9.0-1
 # HF ARGS
-ARG TF_URL=https://framework-binaries.s3.us-west-2.amazonaws.com/tensorflow/r2.11_aws/gpu/2023-03-21-12-35/tensorflow_gpu-2.11.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+ARG TF_URL=https://framework-binaries.s3.us-west-2.amazonaws.com/tensorflow/r2.11_aws/gpu/2023-03-28-20-19/tensorflow_gpu-2.11.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 ARG TRANSFORMERS_VERSION
 
 ENV DLC_CONTAINER_TYPE=inference

--- a/huggingface/tensorflow/inference/docker/2.11/py3/cu112/Dockerfile.gpu.os_scan_allowlist.json
+++ b/huggingface/tensorflow/inference/docker/2.11/py3/cu112/Dockerfile.gpu.os_scan_allowlist.json
@@ -63,6 +63,7 @@
   ],
   "tensorflow-gpu": [
     {
+      "reason_to_ignore": "TF 2.11.1 is noted as a fix version, and this is version 2.11.1. This appears to be an issue with ecr scan reporting."
       "description": "TensorFlow is an open source platform for machine learning. There is out-of-bounds access due to mismatched integer type sizes. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
       "vulnerability_id": "CVE-2023-25671",
       "name": "CVE-2023-25671",

--- a/huggingface/tensorflow/inference/docker/2.11/py3/cu112/Dockerfile.gpu.os_scan_allowlist.json
+++ b/huggingface/tensorflow/inference/docker/2.11/py3/cu112/Dockerfile.gpu.os_scan_allowlist.json
@@ -60,5 +60,1015 @@
       "status": "ACTIVE",
       "title": "IN1-PYTHON-RDFLIB-1324490 - rdflib"
     }
+  ],
+  "tensorflow-gpu": [
+    {
+      "description": "TensorFlow is an open source platform for machine learning. There is out-of-bounds access due to mismatched integer type sizes. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25671",
+      "name": "CVE-2023-25671",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25671",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25671 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS). When the parameter `summarize` of `tf.raw_ops.Print` is zero, the new method `SummarizeArray<bool>` will reference to a nullptr, leading to a seg fault.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\ntf.raw_ops.Print(input =  tf.constant([1, 1, 1, 1],dtype=tf.int32),\r\n                            data =  [[False, False, False, False], [False], [False, False, False]],\r\n                            message =  'tmp/I',\r\n                            first_n = 100,\r\n                            summarize = 0)\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nO",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373003",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373003",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373003",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373003 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, when `ctx->step_containter()` is a null ptr, the Lookup function will be executed with a null pointer. A fix is included in TensorFlow 2.12.0 and 2.11.1.",
+      "vulnerability_id": "CVE-2023-25663",
+      "name": "CVE-2023-25663",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25663",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25663 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Versions prior to 2.12.0 and 2.11.1 have a Floating Point Exception in TensorListSplit with XLA. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25673",
+      "name": "CVE-2023-25673",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25673",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25673 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source machine learning platform. Versions prior to 2.12.0 and 2.11.1 have a null pointer error in RandomShuffle with XLA enabled. A fix is included in TensorFlow 2.12.0 and 2.11.1.",
+      "vulnerability_id": "CVE-2023-25674",
+      "name": "CVE-2023-25674",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25674",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25674 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Versions prior to 2.12.0 and 2.11.1 have a null point error in QuantizedMatMulWithBiasAndDequantize with MKL enabled. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25670",
+      "name": "CVE-2023-25670",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25670",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25670 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS). When running with XLA, `tf.raw_ops.Bincount` segfaults when given a parameter `weights` that is neither the same shape as parameter `arr` nor a length-0 tensor.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\nfunc = tf.raw_ops.Bincount\r\npara={'arr': 6, 'size': 804, 'weights': [52, 351]}\r\n\r\n@tf.function(jit_compile=True)\r\ndef fuzz_jit():\r\n y = func(**para)\r\n return y\r\n\r\nprint(fuzz_jit())\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373027",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373027",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373027",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373027 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to NULL Pointer Dereference due to a null pointer error in `RandomShuffle` with `XLA` enabled.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\nfunc = tf.raw_ops.RandomShuffle\r\npara = {'value': 1e+20, 'seed': -4294967297, 'seed2': -2147483649}\r\n\r\n@tf.function(jit_compile=True)\r\ndef test():\r\n   y = func(**para)\r\n   return y\r\n\r\ntest()\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/728113a3be690facad6ce436660a0bc1858017fa)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373039",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373039",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373039",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373039 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Attackers using Tensorflow prior to 2.12.0 or 2.11.1 can access heap memory which is not in the control of user, leading to a crash or remote code execution. The fix will be included in TensorFlow version 2.12.0 and will also cherrypick this commit on TensorFlow version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25668",
+      "name": "CVE-2023-25668",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25668",
+      "source": "NVD",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25668 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Versions prior to 2.12.0 and 2.11.1 are vulnerable to integer overflow in EditDistance. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25662",
+      "name": "CVE-2023-25662",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25662",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25662 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. The function `tf.raw_ops.LookupTableImportV2` cannot handle scalars in the `values` parameter and gives an NPE. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25672",
+      "name": "CVE-2023-25672",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25672",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25672 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to NULL Pointer Dereference. When `ctx->step_containter()` is a null ptr, the `Lookup` function will be executed with a null pointer.\n## PoC\n```\r\nimport tensorflow as tf\r\ntf.raw_ops.TensorArrayConcatV2(handle=['a', 'b'], flow_in = 0.1, dtype=tf.int32, element_shape_except0=1)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/239139d2ae6a81ae9ba499ad78b56d9b2931538a)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373006",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373006",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373006",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373006 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, when the parameter `summarize` of `tf.raw_ops.Print` is zero, the new method `SummarizeArray<bool>` will reference to a nullptr, leading to a seg fault. A fix is included in TensorFlow version 2.12 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25660",
+      "name": "CVE-2023-25660",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25660",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25660 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, integer overflow occurs when `2^31 <= num_frames * height * width * channels < 2^32`, for example Full HD screencast of at least 346 frames. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25667",
+      "name": "CVE-2023-25667",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25667",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25667 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS) due to a floating point exception if the stride and window size are not positive for `tf.raw_ops.AvgPoolGrad`.\n## PoC\n```\r\nimport tensorflow as tf\r\nimport numpy as np\r\n\r\n@tf.function(jit_compile=True)\r\ndef test():\r\n   y = tf.raw_ops.AvgPoolGrad(orig_input_shape=[1,0,0,0], grad=[[[[0.39117979]]]], ksize=[1,0,0,0], strides=[1,0,0,0], padding=\"SAME\", data_format=\"NCHW\")\r\n   return y\r\n\r\nprint(test())\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack tha",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373009",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373009",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373009",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373009 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, an out of bounds read is in GRUBlockCellGrad. A fix is included in TensorFlow 2.12.0 and 2.11.1.",
+      "vulnerability_id": "CVE-2023-25658",
+      "name": "CVE-2023-25658",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25658",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25658 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, when `SparseSparseMaximum` is given invalid sparse tensors as inputs, it can give a null pointer error. A fix is included in TensorFlow version 2.12 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25665",
+      "name": "CVE-2023-25665",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25665",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25665 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to NULL Pointer Dereference when `SparseSparseMaximum` is given invalid sparse tensors as inputs.\n## PoC\n```\r\nimport tensorflow as tf\r\ntf.raw_ops.SparseSparseMaximum(\r\n a_indices=[[1]],\r\n a_values =[ 0.1 ],\r\n a_shape = [2],\r\n b_indices=[[]],\r\n b_values =[2 ],\r\n b_shape = [2],\r\n)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/5e0ecfb42f5f65629fd7a4edd6c4afe7ff0feb04)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3372986",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3372986",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3372986",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3372986 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Out-of-bounds Read if the parameter `indices` for `DynamicStitch` does not match the shape of the parameter `data`.\n## PoC\n```\r\nimport tensorflow as tf\r\nfunc = tf.raw_ops.DynamicStitch\r\npara={'indices': [[0xdeadbeef], [405], [519], [758], [1015]], 'data': [[110.27793884277344], [120.29475402832031], [157.2418212890625], [157.2626953125], [188.45382690429688]]}\r\ny = func(**para)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/ee004b18b976eeb5a758020af8880236cd707d05)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3372991",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3372991",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3372991",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3372991 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Double Free. The `nn_ops.fractional_avg_pool_v2` and `nn_ops.fractional_max_pool_v2` functions require the first and fourth elements of their parameter `pooling_ratio` to be equal to 1.0, as pooling on batch and channel dimensions is not supported.\n## PoC\n```\r\nimport tensorflow as tf\r\nimport os\r\nimport numpy as np\r\nfrom tensorflow.python.ops import nn_ops\r\ntry:\r\n  arg_0_tensor = tf.random.uniform([3, 30, 50, 3], dtype=tf.float64)\r\n  arg_0 = tf.identity(arg_0_tensor)\r\n  arg_1_0 = 2\r\n  arg_1_1 = 3\r\n  arg_1_2 = 1\r\n  arg_1_3 = 1\r\n  arg_1 = [arg_1_0,arg_1_1,arg_1_2,arg_1_3,]\r\n  arg_2 = True\r\n  arg_3 = True\r\n  seed = 341261001\r\n  out = nn_ops.fractional_avg_pool_v2(arg_0,arg_1,arg_2,arg_3,seed=seed,)\r\nexcept Exception as e:\r\n  print(\"Error:\"+str(e))\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://gith",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373000",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373000",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 8,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373000",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373000 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Integer Overflow to Buffer Overflow when `2^31 <= num_frames * height * width * channels < 2^32`, for example Full HD screencast of at least 346 frames.\n## PoC\n```\r\nimport urllib.request\r\ndat = urllib.request.urlopen('https://raw.githubusercontent.com/tensorflow/tensorflow/1c38ad9b78ffe06076745a1ee00cec42f39ff726/tensorflow/core/lib/gif/testdata/3g_multiframe.gif').read()\r\nimport tensorflow as tf\r\ntf.io.decode_gif(dat)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/8dc723fcdd1a6127d6c970bd2ecb18b019a1a58d)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373018",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373018",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373018",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373018 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Integer Overflow or Wraparound in `EditDistance`. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.\n## PoC\n```\r\nimport tensorflow as tf\r\npara={\r\n    'hypothesis_indices': [[]],\r\n    'hypothesis_values': ['tmp/'],\r\n    'hypothesis_shape': [],\r\n    'truth_indices': [[]],\r\n    'truth_values': [''],\r\n    'truth_shape': [],\r\n    'normalize': False\r\n    }\r\ntf.raw_ops.EditDistance(**para)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/08b8e18643d6dcde00890733b270ff8d9960c56c)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373015",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373015",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.3,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.3,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373015",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373015 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS) due to a floating point exception in `AudioSpectrogram`.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\npara = {'input': tf.constant([[14.], [24.]], dtype=tf.float32), 'window_size': 1, 'stride': 0, 'magnitude_squared': False}\r\nfunc = tf.raw_ops.AudioSpectrogram\r\n\r\n@tf.function(jit_compile=True)\r\ndef fuzz_jit():\r\n   y = func(**para)\r\n   return y\r\n\r\nfuzz_jit()\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3372994",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3372994",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3372994",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3372994 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS) when running with XLA, `tf.raw_ops.ParallelConcat` segfaults with a nullptr dereference when given a parameter `shape` with rank that is not greater than zero.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\nfunc = tf.raw_ops.ParallelConcat\r\npara = {'shape':  0, 'values': [1]}\r\n\r\n@tf.function(jit_compile=True)\r\ndef test():\r\n   y = func(**para)\r\n   return y\r\n\r\ntest()\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the ",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373042",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373042",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373042",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373042 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, there is a floating point exception in AudioSpectrogram. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25666",
+      "name": "CVE-2023-25666",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25666",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25666 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Incorrect Comparison. Constructing a `tflite` model with a paramater `filter_input_channel` of less than 1 gives a float pointer exception.\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/34f8368c535253f5c9cb3a303297743b62442aaa)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373030",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373030",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373030",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373030 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Out-of-Bounds due to mismatched integer type sizes in `ValueMap::Manager::GetValueOrCreatePlaceholder`, because there is a bug with the `tfg-translate` call to `InitMlir`.\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/2eedc8f676d2c3b8be9492e547b2bc814c10b367)\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/760322a71ac9033e122ef1f4b1c62813021e5938)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373012",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373012",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373012",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373012 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, if the parameter `indices` for `DynamicStitch` does not match the shape of the parameter `data`, it can trigger an stack OOB read. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25659",
+      "name": "CVE-2023-25659",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25659",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25659 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Heap-based Buffer Overflow. Attackers can access heap memory which is not in the control of user, leading to a crash or remote code execution. The fix will be included in TensorFlow version 2.12.0 and will also cherrypick this commit on TensorFlow version 2.11.1.\n## PoC\n```\r\nimport tensorflow as tf\r\n@tf.function\r\ndef test():\r\n    tf.raw_ops.QuantizeAndDequantizeV2(input=[2.5],\r\n    \t\t\t\t\t\t\t\t   input_min=[1.0],\r\n    \t\t\t\t\t\t\t\t   input_max=[10.0],\r\n    \t\t\t\t\t\t\t\t   signed_input=True,\r\n    \t\t\t\t\t\t\t\t   num_bits=1,\r\n    \t\t\t\t\t\t\t\t   range_given=True,\r\n    \t\t\t\t\t\t\t\t   round_mode='HALF_TO_EVEN',\r\n    \t\t\t\t\t\t\t\t   narrow_range=True,\r\n    \t\t\t\t\t\t\t\t   axis=0x7fffffff)\r\ntest()\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/7b174a0f2e40ff3f3aa957aecddfd5aaae35eccb)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373021",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373021",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373021",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373021 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Buffer Overflow in `TAvgPoolGrad`.\n## PoC\n```\r\nimport os\r\nos.environ['TF_ENABLE_ONEDNN_OPTS'] = '0'\r\nimport tensorflow as tf\r\nprint(tf.__version__)\r\nwith tf.device(\"CPU\"):\r\n    ksize = [1, 40, 128, 1]\r\n    strides = [1, 128, 128, 30]\r\n    padding = \"SAME\"\r\n    data_format = \"NHWC\"\r\n    orig_input_shape = [11, 9, 78, 9]\r\n    grad = tf.saturate_cast(tf.random.uniform([16, 16, 16, 16], minval=-128, maxval=129, dtype=tf.int64), dtype=tf.float32)\r\n    res = tf.raw_ops.AvgPoolGrad(\r\n        ksize=ksize,\r\n        strides=strides,\r\n        padding=padding,\r\n        data_format=data_format,\r\n        orig_input_shape=orig_input_shape,\r\n        grad=grad,\r\n    )\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/ddaac2bdd099bec5d7923dea45276a7558217e5b)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373025",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373025",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373025",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373025 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, if the stride and window size are not positive for `tf.raw_ops.AvgPoolGrad`, it can give a floating point exception. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25669",
+      "name": "CVE-2023-25669",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25669",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25669 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an end-to-end open source platform for machine learning. Constructing a tflite model with a paramater `filter_input_channel` of less than 1 gives a FPE. This issue has been patched in version 2.12. TensorFlow will also cherrypick the fix commit on TensorFlow 2.11.1.",
+      "vulnerability_id": "CVE-2023-27579",
+      "name": "CVE-2023-27579",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27579",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-27579 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS) due to a floating point exception in `TensorListSplit` with `XLA`.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\nfunc = tf.raw_ops.TensorListSplit\r\npara = {'tensor': [1], 'element_shape': -1, 'lengths': [0]}\r\n\r\n@tf.function(jit_compile=True)\r\ndef fuzz_jit():\r\n y = func(**para)\r\n return y\r\n\r\nprint(fuzz_jit())\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many ",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373036",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373036",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373036",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373036 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Out-of-bounds Read in `GRUBlockCellGrad`.\n## PoC\n```\r\nfunc = tf.raw_ops.GRUBlockCellGrad\r\n\r\npara = {'x': [[21.1, 156.2], [83.3, 115.4]], 'h_prev': array([[136.5],\r\n      [136.6]]), 'w_ru': array([[26.7,  0.8],\r\n      [47.9, 26.1],\r\n      [26.2, 26.3]]), 'w_c': array([[ 0.4],\r\n      [31.5],\r\n      [ 0.6]]), 'b_ru': array([0.1, 0.2 ], dtype=float32), 'b_c': 0x41414141, 'r': array([[0.3],\r\n      [0.4]], dtype=float32), 'u': array([[5.7],\r\n      [5.8]]), 'c': array([[52.9],\r\n      [53.1]]), 'd_h': array([[172.2],\r\n      [188.3 ]])}\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/ff459137c2716a2a60f7d441b855fcb466d778cb)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3372988",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3372988",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3372988",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3372988 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, there is a heap buffer overflow in TAvgPoolGrad. A fix is included in TensorFlow 2.12.0 and 2.11.1.",
+      "vulnerability_id": "CVE-2023-25664",
+      "name": "CVE-2023-25664",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25664",
+      "source": "NVD",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25664 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to NULL Pointer Dereference. The function `tf.raw_ops.LookupTableImportV2` cannot handle scalars in the `values` parameter and gives a null pointer exception.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\nv = tf.Variable(1)\r\n\r\n@tf.function(jit_compile=True)\r\ndef test():\r\n   func = tf.raw_ops.LookupTableImportV2\r\n   para={'table_handle': v.handle,'keys': [62.98910140991211, 94.36528015136719], 'values': -919}\r\n\r\n   y = func(**para)\r\n   return y\r\n\r\nprint(test())\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/980b22536abcbbe1b4a5642fc940af33d8c19b69)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373033",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373033",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373033",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373033 - tensorflow-gpu"
+    }
   ]
 }

--- a/huggingface/tensorflow/inference/docker/2.11/py3/cu112/Dockerfile.gpu.os_scan_allowlist.json
+++ b/huggingface/tensorflow/inference/docker/2.11/py3/cu112/Dockerfile.gpu.os_scan_allowlist.json
@@ -1,7 +1,7 @@
 {
   "libzmq5": [
     {
-      "reason_to_ignore": "The current version is marked as a fix version in the CVE notes, and this is the latest version.",
+      "reason_to_ignore": "Version is passed the fix version from vendor",
       "description": "\n It was discovered that ZeroMQ incorrectly handled certain application metadata.\n A remote attacker could use this issue to cause ZeroMQ to crash, or possibly\n execute arbitrary code.",
       "vulnerability_id": "CVE-2019-13132",
       "name": "CVE-2019-13132",
@@ -30,180 +30,9 @@
       "title": "CVE-2019-13132 - libzmq5"
     }
   ],
-  "rdflib": [
-    {
-      "reason_to_ignore": "This is the latest version of the package.",
-      "description": "## Overview\n[rdflib](https://pypi.org/project/rdflib/) is a Python library for working with RDF, a simple yet powerful language for representing information.\nAffected versions of this package are vulnerable to Server-Side Request Forgery (SSRF). `rdflib` provides no way to control how external references are resolved, nor a way to implement caching of external resources.\r\n\r\nIf a web service takes `POST`ed `JSON-LD` data, `rdflib` will attempt to resolve any URL in the `@context`.\r\nThis can lead to:\r\n1. attackers being able to probe internal networks, by having `rdflib` request potential non-public URLs\r\n2. reflection attacks, if the same or slightly-different URLs are repeated multiple times in the `@context`\r\n3. resource exhaustion, as the entire remote file is loaded into memory before JSON parsing is attempted\r\n4. Denial of Service, if web or task workers are tied up waiting for extended periods for HTTP requests to complete\r\n5. attackers being able to probe the local filesystem using `file://` URLs\n## Rem",
-      "vulnerability_id": "SNYK-PYTHON-RDFLIB-1324490",
-      "name": "SNYK-PYTHON-RDFLIB-1324490",
-      "package_name": "rdflib",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/rdflib-6.3.1.dist-info/METADATA",
-        "name": "rdflib",
-        "package_manager": "PYTHONPKG",
-        "version": "6.3.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 8.6,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 8.6,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-RDFLIB-1324490",
-      "source": "SNYK",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "IN1-PYTHON-RDFLIB-1324490 - rdflib"
-    }
-  ],
   "tensorflow-gpu": [
     {
-      "reason_to_ignore": "TF 2.11.1 is noted as a fix version, and this is version 2.11.1. This appears to be an issue with ecr scan reporting."
-      "description": "TensorFlow is an open source platform for machine learning. There is out-of-bounds access due to mismatched integer type sizes. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
-      "vulnerability_id": "CVE-2023-25671",
-      "name": "CVE-2023-25671",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25671",
-      "source": "NVD",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2023-25671 - tensorflow-gpu"
-    },
-    {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS). When the parameter `summarize` of `tf.raw_ops.Print` is zero, the new method `SummarizeArray<bool>` will reference to a nullptr, leading to a seg fault.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\ntf.raw_ops.Print(input =  tf.constant([1, 1, 1, 1],dtype=tf.int32),\r\n                            data =  [[False, False, False, False], [False], [False, False, False]],\r\n                            message =  'tmp/I',\r\n                            first_n = 100,\r\n                            summarize = 0)\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nO",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373003",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373003",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373003",
-      "source": "SNYK",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3373003 - tensorflow-gpu"
-    },
-    {
-      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, when `ctx->step_containter()` is a null ptr, the Lookup function will be executed with a null pointer. A fix is included in TensorFlow 2.12.0 and 2.11.1.",
-      "vulnerability_id": "CVE-2023-25663",
-      "name": "CVE-2023-25663",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25663",
-      "source": "NVD",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2023-25663 - tensorflow-gpu"
-    },
-    {
-      "description": "TensorFlow is an open source platform for machine learning. Versions prior to 2.12.0 and 2.11.1 have a Floating Point Exception in TensorListSplit with XLA. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
-      "vulnerability_id": "CVE-2023-25673",
-      "name": "CVE-2023-25673",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25673",
-      "source": "NVD",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2023-25673 - tensorflow-gpu"
-    },
-    {
-      "description": "TensorFlow is an open source machine learning platform. Versions prior to 2.12.0 and 2.11.1 have a null pointer error in RandomShuffle with XLA enabled. A fix is included in TensorFlow 2.12.0 and 2.11.1.",
-      "vulnerability_id": "CVE-2023-25674",
-      "name": "CVE-2023-25674",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25674",
-      "source": "NVD",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2023-25674 - tensorflow-gpu"
-    },
-    {
+      "reason_to_ignore": "Already at latest patch version of TF 2.11",
       "description": "TensorFlow is an open source platform for machine learning. Versions prior to 2.12.0 and 2.11.1 have a null point error in QuantizedMatMulWithBiasAndDequantize with MKL enabled. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
       "vulnerability_id": "CVE-2023-25670",
       "name": "CVE-2023-25670",
@@ -232,9 +61,9 @@
       "title": "CVE-2023-25670 - tensorflow-gpu"
     },
     {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS). When running with XLA, `tf.raw_ops.Bincount` segfaults when given a parameter `weights` that is neither the same shape as parameter `arr` nor a length-0 tensor.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\nfunc = tf.raw_ops.Bincount\r\npara={'arr': 6, 'size': 804, 'weights': [52, 351]}\r\n\r\n@tf.function(jit_compile=True)\r\ndef fuzz_jit():\r\n y = func(**para)\r\n return y\r\n\r\nprint(fuzz_jit())\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373027",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373027",
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to NULL Pointer Dereference. The function `tf.raw_ops.LookupTableImportV2` cannot handle scalars in the `values` parameter and gives a null pointer exception.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\nv = tf.Variable(1)\r\n\r\n@tf.function(jit_compile=True)\r\ndef test():\r\n   func = tf.raw_ops.LookupTableImportV2\r\n   para={'table_handle': v.handle,'keys': [62.98910140991211, 94.36528015136719], 'values': -919}\r\n\r\n   y = func(**para)\r\n   return y\r\n\r\nprint(test())\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/980b22536abcbbe1b4a5642fc940af33d8c19b69)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373033",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373033",
       "package_name": "tensorflow-gpu",
       "package_details": {
         "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
@@ -253,11 +82,11 @@
       "cvss_v31_score": 7.5,
       "cvss_v2_score": 0,
       "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373027",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373033",
       "source": "SNYK",
       "severity": "HIGH",
       "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3373027 - tensorflow-gpu"
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373033 - tensorflow-gpu"
     },
     {
       "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to NULL Pointer Dereference due to a null pointer error in `RandomShuffle` with `XLA` enabled.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\nfunc = tf.raw_ops.RandomShuffle\r\npara = {'value': 1e+20, 'seed': -4294967297, 'seed2': -2147483649}\r\n\r\n@tf.function(jit_compile=True)\r\ndef test():\r\n   y = func(**para)\r\n   return y\r\n\r\ntest()\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/728113a3be690facad6ce436660a0bc1858017fa)",
@@ -288,202 +117,6 @@
       "title": "IN1-PYTHON-TENSORFLOWGPU-3373039 - tensorflow-gpu"
     },
     {
-      "description": "TensorFlow is an open source platform for machine learning. Attackers using Tensorflow prior to 2.12.0 or 2.11.1 can access heap memory which is not in the control of user, leading to a crash or remote code execution. The fix will be included in TensorFlow version 2.12.0 and will also cherrypick this commit on TensorFlow version 2.11.1.",
-      "vulnerability_id": "CVE-2023-25668",
-      "name": "CVE-2023-25668",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 9.8,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 9.8,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "CRITICAL",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25668",
-      "source": "NVD",
-      "severity": "CRITICAL",
-      "status": "ACTIVE",
-      "title": "CVE-2023-25668 - tensorflow-gpu"
-    },
-    {
-      "description": "TensorFlow is an open source platform for machine learning. Versions prior to 2.12.0 and 2.11.1 are vulnerable to integer overflow in EditDistance. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
-      "vulnerability_id": "CVE-2023-25662",
-      "name": "CVE-2023-25662",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25662",
-      "source": "NVD",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2023-25662 - tensorflow-gpu"
-    },
-    {
-      "description": "TensorFlow is an open source platform for machine learning. The function `tf.raw_ops.LookupTableImportV2` cannot handle scalars in the `values` parameter and gives an NPE. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
-      "vulnerability_id": "CVE-2023-25672",
-      "name": "CVE-2023-25672",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25672",
-      "source": "NVD",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2023-25672 - tensorflow-gpu"
-    },
-    {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to NULL Pointer Dereference. When `ctx->step_containter()` is a null ptr, the `Lookup` function will be executed with a null pointer.\n## PoC\n```\r\nimport tensorflow as tf\r\ntf.raw_ops.TensorArrayConcatV2(handle=['a', 'b'], flow_in = 0.1, dtype=tf.int32, element_shape_except0=1)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/239139d2ae6a81ae9ba499ad78b56d9b2931538a)",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373006",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373006",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373006",
-      "source": "SNYK",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3373006 - tensorflow-gpu"
-    },
-    {
-      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, when the parameter `summarize` of `tf.raw_ops.Print` is zero, the new method `SummarizeArray<bool>` will reference to a nullptr, leading to a seg fault. A fix is included in TensorFlow version 2.12 and version 2.11.1.",
-      "vulnerability_id": "CVE-2023-25660",
-      "name": "CVE-2023-25660",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25660",
-      "source": "NVD",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2023-25660 - tensorflow-gpu"
-    },
-    {
-      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, integer overflow occurs when `2^31 <= num_frames * height * width * channels < 2^32`, for example Full HD screencast of at least 346 frames. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
-      "vulnerability_id": "CVE-2023-25667",
-      "name": "CVE-2023-25667",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25667",
-      "source": "NVD",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2023-25667 - tensorflow-gpu"
-    },
-    {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS) due to a floating point exception if the stride and window size are not positive for `tf.raw_ops.AvgPoolGrad`.\n## PoC\n```\r\nimport tensorflow as tf\r\nimport numpy as np\r\n\r\n@tf.function(jit_compile=True)\r\ndef test():\r\n   y = tf.raw_ops.AvgPoolGrad(orig_input_shape=[1,0,0,0], grad=[[[[0.39117979]]]], ksize=[1,0,0,0], strides=[1,0,0,0], padding=\"SAME\", data_format=\"NCHW\")\r\n   return y\r\n\r\nprint(test())\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack tha",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373009",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373009",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373009",
-      "source": "SNYK",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3373009 - tensorflow-gpu"
-    },
-    {
       "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, an out of bounds read is in GRUBlockCellGrad. A fix is included in TensorFlow 2.12.0 and 2.11.1.",
       "vulnerability_id": "CVE-2023-25658",
       "name": "CVE-2023-25658",
@@ -510,342 +143,6 @@
       "severity": "HIGH",
       "status": "ACTIVE",
       "title": "CVE-2023-25658 - tensorflow-gpu"
-    },
-    {
-      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, when `SparseSparseMaximum` is given invalid sparse tensors as inputs, it can give a null pointer error. A fix is included in TensorFlow version 2.12 and version 2.11.1.",
-      "vulnerability_id": "CVE-2023-25665",
-      "name": "CVE-2023-25665",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25665",
-      "source": "NVD",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2023-25665 - tensorflow-gpu"
-    },
-    {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to NULL Pointer Dereference when `SparseSparseMaximum` is given invalid sparse tensors as inputs.\n## PoC\n```\r\nimport tensorflow as tf\r\ntf.raw_ops.SparseSparseMaximum(\r\n a_indices=[[1]],\r\n a_values =[ 0.1 ],\r\n a_shape = [2],\r\n b_indices=[[]],\r\n b_values =[2 ],\r\n b_shape = [2],\r\n)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/5e0ecfb42f5f65629fd7a4edd6c4afe7ff0feb04)",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3372986",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3372986",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3372986",
-      "source": "SNYK",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3372986 - tensorflow-gpu"
-    },
-    {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Out-of-bounds Read if the parameter `indices` for `DynamicStitch` does not match the shape of the parameter `data`.\n## PoC\n```\r\nimport tensorflow as tf\r\nfunc = tf.raw_ops.DynamicStitch\r\npara={'indices': [[0xdeadbeef], [405], [519], [758], [1015]], 'data': [[110.27793884277344], [120.29475402832031], [157.2418212890625], [157.2626953125], [188.45382690429688]]}\r\ny = func(**para)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/ee004b18b976eeb5a758020af8880236cd707d05)",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3372991",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3372991",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3372991",
-      "source": "SNYK",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3372991 - tensorflow-gpu"
-    },
-    {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Double Free. The `nn_ops.fractional_avg_pool_v2` and `nn_ops.fractional_max_pool_v2` functions require the first and fourth elements of their parameter `pooling_ratio` to be equal to 1.0, as pooling on batch and channel dimensions is not supported.\n## PoC\n```\r\nimport tensorflow as tf\r\nimport os\r\nimport numpy as np\r\nfrom tensorflow.python.ops import nn_ops\r\ntry:\r\n  arg_0_tensor = tf.random.uniform([3, 30, 50, 3], dtype=tf.float64)\r\n  arg_0 = tf.identity(arg_0_tensor)\r\n  arg_1_0 = 2\r\n  arg_1_1 = 3\r\n  arg_1_2 = 1\r\n  arg_1_3 = 1\r\n  arg_1 = [arg_1_0,arg_1_1,arg_1_2,arg_1_3,]\r\n  arg_2 = True\r\n  arg_3 = True\r\n  seed = 341261001\r\n  out = nn_ops.fractional_avg_pool_v2(arg_0,arg_1,arg_2,arg_3,seed=seed,)\r\nexcept Exception as e:\r\n  print(\"Error:\"+str(e))\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://gith",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373000",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373000",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 8,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 8,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373000",
-      "source": "SNYK",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3373000 - tensorflow-gpu"
-    },
-    {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Integer Overflow to Buffer Overflow when `2^31 <= num_frames * height * width * channels < 2^32`, for example Full HD screencast of at least 346 frames.\n## PoC\n```\r\nimport urllib.request\r\ndat = urllib.request.urlopen('https://raw.githubusercontent.com/tensorflow/tensorflow/1c38ad9b78ffe06076745a1ee00cec42f39ff726/tensorflow/core/lib/gif/testdata/3g_multiframe.gif').read()\r\nimport tensorflow as tf\r\ntf.io.decode_gif(dat)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/8dc723fcdd1a6127d6c970bd2ecb18b019a1a58d)",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373018",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373018",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373018",
-      "source": "SNYK",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3373018 - tensorflow-gpu"
-    },
-    {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Integer Overflow or Wraparound in `EditDistance`. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.\n## PoC\n```\r\nimport tensorflow as tf\r\npara={\r\n    'hypothesis_indices': [[]],\r\n    'hypothesis_values': ['tmp/'],\r\n    'hypothesis_shape': [],\r\n    'truth_indices': [[]],\r\n    'truth_values': [''],\r\n    'truth_shape': [],\r\n    'normalize': False\r\n    }\r\ntf.raw_ops.EditDistance(**para)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/08b8e18643d6dcde00890733b270ff8d9960c56c)",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373015",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373015",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.3,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.3,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373015",
-      "source": "SNYK",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3373015 - tensorflow-gpu"
-    },
-    {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS) due to a floating point exception in `AudioSpectrogram`.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\npara = {'input': tf.constant([[14.], [24.]], dtype=tf.float32), 'window_size': 1, 'stride': 0, 'magnitude_squared': False}\r\nfunc = tf.raw_ops.AudioSpectrogram\r\n\r\n@tf.function(jit_compile=True)\r\ndef fuzz_jit():\r\n   y = func(**para)\r\n   return y\r\n\r\nfuzz_jit()\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3372994",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3372994",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3372994",
-      "source": "SNYK",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3372994 - tensorflow-gpu"
-    },
-    {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS) when running with XLA, `tf.raw_ops.ParallelConcat` segfaults with a nullptr dereference when given a parameter `shape` with rank that is not greater than zero.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\nfunc = tf.raw_ops.ParallelConcat\r\npara = {'shape':  0, 'values': [1]}\r\n\r\n@tf.function(jit_compile=True)\r\ndef test():\r\n   y = func(**para)\r\n   return y\r\n\r\ntest()\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the ",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373042",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373042",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373042",
-      "source": "SNYK",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3373042 - tensorflow-gpu"
-    },
-    {
-      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, there is a floating point exception in AudioSpectrogram. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
-      "vulnerability_id": "CVE-2023-25666",
-      "name": "CVE-2023-25666",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25666",
-      "source": "NVD",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2023-25666 - tensorflow-gpu"
-    },
-    {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Incorrect Comparison. Constructing a `tflite` model with a paramater `filter_input_channel` of less than 1 gives a float pointer exception.\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/34f8368c535253f5c9cb3a303297743b62442aaa)",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373030",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373030",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373030",
-      "source": "SNYK",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3373030 - tensorflow-gpu"
-    },
-    {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Out-of-Bounds due to mismatched integer type sizes in `ValueMap::Manager::GetValueOrCreatePlaceholder`, because there is a bug with the `tfg-translate` call to `InitMlir`.\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/2eedc8f676d2c3b8be9492e547b2bc814c10b367)\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/760322a71ac9033e122ef1f4b1c62813021e5938)",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373012",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373012",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373012",
-      "source": "SNYK",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3373012 - tensorflow-gpu"
-    },
-    {
-      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, if the parameter `indices` for `DynamicStitch` does not match the shape of the parameter `data`, it can trigger an stack OOB read. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
-      "vulnerability_id": "CVE-2023-25659",
-      "name": "CVE-2023-25659",
-      "package_name": "tensorflow-gpu",
-      "package_details": {
-        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
-        "name": "tensorflow-gpu",
-        "package_manager": "PYTHONPKG",
-        "version": "2.11.1",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25659",
-      "source": "NVD",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2023-25659 - tensorflow-gpu"
     },
     {
       "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Heap-based Buffer Overflow. Attackers can access heap memory which is not in the control of user, leading to a crash or remote code execution. The fix will be included in TensorFlow version 2.12.0 and will also cherrypick this commit on TensorFlow version 2.11.1.\n## PoC\n```\r\nimport tensorflow as tf\r\n@tf.function\r\ndef test():\r\n    tf.raw_ops.QuantizeAndDequantizeV2(input=[2.5],\r\n    \t\t\t\t\t\t\t\t   input_min=[1.0],\r\n    \t\t\t\t\t\t\t\t   input_max=[10.0],\r\n    \t\t\t\t\t\t\t\t   signed_input=True,\r\n    \t\t\t\t\t\t\t\t   num_bits=1,\r\n    \t\t\t\t\t\t\t\t   range_given=True,\r\n    \t\t\t\t\t\t\t\t   round_mode='HALF_TO_EVEN',\r\n    \t\t\t\t\t\t\t\t   narrow_range=True,\r\n    \t\t\t\t\t\t\t\t   axis=0x7fffffff)\r\ntest()\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/7b174a0f2e40ff3f3aa957aecddfd5aaae35eccb)",
@@ -876,9 +173,9 @@
       "title": "IN1-PYTHON-TENSORFLOWGPU-3373021 - tensorflow-gpu"
     },
     {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Buffer Overflow in `TAvgPoolGrad`.\n## PoC\n```\r\nimport os\r\nos.environ['TF_ENABLE_ONEDNN_OPTS'] = '0'\r\nimport tensorflow as tf\r\nprint(tf.__version__)\r\nwith tf.device(\"CPU\"):\r\n    ksize = [1, 40, 128, 1]\r\n    strides = [1, 128, 128, 30]\r\n    padding = \"SAME\"\r\n    data_format = \"NHWC\"\r\n    orig_input_shape = [11, 9, 78, 9]\r\n    grad = tf.saturate_cast(tf.random.uniform([16, 16, 16, 16], minval=-128, maxval=129, dtype=tf.int64), dtype=tf.float32)\r\n    res = tf.raw_ops.AvgPoolGrad(\r\n        ksize=ksize,\r\n        strides=strides,\r\n        padding=padding,\r\n        data_format=data_format,\r\n        orig_input_shape=orig_input_shape,\r\n        grad=grad,\r\n    )\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/ddaac2bdd099bec5d7923dea45276a7558217e5b)",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373025",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373025",
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, when the parameter `summarize` of `tf.raw_ops.Print` is zero, the new method `SummarizeArray<bool>` will reference to a nullptr, leading to a seg fault. A fix is included in TensorFlow version 2.12 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25660",
+      "name": "CVE-2023-25660",
       "package_name": "tensorflow-gpu",
       "package_details": {
         "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
@@ -897,11 +194,235 @@
       "cvss_v31_score": 7.5,
       "cvss_v2_score": 0,
       "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373025",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25660",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25660 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS). When running with XLA, `tf.raw_ops.Bincount` segfaults when given a parameter `weights` that is neither the same shape as parameter `arr` nor a length-0 tensor.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\nfunc = tf.raw_ops.Bincount\r\npara={'arr': 6, 'size': 804, 'weights': [52, 351]}\r\n\r\n@tf.function(jit_compile=True)\r\ndef fuzz_jit():\r\n y = func(**para)\r\n return y\r\n\r\nprint(fuzz_jit())\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373027",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373027",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373027",
       "source": "SNYK",
       "severity": "HIGH",
       "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3373025 - tensorflow-gpu"
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373027 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS) when running with XLA, `tf.raw_ops.ParallelConcat` segfaults with a nullptr dereference when given a parameter `shape` with rank that is not greater than zero.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\nfunc = tf.raw_ops.ParallelConcat\r\npara = {'shape':  0, 'values': [1]}\r\n\r\n@tf.function(jit_compile=True)\r\ndef test():\r\n   y = func(**para)\r\n   return y\r\n\r\ntest()\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the ",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373042",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373042",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373042",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373042 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source machine learning platform. Versions prior to 2.12.0 and 2.11.1 have a null pointer error in RandomShuffle with XLA enabled. A fix is included in TensorFlow 2.12.0 and 2.11.1.",
+      "vulnerability_id": "CVE-2023-25674",
+      "name": "CVE-2023-25674",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25674",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25674 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Integer Overflow or Wraparound in `EditDistance`. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.\n## PoC\n```\r\nimport tensorflow as tf\r\npara={\r\n    'hypothesis_indices': [[]],\r\n    'hypothesis_values': ['tmp/'],\r\n    'hypothesis_shape': [],\r\n    'truth_indices': [[]],\r\n    'truth_values': [''],\r\n    'truth_shape': [],\r\n    'normalize': False\r\n    }\r\ntf.raw_ops.EditDistance(**para)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/08b8e18643d6dcde00890733b270ff8d9960c56c)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373015",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373015",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.3,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.3,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373015",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373015 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, when `ctx->step_containter()` is a null ptr, the Lookup function will be executed with a null pointer. A fix is included in TensorFlow 2.12.0 and 2.11.1.",
+      "vulnerability_id": "CVE-2023-25663",
+      "name": "CVE-2023-25663",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25663",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25663 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, integer overflow occurs when `2^31 <= num_frames * height * width * channels < 2^32`, for example Full HD screencast of at least 346 frames. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25667",
+      "name": "CVE-2023-25667",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25667",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25667 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Integer Overflow to Buffer Overflow when `2^31 <= num_frames * height * width * channels < 2^32`, for example Full HD screencast of at least 346 frames.\n## PoC\n```\r\nimport urllib.request\r\ndat = urllib.request.urlopen('https://raw.githubusercontent.com/tensorflow/tensorflow/1c38ad9b78ffe06076745a1ee00cec42f39ff726/tensorflow/core/lib/gif/testdata/3g_multiframe.gif').read()\r\nimport tensorflow as tf\r\ntf.io.decode_gif(dat)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/8dc723fcdd1a6127d6c970bd2ecb18b019a1a58d)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373018",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373018",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373018",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373018 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Incorrect Comparison. Constructing a `tflite` model with a paramater `filter_input_channel` of less than 1 gives a float pointer exception.\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/34f8368c535253f5c9cb3a303297743b62442aaa)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373030",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373030",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373030",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373030 - tensorflow-gpu"
     },
     {
       "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, if the stride and window size are not positive for `tf.raw_ops.AvgPoolGrad`, it can give a floating point exception. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
@@ -932,9 +453,9 @@
       "title": "CVE-2023-25669 - tensorflow-gpu"
     },
     {
-      "description": "TensorFlow is an end-to-end open source platform for machine learning. Constructing a tflite model with a paramater `filter_input_channel` of less than 1 gives a FPE. This issue has been patched in version 2.12. TensorFlow will also cherrypick the fix commit on TensorFlow 2.11.1.",
-      "vulnerability_id": "CVE-2023-27579",
-      "name": "CVE-2023-27579",
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, when `SparseSparseMaximum` is given invalid sparse tensors as inputs, it can give a null pointer error. A fix is included in TensorFlow version 2.12 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25665",
+      "name": "CVE-2023-25665",
       "package_name": "tensorflow-gpu",
       "package_details": {
         "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
@@ -953,11 +474,67 @@
       "cvss_v31_score": 7.5,
       "cvss_v2_score": 0,
       "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27579",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25665",
       "source": "NVD",
       "severity": "HIGH",
       "status": "ACTIVE",
-      "title": "CVE-2023-27579 - tensorflow-gpu"
+      "title": "CVE-2023-25665 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. The function `tf.raw_ops.LookupTableImportV2` cannot handle scalars in the `values` parameter and gives an NPE. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25672",
+      "name": "CVE-2023-25672",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25672",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25672 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Attackers using Tensorflow prior to 2.12.0 or 2.11.1 can access heap memory which is not in the control of user, leading to a crash or remote code execution. The fix will be included in TensorFlow version 2.12.0 and will also cherrypick this commit on TensorFlow version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25668",
+      "name": "CVE-2023-25668",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25668",
+      "source": "NVD",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25668 - tensorflow-gpu"
     },
     {
       "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS) due to a floating point exception in `TensorListSplit` with `XLA`.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\nfunc = tf.raw_ops.TensorListSplit\r\npara = {'tensor': [1], 'element_shape': -1, 'lengths': [0]}\r\n\r\n@tf.function(jit_compile=True)\r\ndef fuzz_jit():\r\n y = func(**para)\r\n return y\r\n\r\nprint(fuzz_jit())\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many ",
@@ -1016,6 +593,314 @@
       "title": "IN1-PYTHON-TENSORFLOWGPU-3372988 - tensorflow-gpu"
     },
     {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS). When the parameter `summarize` of `tf.raw_ops.Print` is zero, the new method `SummarizeArray<bool>` will reference to a nullptr, leading to a seg fault.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\ntf.raw_ops.Print(input =  tf.constant([1, 1, 1, 1],dtype=tf.int32),\r\n                            data =  [[False, False, False, False], [False], [False, False, False]],\r\n                            message =  'tmp/I',\r\n                            first_n = 100,\r\n                            summarize = 0)\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nO",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373003",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373003",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373003",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373003 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Out-of-Bounds due to mismatched integer type sizes in `ValueMap::Manager::GetValueOrCreatePlaceholder`, because there is a bug with the `tfg-translate` call to `InitMlir`.\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/2eedc8f676d2c3b8be9492e547b2bc814c10b367)\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/760322a71ac9033e122ef1f4b1c62813021e5938)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373012",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373012",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373012",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373012 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, there is a floating point exception in AudioSpectrogram. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25666",
+      "name": "CVE-2023-25666",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25666",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25666 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS) due to a floating point exception if the stride and window size are not positive for `tf.raw_ops.AvgPoolGrad`.\n## PoC\n```\r\nimport tensorflow as tf\r\nimport numpy as np\r\n\r\n@tf.function(jit_compile=True)\r\ndef test():\r\n   y = tf.raw_ops.AvgPoolGrad(orig_input_shape=[1,0,0,0], grad=[[[[0.39117979]]]], ksize=[1,0,0,0], strides=[1,0,0,0], padding=\"SAME\", data_format=\"NCHW\")\r\n   return y\r\n\r\nprint(test())\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack tha",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373009",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373009",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373009",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373009 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Denial of Service (DoS) due to a floating point exception in `AudioSpectrogram`.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\npara = {'input': tf.constant([[14.], [24.]], dtype=tf.float32), 'window_size': 1, 'stride': 0, 'magnitude_squared': False}\r\nfunc = tf.raw_ops.AudioSpectrogram\r\n\r\n@tf.function(jit_compile=True)\r\ndef fuzz_jit():\r\n   y = func(**para)\r\n   return y\r\n\r\nfuzz_jit()\r\n```\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3372994",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3372994",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3372994",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3372994 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to NULL Pointer Dereference when `SparseSparseMaximum` is given invalid sparse tensors as inputs.\n## PoC\n```\r\nimport tensorflow as tf\r\ntf.raw_ops.SparseSparseMaximum(\r\n a_indices=[[1]],\r\n a_values =[ 0.1 ],\r\n a_shape = [2],\r\n b_indices=[[]],\r\n b_values =[2 ],\r\n b_shape = [2],\r\n)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/5e0ecfb42f5f65629fd7a4edd6c4afe7ff0feb04)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3372986",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3372986",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3372986",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3372986 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to NULL Pointer Dereference. When `ctx->step_containter()` is a null ptr, the `Lookup` function will be executed with a null pointer.\n## PoC\n```\r\nimport tensorflow as tf\r\ntf.raw_ops.TensorArrayConcatV2(handle=['a', 'b'], flow_in = 0.1, dtype=tf.int32, element_shape_except0=1)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/239139d2ae6a81ae9ba499ad78b56d9b2931538a)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373006",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373006",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373006",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373006 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Buffer Overflow in `TAvgPoolGrad`.\n## PoC\n```\r\nimport os\r\nos.environ['TF_ENABLE_ONEDNN_OPTS'] = '0'\r\nimport tensorflow as tf\r\nprint(tf.__version__)\r\nwith tf.device(\"CPU\"):\r\n    ksize = [1, 40, 128, 1]\r\n    strides = [1, 128, 128, 30]\r\n    padding = \"SAME\"\r\n    data_format = \"NHWC\"\r\n    orig_input_shape = [11, 9, 78, 9]\r\n    grad = tf.saturate_cast(tf.random.uniform([16, 16, 16, 16], minval=-128, maxval=129, dtype=tf.int64), dtype=tf.float32)\r\n    res = tf.raw_ops.AvgPoolGrad(\r\n        ksize=ksize,\r\n        strides=strides,\r\n        padding=padding,\r\n        data_format=data_format,\r\n        orig_input_shape=orig_input_shape,\r\n        grad=grad,\r\n    )\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/ddaac2bdd099bec5d7923dea45276a7558217e5b)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373025",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373025",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373025",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373025 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Out-of-bounds Read if the parameter `indices` for `DynamicStitch` does not match the shape of the parameter `data`.\n## PoC\n```\r\nimport tensorflow as tf\r\nfunc = tf.raw_ops.DynamicStitch\r\npara={'indices': [[0xdeadbeef], [405], [519], [758], [1015]], 'data': [[110.27793884277344], [120.29475402832031], [157.2418212890625], [157.2626953125], [188.45382690429688]]}\r\ny = func(**para)\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/ee004b18b976eeb5a758020af8880236cd707d05)",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3372991",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3372991",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3372991",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3372991 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an end-to-end open source platform for machine learning. Constructing a tflite model with a paramater `filter_input_channel` of less than 1 gives a FPE. This issue has been patched in version 2.12. TensorFlow will also cherrypick the fix commit on TensorFlow 2.11.1.",
+      "vulnerability_id": "CVE-2023-27579",
+      "name": "CVE-2023-27579",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-27579",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-27579 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. There is out-of-bounds access due to mismatched integer type sizes. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25671",
+      "name": "CVE-2023-25671",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25671",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25671 - tensorflow-gpu"
+    },
+    {
       "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, there is a heap buffer overflow in TAvgPoolGrad. A fix is included in TensorFlow 2.12.0 and 2.11.1.",
       "vulnerability_id": "CVE-2023-25664",
       "name": "CVE-2023-25664",
@@ -1044,9 +929,9 @@
       "title": "CVE-2023-25664 - tensorflow-gpu"
     },
     {
-      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to NULL Pointer Dereference. The function `tf.raw_ops.LookupTableImportV2` cannot handle scalars in the `values` parameter and gives a null pointer exception.\n## PoC\n```\r\nimport tensorflow as tf\r\n\r\nv = tf.Variable(1)\r\n\r\n@tf.function(jit_compile=True)\r\ndef test():\r\n   func = tf.raw_ops.LookupTableImportV2\r\n   para={'table_handle': v.handle,'keys': [62.98910140991211, 94.36528015136719], 'values': -919}\r\n\r\n   y = func(**para)\r\n   return y\r\n\r\nprint(test())\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://github.com/tensorflow/tensorflow/commit/980b22536abcbbe1b4a5642fc940af33d8c19b69)",
-      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373033",
-      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373033",
+      "description": "TensorFlow is an open source platform for machine learning. Prior to versions 2.12.0 and 2.11.1, if the parameter `indices` for `DynamicStitch` does not match the shape of the parameter `data`, it can trigger an stack OOB read. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25659",
+      "name": "CVE-2023-25659",
       "package_name": "tensorflow-gpu",
       "package_details": {
         "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
@@ -1065,11 +950,95 @@
       "cvss_v31_score": 7.5,
       "cvss_v2_score": 0,
       "cvss_v3_severity": "HIGH",
-      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373033",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25659",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25659 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Versions prior to 2.12.0 and 2.11.1 are vulnerable to integer overflow in EditDistance. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25662",
+      "name": "CVE-2023-25662",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25662",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25662 - tensorflow-gpu"
+    },
+    {
+      "description": "## Overview\n[tensorflow-gpu](https://pypi.org/project/tensorflow/) is a machine learning framework.\nAffected versions of this package are vulnerable to Double Free. The `nn_ops.fractional_avg_pool_v2` and `nn_ops.fractional_max_pool_v2` functions require the first and fourth elements of their parameter `pooling_ratio` to be equal to 1.0, as pooling on batch and channel dimensions is not supported.\n## PoC\n```\r\nimport tensorflow as tf\r\nimport os\r\nimport numpy as np\r\nfrom tensorflow.python.ops import nn_ops\r\ntry:\r\n  arg_0_tensor = tf.random.uniform([3, 30, 50, 3], dtype=tf.float64)\r\n  arg_0 = tf.identity(arg_0_tensor)\r\n  arg_1_0 = 2\r\n  arg_1_1 = 3\r\n  arg_1_2 = 1\r\n  arg_1_3 = 1\r\n  arg_1 = [arg_1_0,arg_1_1,arg_1_2,arg_1_3,]\r\n  arg_2 = True\r\n  arg_3 = True\r\n  seed = 341261001\r\n  out = nn_ops.fractional_avg_pool_v2(arg_0,arg_1,arg_2,arg_3,seed=seed,)\r\nexcept Exception as e:\r\n  print(\"Error:\"+str(e))\r\n```\n## Remediation\nUpgrade `tensorflow-gpu` to version 2.12.0 or higher.\n## References\n- [GitHub Commit](https://gith",
+      "vulnerability_id": "SNYK-PYTHON-TENSORFLOWGPU-3373000",
+      "name": "SNYK-PYTHON-TENSORFLOWGPU-3373000",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 8,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TENSORFLOWGPU-3373000",
       "source": "SNYK",
       "severity": "HIGH",
       "status": "ACTIVE",
-      "title": "IN1-PYTHON-TENSORFLOWGPU-3373033 - tensorflow-gpu"
+      "title": "IN1-PYTHON-TENSORFLOWGPU-3373000 - tensorflow-gpu"
+    },
+    {
+      "description": "TensorFlow is an open source platform for machine learning. Versions prior to 2.12.0 and 2.11.1 have a Floating Point Exception in TensorListSplit with XLA. A fix is included in TensorFlow version 2.12.0 and version 2.11.1.",
+      "vulnerability_id": "CVE-2023-25673",
+      "name": "CVE-2023-25673",
+      "package_name": "tensorflow-gpu",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.9/site-packages/tensorflow_gpu-2.11.1.dist-info/METADATA",
+        "name": "tensorflow-gpu",
+        "package_manager": "PYTHONPKG",
+        "version": "2.11.1",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-25673",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-25673 - tensorflow-gpu"
     }
   ]
 }


### PR DESCRIPTION
*GitHub Issue #, if available:*

Note: If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 



### Description
Update HF TF to TF 2.11.1 patch version

### Tests run
- [x] Update HF TF to TF 2.11.1 patch version, test sagemaker tests ([f5fad14](https://github.com/aws/deep-learning-containers/pull/2842/commits/f5fad14904634907ac9bc057d96ca89835634bde))
- [x] Update HF TF gpu allowlist, as TF 2.11.1 is false reporting - test sanity tests ([42fb0a5](https://github.com/aws/deep-learning-containers/pull/2842/commits/42fb0a54635fffbae85c354590474fbde1370454))

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
