### PR TITLE
[pytorch][release] Patch release PT 1.13 Inference x86_64

### DIFF
--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -1,30 +1,6 @@
 ---
 release_images:
   1:
-    framework: "tensorflow"
-    version: "2.13.0"
-    customer_type: "ec2"
-    arch_type: "graviton"
-    inference:
-      device_types: ["cpu"]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  2:
-    framework: "tensorflow"
-    version: "2.13.0"
-    customer_type: "sagemaker"
-    arch_type: "graviton"
-    inference:
-      device_types: ["cpu"]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  3:
     framework: "stabilityai_pytorch"
     version: "2.0.1"
     arch_type: "x86"
@@ -38,70 +14,7 @@ release_images:
       example: False        
       disable_sm_tag: False
       force_release: False
-  4:
-    framework: "pytorch"
-    version: "2.0.1"
-    customer_type: "ec2"
-    arch_type: "x86"
-    inference:
-      device_types: ["cpu", "gpu"]
-      cuda_version: "cu118"
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  5:
-    framework: "pytorch"
-    version: "2.0.1"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    inference:
-      device_types: ["cpu", "gpu"]
-      cuda_version: "cu118"
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  6:
-    framework: "pytorch"
-    version: "2.0.1"
-    customer_type: "ec2"
-    arch_type: "graviton"
-    inference:
-      device_types: ["cpu"]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  7:
-    framework: "pytorch"
-    version: "2.0.1"
-    customer_type: "sagemaker"
-    arch_type: "graviton"
-    inference:
-      device_types: ["cpu"]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  8:
-    framework: "huggingface_pytorch_tgi"
-    version: "2.0.1"
-    arch_type: "x86"
-    hf_tgi: "1.0.3"
-    inference:
-      device_types: [ "gpu" ]
-      python_versions: [ "py39" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: True
-      force_release: False
-  9:
+  2:
     framework: "djl"
     version: "0.23.0"
     arch_type: "x86"
@@ -116,7 +29,7 @@ release_images:
       # to images being published.
       force_release: False   # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-  10:
+  3:
     framework: "huggingface_pytorch_tgi"
     version: "2.0.1"
     arch_type: "x86"
@@ -128,4 +41,30 @@ release_images:
       cuda_version: "cu118"
       example: False
       disable_sm_tag: True
+      force_release: False
+  4:
+    framework: "pytorch"
+    version: "1.13.1"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py39" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu117"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  5:
+    framework: "pytorch"
+    version: "1.13.1"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py39" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu117"
+      example: False
+      disable_sm_tag: False
       force_release: False


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
removed old TF 1.13 and PT 2.0.1 entries and added PT 1.13 x86_64 for release_images_inference.yml

### Tests run
Quick PR checks on initial commit.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
