### PR TITLE
Remove datetime tag config option

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,15 +34,15 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = false
+build_training = true
 build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
-do_build = false
+do_build = true
 autopatch_build = false
 
 [notify]

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -40,10 +40,7 @@ build_frameworks = ["pytorch"]
 build_training = false
 build_inference = true
 
-# Set to false in order to remove datetime tag on PR builds
-datetime_tag = true
-# Note: Need to build the images at least once with datetime_tag = false
-# before disabling new builds, or tests will fail
+# Note: at least one build is required to set do_build to False
 do_build = true
 autopatch_build = false
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,10 +34,10 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
+build_training = false
 build_inference = true
 
 # Set to false in order to remove datetime tag on PR builds

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -40,8 +40,9 @@ build_frameworks = ["pytorch"]
 build_training = false
 build_inference = true
 
-# Note: at least one build is required to set do_build to False
-do_build = true
+# Set do_build to "false" to skip builds and test the latest image built by this PR
+# Note: at least one build is required to set do_build to "false"
+do_build = false
 autopatch_build = false
 
 [notify]

--- a/src/image_builder.py
+++ b/src/image_builder.py
@@ -140,9 +140,9 @@ def image_builder(buildspec, image_types=[], device_types=[]):
         if is_nightly_build_context():
             additional_image_tags.append(tag_image_with_date(image_tag))
 
-        # If build is not enabled, we don't care about the datetime tag
         if build_context != "PR":
             image_tag = tag_image_with_datetime(image_tag)
+        # If build is not enabled, we don't care about the datetime tag
         elif is_build_enabled():
             # Order appears to matter in datetime tagging, so tag with no datetime first, then
             # set image_tag to have datetime

--- a/src/image_builder.py
+++ b/src/image_builder.py
@@ -142,6 +142,9 @@ def image_builder(buildspec, image_types=[], device_types=[]):
             additional_image_tags.append(tag_image_with_date(image_tag))
 
         if enable_datetime_tag or build_context != "PR":
+            # Order appears to matter in datetime tagging
+            no_datetime = image_tag
+            additional_image_tags.append(no_datetime)
             image_tag = tag_image_with_datetime(image_tag)
 
         additional_image_tags.append(image_tag)

--- a/src/image_builder.py
+++ b/src/image_builder.py
@@ -109,7 +109,6 @@ def image_builder(buildspec, image_types=[], device_types=[]):
 
         extra_build_args = {}
         labels = {}
-        enable_datetime_tag = parse_dlc_developer_configs("build", "datetime_tag")
 
         prod_repo_uri = ""
         if is_autopatch_build_enabled(buildspec_path=buildspec):
@@ -141,8 +140,12 @@ def image_builder(buildspec, image_types=[], device_types=[]):
         if is_nightly_build_context():
             additional_image_tags.append(tag_image_with_date(image_tag))
 
-        if enable_datetime_tag or build_context != "PR":
-            # Order appears to matter in datetime tagging
+        # If build is not enabled, we don't care about the datetime tag
+        if build_context != "PR":
+            image_tag = tag_image_with_datetime(image_tag)
+        elif is_build_enabled():
+            # Order appears to matter in datetime tagging, so tag with no datetime first, then
+            # set image_tag to have datetime
             no_datetime = image_tag
             additional_image_tags.append(no_datetime)
             image_tag = tag_image_with_datetime(image_tag)

--- a/test/dlc_tests/sanity/quick_checks/test_dlc_developer_config.py
+++ b/test/dlc_tests/sanity/quick_checks/test_dlc_developer_config.py
@@ -27,7 +27,6 @@ def test_developer_configuration():
     assert config.parse_dlc_developer_configs("build", "build_frameworks") == []
     assert config.parse_dlc_developer_configs("build", "build_training") is True
     assert config.parse_dlc_developer_configs("build", "build_inference") is True
-    assert config.parse_dlc_developer_configs("build", "datetime_tag") is True
     assert config.parse_dlc_developer_configs("build", "do_build") is True
     assert config.parse_dlc_developer_configs("build", "autopatch_build") is False
 


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
- Remove "datetime" tag option from toml
- If you want to disable builds, only one option to change (do_build --> False)
- Always add datetime when building an image.
- Still require at least one build before turning off "do_build"

### Tests run
- Test that do_build flag turned on tags both datetime and non-datetime([8787979](https://github.com/aws/deep-learning-containers/pull/3733/commits/878797916c936e4a49d372f853b6614b99fab5a9)), but test jobs look for datetime
- Test that do_build flag turned off looks for non-datetime image ([4fd4fc2](https://github.com/aws/deep-learning-containers/pull/3733/commits/4fd4fc2d1a5f0ba7a14b1e694e79a327ac87b6b7))

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [x] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [ ] build_pytorch_training_latest
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
