### PR TITLE
[djl-serving] cve patch on 0.21.0 fastertransformer lmi container

### DIFF
--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -2,42 +2,16 @@
 release_images:
   1:
     framework: "djl"
-    version: "0.22.1"
+    version: "0.21.0"
     arch_type: "x86"
     inference:
       device_types: [ "gpu" ]
       python_versions: [ "py39" ]
       os_version: "ubuntu20.04"
       fastertransformer_version: "5.3.0"
-      cuda_version: "cu118"
+      cuda_version: "cu117"
       example: False        # [Default: False] Set to True to denote that this image is an Example image
       disable_sm_tag: True # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
       # to images being published.
       force_release: False   # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-  2:
-    framework: "pytorch"
-    version: "2.0.1"
-    customer_type: "ec2"
-    arch_type: "x86"
-    inference:
-      device_types: ["cpu", "gpu"]
-      cuda_version: "cu118"
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  3:
-    framework: "pytorch"
-    version: "2.0.1"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    inference:
-      device_types: ["cpu", "gpu"]
-      cuda_version: "cu118"
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False

--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -5,19 +5,6 @@ release_images:
     version: "0.21.0"
     arch_type: "x86"
     inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py38" ]
-      os_version: "ubuntu20.04"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: True # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-      # to images being published.
-      force_release: False   # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
-  2:
-    framework: "djl"
-    version: "0.21.0"
-    arch_type: "x86"
-    inference:
       device_types: [ "gpu" ]
       python_versions: [ "py39" ]
       os_version: "ubuntu20.04"


### PR DESCRIPTION
CVE patch for FasterTransformer DJL 0.21.0 LMI container
