### PR TITLE
Move 1p-algos to end of codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -51,3 +51,8 @@ dgl_tests/ @aws/dlc-dgl-reviewers
 # Files under stabilityai/ and huggingface/ directories can be directly reviewed by below teams
 stabilityai/ @aws/sagemaker-1p-algorithms
 huggingface/ @aws/sagemaker-1p-algorithms
+test/sagemaker_tests/huggingface/ @aws/sagemaker-1p-algorithms
+test/sagemaker_tests/huggingface_pytorch/ @aws/sagemaker-1p-algorithms
+test/sagemaker_tests/huggingface_tensorflow/ @aws/sagemaker-1p-algorithms
+test/sagemaker_tests/pytorch/inference/integration/sagemaker/test_stabilityai.py @aws/sagemaker-1p-algorithms
+test/sagemaker_tests/pytorch/inference/resources/stabilityai/ @aws/sagemaker-1p-algorithms

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -17,10 +17,6 @@ release_images_training.yml @aws/dl-containers @aws/dlc-autogluon-reviewers @aws
 autogluon/ @aws/dlc-autogluon-reviewers
 test/sagemaker_tests/autogluon @aws/dlc-autogluon-reviewers
 
-# Files under stabilityai/ and huggingface/ directories can be directly reviewed by below teams
-stabilityai/ @aws/sagemaker-1p-algorithms
-huggingface/ @aws/sagemaker-1p-algorithms
-
 # Any PR with a file with "pytorch" in it will be assigned to the conda reviewer team
 *pytorch* @aws/dlc-pytorch-reviewers
 
@@ -51,3 +47,7 @@ dgl_tests/ @aws/dlc-dgl-reviewers
 
 # Any PR with a file with "triton" in it will be assigned to the SM Triton/ModelServing team
 *triton* @aws/dlc-triton-reviewers
+
+# Files under stabilityai/ and huggingface/ directories can be directly reviewed by below teams
+stabilityai/ @aws/sagemaker-1p-algorithms
+huggingface/ @aws/sagemaker-1p-algorithms


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
From codeowners docs - https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

```
# Order is important; the last matching pattern takes the most
# precedence. When someone opens a pull request that only
# modifies JS files, only @js-owner and not the global
# owner(s) will be requested for a review.
```

Modifying codeowners file to remove conflict of 1p algos/conda

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
