### PR TITLE
[PT20-training-gpu] [CUDA121] Fix typos

### DIFF
--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -870,7 +870,7 @@ def skip_dgl_test(request):
             image_cuda_version.strip("cu")
         ) >= Version("121"):
             pytest.skip(
-                f"DGL doesn't support cuda12.x for now, so skipping this container with tag {fw_ver}"
+                f"DGL doesn't support cuda12.x for now, so skipping this container with tag {image_framework_version}"
             )
 
 

--- a/test/dlc_tests/ec2/test_efa.py
+++ b/test/dlc_tests/ec2/test_efa.py
@@ -34,6 +34,7 @@ EC2_EFA_GPU_INSTANCE_TYPE_AND_REGION = get_efa_ec2_instance_type(
     filter_function=filter_efa_instance_type,
 )
 
+
 @pytest.mark.processor("gpu")
 @pytest.mark.model("N/A")
 @pytest.mark.integration("efa")

--- a/test/dlc_tests/ec2/test_efa.py
+++ b/test/dlc_tests/ec2/test_efa.py
@@ -34,37 +34,6 @@ EC2_EFA_GPU_INSTANCE_TYPE_AND_REGION = get_efa_ec2_instance_type(
     filter_function=filter_efa_instance_type,
 )
 
-
-@pytest.mark.processor("gpu")
-@pytest.mark.model("N/A")
-@pytest.mark.integration("efa")
-@pytest.mark.usefixtures("sagemaker")
-@pytest.mark.allow_p4de_use
-@pytest.mark.multinode(2)
-@pytest.mark.parametrize("ec2_instance_type,region", EC2_EFA_GPU_INSTANCE_TYPE_AND_REGION)
-@pytest.mark.skipif(
-    is_pr_context() and not is_efa_dedicated(),
-    reason="Skip EFA test in PR context unless explicitly enabled",
-)
-def test_pytorch_nccl_tests_using_efa(
-    pytorch_training, efa_ec2_instances, efa_ec2_connections, ec2_instance_type, region, gpu_only
-):
-    """
-    Run EFA Sanity tests on DLC, and then run NCCL Message Transfer and All Reduce tests using EFA
-    on multiple nodes using DLC images. The test scripts are agnostic to the framework and version
-    installed in the DLC image. The test also builds nccl-tests to create the all_reduce_perf
-    binary necessary for multinode tests, on each node.
-    Note: This test must be explicitly enabled on CI, and will only run on EFA-capable instances
-    on pipelines.
-    :param pytorch_training: str PyTorch Training DLC image URI
-    :param efa_ec2_instances: list of tuples of instance-ids and SSH-keys for EFA-enabled instances
-    :param efa_ec2_connections: list of Fabric Connection objects for EFA-enabled instances
-    :param ec2_instance_type: str Instance Type being tested
-    :param region: str Region in which EFA-enabled instances are launched
-    :param gpu_only: pytest fixture to limit test only to GPU DLCs
-    """
-
-
 @pytest.mark.processor("gpu")
 @pytest.mark.model("N/A")
 @pytest.mark.integration("efa")


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

### Additional context

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
