### PR TITLE
[PyTorch][EC2][test] Update testTorchdata

### DIFF
--- a/test/dlc_tests/container_tests/bin/pytorch_tests/testTorchdata
+++ b/test/dlc_tests/container_tests/bin/pytorch_tests/testTorchdata
@@ -10,6 +10,8 @@ TORCHDATA_TEST_SCRIPT="data/test/test_remote_io.py"
 
 echo "Fetch Torchdata S3 IO test script."
 TORCHDATA_RELEASE_TAG=$(python -c "import torchdata as td; print(td.__version__.split('+')[0])")
+# checkout latest commit on main branch as of 10/12/23, as it has been tested to work on PT 2.0.1 and PT 2.1.0. 
+# torchdata is no longer being maintained, so the test script most likely will not be updated after this.
 git clone $TORCHDATA_REPO \
     && pushd data \
     && git checkout ce075397428c90be312f87b60d4701b2e3ff3700 \

--- a/test/dlc_tests/container_tests/bin/pytorch_tests/testTorchdata
+++ b/test/dlc_tests/container_tests/bin/pytorch_tests/testTorchdata
@@ -12,7 +12,7 @@ echo "Fetch Torchdata S3 IO test script."
 TORCHDATA_RELEASE_TAG=$(python -c "import torchdata as td; print(td.__version__.split('+')[0])")
 git clone $TORCHDATA_REPO \
     && pushd data \
-    && git checkout tags/v${TORCHDATA_RELEASE_TAG} -b ${TORCHDATA_RELEASE_TAG} \
+    && git checkout ce075397428c90be312f87b60d4701b2e3ff3700 \
     && popd
 
 # removing awscli requirement as it should already be installed, and is causing dependency issues

--- a/test/dlc_tests/ec2/pytorch/inference/test_pytorch_inference.py
+++ b/test/dlc_tests/ec2/pytorch/inference/test_pytorch_inference.py
@@ -162,7 +162,6 @@ def test_pytorch_inference_torchaudio_cpu(pytorch_inference, ec2_connection, cpu
     execute_ec2_inference_test(ec2_connection, pytorch_inference, PT_TORCHAUDIO_CMD)
 
 
-@pytest.mark.skip(reason="torchdata is no longer actively maintained on github")
 @pytest.mark.usefixtures("feature_torchdata_present")
 @pytest.mark.usefixtures("sagemaker", "stabilityai")
 @pytest.mark.integration("pt_torchdata_gpu")
@@ -182,7 +181,6 @@ def test_pytorch_inference_torchdata_gpu(
         execute_ec2_inference_test(ec2_connection, pytorch_inference, PT_TORCHDATA_CMD)
 
 
-@pytest.mark.skip(reason="torchdata is no longer actively maintained on github")
 @pytest.mark.usefixtures("feature_torchdata_present")
 @pytest.mark.usefixtures("sagemaker")
 @pytest.mark.integration("pt_torchdata_cpu")


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

- Torchdata has paused development and is missing the latest release tag for v0.7.0 (which corresponds to PT2.1.0), so use main branch instead. 
- Checkout the latest commit on main as of 10/12/23. The test script most likely will not be updated after this, but pinning the commit just in case.
- I've manually tested that the test on this commit works on inference and training PT2.0.1 EC2 images, which will be the oldest supported images after PT2.1.0 release. 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
