### PR TITLE
Remove kubeflow manifests with old version

### DIFF
--- a/test/dlc_tests/eks/eks_manifest_templates/kubeflow/install_kubeflow.sh
+++ b/test/dlc_tests/eks/eks_manifest_templates/kubeflow/install_kubeflow.sh
@@ -24,6 +24,16 @@ install_kustomize(){
 
 # Function to install kubeflow in EKS cluster using kustomize
 install_kubeflow(){
+    local EKS_CLUSTER_NAME=$1
+    KUBEFLOW_VERSION="v1.7.0"
+    DIRECTORY="${HOME}/${EKS_CLUSTER_NAME}/manifests"
+
+    if [ -d "${DIRECTORY}" ]; then
+        rm -rf ${DIRECTORY};
+    fi
+
+    # clones manifests from kubeflow github into a folder named manifests
+    git clone -b ${KUBEFLOW_VERSION} --single-branch https://github.com/kubeflow/manifests.git
 
     echo "> Installing kubeflow namespace"
     kustomize build manifests/common/kubeflow-namespace/base | kubectl apply -f -
@@ -34,6 +44,16 @@ install_kubeflow(){
 
 # Function to remove kubeflow in EKS cluster using kustomize
 uninstall_kubeflow(){
+    local EKS_CLUSTER_NAME=$1
+    KUBEFLOW_VERSION="v1.6.1"
+    DIRECTORY="${HOME}/${EKS_CLUSTER_NAME}/manifests"
+
+    if [ -d "${DIRECTORY}" ]; then
+        rm -rf ${DIRECTORY};
+    fi
+
+    # clones manifests from kubeflow github into a folder named manifests
+    git clone -b ${KUBEFLOW_VERSION} --single-branch https://github.com/kubeflow/manifests.git
 
     echo "> Uninstalling training operators"
     while ! kustomize build manifests/apps/training-operator/upstream/overlays/kubeflow | kubectl delete -f -; do echo "Retrying to delete training operator resources"; sleep 10; done
@@ -44,7 +64,6 @@ uninstall_kubeflow(){
 
 # Function to create directory and download kubeflow components
 setup_kubeflow(){
-    KUBEFLOW_VERSION="v1.7.0"
     local EKS_CLUSTER_NAME=$1
     DIRECTORY="${HOME}/${EKS_CLUSTER_NAME}"
 
@@ -54,12 +73,7 @@ setup_kubeflow(){
         
     mkdir ${DIRECTORY} 
     cd ${DIRECTORY}
-    
-    # clones manifests from kubeflow github into a folder named manifests
-    git clone -b ${KUBEFLOW_VERSION} --single-branch https://github.com/kubeflow/manifests.git
 }
-
-
 
 # Check for input arguments
 if [ $# ge 1 ]; then
@@ -79,10 +93,10 @@ setup_kubeflow ${EKS_CLUSTER_NAME}
 # uninstall the manifest if operation is to upgrade kubeflow
 if [ "${OPERATION}" = "UPGRADE" ]; then
     echo "> Uninstalling kubeflow manifest"
-    uninstall_kubeflow
+    uninstall_kubeflow ${EKS_CLUSTER_NAME}
 fi
 
 echo "> Setting up kubeflow"
-install_kubeflow
+install_kubeflow ${EKS_CLUSTER_NAME}
 
 echo "> Installation complete"


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
This PR contains change to upgrade script that is meant to address issue seen with the removal of old version (v1.6.1) KubeFlow (KF) manifests from live EKS clusters and installing newer version (v1.7.0)of the KF manifests.

### Tests run
Test executed locally. Create a test cluster and installed v1.6.1 and then ran the upgrade script to remove KF manifests using v1.6.1 KF repo and then install manifests using v1.7.0 KF repo.

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

### DLC image/dockerfile

### Additional context

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
