### PR TITLE
[test] Temporarily disable pytest failure remote caching

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,7 @@
 wheel==0.33.4
 docker==4.2.0
 fabric==2.5.0
+invoke!=2.1.0
 pyfiglet==0.8.post1
 reprint==0.5.2
 ruamel.yaml==0.16.7

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,5 +1,6 @@
 docker
 fabric
+invoke!=2.1.0
 junit-xml==1.9
 packaging==20.1
 pytest

--- a/test/sagemaker_tests/autogluon/inference/requirements.txt
+++ b/test/sagemaker_tests/autogluon/inference/requirements.txt
@@ -18,5 +18,6 @@ requests==2.24
 tox==3.7.0
 requests_mock==1.6.0
 fabric
+invoke!=2.1.0
 retrying
 gitpython

--- a/test/sagemaker_tests/autogluon/training/requirements.txt
+++ b/test/sagemaker_tests/autogluon/training/requirements.txt
@@ -18,5 +18,6 @@ requests==2.24
 tox==3.7.0
 requests_mock==1.6.0
 fabric
+invoke!=2.1.0
 retrying
 gitpython

--- a/test/sagemaker_tests/huggingface/inference/requirements.txt
+++ b/test/sagemaker_tests/huggingface/inference/requirements.txt
@@ -23,6 +23,7 @@ requests_mock==1.6.0
 sagemaker-inference==1.1.2
 retrying==1.3.3
 fabric
+invoke!=2.1.0
 gitpython
 toml
 transformers==4.26.0

--- a/test/sagemaker_tests/huggingface_pytorch/training/requirements.txt
+++ b/test/sagemaker_tests/huggingface_pytorch/training/requirements.txt
@@ -19,6 +19,7 @@ pluggy<1,>=0.3.0
 tox==3.7.0
 requests_mock==1.6.0
 fabric
+invoke!=2.1.0
 retrying==1.3.3
 gitpython
 toml

--- a/test/sagemaker_tests/huggingface_tensorflow/training/requirements.txt
+++ b/test/sagemaker_tests/huggingface_tensorflow/training/requirements.txt
@@ -27,7 +27,7 @@ requests-mock
 # without the below package
 tensorflow==2.11.1
 fabric==2.5.0
+invoke!=2.1.0
 retrying==1.3.3
 gitpython
 toml
-

--- a/test/sagemaker_tests/mxnet/inference/requirements.txt
+++ b/test/sagemaker_tests/mxnet/inference/requirements.txt
@@ -6,7 +6,7 @@ pytest==5.3.5
 pytest-cov
 pytest-rerunfailures==9.0
 pytest-xdist
-requests==2.25.1 
+requests==2.25.1
 urllib3>=1.26.6
 mock
 sagemaker
@@ -14,6 +14,7 @@ docker-compose
 awslogs
 requests_mock==1.7.0
 fabric
+invoke!=2.1.0
 gitpython
 toml
 numpy

--- a/test/sagemaker_tests/mxnet/training/requirements.txt
+++ b/test/sagemaker_tests/mxnet/training/requirements.txt
@@ -5,7 +5,7 @@ pytest==5.3.5
 pytest-cov
 pytest-rerunfailures==9.0
 pytest-xdist
-requests==2.25.1 
+requests==2.25.1
 urllib3>=1.26.6
 mock
 sagemaker
@@ -17,6 +17,7 @@ botocore
 awscli
 requests_mock==1.7.0
 fabric
+invoke!=2.1.0
 retrying
 gitpython
 toml

--- a/test/sagemaker_tests/pytorch/inference/requirements.txt
+++ b/test/sagemaker_tests/pytorch/inference/requirements.txt
@@ -23,6 +23,7 @@ requests_mock==1.6.0
 sagemaker-inference==1.1.2
 retrying==1.3.3
 fabric
+invoke!=2.1.0
 gitpython
 toml
 packaging==21.3

--- a/test/sagemaker_tests/pytorch/training/requirements.txt
+++ b/test/sagemaker_tests/pytorch/training/requirements.txt
@@ -17,6 +17,7 @@ requests
 tox
 requests_mock
 fabric
+invoke!=2.1.0
 retrying
 gitpython
 toml

--- a/test/sagemaker_tests/tensorflow/inference/requirements.txt
+++ b/test/sagemaker_tests/tensorflow/inference/requirements.txt
@@ -6,6 +6,7 @@ pytest-timeout==1.3.4
 pytest-xdist==1.31.0
 requests==2.24
 fabric
+invoke!=2.1.0
 retrying
 gitpython
 toml

--- a/test/sagemaker_tests/tensorflow/tensorflow1_training/requirements.txt
+++ b/test/sagemaker_tests/tensorflow/tensorflow1_training/requirements.txt
@@ -21,6 +21,7 @@ botocore
 requests-mock
 awscli
 fabric==2.5.0
+invoke!=2.1.0
 sagemaker-experiments==0.1.17
 retrying==1.3.3
 gitpython

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/requirements.txt
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/requirements.txt
@@ -26,6 +26,7 @@ requests-mock
 # without the below package
 tensorflow
 fabric==2.5.0
+invoke!=2.1.0
 retrying==1.3.3
 gitpython
 toml


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
Temporarily disable remote caching on S3 of the pytest `lastfailed` file outside of PR context

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

### Additional context

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
