### PR TITLE
Look at all available reservations

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -42,7 +42,7 @@ build_inference = false
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
-do_build = true
+do_build = false
 autopatch_build = true
 
 [notify]

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,16 +34,16 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
-do_build = false
-autopatch_build = true
+do_build = true
+autopatch_build = false
 
 [notify]
 ### Notify on test failures
@@ -67,7 +67,7 @@ ec2_benchmark_tests = false
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = true
+ec2_tests_on_heavy_instances = false
 
 ### SM specific tests
 ### Off by default

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,16 +34,16 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
 do_build = true
-autopatch_build = false
+autopatch_build = true
 
 [notify]
 ### Notify on test failures
@@ -67,7 +67,7 @@ ec2_benchmark_tests = false
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = false
+ec2_tests_on_heavy_instances = true
 
 ### SM specific tests
 ### Off by default

--- a/test/dlc_tests/conftest.py
+++ b/test/dlc_tests/conftest.py
@@ -402,7 +402,11 @@ def efa_ec2_instances(
         ],
     }
     response = ec2_utils.launch_efa_instances_with_retry(
-        ec2_client, ec2_instance_type, availability_zone_options, ec2_run_instances_definition
+        ec2_client,
+        ec2_instance_type,
+        availability_zone_options,
+        ec2_run_instances_definition,
+        fn_name=request.node.name,
     )
 
     instances = response["Instances"]
@@ -694,6 +698,7 @@ def ec2_instance(
         availability_zone_options=availability_zone_options,
         ec2_create_instances_definition=params,
         ec2_client=ec2_client,
+        fn_name=request.node.name,
     )
     instance_id = instances[0].id
 

--- a/test/test_utils/ec2.py
+++ b/test/test_utils/ec2.py
@@ -327,7 +327,6 @@ def get_available_reservations(ec2_client, instance_type, min_availability=1):
     return sorted(open_tables, key=lambda res: res["AvailableInstanceCount"])
 
 
-
 @retry(
     reraise=True,
     stop=stop_after_delay(30 * 60),  # Keep retrying for 30 minutes
@@ -369,8 +368,10 @@ def launch_instances_with_retry(
             return instances
         except ClientError as e:
             LOGGER.error(f"Failed to launch via reservation - {e}")
-    
-    LOGGER.info("Looks like you didn't have a reservation, let's see if we can seat you as a walk-in...")
+
+    LOGGER.info(
+        "Looks like you didn't have a reservation, let's see if we can seat you as a walk-in..."
+    )
 
     if availability_zone_options:
         error = None
@@ -444,7 +445,9 @@ def launch_efa_instances_with_retry(
                 "Checking additional open reservations..."
             )
 
-    LOGGER.info("Looks like you didn't have an EFA reservation, let's see if we can seat you as a walk-in...")
+    LOGGER.info(
+        "Looks like you didn't have an EFA reservation, let's see if we can seat you as a walk-in..."
+    )
 
     for availability_zone in availability_zone_options:
         ec2_run_instances_definition.update(


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

- Sort priority - 1) available capacity, 2) total capacity; Do this to prioritize minimum instances required, to leave double openings open for heavier instance types
- Look through all reservations; return if we launch successfully
- Follow up from #3752 
- add function names to logs

### Tests run

- Execute without function name logs([462a956](https://github.com/aws/deep-learning-containers/pull/3756/commits/462a95603887eb219b7f56ecb7d347e8c7e0ef43))
- Execute with function name logs ([781c651](https://github.com/aws/deep-learning-containers/pull/3756/commits/781c65119ef1883202a9e245b3e22207248e85ce))

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [x] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [x] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [x] build_pytorch_training_latest
- [ ] build_pytorch_training_2.2_ec2
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
