### PR TITLE
Add additional ignores

### DIFF
--- a/data/ignore_ids_safety_scan.json
+++ b/data/ignore_ids_safety_scan.json
@@ -1367,7 +1367,21 @@
                 "65213": "Covered elsewhere",
                 "65215": "Covered elsewhere",
                 "65398": "Covered elsewhere",
-                "64402": "Covered elsewhere"
+                "64402": "Covered elsewhere",
+                "66777": "Covered elsewhere",
+                "65212": "Covered elsewhere",
+                "62556": "Covered elsewhere",
+                "65647": "Covered elsewhere",
+                "66704": "Covered elsewhere",
+                "65278": "Covered elsewhere",
+                "62044": "Covered elsewhere",
+                "65501": "Covered elsewhere",
+                "61949": "Covered elsewhere", 
+                "65581": "Covered elsewhere",
+                "65095": "Covered elsewhere",
+                "61503": "Covered elsewhere",
+                "65193": "Covered elsewhere",
+                "62019": "Covered elsehwere"
             }
         },
         "inference": {

--- a/huggingface/pytorch/training/docker/1.13/py3/cu117/Dockerfile.gpu.os_scan_allowlist.json
+++ b/huggingface/pytorch/training/docker/1.13/py3/cu117/Dockerfile.gpu.os_scan_allowlist.json
@@ -1,4 +1,375 @@
 {
+  "Pillow":
+  [
+    {
+      "description": "## Overview\n\nAffected versions of this package are vulnerable to Denial of Service (DoS) when using arbitrary strings as text input and the number of characters passed into `PIL.ImageFont.ImageFont.getmask()` is over a certain limit. This can lead to a system crash.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source ",
+      "vulnerability_id": "SNYK-PYTHON-PILLOW-6219984",
+      "name": "SNYK-PYTHON-PILLOW-6219984",
+      "package_name": "Pillow",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/Pillow-10.0.0.dist-info/METADATA",
+        "name": "Pillow",
+        "package_manager": "PYTHONPKG",
+        "version": "10.0.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-PILLOW-6219984",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-PILLOW-6219984 - Pillow",
+      "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Heap buffer overflow in libwebp in Google Chrome prior to 116.0.5845.187 and libwebp 1.3.2 allowed a remote attacker to perform an out of bounds memory write via a crafted HTML page. (Chromium security severity: Critical)",
+      "vulnerability_id": "CVE-2023-4863",
+      "name": "CVE-2023-4863",
+      "package_name": "Pillow",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/Pillow-10.0.0.dist-info/METADATA",
+        "name": "Pillow",
+        "package_manager": "PYTHONPKG",
+        "version": "10.0.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-4863",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-4863 - opencv-python, Pillow",
+      "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "## Overview\n\nAffected versions of this package are vulnerable to Denial of Service (DoS) if the size of individual glyphs extends beyond the bitmap image, when using `PIL.ImageFont.ImageFont` function. Exploiting this vulnerability could lead to a system crash.\n\n## Details\n\nDenial of Service (DoS) describes a family of attacks, all aimed at making a system inaccessible to its intended and legitimate users.\n\nUnlike other vulnerabilities, DoS attacks usually do not aim at breaching security. Rather, they are focused on making websites and services unavailable to genuine users resulting in downtime.\n\nOne popular Denial of Service vulnerability is DDoS (a Distributed Denial of Service), an attack that attempts to clog network pipes to the system by generating a large volume of traffic from many machines.\n\nWhen it comes to open source libraries, DoS vulnerabilities allow attackers to trigger such a crash or crippling of the service by using a flaw either in the application code or from the use of open source libra",
+      "vulnerability_id": "SNYK-PYTHON-PILLOW-6219986",
+      "name": "SNYK-PYTHON-PILLOW-6219986",
+      "package_name": "Pillow",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/Pillow-10.0.0.dist-info/METADATA",
+        "name": "Pillow",
+        "package_manager": "PYTHONPKG",
+        "version": "10.0.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://security.snyk.io/vuln/SNYK-PYTHON-PILLOW-6219986",
+      "source": "SNYK",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "IN1-PYTHON-PILLOW-6219986 - Pillow",
+      "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Pillow through 10.1.0 allows PIL.ImageMath.eval Arbitrary Code Execution via the environment parameter, a different vulnerability than CVE-2022-22817 (which was about the expression parameter).",
+      "vulnerability_id": "CVE-2023-50447",
+      "name": "CVE-2023-50447",
+      "package_name": "Pillow",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/Pillow-10.0.0.dist-info/METADATA",
+        "name": "Pillow",
+        "package_manager": "PYTHONPKG",
+        "version": "10.0.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.1,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.1,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-50447",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-50447 - Pillow",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "Werkzeug":
+  [
+    {
+      "description": "Werkzeug is a comprehensive WSGI web application library. If an upload of a file that starts with CR or LF and then is followed by megabytes of data without these characters: all of these bytes are appended chunk by chunk into internal bytearray and lookup for boundary is performed on growing buffer. This allows an attacker to cause a denial of service by sending crafted multipart data to an endpoint that will parse it. The amount of CPU time required can block worker processes from handling legitimate requests. This vulnerability has been patched in version 3.0.1.",
+      "vulnerability_id": "CVE-2023-46136",
+      "name": "CVE-2023-46136",
+      "package_name": "Werkzeug",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/Werkzeug-2.3.6.dist-info/METADATA",
+        "name": "Werkzeug",
+        "package_manager": "PYTHONPKG",
+        "version": "2.3.6",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-46136",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-46136 - Werkzeug",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "cryptography":
+  [
+    {
+      "description": " If an X.509 certificate contains a malformed policy constraint and policy processing is enabled, then a write lock will be taken twice recursively. On some operating systems (most widely: Windows) this results in a denial of service when the affected process hangs. Policy processing being enabled on a publicly facing server is not considered to be a common setup. Policy processing is enabled by passing the `-policy' argument to the command line utilities or by calling either `X509_VERIFY_PARAM_add0_policy()' or `X509_VERIFY_PARAM_set1_policies()' functions.",
+      "vulnerability_id": "CVE-2022-3996",
+      "name": "CVE-2022-3996",
+      "package_name": "cryptography",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/cryptography-39.0.0.dist-info/METADATA",
+        "name": "cryptography",
+        "package_manager": "PYTHONPKG",
+        "version": "39.0.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-3996.html",
+      "source": "UBUNTU_CVE",
+      "severity": "LOW",
+      "status": "ACTIVE",
+      "title": "CVE-2022-3996 - cryptography"
+    },
+    {
+      "description": " If an X.509 certificate contains a malformed policy constraint and policy processing is enabled, then a write lock will be taken twice recursively. On some operating systems (most widely: Windows) this results in a denial of service when the affected process hangs. Policy processing being enabled on a publicly facing server is not considered to be a common setup. Policy processing is enabled by passing the `-policy' argument to the command line utilities or by calling either `X509_VERIFY_PARAM_add0_policy()' or `X509_VERIFY_PARAM_set1_policies()' functions.",
+      "vulnerability_id": "CVE-2022-3996",
+      "name": "CVE-2022-3996",
+      "package_name": "cryptography",
+      "package_details":
+      {
+        "file_path": "root/micromamba/pkgs/cryptography-39.0.0-py310h34c0648_0/lib/python3.10/site-packages/cryptography-39.0.0.dist-info/METADATA",
+        "name": "cryptography",
+        "package_manager": "PYTHONPKG",
+        "version": "39.0.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-3996.html",
+      "source": "UBUNTU_CVE",
+      "severity": "LOW",
+      "status": "ACTIVE",
+      "title": "CVE-2022-3996 - cryptography, cryptography"
+    }
+  ],
+  "fonttools":
+  [
+    {
+      "description": "fontTools is a library for manipulating fonts, written in Python. The subsetting module has a XML External Entity Injection (XXE) vulnerability which allows an attacker to resolve arbitrary entities when a candidate font (OT-SVG fonts), which contains a SVG table, is parsed. This allows attackers to include arbitrary files from the filesystem fontTools is running on or make web requests from the host system. This vulnerability has been patched in version 4.43.0.",
+      "vulnerability_id": "CVE-2023-45139",
+      "name": "CVE-2023-45139",
+      "package_name": "fonttools",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/fonttools-4.41.1.dist-info/METADATA",
+        "name": "fonttools",
+        "package_manager": "PYTHONPKG",
+        "version": "4.41.1",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-45139",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-45139 - fonttools",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "gevent":
+  [
+    {
+      "description": "An issue in Gevent before version 23.9.0 allows a remote attacker to escalate privileges via a crafted script to the WSGIServer component.",
+      "vulnerability_id": "CVE-2023-41419",
+      "name": "CVE-2023-41419",
+      "package_name": "gevent",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/gevent-23.7.0.dist-info/METADATA",
+        "name": "gevent",
+        "package_manager": "PYTHONPKG",
+        "version": "23.7.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-41419",
+      "source": "NVD",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2023-41419 - gevent",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "opencv-python":
+  [
+    {
+      "description": "Heap buffer overflow in libwebp in Google Chrome prior to 116.0.5845.187 and libwebp 1.3.2 allowed a remote attacker to perform an out of bounds memory write via a crafted HTML page. (Chromium security severity: Critical)",
+      "vulnerability_id": "CVE-2023-4863",
+      "name": "CVE-2023-4863",
+      "package_name": "opencv-python",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/opencv_python-4.8.0.74.dist-info/METADATA",
+        "name": "opencv-python",
+        "package_manager": "PYTHONPKG",
+        "version": "4.8.0.74",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-4863",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-4863 - opencv-python, Pillow",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "pyarrow":
+  [
+    {
+      "description": "Deserialization of untrusted data in IPC and Parquet readers in PyArrow versions 0.14.0 to 14.0.0 allows arbitrary code execution. An application is vulnerable if it reads Arrow IPC, Feather or Parquet data from untrusted sources (for example user-supplied input files).\n\nThis vulnerability only affects PyArrow, not other Apache Arrow implementations or bindings.\n\nIt is recommended that users of PyArrow upgrade to 14.0.1. Similarly, it is recommended that downstream libraries upgrade their dependency requirements to PyArrow 14.0.1 or later. PyPI packages are already available, and we hope that conda-forge packages will be available soon.\n\nIf it is not possible to upgrade, we provide a separate package `pyarrow-hotfix` that disables the vulnerability on older PyArrow versions. See  https://pypi.org/project/pyarrow-hotfix/  for instructions.\n\n",
+      "vulnerability_id": "CVE-2023-47248",
+      "name": "CVE-2023-47248",
+      "package_name": "pyarrow",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/pyarrow-12.0.1.dist-info/METADATA",
+        "name": "pyarrow",
+        "package_manager": "PYTHONPKG",
+        "version": "12.0.1",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-47248",
+      "source": "NVD",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2023-47248 - pyarrow",
+      "reason_to_ignore": "N/A"
+    }
+  ],
   "transformers":
   [
     {
@@ -66,19 +437,19 @@
       "reason_to_ignore": "N/A"
     }
   ],
-  "cryptography":
+  "urllib3":
   [
     {
-      "description": " If an X.509 certificate contains a malformed policy constraint and policy processing is enabled, then a write lock will be taken twice recursively. On some operating systems (most widely: Windows) this results in a denial of service when the affected process hangs. Policy processing being enabled on a publicly facing server is not considered to be a common setup. Policy processing is enabled by passing the `-policy' argument to the command line utilities or by calling either `X509_VERIFY_PARAM_add0_policy()' or `X509_VERIFY_PARAM_set1_policies()' functions.",
-      "vulnerability_id": "CVE-2022-3996",
-      "name": "CVE-2022-3996",
-      "package_name": "cryptography",
+      "description": "urllib3 is a user-friendly HTTP client library for Python. urllib3 doesn't treat the `Cookie` HTTP header special or provide any helpers for managing cookies over HTTP, that is the responsibility of the user. However, it is possible for a user to specify a `Cookie` header and unknowingly leak information via HTTP redirects to a different origin if that user doesn't disable redirects explicitly. This issue has been patched in urllib3 version 1.26.17 or 2.0.5.",
+      "vulnerability_id": "CVE-2023-43804",
+      "name": "CVE-2023-43804",
+      "package_name": "urllib3",
       "package_details":
       {
-        "file_path": "opt/conda/lib/python3.9/site-packages/cryptography-39.0.0.dist-info/METADATA",
-        "name": "cryptography",
+        "file_path": "opt/conda/lib/python3.9/site-packages/urllib3-1.26.14.dist-info/METADATA",
+        "name": "urllib3",
         "package_manager": "PYTHONPKG",
-        "version": "39.0.0",
+        "version": "1.26.14",
         "release": null
       },
       "remediation":
@@ -88,47 +459,17 @@
           "text": "None Provided"
         }
       },
-      "cvss_v3_score": 7.5,
+      "cvss_v3_score": 8.1,
       "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.5,
+      "cvss_v31_score": 8.1,
       "cvss_v2_score": 0.0,
       "cvss_v3_severity": "HIGH",
-      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-3996.html",
-      "source": "UBUNTU_CVE",
-      "severity": "LOW",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-43804",
+      "source": "NVD",
+      "severity": "HIGH",
       "status": "ACTIVE",
-      "title": "CVE-2022-3996 - cryptography"
-    },
-    {
-      "description": " If an X.509 certificate contains a malformed policy constraint and policy processing is enabled, then a write lock will be taken twice recursively. On some operating systems (most widely: Windows) this results in a denial of service when the affected process hangs. Policy processing being enabled on a publicly facing server is not considered to be a common setup. Policy processing is enabled by passing the `-policy' argument to the command line utilities or by calling either `X509_VERIFY_PARAM_add0_policy()' or `X509_VERIFY_PARAM_set1_policies()' functions.",
-      "vulnerability_id": "CVE-2022-3996",
-      "name": "CVE-2022-3996",
-      "package_name": "cryptography",
-      "package_details":
-      {
-        "file_path": "root/micromamba/pkgs/cryptography-39.0.0-py310h34c0648_0/lib/python3.10/site-packages/cryptography-39.0.0.dist-info/METADATA",
-        "name": "cryptography",
-        "package_manager": "PYTHONPKG",
-        "version": "39.0.0",
-        "release": null
-      },
-      "remediation":
-      {
-        "recommendation":
-        {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0.0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-3996.html",
-      "source": "UBUNTU_CVE",
-      "severity": "LOW",
-      "status": "ACTIVE",
-      "title": "CVE-2022-3996 - cryptography, cryptography"
+      "title": "CVE-2023-43804 - urllib3",
+      "reason_to_ignore": "N/A"
     }
   ],
   "imagemagick":


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [ ] build_pytorch_training_latest
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
