### PR TITLE
PyTorch 2.0.1 EC2 Fix: Increasing PyTorch Training EC2 DLC image size

### DIFF
--- a/pytorch/training/buildspec.yml
+++ b/pytorch/training/buildspec.yml
@@ -44,7 +44,7 @@ images:
   BuildEC2GPUPTTrainPy3DockerImage:
     <<: *TRAINING_REPOSITORY
     build: &PYTORCH_GPU_TRAINING_PY3 false
-    image_size_baseline: 19700
+    image_size_baseline: 21500
     device_type: &DEVICE_TYPE gpu
     python_version: &DOCKER_PYTHON_VERSION py3
     tag_python_version: &TAG_PYTHON_VERSION py310


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

Need to increase image size due to issues with [the build and test pipeline](https://us-west-2.console.aws.amazon.com/codesuite/codebuild/669063966089/projects/pytorch-training-latest-codebuild/build/pytorch-training-latest-codebuild%3A3c04843a-e9b2-4f4c-82e2-9393b5e74ebe/?region=us-west-2).

Error:
```
Successfully built fbe7e2f38a14

Successfully tagged 669063966089.dkr.ecr.us-west-2.amazonaws.com/beta-pytorch-training:2.0.1-gpu-py310-cu118-ubuntu20.04-ec2-2023-08-21-17-43-08-pre-push

[INFO] Completed Build for 669063966089.dkr.ecr.us-west-2.amazonaws.com/beta-pytorch-training:2.0.1-gpu-py310-cu118-ubuntu20.04-ec2-2023-08-21-17-43-08-pre-push
[INFO] Starting image size check for 669063966089.dkr.ecr.us-west-2.amazonaws.com/beta-pytorch-training:2.0.1-gpu-py310-cu118-ubuntu20.04-ec2-2023-08-21-17-43-08-pre-push
Actual image size: 20575.296892166138
Baseline image size: 19700
Image Size Check Succeeded for 669063966089.dkr.ecr.us-west-2.amazonaws.com/beta-pytorch-training:2.0.1-gpu-py310-cu118-ubuntu20.04-ec2-2023-08-21-17-43-08-pre-push
```

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

### Additional context

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
