### PR TITLE
[PyTorch][Graviton][SM, EC2] Upgrade torchserve version from 0.8.1 to 0.8.2

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -12,7 +12,7 @@ neuron_mode = false
 neuronx_mode = false
 # Please only set it to true if you are preparing a GRAVITON related PR
 # Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = false
+graviton_mode = true
 # Please only set it to True if you are preparing a HABANA related PR
 # Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false
@@ -31,14 +31,14 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
+build_training = false
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = true
+datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true
@@ -60,14 +60,14 @@ ec2_tests_on_heavy_instances = false
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = false
+sagemaker_local_tests = true
 
 # SM remote test valid values:
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "off"
+sagemaker_remote_tests = "standard"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -12,7 +12,7 @@ neuron_mode = false
 neuronx_mode = false
 # Please only set it to true if you are preparing a GRAVITON related PR
 # Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = true
+graviton_mode = false
 # Please only set it to True if you are preparing a HABANA related PR
 # Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false
@@ -31,14 +31,14 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = false
+build_training = true
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = false
+datetime_tag = true
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true
@@ -60,14 +60,14 @@ ec2_tests_on_heavy_instances = false
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = true
+sagemaker_local_tests = false
 
 # SM remote test valid values:
 # "off" --> do not trigger sagemaker remote tests (default)
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "standard"
+sagemaker_remote_tests = "off"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/pytorch/inference/buildspec-graviton.yml
+++ b/pytorch/inference/buildspec-graviton.yml
@@ -34,7 +34,7 @@ images:
     image_size_baseline: 10000
     device_type: &DEVICE_TYPE cpu
     os_version: &OS_VERSION ubuntu20.04
-    torch_serve_version: &TORCHSERVE_VERSION 0.8.1
+    torch_serve_version: &TORCHSERVE_VERSION 0.8.2
     python_version: &DOCKER_PYTHON_VERSION py3
     tag_python_version: &TAG_PYTHON_VERSION py310
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION , "-ec2"]
@@ -48,7 +48,7 @@ images:
     image_size_baseline: 10000
     device_type: &DEVICE_TYPE cpu
     os_version: &OS_VERSION ubuntu20.04
-    torch_serve_version: &TORCHSERVE_VERSION 0.8.1
+    torch_serve_version: &TORCHSERVE_VERSION 0.8.2
     tool_kit_version: &SM_TOOLKIT_VERSION 2.0.16
     python_version: &DOCKER_PYTHON_VERSION py3
     tag_python_version: &TAG_PYTHON_VERSION py310

--- a/pytorch/inference/docker/2.0/py3/Dockerfile.ec2.graviton.cpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.0/py3/Dockerfile.ec2.graviton.cpu.os_scan_allowlist.json
@@ -1,0 +1,29 @@
+{
+  "torch": [
+    {
+      "description": "## Overview\n[torch](https://pypi.org/project/torch) is a Tensors and Dynamic neural networks in Python with strong GPU acceleration\n\nAffected versions of this package are vulnerable to Arbitrary Code Injection through `filter-test-configs` in the `pull_request_target-triggered` workflow, allowing an attacker to use a malicious branch name to gain command execution and potentially leak secrets.\r\n\r\n**Mitigation:**\r\n\r\nUse an intermediate environment variable for potentially attacker-controlled values such as `github.event.workflow_run.head_branch`:\r\n\r\n```\r\n- name: Select all requested test configurations\r\n  shell: bash\r\n  env:\r\n    GITHUB_TOKEN: ${{ inputs.github-token }}\r\n    JOB_NAME: ${{ steps.get-job-name.outputs.job-name }}\r\n    HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}\r\n  id: filter\r\n  run: |\r\n    ...\r\n    python3 \"${GITHUB_ACTION_PATH}/../../scripts/filter_test_configs.py\" \\\r\n      ...\r\n      --branch \"$HEAD_BRANCH\"\r\n```\n## Remediation\nThere is no fixed version for `torch`.\n## References\n-", 
+      "vulnerability_id": "SNYK-PYTHON-TORCH-5876728", 
+      "name": "SNYK-PYTHON-TORCH-5876728", 
+      "package_name": "torch", 
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.10/site-packages/torch-2.0.1+cpu.dist-info/METADATA", 
+        "name": "torch", 
+        "package_manager": "PYTHONPKG", 
+        "version": "2.0.1+cpu", 
+        "release": null
+      }, 
+      "remediation": {"recommendation": {"text": "None Provided"}},
+      "cvss_v3_score": 9.8, 
+      "cvss_v30_score": 0.0, 
+      "cvss_v31_score": 9.8, 
+      "cvss_v2_score": 0.0, 
+      "cvss_v3_severity": 
+      "CRITICAL", 
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TORCH-5876728", 
+      "source": "SNYK", 
+      "severity": "CRITICAL", 
+      "status": "ACTIVE", 
+      "title": "IN1-PYTHON-TORCH-5876728 - torch"
+    }
+  ]
+}

--- a/pytorch/inference/docker/2.0/py3/Dockerfile.sagemaker.graviton.cpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.0/py3/Dockerfile.sagemaker.graviton.cpu.os_scan_allowlist.json
@@ -1,0 +1,29 @@
+{
+  "torch": [
+    {
+      "description": "## Overview\n[torch](https://pypi.org/project/torch) is a Tensors and Dynamic neural networks in Python with strong GPU acceleration\n\nAffected versions of this package are vulnerable to Arbitrary Code Injection through `filter-test-configs` in the `pull_request_target-triggered` workflow, allowing an attacker to use a malicious branch name to gain command execution and potentially leak secrets.\r\n\r\n**Mitigation:**\r\n\r\nUse an intermediate environment variable for potentially attacker-controlled values such as `github.event.workflow_run.head_branch`:\r\n\r\n```\r\n- name: Select all requested test configurations\r\n  shell: bash\r\n  env:\r\n    GITHUB_TOKEN: ${{ inputs.github-token }}\r\n    JOB_NAME: ${{ steps.get-job-name.outputs.job-name }}\r\n    HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}\r\n  id: filter\r\n  run: |\r\n    ...\r\n    python3 \"${GITHUB_ACTION_PATH}/../../scripts/filter_test_configs.py\" \\\r\n      ...\r\n      --branch \"$HEAD_BRANCH\"\r\n```\n## Remediation\nThere is no fixed version for `torch`.\n## References\n-", 
+      "vulnerability_id": "SNYK-PYTHON-TORCH-5876728", 
+      "name": "SNYK-PYTHON-TORCH-5876728", 
+      "package_name": "torch", 
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.10/site-packages/torch-2.0.1+cpu.dist-info/METADATA", 
+        "name": "torch", 
+        "package_manager": "PYTHONPKG", 
+        "version": "2.0.1+cpu", 
+        "release": null
+      }, 
+      "remediation": {"recommendation": {"text": "None Provided"}},
+      "cvss_v3_score": 9.8, 
+      "cvss_v30_score": 0.0, 
+      "cvss_v31_score": 9.8, 
+      "cvss_v2_score": 0.0, 
+      "cvss_v3_severity": 
+      "CRITICAL", 
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-TORCH-5876728", 
+      "source": "SNYK", 
+      "severity": "CRITICAL", 
+      "status": "ACTIVE", 
+      "title": "IN1-PYTHON-TORCH-5876728 - torch"
+    }
+  ]
+}


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
Upgrading torchserve version from 0.8.1 to [0.8.2](https://github.com/pytorch/serve/releases/tag/v0.8.2) in PyTorch 2.0.1 inference DLCs for graviton for both SM and EC2. 

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [x] All tests (ec2, ecs, eks, sanity, sm remote, sm local) successful at [5275316](https://github.com/aws/deep-learning-containers/pull/3316/commits/52753169845fbb635fddba6b869a6b0b509767af)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
