### PR TITLE
Add additional ignores

### DIFF
--- a/data/ignore_ids_safety_scan.json
+++ b/data/ignore_ids_safety_scan.json
@@ -1450,7 +1450,8 @@
                 "66710": "Covered elsewhere",
                 "65215": "Covered elsewhere",
                 "65212": "Covered elsewhere",
-                "64402": "Covered elsewhere"
+                "64402": "Covered elsewhere",
+                "65647": "Covered elsewhere"
 
             }
         }

--- a/huggingface/pytorch/inference/docker/1.13/py3/cu117/Dockerfile.gpu
+++ b/huggingface/pytorch/inference/docker/1.13/py3/cu117/Dockerfile.gpu
@@ -225,7 +225,8 @@ RUN pip install --no-cache-dir \
     "accelerate>=0.11.0" \
 	"protobuf>=3.19.5,<=3.20.2" \
 	numpy>=1.21.5 \
-	"sagemaker-huggingface-inference-toolkit<3"
+	"sagemaker-huggingface-inference-toolkit<3" \
+    "pyOpenSSL~=24.1.0"
 
 
 RUN HOME_DIR=/root \

--- a/huggingface/pytorch/inference/docker/1.13/py3/cu117/Dockerfile.gpu
+++ b/huggingface/pytorch/inference/docker/1.13/py3/cu117/Dockerfile.gpu
@@ -220,12 +220,12 @@ RUN curl -o /license.txt  https://aws-dlc-licenses.s3.amazonaws.com/pytorch-1.13
 
 # install Hugging Face libraries and its dependencies
 RUN pip install --no-cache-dir \
-	transformers[sentencepiece,audio,vision]==${TRANSFORMERS_VERSION} \
+    transformers[sentencepiece,audio,vision]==${TRANSFORMERS_VERSION} \
     diffusers==${DIFFUSERS_VERSION} \
     "accelerate>=0.11.0" \
-	"protobuf>=3.19.5,<=3.20.2" \
-	numpy>=1.21.5 \
-	"sagemaker-huggingface-inference-toolkit<3" \
+    "protobuf>=3.19.5,<=3.20.2" \
+    numpy>=1.21.5 \
+    "sagemaker-huggingface-inference-toolkit<3" \
     "pyOpenSSL~=24.1.0"
 
 

--- a/huggingface/pytorch/training/docker/1.13/py3/cu117/Dockerfile.gpu
+++ b/huggingface/pytorch/training/docker/1.13/py3/cu117/Dockerfile.gpu
@@ -19,7 +19,9 @@ ARG PT_TORCHAUDIO_URL=https://download.pytorch.org/whl/cu117/torchaudio-0.13.1%2
 RUN pip install --no-cache-dir \
 	transformers[sklearn,sentencepiece,audio,vision]==${TRANSFORMERS_VERSION} \
 	datasets==${DATASETS_VERSION} \
-	$PT_TORCHAUDIO_URL
+	$PT_TORCHAUDIO_URL \
+	multiprocess~=0.70.15 \
+	dill~=0.3.7
 
 RUN apt-get update \
  # TODO: Remove upgrade statements once packages are updated in base image

--- a/huggingface/pytorch/training/docker/1.13/py3/cu117/Dockerfile.gpu
+++ b/huggingface/pytorch/training/docker/1.13/py3/cu117/Dockerfile.gpu
@@ -17,11 +17,11 @@ ARG PT_TORCHAUDIO_URL=https://download.pytorch.org/whl/cu117/torchaudio-0.13.1%2
 
 # install Hugging Face libraries and its dependencies
 RUN pip install --no-cache-dir \
-	transformers[sklearn,sentencepiece,audio,vision]==${TRANSFORMERS_VERSION} \
-	datasets==${DATASETS_VERSION} \
-	$PT_TORCHAUDIO_URL \
-	multiprocess~=0.70.15 \
-	dill~=0.3.7
+    transformers[sklearn,sentencepiece,audio,vision]==${TRANSFORMERS_VERSION} \
+    datasets==${DATASETS_VERSION} \
+    $PT_TORCHAUDIO_URL \
+    multiprocess~=0.70.15 \
+    dill~=0.3.7
 
 RUN apt-get update \
  # TODO: Remove upgrade statements once packages are updated in base image

--- a/huggingface/pytorch/training/docker/1.13/py3/cu117/Dockerfile.gpu.os_scan_allowlist.json
+++ b/huggingface/pytorch/training/docker/1.13/py3/cu117/Dockerfile.gpu.os_scan_allowlist.json
@@ -1,4 +1,136 @@
 {
+  "cryptography":
+  [
+    {
+      "description": " If an X.509 certificate contains a malformed policy constraint and policy processing is enabled, then a write lock will be taken twice recursively. On some operating systems (most widely: Windows) this results in a denial of service when the affected process hangs. Policy processing being enabled on a publicly facing server is not considered to be a common setup. Policy processing is enabled by passing the `-policy' argument to the command line utilities or by calling either `X509_VERIFY_PARAM_add0_policy()' or `X509_VERIFY_PARAM_set1_policies()' functions.",
+      "vulnerability_id": "CVE-2022-3996",
+      "name": "CVE-2022-3996",
+      "package_name": "cryptography",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/cryptography-39.0.0.dist-info/METADATA",
+        "name": "cryptography",
+        "package_manager": "PYTHONPKG",
+        "version": "39.0.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-3996.html",
+      "source": "UBUNTU_CVE",
+      "severity": "LOW",
+      "status": "ACTIVE",
+      "title": "CVE-2022-3996 - cryptography"
+    },
+    {
+      "description": " If an X.509 certificate contains a malformed policy constraint and policy processing is enabled, then a write lock will be taken twice recursively. On some operating systems (most widely: Windows) this results in a denial of service when the affected process hangs. Policy processing being enabled on a publicly facing server is not considered to be a common setup. Policy processing is enabled by passing the `-policy' argument to the command line utilities or by calling either `X509_VERIFY_PARAM_add0_policy()' or `X509_VERIFY_PARAM_set1_policies()' functions.",
+      "vulnerability_id": "CVE-2022-3996",
+      "name": "CVE-2022-3996",
+      "package_name": "cryptography",
+      "package_details":
+      {
+        "file_path": "root/micromamba/pkgs/cryptography-39.0.0-py310h34c0648_0/lib/python3.10/site-packages/cryptography-39.0.0.dist-info/METADATA",
+        "name": "cryptography",
+        "package_manager": "PYTHONPKG",
+        "version": "39.0.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-3996.html",
+      "source": "UBUNTU_CVE",
+      "severity": "LOW",
+      "status": "ACTIVE",
+      "title": "CVE-2022-3996 - cryptography, cryptography"
+    }
+  ],
+  "transformers":
+  [
+    {
+      "description": "Deserialization of Untrusted Data in GitHub repository huggingface/transformers prior to 4.36.",
+      "vulnerability_id": "CVE-2023-6730",
+      "name": "CVE-2023-6730",
+      "package_name": "transformers",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/transformers-4.26.0.dist-info/METADATA",
+        "name": "transformers",
+        "package_manager": "PYTHONPKG",
+        "version": "4.26.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6730",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-6730 - transformers",
+      "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Deserialization of Untrusted Data in GitHub repository huggingface/transformers prior to 4.36.",
+      "vulnerability_id": "CVE-2023-7018",
+      "name": "CVE-2023-7018",
+      "package_name": "transformers",
+      "package_details":
+      {
+        "file_path": "opt/conda/lib/python3.9/site-packages/transformers-4.26.0.dist-info/METADATA",
+        "name": "transformers",
+        "package_manager": "PYTHONPKG",
+        "version": "4.26.0",
+        "release": null
+      },
+      "remediation":
+      {
+        "recommendation":
+        {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-7018",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2023-7018 - transformers",
+      "reason_to_ignore": "N/A"
+    }
+  ],
   "Pillow":
   [
     {
@@ -165,71 +297,6 @@
       "reason_to_ignore": "N/A"
     }
   ],
-  "cryptography":
-  [
-    {
-      "description": " If an X.509 certificate contains a malformed policy constraint and policy processing is enabled, then a write lock will be taken twice recursively. On some operating systems (most widely: Windows) this results in a denial of service when the affected process hangs. Policy processing being enabled on a publicly facing server is not considered to be a common setup. Policy processing is enabled by passing the `-policy' argument to the command line utilities or by calling either `X509_VERIFY_PARAM_add0_policy()' or `X509_VERIFY_PARAM_set1_policies()' functions.",
-      "vulnerability_id": "CVE-2022-3996",
-      "name": "CVE-2022-3996",
-      "package_name": "cryptography",
-      "package_details":
-      {
-        "file_path": "opt/conda/lib/python3.9/site-packages/cryptography-39.0.0.dist-info/METADATA",
-        "name": "cryptography",
-        "package_manager": "PYTHONPKG",
-        "version": "39.0.0",
-        "release": null
-      },
-      "remediation":
-      {
-        "recommendation":
-        {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0.0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-3996.html",
-      "source": "UBUNTU_CVE",
-      "severity": "LOW",
-      "status": "ACTIVE",
-      "title": "CVE-2022-3996 - cryptography"
-    },
-    {
-      "description": " If an X.509 certificate contains a malformed policy constraint and policy processing is enabled, then a write lock will be taken twice recursively. On some operating systems (most widely: Windows) this results in a denial of service when the affected process hangs. Policy processing being enabled on a publicly facing server is not considered to be a common setup. Policy processing is enabled by passing the `-policy' argument to the command line utilities or by calling either `X509_VERIFY_PARAM_add0_policy()' or `X509_VERIFY_PARAM_set1_policies()' functions.",
-      "vulnerability_id": "CVE-2022-3996",
-      "name": "CVE-2022-3996",
-      "package_name": "cryptography",
-      "package_details":
-      {
-        "file_path": "root/micromamba/pkgs/cryptography-39.0.0-py310h34c0648_0/lib/python3.10/site-packages/cryptography-39.0.0.dist-info/METADATA",
-        "name": "cryptography",
-        "package_manager": "PYTHONPKG",
-        "version": "39.0.0",
-        "release": null
-      },
-      "remediation":
-      {
-        "recommendation":
-        {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0.0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-3996.html",
-      "source": "UBUNTU_CVE",
-      "severity": "LOW",
-      "status": "ACTIVE",
-      "title": "CVE-2022-3996 - cryptography, cryptography"
-    }
-  ],
   "fonttools":
   [
     {
@@ -367,73 +434,6 @@
       "severity": "CRITICAL",
       "status": "ACTIVE",
       "title": "CVE-2023-47248 - pyarrow",
-      "reason_to_ignore": "N/A"
-    }
-  ],
-  "transformers":
-  [
-    {
-      "description": "Deserialization of Untrusted Data in GitHub repository huggingface/transformers prior to 4.36.",
-      "vulnerability_id": "CVE-2023-6730",
-      "name": "CVE-2023-6730",
-      "package_name": "transformers",
-      "package_details":
-      {
-        "file_path": "opt/conda/lib/python3.9/site-packages/transformers-4.26.0.dist-info/METADATA",
-        "name": "transformers",
-        "package_manager": "PYTHONPKG",
-        "version": "4.26.0",
-        "release": null
-      },
-      "remediation":
-      {
-        "recommendation":
-        {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 8.8,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 8.8,
-      "cvss_v2_score": 0.0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-6730",
-      "source": "NVD",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2023-6730 - transformers",
-      "reason_to_ignore": "N/A"
-    },
-    {
-      "description": "Deserialization of Untrusted Data in GitHub repository huggingface/transformers prior to 4.36.",
-      "vulnerability_id": "CVE-2023-7018",
-      "name": "CVE-2023-7018",
-      "package_name": "transformers",
-      "package_details":
-      {
-        "file_path": "opt/conda/lib/python3.9/site-packages/transformers-4.26.0.dist-info/METADATA",
-        "name": "transformers",
-        "package_manager": "PYTHONPKG",
-        "version": "4.26.0",
-        "release": null
-      },
-      "remediation":
-      {
-        "recommendation":
-        {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 7.8,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.8,
-      "cvss_v2_score": 0.0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2023-7018",
-      "source": "NVD",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2023-7018 - transformers",
       "reason_to_ignore": "N/A"
     }
   ],


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [ ] build_pytorch_training_latest
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
