### PR TITLE
fix pytorch installation between ec2 and sm

### DIFF
--- a/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
+++ b/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
@@ -239,7 +239,7 @@ WORKDIR /
 
 # Install ec2 PyTorch
 RUN /opt/conda/bin/mamba install -y python=${PYTHON_SHORT_VERSION} pytorch=${PYTORCH_VERSION} \
-  pytorch-cuda=12.1 cuda-nvcc=12.1.* torchvision torchaudio torchtext aws-ofi-nccl-dlc \
+  pytorch-cuda=12.1 cuda-nvcc=12.1.* torchvision torchaudio torchtext aws-ofi-nccl \
   --override-channels \
   -c ${CONDA_CHANNEL} \
   -c nvidia \
@@ -366,7 +366,7 @@ WORKDIR /
 
 # Install sm PyTorch
 RUN /opt/conda/bin/mamba install -y python=${PYTHON_SHORT_VERSION} pytorch=${PYTORCH_VERSION} \
-  pytorch-cuda=12.1 cuda-nvcc=12.1.* torchvision torchaudio torchtext aws-ofi-nccl-dlc \
+  pytorch-cuda=12.1 cuda-nvcc=12.1.* torchvision torchaudio torchtext aws-ofi-nccl \
   --override-channels \
   -c ${CONDA_CHANNEL} \
   -c nvidia \

--- a/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
+++ b/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
@@ -2,7 +2,7 @@ ARG PYTHON=python3
 ARG PYTHON_VERSION=3.10.12
 ARG PYTHON_SHORT_VERSION=3.10
 ARG MAMBA_VERSION=23.3.1-1
-ARG PYTORCH_VERSION_EC2=2.1.0
+ARG PYTORCH_VERSION=2.1.0
 ARG CONDA_CHANNEL=https://aws-ml-conda-ec2.s3.us-west-2.amazonaws.com
 # SageMaker Profiler Binary
 ARG SMP_URL=https://smppy.s3.amazonaws.com/pytorch/cu121/smprof-0.3.334-cp310-cp310-linux_x86_64.whl
@@ -229,7 +229,7 @@ FROM common AS ec2
 ARG PYTHON
 ARG PYTHON_VERSION
 ARG PYTHON_SHORT_VERSION
-ARG PYTORCH_VERSION_EC2
+ARG PYTORCH_VERSION
 ARG CONDA_CHANNEL
 ARG CUDA_HOME
 ARG TORCH_CUDA_ARCH_LIST
@@ -238,7 +238,7 @@ ARG NCCL_ASYNC_ERROR_HANDLING
 WORKDIR /
 
 # Install ec2 PyTorch
-RUN /opt/conda/bin/mamba install -y python=${PYTHON_SHORT_VERSION} pytorch=${PYTORCH_VERSION_EC2} \
+RUN /opt/conda/bin/mamba install -y python=${PYTHON_SHORT_VERSION} pytorch=${PYTORCH_VERSION} \
   pytorch-cuda=12.1 cuda-nvcc=12.1.* torchvision torchaudio torchtext aws-ofi-nccl-dlc \
   --override-channels \
   -c ${CONDA_CHANNEL} \
@@ -249,7 +249,7 @@ RUN /opt/conda/bin/mamba install -y python=${PYTHON_SHORT_VERSION} pytorch=${PYT
 # CUDA libraries should be installed as a separate installation command to reduce memory size of single layer.
 # If single layer is huge in size (like 17 GB), then ECR pull can timeout on smaller EC2 instances like P3.2x.
 # Have added python and pytorch again in below command to make sure pytorch version wont be changed.
-RUN /opt/conda/bin/mamba install -y python=${PYTHON_SHORT_VERSION} pytorch=${PYTORCH_VERSION_EC2} \
+RUN /opt/conda/bin/mamba install -y python=${PYTHON_SHORT_VERSION} pytorch=${PYTORCH_VERSION} \
   cuda-libraries-dev=12.1 cuda-libraries-static=12.1 cuda-compiler=12.1 \
   --override-channels \
   -c ${CONDA_CHANNEL} \
@@ -351,7 +351,7 @@ ENV SAGEMAKER_TRAINING_MODULE=sagemaker_pytorch_container.training:main
 ARG PYTHON
 ARG PYTHON_VERSION
 ARG PYTHON_SHORT_VERSION
-ARG PYTORCH_VERSION_SM
+ARG PYTORCH_VERSION
 ARG CONDA_CHANNEL
 ARG CUDA_HOME
 ARG TORCH_CUDA_ARCH_LIST
@@ -365,7 +365,7 @@ ENV TORCH_LOGS=+dynamo,+aot,+inductor
 WORKDIR /
 
 # Install sm PyTorch
-RUN /opt/conda/bin/mamba install -y python=${PYTHON_SHORT_VERSION} pytorch=${PYTORCH_VERSION_SM} \
+RUN /opt/conda/bin/mamba install -y python=${PYTHON_SHORT_VERSION} pytorch=${PYTORCH_VERSION} \
   pytorch-cuda=12.1 cuda-nvcc=12.1.* torchvision torchaudio torchtext aws-ofi-nccl-dlc \
   --override-channels \
   -c ${CONDA_CHANNEL} \
@@ -380,7 +380,7 @@ RUN pip install --no-cache-dir -U ${SMP_URL}
 # CUDA libraries should be installed after pytorch installation command to reduce memory size of single layer.
 # If single layer is huge in size (like 17 GB), then ECR pull can timeout on smaller EC2 instances like P3.2x.
 # Have added python and pytorch again in below command to make sure pytorch version wont be changed.
-RUN /opt/conda/bin/mamba install -y python=${PYTHON_SHORT_VERSION} pytorch=${PYTORCH_VERSION_SM} \
+RUN /opt/conda/bin/mamba install -y python=${PYTHON_SHORT_VERSION} pytorch=${PYTORCH_VERSION} \
   cuda-libraries-dev=12.1 cuda-libraries-static=12.1 cuda-compiler=12.1 \
   --override-channels \
   -c ${CONDA_CHANNEL} \


### PR DESCRIPTION
*GitHub Issue #, if available:*


### Description
This PR fixes installation of PyTorch since both EC2 and SM layer now use the same binary.
This PR also fixes issue of installing PyTorch in SM layer since `PYTORCH_VERSION_SM` variable is not declared and has since been installing the latest PyTorch version which worked with PT 2.1.0 currency but this will no longer work when PT 2.2.0 is released.

### Tests run


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
