### PR TITLE
Add sagemaker_region to s3 bucket name for ``smmodelparallel_gpt2_multigpu`` tests

### DIFF
--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_distributed_operations.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_distributed_operations.py
@@ -221,8 +221,10 @@ def test_smmodelparallel_gpt2_multigpu_singlenode(
         "manual_partition": 1,
         "smp_version": smp_version,
     }
+    s3_bucket = "s3://gpt2-data-"+ sagemaker_regions[0] + "/train_synthetic_small/"
+
     train = sagemaker.session.s3_input(
-        "s3://gpt2-data/train_synthetic_small/",
+        s3_bucket,
         distribution="FullyReplicated",
         content_type="application/tfrecord",
         s3_data_type="S3Prefix",
@@ -328,8 +330,10 @@ def test_smmodelparallel_gpt2_multigpu_singlenode_flashattn(
         "query_key_layer_scaling": 0,
         "assert_flash_attn": 1,
     }
+    s3_bucket = "s3://gpt2-data-"+ sagemaker_regions[0] + "/train_synthetic_small/"
+
     train = sagemaker.session.s3_input(
-        "s3://gpt2-data/train_synthetic_small/",
+        s3_bucket,
         distribution="FullyReplicated",
         content_type="application/tfrecord",
         s3_data_type="S3Prefix",


### PR DESCRIPTION
*GitHub Issue #, if available:*

@saimidu will create region specific new buckets.  
_**Please ONLY merge this PR after buckets are created.**_ 

Following tests are failing since cross-region bucket access is no longer supported. 

1. test_smmodelparallel_gpt2_multigpu_singlenode
2. test_smmodelparallel_gpt2_multigpu_singlenode_flashattn 


### Description

This PR replaces s3 bucket name with region specific bucket name. 

### Tests run

Reran these 2 tests locally on Sagemaker:
1. test_smmodelparallel_gpt2_multigpu_singlenode
2. test_smmodelparallel_gpt2_multigpu_singlenode_flashattn 

@saimidu will create region specific new buckets.  
_**Please ONLY merge this PR after buckets are created.**_ 

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**

- [ ] Revision A: `sagemaker_remote_tests = "standard"`
- [ ] Revision B: `sagemaker_remote_tests = "rc"`
- [ ] Revision C: `sagemaker_remote_tests = "efa"`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch-training:1.13.1-gpu-py39-cu117-ubuntu20.04-sagemaker

### Additional context

## PR Checklist
- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

## Pytest Marker Checklist
- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type

#### EIA/NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ei_mode = true`, `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `benchmark_mode = true`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
