### PR TITLE
Revert aws-ofi-nccl to aws-ofi-nccl-dlc

### DIFF
--- a/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
+++ b/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
@@ -239,7 +239,7 @@ WORKDIR /
 
 # Install ec2 PyTorch
 RUN /opt/conda/bin/mamba install -y python=${PYTHON_SHORT_VERSION} pytorch=${PYTORCH_VERSION} \
-  pytorch-cuda=12.1 cuda-nvcc=12.1.* torchvision torchaudio torchtext aws-ofi-nccl \
+  pytorch-cuda=12.1 cuda-nvcc=12.1.* torchvision torchaudio torchtext aws-ofi-nccl-dlc \
   --override-channels \
   -c ${CONDA_CHANNEL} \
   -c nvidia \
@@ -366,7 +366,7 @@ WORKDIR /
 
 # Install sm PyTorch
 RUN /opt/conda/bin/mamba install -y python=${PYTHON_SHORT_VERSION} pytorch=${PYTORCH_VERSION} \
-  pytorch-cuda=12.1 cuda-nvcc=12.1.* torchvision torchaudio torchtext aws-ofi-nccl \
+  pytorch-cuda=12.1 cuda-nvcc=12.1.* torchvision torchaudio torchtext aws-ofi-nccl-dlc \
   --override-channels \
   -c ${CONDA_CHANNEL} \
   -c nvidia \


### PR DESCRIPTION
*GitHub Issue #, if available:*

### Description
Revert `aws-ofi-nccl` installation to `aws-ofi-nccl-dlc`.
This is because ec2 channel contains `aws-ofi-nccl-dlc` along with `torchtext` and `torchdata` that is installed in the SM DLC. 
Conda channel, however, contains only `aws-ofi-nccl` without `torchtext` and `torchdata`. Moving forward with PT 2.2.0 releases, the conda channel will include `torchtext` and `torchdata`.

### Tests run


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
