### PR TITLE
[tensorflow][training] disable SM dataparallel tests for TF 2.13 and above

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -31,11 +31,11 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["tensorflow"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
 datetime_tag = true
@@ -45,12 +45,12 @@ do_build = true
 
 [test]
 ### On by default
-sanity_tests = false
+sanity_tests = true
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = false
-eks_tests = false
-ec2_tests = false
+ecs_tests = true
+eks_tests = true
+ec2_tests = true
 
 ### Set ec2_efa_tests = true to be able to run any EC2 tests on any instance type that uses EFA-capable instances by
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
@@ -67,7 +67,7 @@ sagemaker_local_tests = false
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "rc"
+sagemaker_remote_tests = "off"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -60,14 +60,14 @@ ec2_efa_tests = false
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = true
+sagemaker_local_tests = false
 
 # SM remote test valid values:
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "efa"
+sagemaker_remote_tests = "rc"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -31,11 +31,11 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["tensorflow"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set to false in order to remove datetime tag on PR builds
 datetime_tag = true
@@ -45,12 +45,12 @@ do_build = true
 
 [test]
 ### On by default
-sanity_tests = true
+sanity_tests = false
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = true
-eks_tests = true
-ec2_tests = true
+ecs_tests = false
+eks_tests = false
+ec2_tests = false
 
 ### Set ec2_efa_tests = true to be able to run any EC2 tests on any instance type that uses EFA-capable instances by
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
@@ -60,14 +60,14 @@ ec2_efa_tests = false
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = false
+sagemaker_local_tests = true
 
 # SM remote test valid values:
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "off"
+sagemaker_remote_tests = "efa"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/test/dlc_tests/release_candidate_integration/test_sm_profiler.py
+++ b/test/dlc_tests/release_candidate_integration/test_sm_profiler.py
@@ -82,7 +82,7 @@ def test_sm_profiler_pt(pytorch_training):
 @pytest.mark.skipif(
     not is_mainline_context() and not is_rc_test_context(), reason="Mainline only test"
 )
-def test_sm_profiler_tf(tensorflow_training):
+def test_sm_profiler_tf(tensorflow_training, below_tf213_only):
     if is_tf_version("1", tensorflow_training):
         pytest.skip("Skipping test on TF1, since there are no smprofiler config files for TF1")
     processor = get_processor_from_image_uri(tensorflow_training)

--- a/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/sagemaker/test_smdataparallel.py
+++ b/test/sagemaker_tests/tensorflow/tensorflow2_training/integration/sagemaker/test_smdataparallel.py
@@ -116,7 +116,9 @@ def _test_distributed_training_smdataparallel_script_mode_function(
 @pytest.mark.skip_py2_containers
 @pytest.mark.efa()
 @pytest.mark.parametrize("instance_types", ["ml.p3.16xlarge", "ml.p4d.24xlarge"])
-def test_smdataparallel_mnist(ecr_image, sagemaker_regions, instance_types, py_version, tmpdir):
+def test_smdataparallel_mnist(
+    ecr_image, sagemaker_regions, instance_types, py_version, tmpdir, sm_below_tf213_only
+):
     invoke_sm_helper_function(
         ecr_image, sagemaker_regions, _test_smdataparallel_mnist_function, instance_types
     )
@@ -152,7 +154,9 @@ def _test_smdataparallel_mnist_function(ecr_image, sagemaker_session, instance_t
 @pytest.mark.skip_py2_containers
 @pytest.mark.efa()
 @pytest.mark.parametrize("instance_types", ["ml.p3.16xlarge", "ml.p4d.24xlarge"])
-def test_hc_smdataparallel_mnist(ecr_image, sagemaker_regions, instance_types, py_version, tmpdir):
+def test_hc_smdataparallel_mnist(
+    ecr_image, sagemaker_regions, instance_types, py_version, tmpdir, sm_below_tf213_only
+):
     training_group = InstanceGroup("train_group", instance_types, 2)
     invoke_sm_helper_function(
         ecr_image, sagemaker_regions, _test_hc_smdataparallel_mnist_function, [training_group]
@@ -192,7 +196,7 @@ def _test_hc_smdataparallel_mnist_function(ecr_image, sagemaker_session, instanc
 @pytest.mark.efa()
 @pytest.mark.parametrize("instance_types", ["ml.p4d.24xlarge"])
 def test_smdataparallel_throughput(
-    ecr_image, sagemaker_regions, instance_types, py_version, tmpdir
+    ecr_image, sagemaker_regions, instance_types, py_version, tmpdir, sm_below_tf213_only
 ):
     invoke_sm_helper_function(
         ecr_image, sagemaker_regions, _test_smdataparallel_throughput_function, instance_types


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
* SM Data-Parallel is no longer supported, nor installed for TF 2.13 and above. Skipping the tests associated to it.
* SM Profiler (Part of SM Debugger) is no longer supported or installed on TF 2.13 and above. Skipping tests associated to it.

### Tests run
On Commit: [1346c13](https://github.com/aws/deep-learning-containers/pull/3232/commits/1346c13e06e3215f3829bd7b434b47cb57b69446)
* SM EFA Tests
* SM Local tests
On Commit: [7024bd0](https://github.com/aws/deep-learning-containers/pull/3232/commits/7024bd0d1d8fc41c5204b2c2322cc37261c3a7c1)
* SM RC Integrations Tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
