### PR TITLE
[PyTorch] [SM, EC2] Pin mkl version in x86 inference Dockerfiles

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -38,7 +38,7 @@ build_training = false
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = false
+datetime_tag = true
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -31,14 +31,14 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
+build_training = false
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = true
+datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true
@@ -60,14 +60,14 @@ ec2_efa_tests = false
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = false
+sagemaker_local_tests = true
 
 # SM remote test valid values:
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "off"
+sagemaker_remote_tests = "standard"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -38,7 +38,7 @@ build_training = false
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = true
+datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -31,14 +31,14 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = false
+build_training = true
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = false
+datetime_tag = true
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true
@@ -60,14 +60,14 @@ ec2_efa_tests = false
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = true
+sagemaker_local_tests = false
 
 # SM remote test valid values:
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "standard"
+sagemaker_remote_tests = "off"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/pytorch/inference/docker/2.0/py3/Dockerfile.cpu
+++ b/pytorch/inference/docker/2.0/py3/Dockerfile.cpu
@@ -108,7 +108,7 @@ RUN curl -L -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases
  && rm ~/mambaforge.sh \
  && /opt/conda/bin/conda install -c conda-forge python=${PYTHON_VERSION} \
     cython \
-    mkl \
+    "mkl>=2023.2.0" \
     mkl-include \
     parso \
     typing \

--- a/pytorch/inference/docker/2.0/py3/cu118/Dockerfile.gpu
+++ b/pytorch/inference/docker/2.0/py3/cu118/Dockerfile.gpu
@@ -157,7 +157,7 @@ RUN curl -L -o ~/mambaforge.sh https://github.com/conda-forge/miniforge/releases
  && rm ~/mambaforge.sh \
  && /opt/conda/bin/conda install -c conda-forge python=${PYTHON_VERSION} \
     cython \
-    mkl \
+    "mkl>=2023.2.0" \
     mkl-include \
     parso \
     scipy \


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
Sanity test was failing due to mkl not found. After investigation, we found that mkl was somehow being downgraded to an older version, possibly due to a new cryptography release yesterday (08/01). The fix is to lower-pin the mkl version.

### Tests run

x86 tests successful at comimt [f891aea](https://github.com/aws/deep-learning-containers/pull/3219/commits/f891aea969832fff58160e6d6c649fc45db7abeb):
dlc-pr-pytorch-inference_dlc-pr-ec2-test
dlc-pr-pytorch-inference_dlc-pr-ecs-test
dlc-pr-pytorch-inference_dlc-pr-eks-test
dlc-pr-pytorch-inference_dlc-pr-sagemaker-local-test
dlc-pr-pytorch-inference_dlc-pr-sagemaker-test
dlc-pr-pytorch-inference_dlc-pr-sanity-test


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
