### PR TITLE
fix: Removing libwebp6 in SAI images

### DIFF
--- a/stabilityai/pytorch/inference/docker/2.0/py3/cu118/Dockerfile.gpu
+++ b/stabilityai/pytorch/inference/docker/2.0/py3/cu118/Dockerfile.gpu
@@ -4,9 +4,6 @@ LABEL dlc_major_version="1"
 ARG PYTHON=python3
 ARG XFORMERS_VERSION=0.0.20
 
-RUN apt-get update \
- && apt-get -y upgrade --only-upgrade libwebp6
-
 # xformers must be installed from source due to the older version of python in the DLC
 RUN pip install ninja \
   && pip install -v -U git+https://github.com/facebookresearch/xformers.git@v${XFORMERS_VERSION}#egg=xformers


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

Removing libwebp6 in all SAI images as it seems to be causing test failures (reverting https://github.com/aws/deep-learning-containers/pull/3349)

This was originally added to handle a CVE, but the base image has been patched. The integ tests have passed when the update was removed according to @arjunkes - and if it were needed, the sanity checks would have failed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
