### PR TITLE
Resolve build failures

### DIFF
--- a/data/ignore_ids_safety_scan.json
+++ b/data/ignore_ids_safety_scan.json
@@ -1406,7 +1406,8 @@
                 "65215": "Covered elsewhere",
                 "65398": "Covered elsewhere",
                 "64402": "Covered elsewhere",
-                "65278": "Covered elsewhere"
+                "65278": "Covered elsewhere",
+                "66704": "Covered elsewhere"
             }
         },
         "inference-neuron": {

--- a/huggingface/pytorch/inference/docker/1.13/py3/cu117/Dockerfile.gpu
+++ b/huggingface/pytorch/inference/docker/1.13/py3/cu117/Dockerfile.gpu
@@ -169,7 +169,8 @@ RUN pip uninstall -y torch torchvision torchaudio model-archiver multi-model-ser
 RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cu117 -U \
     "awscli<2" \
     boto3 \
-    "cryptography>3.2" \
+    "cryptography~=41.0" \
+    "pyOpenSSL~=24.1.0" \
     enum-compat==0.0.3 \
     numpy==1.22.2 \
     opencv-python \
@@ -226,9 +227,7 @@ RUN pip install --no-cache-dir \
     "accelerate>=0.11.0" \
     "protobuf>=3.19.5,<=3.20.2" \
     numpy>=1.21.5 \
-    "sagemaker-huggingface-inference-toolkit<3" \
-    "pyOpenSSL~=24.1.0" \
-    "cryptography~=41.0"
+    "sagemaker-huggingface-inference-toolkit<3"
 
 
 RUN HOME_DIR=/root \

--- a/huggingface/pytorch/training/buildspec-1-13.yml
+++ b/huggingface/pytorch/training/buildspec-1-13.yml
@@ -25,7 +25,7 @@ images:
     cuda_version: &CUDA_VERSION cu117
     os_version: &OS_VERSION ubuntu20.04
     transformers_version: &TRANSFORMERS_VERSION 4.26.0
-    datasets_version: &DATASETS_VERSION 2.9.0
+    datasets_version: &DATASETS_VERSION 2.16.1
     tag: !join [ *VERSION, '-', 'transformers', *TRANSFORMERS_VERSION, '-', *DEVICE_TYPE, '-', *TAG_PYTHON_VERSION, '-',
                  *CUDA_VERSION, '-', *OS_VERSION ]
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /,


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [ ] build_pytorch_training_latest
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
