### PR TITLE
[Build][Test] Handle cases for ECR Scanning tests

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,10 +34,10 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
+build_training = false
 build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
@@ -131,7 +131,7 @@ dlc-pr-tensorflow-2-habana-training = ""
 
 # Standard Framework Inference
 dlc-pr-mxnet-inference = ""
-dlc-pr-pytorch-inference = ""
+dlc-pr-pytorch-inference = "pytorch/inference/buildspec-1-13.yml"
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,10 +34,10 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = false
+build_training = true
 build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
@@ -131,7 +131,7 @@ dlc-pr-tensorflow-2-habana-training = ""
 
 # Standard Framework Inference
 dlc-pr-mxnet-inference = ""
-dlc-pr-pytorch-inference = "pytorch/inference/buildspec-1-13.yml"
+dlc-pr-pytorch-inference = ""
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
 

--- a/src/patch_helper.py
+++ b/src/patch_helper.py
@@ -84,7 +84,7 @@ def get_impacted_os_packages(image_uri, python_version=None):
     ) = helper_function_for_leftover_vulnerabilities_from_enhanced_scanning(
         image_uri,
         python_version=python_version,
-        minimum_sev_threshold="LOW",
+        minimum_sev_threshold="UNDEFINED",
         allowlist_removal_enabled=False,
     )
     impacted_packages = set()

--- a/test/dlc_tests/sanity/test_ecr_scan.py
+++ b/test/dlc_tests/sanity/test_ecr_scan.py
@@ -221,10 +221,17 @@ def helper_function_for_leftover_vulnerabilities_from_enhanced_scanning(
     remaining_vulnerabilities = ecr_image_vulnerability_list - image_scan_allowlist
     LOGGER.info(f"ECR Enhanced Scanning test completed for image: {image}")
 
-    if remove_non_patchable_vulns and remaining_vulnerabilities:
-        non_patchable_vulnerabilities = extract_non_patchable_vulnerabilities(
-            remaining_vulnerabilities, ecr_enhanced_repo_uri
+    if remove_non_patchable_vulns:
+        non_patchable_vulnerabilities = None
+        if remaining_vulnerabilities:
+            non_patchable_vulnerabilities = extract_non_patchable_vulnerabilities(
+                remaining_vulnerabilities, ecr_enhanced_repo_uri
+            )
+
+        non_patchable_vulnerabilities = non_patchable_vulnerabilities or ECREnhancedScanVulnerabilityList(
+            minimum_severity=CVESeverity[minimum_sev_threshold]
         )
+
         future_allowlist = generate_future_allowlist(
             ecr_image_vulnerability_list=ecr_image_vulnerability_list,
             image_scan_allowlist=image_scan_allowlist,

--- a/test/dlc_tests/sanity/test_ecr_scan.py
+++ b/test/dlc_tests/sanity/test_ecr_scan.py
@@ -187,9 +187,6 @@ def helper_function_for_leftover_vulnerabilities_from_enhanced_scanning(
     scan_results = ecr_utils.get_all_ecr_enhanced_scan_findings(
         ecr_client=ecr_client_for_enhanced_scanning_repo, image_uri=ecr_enhanced_repo_uri
     )
-
-    LOGGER.info(f"SCAN RESULTS TRSHANTA {scan_results}")
-
     scan_results = json.loads(json.dumps(scan_results, cls=EnhancedJSONEncoder))
 
     minimum_sev_threshold = minimum_sev_threshold or get_minimum_sev_threshold_level(image)
@@ -197,8 +194,6 @@ def helper_function_for_leftover_vulnerabilities_from_enhanced_scanning(
         minimum_severity=CVESeverity[minimum_sev_threshold]
     )
     ecr_image_vulnerability_list.construct_allowlist_from_ecr_scan_result(scan_results)
-
-    LOGGER.info(f"ecr_image_vulnerability_list {json.dumps(ecr_image_vulnerability_list.vulnerability_list, cls= test_utils.EnhancedJSONEncoder)}")
 
     image_scan_allowlist = ECREnhancedScanVulnerabilityList(
         minimum_severity=CVESeverity[minimum_sev_threshold]
@@ -266,7 +261,10 @@ def helper_function_for_leftover_vulnerabilities_from_enhanced_scanning(
             s3_filepath=future_allowlist_upload_path,
             tag_set=upload_tag_set,
         )
-        remaining_vulnerabilities = remaining_vulnerabilities - non_patchable_vulnerabilities
+
+        if remaining_vulnerabilities:
+            remaining_vulnerabilities = remaining_vulnerabilities - non_patchable_vulnerabilities
+
         LOGGER.info(
             f"[FutureAllowlist][image_uri:{ecr_enhanced_repo_uri}] {json.dumps(future_allowlist.vulnerability_list, cls= test_utils.EnhancedJSONEncoder)}"
         )

--- a/test/dlc_tests/sanity/test_ecr_scan.py
+++ b/test/dlc_tests/sanity/test_ecr_scan.py
@@ -222,15 +222,16 @@ def helper_function_for_leftover_vulnerabilities_from_enhanced_scanning(
     LOGGER.info(f"ECR Enhanced Scanning test completed for image: {image}")
 
     if remove_non_patchable_vulns:
-        non_patchable_vulnerabilities = None
+        non_patchable_vulnerabilities = ECREnhancedScanVulnerabilityList(
+            minimum_severity=CVESeverity[minimum_sev_threshold]
+        )
+
+        ## non_patchable_vulnerabilities is a subset of remaining_vulnerabilities that cannot be patched.
+        ## Thus, if remaining_vulnerabilities exists, we need to find the non_patchable_vulnerabilities from it.
         if remaining_vulnerabilities:
             non_patchable_vulnerabilities = extract_non_patchable_vulnerabilities(
                 remaining_vulnerabilities, ecr_enhanced_repo_uri
             )
-
-        non_patchable_vulnerabilities = non_patchable_vulnerabilities or ECREnhancedScanVulnerabilityList(
-            minimum_severity=CVESeverity[minimum_sev_threshold]
-        )
 
         future_allowlist = generate_future_allowlist(
             ecr_image_vulnerability_list=ecr_image_vulnerability_list,

--- a/test/dlc_tests/sanity/test_ecr_scan.py
+++ b/test/dlc_tests/sanity/test_ecr_scan.py
@@ -187,6 +187,9 @@ def helper_function_for_leftover_vulnerabilities_from_enhanced_scanning(
     scan_results = ecr_utils.get_all_ecr_enhanced_scan_findings(
         ecr_client=ecr_client_for_enhanced_scanning_repo, image_uri=ecr_enhanced_repo_uri
     )
+
+    LOGGER.info(f"SCAN RESULTS TRSHANTA {scan_results}")
+
     scan_results = json.loads(json.dumps(scan_results, cls=EnhancedJSONEncoder))
 
     minimum_sev_threshold = minimum_sev_threshold or get_minimum_sev_threshold_level(image)
@@ -194,6 +197,8 @@ def helper_function_for_leftover_vulnerabilities_from_enhanced_scanning(
         minimum_severity=CVESeverity[minimum_sev_threshold]
     )
     ecr_image_vulnerability_list.construct_allowlist_from_ecr_scan_result(scan_results)
+
+    LOGGER.info(f"ecr_image_vulnerability_list {json.dumps(ecr_image_vulnerability_list.vulnerability_list, cls= test_utils.EnhancedJSONEncoder)}")
 
     image_scan_allowlist = ECREnhancedScanVulnerabilityList(
         minimum_severity=CVESeverity[minimum_sev_threshold]

--- a/test/test_utils/security.py
+++ b/test/test_utils/security.py
@@ -382,7 +382,7 @@ class ScanVulnerabilityList:
         if not self.vulnerability_list:
             return None
         if not other or not other.vulnerability_list:
-            return self
+            return copy.deepcopy(self)
 
         missing_vulnerabilities = [
             vulnerability
@@ -407,7 +407,7 @@ class ScanVulnerabilityList:
         :return: Union of vulnerabilites exisiting in self and other
         """
         flattened_vulnerability_list_self = self.get_flattened_vulnerability_list()
-        flattened_vulnerability_list_other = other.get_flattened_vulnerability_list()
+        flattened_vulnerability_list_other = other.get_flattened_vulnerability_list() if other else []
         all_vulnerabilities = flattened_vulnerability_list_self + flattened_vulnerability_list_other
         if not all_vulnerabilities:
             return None

--- a/test/test_utils/security.py
+++ b/test/test_utils/security.py
@@ -407,7 +407,9 @@ class ScanVulnerabilityList:
         :return: Union of vulnerabilites exisiting in self and other
         """
         flattened_vulnerability_list_self = self.get_flattened_vulnerability_list()
-        flattened_vulnerability_list_other = other.get_flattened_vulnerability_list() if other else []
+        flattened_vulnerability_list_other = (
+            other.get_flattened_vulnerability_list() if other else []
+        )
         all_vulnerabilities = flattened_vulnerability_list_self + flattened_vulnerability_list_other
         if not all_vulnerabilities:
             return None


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

This PR solves 2 issues:

1. In case there was no vulnerability associated with the image, we did not end up removing the stale allowlist vulnerabilities. The changes on the test side help with this issue.
2. AutoPatch patches all the vulnerabilities above `LOW`. However, we will reduce the threshold to patch vulnerabilities above `UNDEFINED`.

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [ ] build_pytorch_training_latest
- [ ] build_pytorch_inference_latest
- [x] build_pytorch_inference_1.13
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
