### PR TITLE
[test][pytorch] Fix SM Training test retry bug

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -31,26 +31,26 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = false
+datetime_tag = true
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
-do_build = false
+do_build = true
 
 [test]
 ### On by default
-sanity_tests = false
+sanity_tests = true
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = false
-eks_tests = false
-ec2_tests = false
+ecs_tests = true
+eks_tests = true
+ec2_tests = true
 
 ### Set ec2_tests_on_heavy_instances = true to be able to run any EC2 tests that use large/expensive instance types by
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
@@ -67,7 +67,7 @@ sagemaker_local_tests = false
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "standard"
+sagemaker_remote_tests = "off"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""
@@ -89,7 +89,7 @@ use_scheduler = false
 
 # Standard Framework Training
 dlc-pr-mxnet-training = ""
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-0-sm.yml"
+dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -31,26 +31,26 @@ benchmark_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set to false in order to remove datetime tag on PR builds
-datetime_tag = true
+datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
 do_build = true
 
 [test]
 ### On by default
-sanity_tests = true
+sanity_tests = false
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = true
-eks_tests = true
-ec2_tests = true
+ecs_tests = false
+eks_tests = false
+ec2_tests = false
 
 ### Set ec2_tests_on_heavy_instances = true to be able to run any EC2 tests that use large/expensive instance types by
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
@@ -89,7 +89,7 @@ use_scheduler = false
 
 # Standard Framework Training
 dlc-pr-mxnet-training = ""
-dlc-pr-pytorch-training = ""
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-0-sm.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -41,7 +41,7 @@ build_inference = false
 datetime_tag = false
 # Note: Need to build the images at least once with datetime_tag = false
 # before disabling new builds, or tests will fail
-do_build = true
+do_build = false
 
 [test]
 ### On by default
@@ -67,7 +67,7 @@ sagemaker_local_tests = false
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "off"
+sagemaker_remote_tests = "standard"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -149,24 +149,22 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     config.addinivalue_line("markers", "efa(): explicitly mark to run efa tests")
     config.addinivalue_line("markers", "skip_py2_containers(): skip testing py2 containers")
-    config.addinivalue_line("model", "model(): note the model being tested")
-    config.addinivalue_line("integration", "integration(): note the feature being tested")
-    config.addinivalue_line("skip_cpu", "skip_cpu(): skip cpu images on test")
-    config.addinivalue_line("skip_gpu", "skip_gpu(): skip gpu images on test")
-    config.addinivalue_line("multinode", "multinode(): mark as multi-node test")
-    config.addinivalue_line("processor", "processor(): note the processor type being tested")
-    config.addinivalue_line("team", "team(): note the team responsible for the test")
+    config.addinivalue_line("markers", "model(): note the model being tested")
+    config.addinivalue_line("markers", "integration(): note the feature being tested")
+    config.addinivalue_line("markers", "skip_cpu(): skip cpu images on test")
+    config.addinivalue_line("markers", "skip_gpu(): skip gpu images on test")
+    config.addinivalue_line("markers", "multinode(): mark as multi-node test")
+    config.addinivalue_line("markers", "processor(): note the processor type being tested")
+    config.addinivalue_line("markers", "team(): note the team responsible for the test")
+    config.addinivalue_line("markers", "skip_trcomp_containers(): skip trcomp images on test")
     config.addinivalue_line(
-        "skip_trcomp_containers", "skip_trcomp_containers(): skip trcomp images on test"
+        "markers", "skip_inductor_test(): skip inductor test on incompatible images"
     )
     config.addinivalue_line(
-        "skip_inductor_test", "skip_inductor_test(): skip inductor test on incompatible images"
+        "markers", "skip_s3plugin_test(): skip s3plugin test on incompatible images"
     )
-    config.addinivalue_line(
-        "skip_s3plugin_test", "skip_s3plugin_test(): skip s3plugin test on incompatible images"
-    )
-    config.addinivalue_line("neuronx_test", "neuronx_test(): mark as neuronx image test")
-    config.addinivalue_line("gdrcopy", "gdrcopy(): mark as gdrcopy integration test")
+    config.addinivalue_line("markers", "neuronx_test(): mark as neuronx image test")
+    config.addinivalue_line("markers", "gdrcopy(): mark as gdrcopy integration test")
 
 
 def pytest_runtest_setup(item):

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -148,6 +148,25 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "efa(): explicitly mark to run efa tests")
+    config.addinivalue_line("markers", "skip_py2_containers(): skip testing py2 containers")
+    config.addinivalue_line("model", "model(): note the model being tested")
+    config.addinivalue_line("integration", "integration(): note the feature being tested")
+    config.addinivalue_line("skip_cpu", "skip_cpu(): skip cpu images on test")
+    config.addinivalue_line("skip_gpu", "skip_gpu(): skip gpu images on test")
+    config.addinivalue_line("multinode", "multinode(): mark as multi-node test")
+    config.addinivalue_line("processor", "processor(): note the processor type being tested")
+    config.addinivalue_line("team", "team(): note the team responsible for the test")
+    config.addinivalue_line(
+        "skip_trcomp_containers", "skip_trcomp_containers(): skip trcomp images on test"
+    )
+    config.addinivalue_line(
+        "skip_inductor_test", "skip_inductor_test(): skip inductor test on incompatible images"
+    )
+    config.addinivalue_line(
+        "skip_s3plugin_test", "skip_s3plugin_test(): skip s3plugin test on incompatible images"
+    )
+    config.addinivalue_line("neuronx_test", "neuronx_test(): mark as neuronx image test")
+    config.addinivalue_line("gdrcopy", "gdrcopy(): mark as gdrcopy integration test")
 
 
 def pytest_runtest_setup(item):

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -148,6 +148,8 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     config.addinivalue_line("markers", "efa(): explicitly mark to run efa tests")
+    config.addinivalue_line("markers", "deploy_test(): mark to run deploy tests")
+    config.addinivalue_line("markers", "skip_test_in_region(): mark to skip test in some regions")
     config.addinivalue_line("markers", "skip_py2_containers(): skip testing py2 containers")
     config.addinivalue_line("markers", "model(): note the model being tested")
     config.addinivalue_line("markers", "integration(): note the feature being tested")

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/__init__.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/__init__.py
@@ -102,7 +102,10 @@ def invoke_pytorch_estimator(
                 training_input = upload_s3_data(pytorch, **upload_s3_data_args)
                 inputs = {"training": training_input}
 
-            pytorch.fit(inputs=inputs, job_name=job_name, logs=True)
+            if job_name:
+                job_name = utils.unique_name_from_base(job_name)
+
+            pytorch.fit(inputs=inputs, job_name=job_name)
             return pytorch, sagemaker_session
 
         except sagemaker.exceptions.UnexpectedStatusException as e:

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_distributed_operations.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_distributed_operations.py
@@ -156,9 +156,9 @@ def test_dist_operations_fastai_gpu(framework_version, ecr_image, sagemaker_regi
             "framework_version": framework_version,
         }
 
-        job_name = utils.unique_name_from_base("test-pt-fastai")
+        job_name_prefix = "test-pt-fastai"
         pytorch, sagemaker_session = invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )
 
     model_s3_url = pytorch.create_model().model_data
@@ -258,9 +258,13 @@ def test_smmodelparallel_gpt2_multigpu_singlenode(
                 },
             },
         }
-        job_name = utils.unique_name_from_base("test-pt-smdmp-gpt2-singlenode")
+        job_name_prefix = "test-pt-smdmp-gpt2-singlenode"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, inputs=inputs, job_name=job_name
+            ecr_image,
+            sagemaker_regions,
+            estimator_parameter,
+            inputs=inputs,
+            job_name=job_name_prefix,
         )
 
 
@@ -359,9 +363,13 @@ def test_smmodelparallel_gpt2_multigpu_singlenode_flashattn(
                 },
             },
         }
-        job_name = utils.unique_name_from_base("test-pt-smdmp-gpt2-singlenode-flashattn")
+        job_name_prefix = "test-pt-smdmp-gpt2-singlenode-flashattn"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, inputs=inputs, job_name=job_name
+            ecr_image,
+            sagemaker_regions,
+            estimator_parameter,
+            inputs=inputs,
+            job_name=job_name_prefix,
         )
 
 
@@ -417,9 +425,9 @@ def test_smmodelparallel_mnist_multigpu_multinode(
                 },
             },
         }
-        job_name = utils.unique_name_from_base("test-pt-smdmp-multinode")
+        job_name_prefix = "test-pt-smdmp-multinode"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )
 
 
@@ -477,9 +485,9 @@ def test_hc_smmodelparallel_mnist_multigpu_multinode(
                 "instance_groups": [training_group],
             },
         }
-        job_name = utils.unique_name_from_base("test-pt-hc-smdmp-multinode")
+        job_name_prefix = "test-pt-hc-smdmp-multinode"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )
 
 
@@ -535,9 +543,9 @@ def test_smmodelparallel_mnist_multigpu_multinode_efa(
                 },
             },
         }
-        job_name = utils.unique_name_from_base("test-pt-smdmp-multinode-efa")
+        job_name_prefix = "test-pt-smdmp-multinode-efa"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )
 
 
@@ -631,9 +639,13 @@ def test_smmodelparallel_gpt2_sdp_multinode_efa(
                 },
             },
         }
-        job_name = utils.unique_name_from_base("test-pt-smdmp-gpt2-sdp-multinode")
+        job_name_prefix = "test-pt-smdmp-gpt2-sdp-multinode"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, inputs=inputs, job_name=job_name
+            ecr_image,
+            sagemaker_regions,
+            estimator_parameter,
+            inputs=inputs,
+            job_name=job_name_prefix,
         )
 
 
@@ -660,9 +672,9 @@ def test_sanity_efa(ecr_image, efa_instance_type, sagemaker_regions):
                 "mpi": {"enabled": True, "processes_per_host": 1},
             },
         }
-        job_name = utils.unique_name_from_base("test-pt-efa-sanity")
+        job_name_prefix = "test-pt-efa-sanity"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )
 
 

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_gdrcopy.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_gdrcopy.py
@@ -67,7 +67,7 @@ def test_sanity_gdrcopy(ecr_image, efa_instance_type, sagemaker_regions):
                 "mpi": {"enabled": True, "processes_per_host": 1},
             },
         }
-        job_name = utils.unique_name_from_base("test-pt-gdrcopy-sanity")
+        job_name_prefix = "test-pt-gdrcopy-sanity"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pt_s3_plugin.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pt_s3_plugin.py
@@ -51,9 +51,9 @@ def test_pt_s3_plugin_sm_gpu(framework_version, ecr_image, sagemaker_regions):
             "framework_version": framework_version,
         }
 
-        job_name = utils.unique_name_from_base("test-pytorch-s3-plugin-gpu")
+        job_name_prefix = "test-pytorch-s3-plugin-gpu"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )
 
 
@@ -76,9 +76,9 @@ def test_hc_pt_s3_plugin_sm_gpu(framework_version, ecr_image, sagemaker_regions)
             "framework_version": framework_version,
         }
 
-        job_name = utils.unique_name_from_base("test-pytorch-hc-s3-plugin-gpu")
+        job_name_prefix = "test-pytorch-hc-s3-plugin-gpu"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )
 
 
@@ -100,9 +100,9 @@ def test_pt_s3_plugin_sm_cpu(framework_version, ecr_image, sagemaker_regions):
             "instance_type": CPU_INSTANCE,
             "framework_version": framework_version,
         }
-        job_name = utils.unique_name_from_base("test-pytorch-s3-plugin-cpu")
+        job_name_prefix = "test-pytorch-s3-plugin-cpu"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )
 
 
@@ -124,7 +124,7 @@ def test_hc_pt_s3_plugin_sm_cpu(framework_version, ecr_image, sagemaker_regions)
             "instance_groups": [training_group],
             "framework_version": framework_version,
         }
-        job_name = utils.unique_name_from_base("test-pytorch-hc-s3-plugin-cpu")
+        job_name_prefix = "test-pytorch-hc-s3-plugin-cpu"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp.py
@@ -63,7 +63,7 @@ def test_pytorchddp_throughput_gpu(
             "distribution": distribution,
         }
 
-        job_name = utils.unique_name_from_base("test-pytorchddp-throughput-gpu")
+        job_name_prefix = "test-pytorchddp-throughput-gpu"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp_inductor.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp_inductor.py
@@ -64,7 +64,7 @@ def test_pytorchddp_throughput_gpu(
             "hyperparameters": {"inductor": 1},
         }
 
-        job_name = utils.unique_name_from_base("test-pytorchddp-throughput-gpu")
+        job_name_prefix = "test-pytorchddp-throughput-gpu"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_smdataparallel.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_smdataparallel.py
@@ -93,9 +93,9 @@ def test_smdataparallel_throughput(
             "distribution": distribution,
         }
 
-        job_name = utils.unique_name_from_base("test-pt-smddp-throughput")
+        job_name_prefix = "test-pt-smddp-throughput"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )
 
 
@@ -126,9 +126,9 @@ def test_smdataparallel_mnist_script_mode_multigpu(
             "instance_type": instance_type,
             "distribution": distribution,
         }
-        job_name = utils.unique_name_from_base("test-pt-smddp-mnist-script-mode")
+        job_name_prefix = "test-pt-smddp-mnist-script-mode"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )
 
 
@@ -163,9 +163,9 @@ def test_smdataparallel_mnist(ecr_image, sagemaker_regions, efa_instance_type, t
             "distribution": distribution,
         }
 
-        job_name = utils.unique_name_from_base("test-pt-smddp-mnist")
+        job_name_prefix = "test-pt-smddp-mnist"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )
 
 
@@ -202,9 +202,9 @@ def test_hc_smdataparallel_mnist(ecr_image, sagemaker_regions, efa_instance_type
             "distribution": distribution,
         }
 
-        job_name = utils.unique_name_from_base("test-pt-hc-smddp-mnist")
+        job_name_prefix = "test-pt-hc-smddp-mnist"
         invoke_pytorch_estimator(
-            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name
+            ecr_image, sagemaker_regions, estimator_parameter, job_name=job_name_prefix
         )
 
 
@@ -244,11 +244,11 @@ def test_smmodelparallel_smdataparallel_mnist(
             "instance_count": 1,
             "instance_type": instance_types,
         }
-        job_name = utils.unique_name_from_base("test-pt-smdmp-smddp-mnist")
+        job_name_prefix = "test-pt-smdmp-smddp-mnist"
         invoke_pytorch_estimator(
             ecr_image,
             sagemaker_regions,
             estimator_parameter,
             disable_sm_profiler=True,
-            job_name=job_name,
+            job_name=job_name_prefix,
         )

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_smppy.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_smppy.py
@@ -61,13 +61,13 @@ def test_training_smppy(framework_version, ecr_image, sagemaker_regions):
             "debug_hook_config": False,
         }
         upload_s3_data_args = {"path": training_dir, "key_prefix": "pytorch/mnist"}
-        job_name = utils.unique_name_from_base("test-pt-smppy-training")
+        job_name_prefix = "test-pt-smppy-training"
         pytorch, _ = invoke_pytorch_estimator(
             ecr_image,
             sagemaker_regions,
             estimator_parameters,
             upload_s3_data_args=upload_s3_data_args,
-            job_name=job_name,
+            job_name=job_name_prefix,
         )
         _check_and_cleanup_s3_output(pytorch, 40)
 
@@ -96,13 +96,13 @@ def test_training_smppy_distributed(framework_version, ecr_image, sagemaker_regi
             "debug_hook_config": False,
         }
         upload_s3_data_args = {"path": training_dir, "key_prefix": "pytorch/mnist"}
-        job_name = utils.unique_name_from_base("test-pt-smppy-training-distributed")
+        job_name_prefix = "test-pt-smppy-training-distributed"
         pytorch, _ = invoke_pytorch_estimator(
             ecr_image,
             sagemaker_regions,
             estimator_parameters,
             upload_s3_data_args=upload_s3_data_args,
-            job_name=job_name,
+            job_name=job_name_prefix,
         )
         _check_and_cleanup_s3_output(pytorch, 60)
 

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_training_smdebug.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_training_smdebug.py
@@ -45,13 +45,13 @@ def test_training_smdebug(framework_version, ecr_image, sagemaker_regions, insta
             "hyperparameters": hyperparameters,
         }
         upload_s3_data_args = {"path": training_dir, "key_prefix": "pytorch/mnist"}
-        job_name = utils.unique_name_from_base("test-pt-smdebug-training")
+        job_name_prefix = "test-pt-smdebug-training"
         invoke_pytorch_estimator(
             ecr_image,
             sagemaker_regions,
             estimator_parameter,
             upload_s3_data_args=upload_s3_data_args,
-            job_name=job_name,
+            job_name=job_name_prefix,
         )
 
 
@@ -79,11 +79,11 @@ def test_hc_training_smdebug(framework_version, ecr_image, sagemaker_regions, in
             "hyperparameters": hyperparameters,
         }
         upload_s3_data_args = {"path": training_dir, "key_prefix": "pytorch/mnist"}
-        job_name = utils.unique_name_from_base("test-pt-hc-smdebug-training")
+        job_name_prefix = "test-pt-hc-smdebug-training"
         invoke_pytorch_estimator(
             ecr_image,
             sagemaker_regions,
             estimator_parameter,
             upload_s3_data_args=upload_s3_data_args,
-            job_name=job_name,
+            job_name=job_name_prefix,
         )


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
Bug in retry logic causes same `job_name` to be passed to multiple attempts of the same training job in a region. SM Training requires each training job to have a unique name. Move `job_name` unique-suffix creation into helper function.

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [x] I have run builds/tests on commit [7de8e4e](https://github.com/aws/deep-learning-containers/pull/3458/commits/7de8e4eab3743c0b81093aadd0b0ac985f13539c) for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [x] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

### Formatting
- [x] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

### Additional context

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
