### PR TITLE
Skip smdataparallel p5 tests

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -104,7 +104,7 @@ use_scheduler = false
 
 # Standard Framework Training
 dlc-pr-mxnet-training = ""
-dlc-pr-pytorch-training = ""
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-1-sm.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,11 +34,11 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds
 datetime_tag = true
@@ -78,14 +78,14 @@ sagemaker_local_tests = false
 # run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = false
 # run efa sagemaker tests
-sagemaker_efa_tests = true
+sagemaker_efa_tests = false
 # run release_candidate_integration tests
 sagemaker_rc_tests = false
 # run sagemaker benchmark tests
 sagemaker_benchmark_tests = false
 
 # SM remote EFA test instance type
-sagemaker_remote_efa_instance_type = "p5.48xlarge"
+sagemaker_remote_efa_instance_type = ""
 
 # Run CI tests for nightly images
 # false by default

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,11 +34,11 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set to false in order to remove datetime tag on PR builds
 datetime_tag = true
@@ -78,14 +78,14 @@ sagemaker_local_tests = false
 # run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = false
 # run efa sagemaker tests
-sagemaker_efa_tests = false
+sagemaker_efa_tests = true
 # run release_candidate_integration tests
 sagemaker_rc_tests = false
 # run sagemaker benchmark tests
 sagemaker_benchmark_tests = false
 
 # SM remote EFA test instance type
-sagemaker_remote_efa_instance_type = ""
+sagemaker_remote_efa_instance_type = "p5.48xlarge"
 
 # Run CI tests for nightly images
 # false by default

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -104,7 +104,7 @@ use_scheduler = false
 
 # Standard Framework Training
 dlc-pr-mxnet-training = ""
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-1-sm.yml"
+dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -570,7 +570,7 @@ def skip_smdataparallel_p5_tests(instance_type, processor, ecr_image):
     skip_dict = {"==2.1.*": ["cu121"]}
     if (
         _validate_pytorch_framework_version(
-            request, processor, ecr_image, "skip_smddataparallel_test", skip_dict
+            request, processor, ecr_image, "skip_smdataparallel_p5_tests", skip_dict
         )
         and "p5." in instance_type
     ):

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -568,7 +568,7 @@ def skip_p5_tests(instance_type, processor, ecr_image):
 def skip_smdataparallel_p5_tests(instance_type, processor, ecr_image):
     """SMDDP tests are broken for PyTorch 2.1 on p5 instances, so we should skip"""
     smdataparallel_skip = False
-    skip_dict = {"==2.1": ["cu121"]}
+    skip_dict = {"==2.1.*": ["cu121"]}
     if _validate_pytorch_framework_version(
         request, processor, ecr_image, "skip_smddataparallel_test", skip_dict
     ):
@@ -580,7 +580,7 @@ def skip_smdataparallel_p5_tests(instance_type, processor, ecr_image):
         if processor != "gpu" or Version(image_cuda_version.strip("cu")) < Version("120"):
             p5_skip = True
 
-    if smdataparallel_skip and p5_skip:
+    if smdataparallel_skip and p5_skip and "pytorch" in ecr_image:
         pytest.skip("SM Data Parallel tests are not working on P5 instances, skipping test")
 
 

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -565,7 +565,7 @@ def skip_p5_tests(instance_type, processor, ecr_image):
 
 
 @pytest.fixture(autouse=True)
-def skip_smdataparallel_p5_tests(request, processor, ecr_image,  efa_instance_type):
+def skip_smdataparallel_p5_tests(request, processor, ecr_image, efa_instance_type):
     """SMDDP tests are broken for PyTorch 2.1 on p5 instances, so we should skip"""
     skip_dict = {"==2.1.*": ["cu121"]}
     if (

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -563,10 +563,10 @@ def skip_p5_tests(instance_type, processor, ecr_image):
         if processor != "gpu" or Version(image_cuda_version.strip("cu")) < Version("120"):
             pytest.skip("P5 EC2 instance require CUDA 12.0 or higher.")
 
+
 @pytest.fixture(autouse=True)
 def skip_smdataparallel_p5_tests(instance_type, processor, ecr_image):
-    """SMDDP tests are broken for PyTorch 2.1 on p5 instances, so we should skip
-    """
+    """SMDDP tests are broken for PyTorch 2.1 on p5 instances, so we should skip"""
     smdataparallel_skip = False
     skip_dict = {"==2.1": ["cu121"]}
     if _validate_pytorch_framework_version(
@@ -582,6 +582,7 @@ def skip_smdataparallel_p5_tests(instance_type, processor, ecr_image):
 
     if smdataparallel_skip and p5_skip:
         pytest.skip("SM Data Parallel tests are not working on P5 instances, skipping test")
+
 
 def _validate_pytorch_framework_version(request, processor, ecr_image, test_name, skip_dict):
     """

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -565,14 +565,14 @@ def skip_p5_tests(instance_type, processor, ecr_image):
 
 
 @pytest.fixture(autouse=True)
-def skip_smdataparallel_p5_tests(instance_type, processor, ecr_image):
+def skip_smdataparallel_p5_tests(request, processor, ecr_image,  efa_instance_type):
     """SMDDP tests are broken for PyTorch 2.1 on p5 instances, so we should skip"""
     skip_dict = {"==2.1.*": ["cu121"]}
     if (
         _validate_pytorch_framework_version(
             request, processor, ecr_image, "skip_smdataparallel_p5_tests", skip_dict
         )
-        and "p5." in instance_type
+        and "p5." in efa_instance_type
     ):
         pytest.skip("SM Data Parallel tests are not working on P5 instances, skipping test")
 

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -567,20 +567,13 @@ def skip_p5_tests(instance_type, processor, ecr_image):
 @pytest.fixture(autouse=True)
 def skip_smdataparallel_p5_tests(instance_type, processor, ecr_image):
     """SMDDP tests are broken for PyTorch 2.1 on p5 instances, so we should skip"""
-    smdataparallel_skip = False
     skip_dict = {"==2.1.*": ["cu121"]}
-    if _validate_pytorch_framework_version(
-        request, processor, ecr_image, "skip_smddataparallel_test", skip_dict
+    if (
+        _validate_pytorch_framework_version(
+            request, processor, ecr_image, "skip_smddataparallel_test", skip_dict
+        )
+        and "p5." in instance_type
     ):
-        smdataparallel_skip = True
-
-    p5_skip = False
-    if "p5." in instance_type:
-        image_cuda_version = get_cuda_version_from_tag(ecr_image)
-        if processor != "gpu" or Version(image_cuda_version.strip("cu")) < Version("120"):
-            p5_skip = True
-
-    if smdataparallel_skip and p5_skip and "pytorch" in ecr_image:
         pytest.skip("SM Data Parallel tests are not working on P5 instances, skipping test")
 
 

--- a/test/sagemaker_tests/pytorch/training/conftest.py
+++ b/test/sagemaker_tests/pytorch/training/conftest.py
@@ -563,6 +563,25 @@ def skip_p5_tests(instance_type, processor, ecr_image):
         if processor != "gpu" or Version(image_cuda_version.strip("cu")) < Version("120"):
             pytest.skip("P5 EC2 instance require CUDA 12.0 or higher.")
 
+@pytest.fixture(autouse=True)
+def skip_smdataparallel_p5_tests(instance_type, processor, ecr_image):
+    """SMDDP tests are broken for PyTorch 2.1 on p5 instances, so we should skip
+    """
+    smdataparallel_skip = False
+    skip_dict = {"==2.1": ["cu121"]}
+    if _validate_pytorch_framework_version(
+        request, processor, ecr_image, "skip_smddataparallel_test", skip_dict
+    ):
+        smdataparallel_skip = True
+
+    p5_skip = False
+    if "p5." in instance_type:
+        image_cuda_version = get_cuda_version_from_tag(ecr_image)
+        if processor != "gpu" or Version(image_cuda_version.strip("cu")) < Version("120"):
+            p5_skip = True
+
+    if smdataparallel_skip and p5_skip:
+        pytest.skip("SM Data Parallel tests are not working on P5 instances, skipping test")
 
 def _validate_pytorch_framework_version(request, processor, ecr_image, test_name, skip_dict):
     """

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp.py
@@ -46,6 +46,7 @@ def can_run_pytorchddp(ecr_image):
 @pytest.mark.skip_py2_containers
 @pytest.mark.skip_trcomp_containers
 @pytest.mark.efa()
+@pytest.mark.skip.skip_smdataparallel_p5_tests
 @pytest.mark.team("conda")
 def test_pytorchddp_throughput_gpu(
     framework_version, ecr_image, sagemaker_regions, efa_instance_type, tmpdir

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp.py
@@ -46,7 +46,6 @@ def can_run_pytorchddp(ecr_image):
 @pytest.mark.skip_py2_containers
 @pytest.mark.skip_trcomp_containers
 @pytest.mark.efa()
-@pytest.mark.skip.skip_smdataparallel_p5_tests
 @pytest.mark.team("conda")
 def test_pytorchddp_throughput_gpu(
     framework_version, ecr_image, sagemaker_regions, efa_instance_type, tmpdir

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp.py
@@ -47,6 +47,7 @@ def can_run_pytorchddp(ecr_image):
 @pytest.mark.skip_trcomp_containers
 @pytest.mark.efa()
 @pytest.mark.team("conda")
+@pytest.mark.skip_smdataparallel_p5_tests
 def test_pytorchddp_throughput_gpu(
     framework_version, ecr_image, sagemaker_regions, efa_instance_type, tmpdir
 ):

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp_inductor.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp_inductor.py
@@ -46,7 +46,6 @@ def can_run_pytorchddp(ecr_image):
 @pytest.mark.skip_cpu
 @pytest.mark.skip_py2_containers
 @pytest.mark.efa()
-@pytest.mark.skip_smdataparallel_p5_tests
 @pytest.mark.skip_inductor_test
 @pytest.mark.team("training-compiler")
 def test_pytorchddp_throughput_gpu(

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp_inductor.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp_inductor.py
@@ -46,6 +46,7 @@ def can_run_pytorchddp(ecr_image):
 @pytest.mark.skip_cpu
 @pytest.mark.skip_py2_containers
 @pytest.mark.efa()
+@pytest.mark.skip_smdataparallel_p5_tests
 @pytest.mark.skip_inductor_test
 @pytest.mark.team("training-compiler")
 def test_pytorchddp_throughput_gpu(

--- a/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp_inductor.py
+++ b/test/sagemaker_tests/pytorch/training/integration/sagemaker/test_pytorchddp_inductor.py
@@ -48,6 +48,7 @@ def can_run_pytorchddp(ecr_image):
 @pytest.mark.efa()
 @pytest.mark.skip_inductor_test
 @pytest.mark.team("training-compiler")
+@pytest.mark.skip_smdataparallel_p5_tests
 def test_pytorchddp_throughput_gpu(
     framework_version, ecr_image, sagemaker_regions, efa_instance_type, tmpdir
 ):


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [x] build_pytorch_training_2.1_sm
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
