### PR TITLE
[PyTorch] [Training] [2.1] [SageMaker] Enabling PyTorch Verbose Logging for advanced modules

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,11 +37,11 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
 datetime_tag = true
@@ -74,7 +74,7 @@ sagemaker_local_tests = false
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "standard"
+sagemaker_remote_tests = "off"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,11 +37,11 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set to false in order to remove datetime tag on PR builds
 datetime_tag = true
@@ -74,7 +74,7 @@ sagemaker_local_tests = false
 # "standard" --> run standard sagemaker remote tests from test/sagemaker_tests
 # "rc" --> run release_candidate_integration tests
 # "efa" --> run efa sagemaker tests
-sagemaker_remote_tests = "off"
+sagemaker_remote_tests = "standard"
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/pytorch/training/docker/2.1/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/2.1/py3/Dockerfile.cpu
@@ -249,6 +249,10 @@ LABEL dlc_major_version="1"
 
 ARG PYTHON
 
+# Selectively enable PyTorch Verbose Logging
+ENV PYTORCH_API_USAGE_STDERR=1
+ENV TORCH_LOGS=+dynamo,+aot,+inductor
+
 ENV SAGEMAKER_TRAINING_MODULE=sagemaker_pytorch_container.training:main
 
 ARG PYTORCH_VERSION_SM

--- a/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
+++ b/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
@@ -358,6 +358,10 @@ ARG TORCH_CUDA_ARCH_LIST
 ARG NCCL_ASYNC_ERROR_HANDLING
 ARG SMP_URL
 
+# Selectively enable PyTorch Verbose Logging
+ENV PYTORCH_API_USAGE_STDERR=1
+ENV TORCH_LOGS=+dynamo,+aot,+inductor
+
 WORKDIR /
 
 # Install sm PyTorch


### PR DESCRIPTION
### Description

Increase the PyTorch Logging Verbosity to record activity in advanced modules involving graph capture, compilation and execution.  This should aide greatly in debugging compilation errors in PyTorch 2.X reducing the need to rerun jobs for troubleshooting purposes.

PyTorch uses static variables to track API usage and print the activity once in lifetime of the process. This should cause no additional overhead since we expect no more than 20 additional lines of logs and the prints from CPP layer have no performance impact. Ref: https://github.com/pytorch/pytorch/blob/main/c10/util/Logging.cpp#L93

PyTorch introduced a new logging mechanism to selectively increase verbosity for certain advanced modules like compiler. This greatly aides in the debugging of failures when using compilation. These log lines are only expected to be dumped when a soft/hard failure occurs and are no more than 10 additional lines of logs. Ref: https://github.com/pytorch/pytorch/blob/main/torch/_dynamo/config.py#L11-L18

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [x] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

### Formatting
- [x] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

### Additional context

## PR Checklist
- [x] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [x] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [x] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image
- [x] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [x] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
