### PR TITLE
[graviton] update PyTorch 2.1 buildspec to use the latest torchserve and sagemaker toolkit

### DIFF
--- a/pytorch/inference/buildspec-graviton.yml
+++ b/pytorch/inference/buildspec-graviton.yml
@@ -34,7 +34,7 @@ images:
     image_size_baseline: 10000
     device_type: &DEVICE_TYPE cpu
     os_version: &OS_VERSION ubuntu20.04
-    torch_serve_version: &TORCHSERVE_VERSION 0.8.2
+    torch_serve_version: &TORCHSERVE_VERSION 0.9.0
     python_version: &DOCKER_PYTHON_VERSION py3
     tag_python_version: &TAG_PYTHON_VERSION py310
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION , "-ec2"]
@@ -48,7 +48,7 @@ images:
     image_size_baseline: 10000
     device_type: &DEVICE_TYPE cpu
     os_version: &OS_VERSION ubuntu20.04
-    torch_serve_version: &TORCHSERVE_VERSION 0.8.2
+    torch_serve_version: &TORCHSERVE_VERSION 0.9.0
     tool_kit_version: &SM_TOOLKIT_VERSION 2.0.16
     python_version: &DOCKER_PYTHON_VERSION py3
     tag_python_version: &TAG_PYTHON_VERSION py310

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.graviton.cpu
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.graviton.cpu
@@ -137,7 +137,7 @@ RUN ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
     "cryptography>=41.0.2" \
     "ipython>=8.10.0,<9.0" \
     "awscli<2" \
-    "urllib3==1.26.17"
+    "urllib3==1.26.18"
 
 # Ensure PyTorch did not get installed from Conda or pip, prior to now
 RUN pip uninstall -y torch torchvision torchaudio torchdata model-archiver multi-model-server


### PR DESCRIPTION


*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
update Graviton buildspec to use the latest torchserve and sagemaker toolkit for PyTorch 2.1 DLCs

### Tests run
SageMaker Inference Recommender tests for hugging face models.

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

### Additional context

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
