### PR TITLE
Add additional ignores

### DIFF
--- a/data/ignore_ids_safety_scan.json
+++ b/data/ignore_ids_safety_scan.json
@@ -1359,7 +1359,15 @@
                 "64437": "Temporarily ignoring to patch CRITICAL vulnerabilties",
                 "64402": "Temporarily ignoring to patch CRITICAL vulnerabilties",
                 "63406": "Temporarily ignoring to patch CRITICAL vulnerabilties",
-                "64227": "Temporarily ignoring to patch CRITICAL vulnerabilties"
+                "64227": "Temporarily ignoring to patch CRITICAL vulnerabilties",
+                "65213": "Covered elsewhere",
+                "65215": "Covered elsewhere",
+                "65398": "Covered elsewhere",
+                "64402": "Covered elsewhere",
+                "65213": "Covered elsewhere",
+                "65215": "Covered elsewhere",
+                "65398": "Covered elsewhere",
+                "64402": "Covered elsewhere"
             }
         },
         "inference": {
@@ -1375,7 +1383,15 @@
                 "51159":"cryptography>38.0.1 does not exist yet",
                 "51450": "This bug is in Jax/Flax backend that would need Transformers 4.23 for fix.",
                 "51396": "Protobuf is only a runtime dependency of transformers. Current version of Protobuf installed in the image is not vulnerable.",
-                "60235": "Temporarily ignoring to patch CRITICAL vulnerabilties at SEV2 pace"
+                "60235": "Temporarily ignoring to patch CRITICAL vulnerabilties at SEV2 pace",
+                "65213": "Covered elsewhere",
+                "65215": "Covered elsewhere",
+                "65398": "Covered elsewhere",
+                "64402": "Covered elsewhere",
+                "65213": "Covered elsewhere",
+                "65215": "Covered elsewhere",
+                "65398": "Covered elsewhere",
+                "64402": "Covered elsewhere"
             }
         },
         "inference-neuron": {

--- a/data/ignore_ids_safety_scan.json
+++ b/data/ignore_ids_safety_scan.json
@@ -1414,7 +1414,11 @@
                 "65278": "Covered elsewhere",
                 "65401": "Covered elsewhere",
                 "65193": "Covered elsewhere",
-                "65398": "Covered elsewhere"
+                "65398": "Covered elsewhere",
+                "64436": "Covered elsewhere",
+                "62556": "Covered elsewhere",
+                "66710": "Covered elsewhere",
+                "65215": "Covered elsewhere"
 
             }
         }

--- a/huggingface/pytorch/inference/docker/1.13/py3/Dockerfile.cpu.os_scan_allowlist.json
+++ b/huggingface/pytorch/inference/docker/1.13/py3/Dockerfile.cpu.os_scan_allowlist.json
@@ -1,20 +1,91 @@
 {
-  "libzmq5": [
+  "transformers":
+  [
+    {
+      "description": "Deserialization of Untrusted Data in GitHub repository huggingface/transformers prior to 4.36.",
+      "vulnerability_id": "CVE-2023-6730",
+      "name": "CVE-2023-6730",
+      "package_name": "transformers",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/transformers-4.26.0.dist-info/METADATA",
+        "name": "transformers",
+        "package_manager": "PYTHONPKG",
+        "version": "4.26.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6730",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-6730 - transformers",
+      "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Deserialization of Untrusted Data in GitHub repository huggingface/transformers prior to 4.36.",
+      "vulnerability_id": "CVE-2023-7018",
+      "name": "CVE-2023-7018",
+      "package_name": "transformers",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/transformers-4.26.0.dist-info/METADATA",
+        "name": "transformers",
+        "package_manager": "PYTHONPKG",
+        "version": "4.26.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-7018",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-7018 - transformers",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "libzmq5":
+  [
     {
       "reason_to_ignore": "The current version is marked as a fix version in the CVE notes, and this is the latest version.",
       "description": "\n It was discovered that ZeroMQ incorrectly handled certain application metadata.\n A remote attacker could use this issue to cause ZeroMQ to crash, or possibly\n execute arbitrary code.",
       "vulnerability_id": "CVE-2019-13132",
       "name": "CVE-2019-13132",
       "package_name": "libzmq5",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "libzmq5",
         "package_manager": "OS",
         "version": "4.3.2",
         "release": "2ubuntu1"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },

--- a/huggingface/pytorch/inference/docker/1.13/py3/cu117/Dockerfile.gpu.os_scan_allowlist.json
+++ b/huggingface/pytorch/inference/docker/1.13/py3/cu117/Dockerfile.gpu.os_scan_allowlist.json
@@ -1,20 +1,91 @@
 {
-  "libzmq5": [
+  "transformers":
+  [
+    {
+      "description": "Deserialization of Untrusted Data in GitHub repository huggingface/transformers prior to 4.36.",
+      "vulnerability_id": "CVE-2023-6730",
+      "name": "CVE-2023-6730",
+      "package_name": "transformers",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/transformers-4.26.0.dist-info/METADATA",
+        "name": "transformers",
+        "package_manager": "PYTHONPKG",
+        "version": "4.26.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6730",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-6730 - transformers",
+      "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Deserialization of Untrusted Data in GitHub repository huggingface/transformers prior to 4.36.",
+      "vulnerability_id": "CVE-2023-7018",
+      "name": "CVE-2023-7018",
+      "package_name": "transformers",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/transformers-4.26.0.dist-info/METADATA",
+        "name": "transformers",
+        "package_manager": "PYTHONPKG",
+        "version": "4.26.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-7018",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-7018 - transformers",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "libzmq5":
+  [
     {
       "reason_to_ignore": "The current version is marked as a fix version in the CVE notes, and this is the latest version.",
       "description": "\n It was discovered that ZeroMQ incorrectly handled certain application metadata.\n A remote attacker could use this issue to cause ZeroMQ to crash, or possibly\n execute arbitrary code.",
       "vulnerability_id": "CVE-2019-13132",
       "name": "CVE-2019-13132",
       "package_name": "libzmq5",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "libzmq5",
         "package_manager": "OS",
         "version": "4.3.2",
         "release": "2ubuntu1"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },

--- a/huggingface/pytorch/training/docker/1.13/py3/cu117/Dockerfile.gpu.os_scan_allowlist.json
+++ b/huggingface/pytorch/training/docker/1.13/py3/cu117/Dockerfile.gpu.os_scan_allowlist.json
@@ -1,19 +1,90 @@
 {
-  "cryptography": [
+  "transformers":
+  [
+    {
+      "description": "Deserialization of Untrusted Data in GitHub repository huggingface/transformers prior to 4.36.",
+      "vulnerability_id": "CVE-2023-6730",
+      "name": "CVE-2023-6730",
+      "package_name": "transformers",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/transformers-4.26.0.dist-info/METADATA",
+        "name": "transformers",
+        "package_manager": "PYTHONPKG",
+        "version": "4.26.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6730",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-6730 - transformers",
+      "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Deserialization of Untrusted Data in GitHub repository huggingface/transformers prior to 4.36.",
+      "vulnerability_id": "CVE-2023-7018",
+      "name": "CVE-2023-7018",
+      "package_name": "transformers",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/transformers-4.26.0.dist-info/METADATA",
+        "name": "transformers",
+        "package_manager": "PYTHONPKG",
+        "version": "4.26.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-7018",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-7018 - transformers",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "cryptography":
+  [
     {
       "description": " If an X.509 certificate contains a malformed policy constraint and policy processing is enabled, then a write lock will be taken twice recursively. On some operating systems (most widely: Windows) this results in a denial of service when the affected process hangs. Policy processing being enabled on a publicly facing server is not considered to be a common setup. Policy processing is enabled by passing the `-policy' argument to the command line utilities or by calling either `X509_VERIFY_PARAM_add0_policy()' or `X509_VERIFY_PARAM_set1_policies()' functions.",
       "vulnerability_id": "CVE-2022-3996",
       "name": "CVE-2022-3996",
       "package_name": "cryptography",
-      "package_details": {
+      "package_details":
+      {
         "file_path": "opt/conda/lib/python3.9/site-packages/cryptography-39.0.0.dist-info/METADATA",
         "name": "cryptography",
         "package_manager": "PYTHONPKG",
         "version": "39.0.0",
         "release": null
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -33,14 +104,21 @@
       "vulnerability_id": "CVE-2022-3996",
       "name": "CVE-2022-3996",
       "package_name": "cryptography",
-      "package_details": {
+      "package_details":
+      {
         "file_path": "root/micromamba/pkgs/cryptography-39.0.0-py310h34c0648_0/lib/python3.10/site-packages/cryptography-39.0.0.dist-info/METADATA",
         "name": "cryptography",
         "package_manager": "PYTHONPKG",
         "version": "39.0.0",
         "release": null
       },
-      "remediation": { "recommendation": { "text": "None Provided" } },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
       "cvss_v3_score": 7.5,
       "cvss_v30_score": 0.0,
       "cvss_v31_score": 7.5,
@@ -53,21 +131,25 @@
       "title": "CVE-2022-3996 - cryptography, cryptography"
     }
   ],
-  "imagemagick": [
+  "imagemagick":
+  [
     {
       "description": " A flaw was found in ImageMagick in versions before 7.0.11. A potential cipher leak when the calculate signatures in TransformSignature is possible. The highest threat from this vulnerability is to data confidentiality.",
       "vulnerability_id": "CVE-2021-20313",
       "name": "CVE-2021-20313",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -87,15 +169,18 @@
       "vulnerability_id": "CVE-2021-20313",
       "name": "CVE-2021-20313",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -115,15 +200,18 @@
       "vulnerability_id": "CVE-2022-32546",
       "name": "CVE-2022-32546",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -143,15 +231,18 @@
       "vulnerability_id": "CVE-2022-32546",
       "name": "CVE-2022-32546",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -171,15 +262,18 @@
       "vulnerability_id": "CVE-2021-20309",
       "name": "CVE-2021-20309",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -199,15 +293,18 @@
       "vulnerability_id": "CVE-2021-20309",
       "name": "CVE-2021-20309",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -227,15 +324,18 @@
       "vulnerability_id": "CVE-2021-20312",
       "name": "CVE-2021-20312",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -255,15 +355,18 @@
       "vulnerability_id": "CVE-2021-20312",
       "name": "CVE-2021-20312",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -283,15 +386,18 @@
       "vulnerability_id": "CVE-2022-1114",
       "name": "CVE-2022-1114",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -311,15 +417,18 @@
       "vulnerability_id": "CVE-2022-1114",
       "name": "CVE-2022-1114",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -339,15 +448,18 @@
       "vulnerability_id": "CVE-2022-28463",
       "name": "CVE-2022-28463",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -367,15 +479,18 @@
       "vulnerability_id": "CVE-2022-28463",
       "name": "CVE-2022-28463",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -395,15 +510,18 @@
       "vulnerability_id": "CVE-2022-32547",
       "name": "CVE-2022-32547",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -423,15 +541,18 @@
       "vulnerability_id": "CVE-2022-32547",
       "name": "CVE-2022-32547",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -451,15 +572,18 @@
       "vulnerability_id": "CVE-2022-32545",
       "name": "CVE-2022-32545",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -479,241 +603,18 @@
       "vulnerability_id": "CVE-2022-32545",
       "name": "CVE-2022-32545",
       "package_name": "imagemagick",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "imagemagick",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.8,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.8,
-      "cvss_v2_score": 6.8,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-32545.html",
-      "source": "UBUNTU_CVE",
-      "severity": "MEDIUM",
-      "status": "ACTIVE",
-      "title": "CVE-2022-32545 - imagemagick, libmagickcore-6.q16-6 and 3 more"
-    }
-  ],
-  "imagemagick-6-common": [
-    {
-      "description": " A flaw was found in ImageMagick in versions before 7.0.11. A potential cipher leak when the calculate signatures in TransformSignature is possible. The highest threat from this vulnerability is to data confidentiality.",
-      "vulnerability_id": "CVE-2021-20313",
-      "name": "CVE-2021-20313",
-      "package_name": "imagemagick-6-common",
-      "package_details": {
-        "file_path": null,
-        "name": "imagemagick-6-common",
-        "package_manager": "OS",
-        "version": "6.9.10.23+dfsg",
-        "release": "2.1ubuntu11.4"
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 5.0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-20313.html",
-      "source": "UBUNTU_CVE",
-      "severity": "LOW",
-      "status": "ACTIVE",
-      "title": "CVE-2021-20313 - imagemagick, libmagickcore-6.q16-6 and 3 more"
-    },
-    {
-      "description": " A vulnerability was found in ImageMagick, causing an outside the range of representable values of type 'unsigned long' at coders/pcl.c, when crafted or untrusted input is processed. This leads to a negative impact to application availability or other problems related to undefined behavior.",
-      "vulnerability_id": "CVE-2022-32546",
-      "name": "CVE-2022-32546",
-      "package_name": "imagemagick-6-common",
-      "package_details": {
-        "file_path": null,
-        "name": "imagemagick-6-common",
-        "package_manager": "OS",
-        "version": "6.9.10.23+dfsg",
-        "release": "2.1ubuntu11.4"
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.8,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.8,
-      "cvss_v2_score": 6.8,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-32546.html",
-      "source": "UBUNTU_CVE",
-      "severity": "MEDIUM",
-      "status": "ACTIVE",
-      "title": "CVE-2022-32546 - imagemagick, libmagickcore-6.q16-6 and 3 more"
-    },
-    {
-      "description": " A flaw was found in ImageMagick in versions before 7.0.11 and before 6.9.12, where a division by zero in WaveImage() of MagickCore/visual-effects.c may trigger undefined behavior via a crafted image file submitted to an application using ImageMagick. The highest threat from this vulnerability is to system availability.",
-      "vulnerability_id": "CVE-2021-20309",
-      "name": "CVE-2021-20309",
-      "package_name": "imagemagick-6-common",
-      "package_details": {
-        "file_path": null,
-        "name": "imagemagick-6-common",
-        "package_manager": "OS",
-        "version": "6.9.10.23+dfsg",
-        "release": "2.1ubuntu11.4"
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 7.8,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-20309.html",
-      "source": "UBUNTU_CVE",
-      "severity": "LOW",
-      "status": "ACTIVE",
-      "title": "CVE-2021-20309 - imagemagick, libmagickcore-6.q16-6 and 3 more"
-    },
-    {
-      "description": " A flaw was found in ImageMagick in versions 7.0.11, where an integer overflow in WriteTHUMBNAILImage of coders/thumbnail.c may trigger undefined behavior via a crafted image file that is submitted by an attacker and processed by an application using ImageMagick. The highest threat from this vulnerability is to system availability.",
-      "vulnerability_id": "CVE-2021-20312",
-      "name": "CVE-2021-20312",
-      "package_name": "imagemagick-6-common",
-      "package_details": {
-        "file_path": null,
-        "name": "imagemagick-6-common",
-        "package_manager": "OS",
-        "version": "6.9.10.23+dfsg",
-        "release": "2.1ubuntu11.4"
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 7.8,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-20312.html",
-      "source": "UBUNTU_CVE",
-      "severity": "LOW",
-      "status": "ACTIVE",
-      "title": "CVE-2021-20312 - imagemagick, libmagickcore-6.q16-6 and 3 more"
-    },
-    {
-      "description": " A heap-use-after-free flaw was found in ImageMagick's RelinquishDCMInfo() function of dcm.c file. This vulnerability is triggered when an attacker passes a specially crafted DICOM image file to ImageMagick for conversion, potentially leading to information disclosure and a denial of service.",
-      "vulnerability_id": "CVE-2022-1114",
-      "name": "CVE-2022-1114",
-      "package_name": "imagemagick-6-common",
-      "package_details": {
-        "file_path": null,
-        "name": "imagemagick-6-common",
-        "package_manager": "OS",
-        "version": "6.9.10.23+dfsg",
-        "release": "2.1ubuntu11.4"
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.1,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.1,
-      "cvss_v2_score": 5.8,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-1114.html",
-      "source": "UBUNTU_CVE",
-      "severity": "MEDIUM",
-      "status": "ACTIVE",
-      "title": "CVE-2022-1114 - imagemagick, libmagickcore-6.q16-6 and 3 more"
-    },
-    {
-      "description": " ImageMagick 7.1.0-27 is vulnerable to Buffer Overflow.",
-      "vulnerability_id": "CVE-2022-28463",
-      "name": "CVE-2022-28463",
-      "package_name": "imagemagick-6-common",
-      "package_details": {
-        "file_path": null,
-        "name": "imagemagick-6-common",
-        "package_manager": "OS",
-        "version": "6.9.10.23+dfsg",
-        "release": "2.1ubuntu11.4"
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.8,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.8,
-      "cvss_v2_score": 6.8,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-28463.html",
-      "source": "UBUNTU_CVE",
-      "severity": "MEDIUM",
-      "status": "ACTIVE",
-      "title": "CVE-2022-28463 - imagemagick, libmagickcore-6.q16-6 and 3 more"
-    },
-    {
-      "description": " In ImageMagick, there is load of misaligned address for type 'double', which requires 8 byte alignment and for type 'float', which requires 4 byte alignment at MagickCore/property.c. Whenever crafted or untrusted input is processed by ImageMagick, this causes a negative impact to application availability or other problems related to undefined behavior.",
-      "vulnerability_id": "CVE-2022-32547",
-      "name": "CVE-2022-32547",
-      "package_name": "imagemagick-6-common",
-      "package_details": {
-        "file_path": null,
-        "name": "imagemagick-6-common",
-        "package_manager": "OS",
-        "version": "6.9.10.23+dfsg",
-        "release": "2.1ubuntu11.4"
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.8,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.8,
-      "cvss_v2_score": 6.8,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-32547.html",
-      "source": "UBUNTU_CVE",
-      "severity": "MEDIUM",
-      "status": "ACTIVE",
-      "title": "CVE-2022-32547 - imagemagick, libmagickcore-6.q16-6 and 3 more"
-    },
-    {
-      "description": " A vulnerability was found in ImageMagick, causing an outside the range of representable values of type 'unsigned char' at coders/psd.c, when crafted or untrusted input is processed. This leads to a negative impact to application availability or other problems related to undefined behavior.",
-      "vulnerability_id": "CVE-2022-32545",
-      "name": "CVE-2022-32545",
-      "package_name": "imagemagick-6-common",
-      "package_details": {
-        "file_path": null,
-        "name": "imagemagick-6-common",
-        "package_manager": "OS",
-        "version": "6.9.10.23+dfsg",
-        "release": "2.1ubuntu11.4"
-      },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -729,21 +630,25 @@
       "title": "CVE-2022-32545 - imagemagick, libmagickcore-6.q16-6 and 3 more"
     }
   ],
-  "libmagickcore-6.q16-6": [
+  "imagemagick-6-common":
+  [
     {
       "description": " A flaw was found in ImageMagick in versions before 7.0.11. A potential cipher leak when the calculate signatures in TransformSignature is possible. The highest threat from this vulnerability is to data confidentiality.",
       "vulnerability_id": "CVE-2021-20313",
       "name": "CVE-2021-20313",
-      "package_name": "libmagickcore-6.q16-6",
-      "package_details": {
+      "package_name": "imagemagick-6-common",
+      "package_details":
+      {
         "file_path": null,
-        "name": "libmagickcore-6.q16-6",
+        "name": "imagemagick-6-common",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -762,16 +667,19 @@
       "description": " A vulnerability was found in ImageMagick, causing an outside the range of representable values of type 'unsigned long' at coders/pcl.c, when crafted or untrusted input is processed. This leads to a negative impact to application availability or other problems related to undefined behavior.",
       "vulnerability_id": "CVE-2022-32546",
       "name": "CVE-2022-32546",
-      "package_name": "libmagickcore-6.q16-6",
-      "package_details": {
+      "package_name": "imagemagick-6-common",
+      "package_details":
+      {
         "file_path": null,
-        "name": "libmagickcore-6.q16-6",
+        "name": "imagemagick-6-common",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -790,16 +698,19 @@
       "description": " A flaw was found in ImageMagick in versions before 7.0.11 and before 6.9.12, where a division by zero in WaveImage() of MagickCore/visual-effects.c may trigger undefined behavior via a crafted image file submitted to an application using ImageMagick. The highest threat from this vulnerability is to system availability.",
       "vulnerability_id": "CVE-2021-20309",
       "name": "CVE-2021-20309",
-      "package_name": "libmagickcore-6.q16-6",
-      "package_details": {
+      "package_name": "imagemagick-6-common",
+      "package_details":
+      {
         "file_path": null,
-        "name": "libmagickcore-6.q16-6",
+        "name": "imagemagick-6-common",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -818,16 +729,19 @@
       "description": " A flaw was found in ImageMagick in versions 7.0.11, where an integer overflow in WriteTHUMBNAILImage of coders/thumbnail.c may trigger undefined behavior via a crafted image file that is submitted by an attacker and processed by an application using ImageMagick. The highest threat from this vulnerability is to system availability.",
       "vulnerability_id": "CVE-2021-20312",
       "name": "CVE-2021-20312",
-      "package_name": "libmagickcore-6.q16-6",
-      "package_details": {
+      "package_name": "imagemagick-6-common",
+      "package_details":
+      {
         "file_path": null,
-        "name": "libmagickcore-6.q16-6",
+        "name": "imagemagick-6-common",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -846,16 +760,19 @@
       "description": " A heap-use-after-free flaw was found in ImageMagick's RelinquishDCMInfo() function of dcm.c file. This vulnerability is triggered when an attacker passes a specially crafted DICOM image file to ImageMagick for conversion, potentially leading to information disclosure and a denial of service.",
       "vulnerability_id": "CVE-2022-1114",
       "name": "CVE-2022-1114",
-      "package_name": "libmagickcore-6.q16-6",
-      "package_details": {
+      "package_name": "imagemagick-6-common",
+      "package_details":
+      {
         "file_path": null,
-        "name": "libmagickcore-6.q16-6",
+        "name": "imagemagick-6-common",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -874,16 +791,19 @@
       "description": " ImageMagick 7.1.0-27 is vulnerable to Buffer Overflow.",
       "vulnerability_id": "CVE-2022-28463",
       "name": "CVE-2022-28463",
-      "package_name": "libmagickcore-6.q16-6",
-      "package_details": {
+      "package_name": "imagemagick-6-common",
+      "package_details":
+      {
         "file_path": null,
-        "name": "libmagickcore-6.q16-6",
+        "name": "imagemagick-6-common",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -902,16 +822,19 @@
       "description": " In ImageMagick, there is load of misaligned address for type 'double', which requires 8 byte alignment and for type 'float', which requires 4 byte alignment at MagickCore/property.c. Whenever crafted or untrusted input is processed by ImageMagick, this causes a negative impact to application availability or other problems related to undefined behavior.",
       "vulnerability_id": "CVE-2022-32547",
       "name": "CVE-2022-32547",
-      "package_name": "libmagickcore-6.q16-6",
-      "package_details": {
+      "package_name": "imagemagick-6-common",
+      "package_details":
+      {
         "file_path": null,
-        "name": "libmagickcore-6.q16-6",
+        "name": "imagemagick-6-common",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -930,16 +853,19 @@
       "description": " A vulnerability was found in ImageMagick, causing an outside the range of representable values of type 'unsigned char' at coders/psd.c, when crafted or untrusted input is processed. This leads to a negative impact to application availability or other problems related to undefined behavior.",
       "vulnerability_id": "CVE-2022-32545",
       "name": "CVE-2022-32545",
-      "package_name": "libmagickcore-6.q16-6",
-      "package_details": {
+      "package_name": "imagemagick-6-common",
+      "package_details":
+      {
         "file_path": null,
-        "name": "libmagickcore-6.q16-6",
+        "name": "imagemagick-6-common",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -955,21 +881,276 @@
       "title": "CVE-2022-32545 - imagemagick, libmagickcore-6.q16-6 and 3 more"
     }
   ],
-  "libmagickwand-6.q16-6": [
+  "libmagickcore-6.q16-6":
+  [
+    {
+      "description": " A flaw was found in ImageMagick in versions before 7.0.11. A potential cipher leak when the calculate signatures in TransformSignature is possible. The highest threat from this vulnerability is to data confidentiality.",
+      "vulnerability_id": "CVE-2021-20313",
+      "name": "CVE-2021-20313",
+      "package_name": "libmagickcore-6.q16-6",
+      "package_details":
+      {
+        "file_path": null,
+        "name": "libmagickcore-6.q16-6",
+        "package_manager": "OS",
+        "version": "6.9.10.23+dfsg",
+        "release": "2.1ubuntu11.4"
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 5.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-20313.html",
+      "source": "UBUNTU_CVE",
+      "severity": "LOW",
+      "status": "ACTIVE",
+      "title": "CVE-2021-20313 - imagemagick, libmagickcore-6.q16-6 and 3 more"
+    },
+    {
+      "description": " A vulnerability was found in ImageMagick, causing an outside the range of representable values of type 'unsigned long' at coders/pcl.c, when crafted or untrusted input is processed. This leads to a negative impact to application availability or other problems related to undefined behavior.",
+      "vulnerability_id": "CVE-2022-32546",
+      "name": "CVE-2022-32546",
+      "package_name": "libmagickcore-6.q16-6",
+      "package_details":
+      {
+        "file_path": null,
+        "name": "libmagickcore-6.q16-6",
+        "package_manager": "OS",
+        "version": "6.9.10.23+dfsg",
+        "release": "2.1ubuntu11.4"
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.8,
+      "cvss_v2_score": 6.8,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-32546.html",
+      "source": "UBUNTU_CVE",
+      "severity": "MEDIUM",
+      "status": "ACTIVE",
+      "title": "CVE-2022-32546 - imagemagick, libmagickcore-6.q16-6 and 3 more"
+    },
+    {
+      "description": " A flaw was found in ImageMagick in versions before 7.0.11 and before 6.9.12, where a division by zero in WaveImage() of MagickCore/visual-effects.c may trigger undefined behavior via a crafted image file submitted to an application using ImageMagick. The highest threat from this vulnerability is to system availability.",
+      "vulnerability_id": "CVE-2021-20309",
+      "name": "CVE-2021-20309",
+      "package_name": "libmagickcore-6.q16-6",
+      "package_details":
+      {
+        "file_path": null,
+        "name": "libmagickcore-6.q16-6",
+        "package_manager": "OS",
+        "version": "6.9.10.23+dfsg",
+        "release": "2.1ubuntu11.4"
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 7.8,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-20309.html",
+      "source": "UBUNTU_CVE",
+      "severity": "LOW",
+      "status": "ACTIVE",
+      "title": "CVE-2021-20309 - imagemagick, libmagickcore-6.q16-6 and 3 more"
+    },
+    {
+      "description": " A flaw was found in ImageMagick in versions 7.0.11, where an integer overflow in WriteTHUMBNAILImage of coders/thumbnail.c may trigger undefined behavior via a crafted image file that is submitted by an attacker and processed by an application using ImageMagick. The highest threat from this vulnerability is to system availability.",
+      "vulnerability_id": "CVE-2021-20312",
+      "name": "CVE-2021-20312",
+      "package_name": "libmagickcore-6.q16-6",
+      "package_details":
+      {
+        "file_path": null,
+        "name": "libmagickcore-6.q16-6",
+        "package_manager": "OS",
+        "version": "6.9.10.23+dfsg",
+        "release": "2.1ubuntu11.4"
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 7.8,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2021/CVE-2021-20312.html",
+      "source": "UBUNTU_CVE",
+      "severity": "LOW",
+      "status": "ACTIVE",
+      "title": "CVE-2021-20312 - imagemagick, libmagickcore-6.q16-6 and 3 more"
+    },
+    {
+      "description": " A heap-use-after-free flaw was found in ImageMagick's RelinquishDCMInfo() function of dcm.c file. This vulnerability is triggered when an attacker passes a specially crafted DICOM image file to ImageMagick for conversion, potentially leading to information disclosure and a denial of service.",
+      "vulnerability_id": "CVE-2022-1114",
+      "name": "CVE-2022-1114",
+      "package_name": "libmagickcore-6.q16-6",
+      "package_details":
+      {
+        "file_path": null,
+        "name": "libmagickcore-6.q16-6",
+        "package_manager": "OS",
+        "version": "6.9.10.23+dfsg",
+        "release": "2.1ubuntu11.4"
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.1,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.1,
+      "cvss_v2_score": 5.8,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-1114.html",
+      "source": "UBUNTU_CVE",
+      "severity": "MEDIUM",
+      "status": "ACTIVE",
+      "title": "CVE-2022-1114 - imagemagick, libmagickcore-6.q16-6 and 3 more"
+    },
+    {
+      "description": " ImageMagick 7.1.0-27 is vulnerable to Buffer Overflow.",
+      "vulnerability_id": "CVE-2022-28463",
+      "name": "CVE-2022-28463",
+      "package_name": "libmagickcore-6.q16-6",
+      "package_details":
+      {
+        "file_path": null,
+        "name": "libmagickcore-6.q16-6",
+        "package_manager": "OS",
+        "version": "6.9.10.23+dfsg",
+        "release": "2.1ubuntu11.4"
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.8,
+      "cvss_v2_score": 6.8,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-28463.html",
+      "source": "UBUNTU_CVE",
+      "severity": "MEDIUM",
+      "status": "ACTIVE",
+      "title": "CVE-2022-28463 - imagemagick, libmagickcore-6.q16-6 and 3 more"
+    },
+    {
+      "description": " In ImageMagick, there is load of misaligned address for type 'double', which requires 8 byte alignment and for type 'float', which requires 4 byte alignment at MagickCore/property.c. Whenever crafted or untrusted input is processed by ImageMagick, this causes a negative impact to application availability or other problems related to undefined behavior.",
+      "vulnerability_id": "CVE-2022-32547",
+      "name": "CVE-2022-32547",
+      "package_name": "libmagickcore-6.q16-6",
+      "package_details":
+      {
+        "file_path": null,
+        "name": "libmagickcore-6.q16-6",
+        "package_manager": "OS",
+        "version": "6.9.10.23+dfsg",
+        "release": "2.1ubuntu11.4"
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.8,
+      "cvss_v2_score": 6.8,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-32547.html",
+      "source": "UBUNTU_CVE",
+      "severity": "MEDIUM",
+      "status": "ACTIVE",
+      "title": "CVE-2022-32547 - imagemagick, libmagickcore-6.q16-6 and 3 more"
+    },
+    {
+      "description": " A vulnerability was found in ImageMagick, causing an outside the range of representable values of type 'unsigned char' at coders/psd.c, when crafted or untrusted input is processed. This leads to a negative impact to application availability or other problems related to undefined behavior.",
+      "vulnerability_id": "CVE-2022-32545",
+      "name": "CVE-2022-32545",
+      "package_name": "libmagickcore-6.q16-6",
+      "package_details":
+      {
+        "file_path": null,
+        "name": "libmagickcore-6.q16-6",
+        "package_manager": "OS",
+        "version": "6.9.10.23+dfsg",
+        "release": "2.1ubuntu11.4"
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.8,
+      "cvss_v2_score": 6.8,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-32545.html",
+      "source": "UBUNTU_CVE",
+      "severity": "MEDIUM",
+      "status": "ACTIVE",
+      "title": "CVE-2022-32545 - imagemagick, libmagickcore-6.q16-6 and 3 more"
+    }
+  ],
+  "libmagickwand-6.q16-6":
+  [
     {
       "description": " A flaw was found in ImageMagick in versions before 7.0.11. A potential cipher leak when the calculate signatures in TransformSignature is possible. The highest threat from this vulnerability is to data confidentiality.",
       "vulnerability_id": "CVE-2021-20313",
       "name": "CVE-2021-20313",
       "package_name": "libmagickwand-6.q16-6",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "libmagickwand-6.q16-6",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -989,15 +1170,18 @@
       "vulnerability_id": "CVE-2022-32546",
       "name": "CVE-2022-32546",
       "package_name": "libmagickwand-6.q16-6",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "libmagickwand-6.q16-6",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -1017,15 +1201,18 @@
       "vulnerability_id": "CVE-2021-20309",
       "name": "CVE-2021-20309",
       "package_name": "libmagickwand-6.q16-6",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "libmagickwand-6.q16-6",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -1045,15 +1232,18 @@
       "vulnerability_id": "CVE-2021-20312",
       "name": "CVE-2021-20312",
       "package_name": "libmagickwand-6.q16-6",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "libmagickwand-6.q16-6",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -1073,15 +1263,18 @@
       "vulnerability_id": "CVE-2022-1114",
       "name": "CVE-2022-1114",
       "package_name": "libmagickwand-6.q16-6",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "libmagickwand-6.q16-6",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -1101,15 +1294,18 @@
       "vulnerability_id": "CVE-2022-28463",
       "name": "CVE-2022-28463",
       "package_name": "libmagickwand-6.q16-6",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "libmagickwand-6.q16-6",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -1129,15 +1325,18 @@
       "vulnerability_id": "CVE-2022-32547",
       "name": "CVE-2022-32547",
       "package_name": "libmagickwand-6.q16-6",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "libmagickwand-6.q16-6",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },
@@ -1157,15 +1356,18 @@
       "vulnerability_id": "CVE-2022-32545",
       "name": "CVE-2022-32545",
       "package_name": "libmagickwand-6.q16-6",
-      "package_details": {
+      "package_details":
+      {
         "file_path": null,
         "name": "libmagickwand-6.q16-6",
         "package_manager": "OS",
         "version": "6.9.10.23+dfsg",
         "release": "2.1ubuntu11.4"
       },
-      "remediation": {
-        "recommendation": {
+      "remediation":
+      {
+        "recommendation":
+        {
           "text": "None Provided"
         }
       },


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [ ] build_pytorch_training_latest
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
