### PR TITLE
[pytorch] update TorchServe to 0.8.0 and disable nvgpu metrics on SM gpu

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -31,10 +31,10 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
+build_training = false
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
@@ -54,14 +54,14 @@ ec2_tests = true
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = false
+sagemaker_local_tests = true
 
 # SM remote test valid values:
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "off"
+sagemaker_remote_tests = "standard"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -12,7 +12,7 @@ neuron_mode = false
 neuronx_mode = false
 # Please only set it to true if you are preparing a GRAVITON related PR
 # Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = true
+graviton_mode = false
 # Please only set it to True if you are preparing a HABANA related PR
 # Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false
@@ -31,10 +31,10 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = false
+build_training = true
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
@@ -54,14 +54,14 @@ ec2_tests = true
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = true
+sagemaker_local_tests = false
 
 # SM remote test valid values:
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "standard"
+sagemaker_remote_tests = "off"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -12,7 +12,7 @@ neuron_mode = false
 neuronx_mode = false
 # Please only set it to true if you are preparing a GRAVITON related PR
 # Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = false
+graviton_mode = true
 # Please only set it to True if you are preparing a HABANA related PR
 # Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false

--- a/pytorch/inference/docker/2.0/py3/Dockerfile.cpu
+++ b/pytorch/inference/docker/2.0/py3/Dockerfile.cpu
@@ -9,7 +9,7 @@ ARG TORCHVISION_URL=https://aws-pytorch-unified-cicd-binaries.s3.us-west-2.amazo
 ARG TORCHAUDIO_URL=https://aws-pytorch-unified-cicd-binaries.s3.us-west-2.amazonaws.com/r2.0.0_inference/cpu_py310/torchaudio-2.0.1%2Bcpu-cp310-cp310-linux_x86_64.whl
 ARG TORCHTEXT_URL=https://aws-pytorch-unified-cicd-binaries.s3.us-west-2.amazonaws.com/r2.0.0_inference/cpu_py310/torchtext-0.15.1%2Bcpu-cp310-cp310-linux_x86_64.whl
 ARG TORCHDATA_URL=https://aws-pytorch-unified-cicd-binaries.s3.us-west-2.amazonaws.com/r2.0.0_inference/cpu_py310/torchdata-0.6.0%2Bcpu-cp310-cp310-linux_x86_64.whl
-ARG TORCHSERVE_VERSION=0.7.1
+ARG TORCHSERVE_VERSION=0.8.0
 ARG SM_TOOLKIT_VERSION=2.0.14
 
 ########################################################

--- a/pytorch/inference/docker/2.0/py3/Dockerfile.graviton.cpu
+++ b/pytorch/inference/docker/2.0/py3/Dockerfile.graviton.cpu
@@ -9,7 +9,7 @@ ARG TORCHVISION_URL=https://aws-pytorch-unified-cicd-binaries.s3.us-west-2.amazo
 ARG TORCHAUDIO_URL=https://aws-pytorch-unified-cicd-binaries.s3.us-west-2.amazonaws.com/r2.0.0_inference/graviton_py310/torchaudio-2.0.1%2Bcpu-cp310-cp310-linux_aarch64.whl
 ARG TORCHTEXT_URL=https://aws-pytorch-unified-cicd-binaries.s3.us-west-2.amazonaws.com/r2.0.0_inference/graviton_py310/torchtext-0.15.1%2Bcpu-cp310-cp310-linux_aarch64.whl
 ARG TORCHDATA_URL=https://aws-pytorch-unified-cicd-binaries.s3.us-west-2.amazonaws.com/r2.0.0_inference/graviton_py310/torchdata-0.6.0%2Bcpu-cp310-cp310-linux_aarch64.whl
-ARG TORCHSERVE_VERSION=0.7.1
+ARG TORCHSERVE_VERSION=0.8.0
 ARG SM_TOOLKIT_VERSION=2.0.14
 
 ########################################################

--- a/pytorch/inference/docker/2.0/py3/cu118/Dockerfile.gpu
+++ b/pytorch/inference/docker/2.0/py3/cu118/Dockerfile.gpu
@@ -15,7 +15,7 @@ ARG TORCHVISION_URL=https://aws-pytorch-unified-cicd-binaries.s3.us-west-2.amazo
 ARG TORCHAUDIO_URL=https://aws-pytorch-unified-cicd-binaries.s3.us-west-2.amazonaws.com/r2.0.0_inference/cu118_py310/torchaudio-2.0.1%2Bcu118-cp310-cp310-linux_x86_64.whl
 ARG TORCHTEXT_URL=https://aws-pytorch-unified-cicd-binaries.s3.us-west-2.amazonaws.com/r2.0.0_inference/cu118_py310/torchtext-0.15.1%2Bcu118-cp310-cp310-linux_x86_64.whl
 ARG TORCHDATA_URL=https://aws-pytorch-unified-cicd-binaries.s3.us-west-2.amazonaws.com/r2.0.0_inference/cu118_py310/torchdata-0.6.0%2Bcu118-cp310-cp310-linux_x86_64.whl
-ARG TORCHSERVE_VERSION=0.7.1
+ARG TORCHSERVE_VERSION=0.8.0
 ARG SM_TOOLKIT_VERSION=2.0.14
 
 ########################################################
@@ -276,6 +276,7 @@ ARG PYTHON
 ARG SM_TOOLKIT_VERSION
 
 ENV SAGEMAKER_SERVING_MODULE sagemaker_pytorch_serving_container.serving:main
+ENV TS_DISABLE_SYSTEM_METRICS=true
 
 # Install scikit-learn and pandas
 RUN conda install -y -c conda-forge \


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
* Update PT 2.0 images (x86 and Graviton) to use TorchServe 0.8.0
* Disabling nvgpu metrics on PT 2.0 GPU SageMaker image.

### Tests run
Commit: [9ba7e9f](https://github.com/aws/deep-learning-containers/pull/3030/commits/9ba7e9fc7ead77b912e7732d4094b22ae8024c97)
* Build (x86)
* EC2 tests (x86) (CPU/GPU)
* ECS tests (x86) (CPU/GPU)
* EKS tests (x86) (CPU/GPU)
* Sanity tests (x86) (CPU/GPU)
* SM local Tests (x86) (CPU/GPU)
* SM remote tests (x86) (CPU/GPU)

Commit: [57f3a75](https://github.com/aws/deep-learning-containers/pull/3030/commits/57f3a75b3653cdf6cc9d9e89aae821cb9169f180)
* Build (x86)
* EC2 tests (x86) (Graviton)
* ECS tests (x86) (Graviton)
* EKS tests (x86) (Graviton)
* Sanity tests (x86) (Graviton)
* SM local Tests (x86) (Graviton)
* SM remote tests (x86) (Graviton)

NOTE: as the Local SM GPU Testing uses newer Nvidia driver on the Docker host than SageMaker. Have taken the SM GPU image to an EC2 instance using the same Nvidia Driver as SageMaker and verified the nvgpu error no longer presists.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
