### PR TITLE
[PyTorch] [SM, EC2] Add release image definitions for PT 2.0.1 inference torchserve upgrade

### DIFF
--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -50,3 +50,16 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
+  5:
+    framework: "djl"
+    version: "0.23.0"
+    arch_type: "x86"
+    inference:
+      device_types: [ "neuronx" ]
+      python_versions: [ "py38" ]
+      os_version: "ubuntu20.04"
+      neuron_sdk_version: "sdk2.12.0"
+      example: False        # [Default: False] Set to True to denote that this image is an Example image
+      disable_sm_tag: True # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
+      # to images being published.
+      force_release: False

--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -1,43 +1,52 @@
 ---
 release_images:
   1:
-    framework: "djl"
-    version: "0.23.0"
-    arch_type: "x86"
-    inference:
-      device_types: [ "neuronx" ]
-      python_versions: [ "py38" ]
-      os_version: "ubuntu20.04"
-      neuron_sdk_version: "sdk2.12.0"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: True # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-      # to images being published.
-      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
-  2:
-    framework: "huggingface_pytorch"
-    version: "2.0.0"
-    arch_type: "x86"
-    hf_transformers: "4.28.1"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False        # [Default: False] Set to True to denote that this image is an Example image
-      disable_sm_tag: False # [Default: False] Set to True to prevent SageMaker Abbreviated Tags from being attached
-      # to images being published.
-      force_release: False  # [Default: False] Set to True to force images to be published even if the same image
-      # has already been published. Re-released image will have minor version incremented by 1.
-  3:
-    framework: "autogluon"
-    version: "0.7.0"
+    framework: "pytorch"
+    version: "2.0.1"
+    customer_type: "ec2"
     arch_type: "x86"
     inference:
       device_types: ["cpu", "gpu"]
-      python_versions: ["py39"]
+      cuda_version: "cu118"
+      python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
-      cuda_version: "cu117"
       example: False
-      disable_sm_tag: False  # [Default: False] This option is not used by Example images
+      disable_sm_tag: False
+      force_release: False
+  2:
+    framework: "pytorch"
+    version: "2.0.1"
+    customer_type: "sagemaker"
+    arch_type: "x86"
+    inference:
+      device_types: ["cpu", "gpu"]
+      cuda_version: "cu118"
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  3:
+    framework: "pytorch"
+    version: "2.0.1"
+    customer_type: "ec2"
+    arch_type: "graviton"
+    inference:
+      device_types: ["cpu"]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  4:
+    framework: "pytorch"
+    version: "2.0.1"
+    customer_type: "sagemaker"
+    arch_type: "graviton"
+    inference:
+      device_types: ["cpu"]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
       force_release: False


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
Release image definitions for re-releasing PyTorch 2.0.1 inference with new torchserve version.
Related PRs: 
[#3199](https://github.com/aws/deep-learning-containers/pull/3199)
[#3219](https://github.com/aws/deep-learning-containers/pull/3219)

### Tests run


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
