### PR TITLE
Skip sagemaker profiler test due to deprecation

### DIFF
--- a/test/dlc_tests/release_candidate_integration/test_sm_profiler.py
+++ b/test/dlc_tests/release_candidate_integration/test_sm_profiler.py
@@ -34,6 +34,8 @@ def test_sm_profiler_pt(pytorch_training):
         pytest.skip(f"Processor {processor} not supported. Skipping test.")
 
     _, image_framework_version = get_framework_and_version_from_tag(pytorch_training)
+    if Version(image_framework_version) in SpecifierSet(">=2.0"):
+        pytest.skip("sm profiler is deprecated after Pytorch 2.0")
     if Version(image_framework_version) in SpecifierSet(">=1.10"):
         pytest.skip("sm profiler ZCC test is not supported in PT 1.10 and above")
 
@@ -88,6 +90,9 @@ def test_sm_profiler_tf(tensorflow_training, below_tf213_only):
     processor = get_processor_from_image_uri(tensorflow_training)
     if processor not in ("cpu", "gpu"):
         pytest.skip(f"Processor {processor} not supported. Skipping test.")
+    _, image_framework_version = get_framework_and_version_from_tag(tensorflow_training)
+    if Version(image_framework_version) in SpecifierSet(">=2.11"):
+        pytest.skip("sm profiler is deprecated after TensorFlow 2.11")
 
     ctx = Context()
 


### PR DESCRIPTION
**Note**: 
- SageMaker Profiler V1 is deprecated for PyTorch >= v2.0 and TensorFlow >= v2.11. See [release notes](https://docs.aws.amazon.com/sagemaker/latest/dg/debugger-release-notes.html). Skip the corresponding tests based on the framework versions.

### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [x] I have run builds/tests on commit 66522594c0fa7839470a3e7350b054f00080b3f5 for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [x] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [x] `sagemaker_local_tests = true`

### Formatting
- [x] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

### Additional context

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [x] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
