### PR TITLE
Onboard PyTorch 2.1 Training/Inference EC2 to Autopatch

### DIFF
--- a/available_images.md
+++ b/available_images.md
@@ -64,7 +64,7 @@ previously, insert the region in the repository URL following this
 example:
 
 
-     763104351884.dkr.ecr.<region>.amazonaws.com/tensorflow-training:2.9.1-gpu-py39-cu112-ubuntu20.04-ec2
+    763104351884.dkr.ecr.<region>.amazonaws.com/tensorflow-training:2.9.1-gpu-py39-cu112-ubuntu20.04-ec2
 
 **Important**
 
@@ -75,7 +75,7 @@ the image. Ensure your CLI is up to date using the steps in [Installing the curr
 
 
 
-        aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 763104351884.dkr.ecr.us-east-1.amazonaws.com
+    aws ecr get-login-password --region us-east-1 | docker login --username AWS --password-stdin 763104351884.dkr.ecr.us-east-1.amazonaws.com
 
 You can then pull these Docker images from ECR by running:
 
@@ -92,7 +92,7 @@ either ``py37``, ``py38``, ``py39``, or ``py310`` depending on availability. Plu
 
 You can pin your version by adding the version tag to your URL as follows:
 
-     763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.4.1-cpu-py37-ubuntu18.04-v1.0
+    763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-training:2.4.1-cpu-py37-ubuntu18.04-v1.0
 
 EC2 Framework Containers (Tested on EC2, ECS, and EKS only)
 ============================
@@ -182,11 +182,11 @@ Large Model Inference Containers
 
 DJL CPU Full Inference Containers
 ===============================
-| Framework         | Job Type  | CPU/GPU | Python Version Options | Example URL                                                                | 
-|-------------------|-----------|---------|------------------------|----------------------------------------------------------------------------| 
-| DJLServing 0.27.0 | inference | CPU     | 3.10 (py310)           | 763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.27.0-cpu-full | 
-| DJLServing 0.26.0 | inference | CPU     | 3.10 (py310)           | 763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.26.0-cpu-full | 
-| DJLServing 0.25.0 | inference | CPU     | 3.8 (py38)             | 763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.25.0-cpu-full | 
+| Framework         | Job Type  | CPU/GPU | Python Version Options | Example URL                                                                |
+|-------------------|-----------|---------|------------------------|----------------------------------------------------------------------------|
+| DJLServing 0.27.0 | inference | CPU     | 3.10 (py310)           | 763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.27.0-cpu-full |
+| DJLServing 0.26.0 | inference | CPU     | 3.10 (py310)           | 763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.26.0-cpu-full |
+| DJLServing 0.25.0 | inference | CPU     | 3.8 (py38)             | 763104351884.dkr.ecr.us-west-2.amazonaws.com/djl-inference:0.25.0-cpu-full |
 
 
 AutoGluon Training Containers
@@ -348,7 +348,7 @@ Prior EC2 Framework Graviton Containers
 
 | Framework         |Job Type	|Horovod Options|CPU/GPU 	|Python Version Options	|Example URL																						|
 |-------------------|-----------|---------------|-----------|-----------------------|---------------------------------------------------------------------------------------------------|
-| PyTorch 2.1.0     |inference	|No			|CPU 		| 3.10 (py310)			| 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference-graviton:2.1.0-cpu-py310-ubuntu20.04-ec2	
+| PyTorch 2.1.0     |inference	|No			|CPU 		| 3.10 (py310)			| 763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference-graviton:2.1.0-cpu-py310-ubuntu20.04-ec2
 |PyTorch 2.0.1     |inference	|No			|CPU 		| 3.10 (py310)			|763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference-graviton:2.0.1-cpu-py310-ubuntu20.04-ec2		|
 |PyTorch 1.12.1     |inference	|No			|CPU 		| 3.8 (py38)			|763104351884.dkr.ecr.us-east-1.amazonaws.com/pytorch-inference-graviton:1.12.1-cpu-py38-ubuntu20.04-ec2		|
 | TensorFlow 2.13.0 |inference	|No			|CPU 		| 3.10 (py310)			| 763104351884.dkr.ecr.us-east-1.amazonaws.com/tensorflow-inference-graviton:2.13.0-cpu-py310-ubuntu20.04-ec2	|

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -42,7 +42,7 @@ build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
-do_build = true
+do_build = false
 
 [notify]
 ### Notify on test failures

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -42,7 +42,7 @@ build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
-do_build = false
+do_build = true
 
 [notify]
 ### Notify on test failures

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,7 +34,7 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ['pytorch']
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
@@ -60,26 +60,26 @@ ecs_tests = true
 eks_tests = true
 ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
-ec2_benchmark_tests = true
+ec2_benchmark_tests = false
 
 ### Set ec2_tests_on_heavy_instances = true to be able to run any EC2 tests that use large/expensive instance types by
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = true
+ec2_tests_on_heavy_instances = false
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = true
+sagemaker_local_tests = false
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = true
+sagemaker_remote_tests = false
 # run efa sagemaker tests
-sagemaker_efa_tests = true
+sagemaker_efa_tests = false
 # run release_candidate_integration tests
-sagemaker_rc_tests = true
+sagemaker_rc_tests = false
 # run sagemaker benchmark tests
-sagemaker_benchmark_tests = true
+sagemaker_benchmark_tests = false
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""
@@ -101,7 +101,7 @@ use_scheduler = false
 
 # Standard Framework Training
 dlc-pr-mxnet-training = ""
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-1-ec2.yml"
+dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 
@@ -130,7 +130,7 @@ dlc-pr-tensorflow-2-habana-training = ""
 
 # Standard Framework Inference
 dlc-pr-mxnet-inference = ""
-dlc-pr-pytorch-inference = "pytorch/inference/buildspec-2-1-ec2.yml"
+dlc-pr-pytorch-inference = ""
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,7 +34,7 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ['pytorch']
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
@@ -60,26 +60,26 @@ ecs_tests = true
 eks_tests = true
 ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
-ec2_benchmark_tests = false
+ec2_benchmark_tests = true
 
 ### Set ec2_tests_on_heavy_instances = true to be able to run any EC2 tests that use large/expensive instance types by
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = false
+ec2_tests_on_heavy_instances = true
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = false
+sagemaker_local_tests = true
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = false
+sagemaker_remote_tests = true
 # run efa sagemaker tests
-sagemaker_efa_tests = false
+sagemaker_efa_tests = true
 # run release_candidate_integration tests
-sagemaker_rc_tests = false
+sagemaker_rc_tests = true
 # run sagemaker benchmark tests
-sagemaker_benchmark_tests = false
+sagemaker_benchmark_tests = true
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""
@@ -101,7 +101,7 @@ use_scheduler = false
 
 # Standard Framework Training
 dlc-pr-mxnet-training = ""
-dlc-pr-pytorch-training = ""
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-1-ec2.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 
@@ -130,7 +130,7 @@ dlc-pr-tensorflow-2-habana-training = ""
 
 # Standard Framework Inference
 dlc-pr-mxnet-inference = ""
-dlc-pr-pytorch-inference = ""
+dlc-pr-pytorch-inference = "pytorch/inference/buildspec-2-1-ec2.yml"
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
 

--- a/pytorch/inference/buildspec-2-1-ec2.yml
+++ b/pytorch/inference/buildspec-2-1-ec2.yml
@@ -1,16 +1,20 @@
 account_id: &ACCOUNT_ID <set-$ACCOUNT_ID-in-environment>
+prod_account_id: &PROD_ACCOUNT_ID 763104351884
 region: &REGION <set-$REGION-in-environment>
 framework: &FRAMEWORK pytorch
 version: &VERSION 2.1.0
 short_version: &SHORT_VERSION "2.1"
 arch_type: x86
+autopatch_build: "True"
 
 repository_info:
   inference_repository: &INFERENCE_REPOSITORY
     image_type: &INFERENCE_IMAGE_TYPE inference
     root: !join [ *FRAMEWORK, "/", *INFERENCE_IMAGE_TYPE ]
-    repository_name: &REPOSITORY_NAME !join [pr, "-", *FRAMEWORK, "-", *INFERENCE_IMAGE_TYPE]
+    repository_name: &REPOSITORY_NAME !join [ pr, "-", *FRAMEWORK, "-", *INFERENCE_IMAGE_TYPE ]
     repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ]
+    release_repository_name: &RELEASE_REPOSITORY_NAME !join [ *FRAMEWORK, "-", *INFERENCE_IMAGE_TYPE ]
+    release_repository: &RELEASE_REPOSITORY !join [ *PROD_ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *RELEASE_REPOSITORY_NAME ]
 
 context:
   inference_context: &INFERENCE_CONTEXT
@@ -38,6 +42,7 @@ images:
     os_version: &OS_VERSION ubuntu20.04
     torch_serve_version: &TORCHSERVE_VERSION 0.8.2
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
+    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
     target: ec2
     context:
@@ -53,6 +58,7 @@ images:
     os_version: &OS_VERSION ubuntu20.04
     torch_serve_version: &TORCHSERVE_VERSION 0.8.2
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
+    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
                          *DEVICE_TYPE ]
     target: ec2

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.cpu
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.cpu
@@ -20,7 +20,7 @@ ARG SM_TOOLKIT_VERSION
 # |_____\____|_____| |___|_| |_| |_|\__,_|\__, |\___|
 #                                         |___/
 #  ____           _
-# |  _ \ ___  ___(_)_ __   ___ 
+# |  _ \ ___  ___(_)_ __   ___
 # | |_) / _ \/ __| | '_ \ / _ \
 # |  _ <  __/ (__| | |_) |  __/
 # |_| \_\___|\___|_| .__/ \___|
@@ -127,8 +127,8 @@ RUN pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pytho
 RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -U \
     boto3 \
     opencv-python \
-    pyOpenSSL \
-    cryptography \
+    "pyOpenSSL>=24.0.0" \
+    "cryptography>=42.0.5" \
     "ipython>=8.10.0,<9.0" \
     "awscli<2" \
     "urllib3>=1.26.18,<2"
@@ -152,7 +152,7 @@ RUN pip install --no-cache-dir -U \
 # -> Numpy is higer version as required by torch
 RUN pip install --no-cache-dir -U -r https://raw.githubusercontent.com/pytorch/serve/v${TORCHSERVE_VERSION}/requirements/common.txt \
  && pip install --no-cache-dir -U \
-    "numpy>=1.22.2,<1.23" \
+    numpy \
     torchserve==${TORCHSERVE_VERSION} \
     torch-model-archiver==${TORCHSERVE_VERSION}
 
@@ -236,7 +236,7 @@ RUN pip install --no-cache-dir sagemaker-pytorch-inference==${SM_TOOLKIT_VERSION
     "awscli" \
     "botocore" \
     "s3transfer"
-    
+
 COPY torchserve-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
 
 RUN chmod +x /usr/local/bin/dockerd-entrypoint.py

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.ec2.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.ec2.cpu.core_packages.json
@@ -1,0 +1,43 @@
+{
+  "captum": {
+    "version_specifier": "==0.6.0",
+    "skip": "True"
+  },
+  "torchaudio": {
+    "version_specifier": "==2.1.0+cpu",
+    "skip": "True"
+  },
+  "torchdata": {
+    "version_specifier": "==0.7.0+7c7597b",
+    "skip": "True"
+  },
+  "torchtext": {
+    "version_specifier": "==0.16.0+cpu",
+    "skip": "True"
+  },
+  "torchvision": {
+    "version_specifier": "==0.16.0+cpu",
+    "skip": "True"
+  },
+  "pyopenssl": {
+    "version_specifier": ">=24.0.0"
+  },
+  "cryptography": {
+    "version_specifier": ">=42.0.5"
+  },
+  "ipython": {
+    "version_specifier": ">=8.10.0,<9.0"
+  },
+  "awscli": {
+    "version_specifier": "<2"
+  },
+  "urllib3": {
+    "version_specifier": ">=1.26.18,<2"
+  },
+  "torchserve": {
+    "version_specifier": "==0.8.2"
+  },
+  "torch-model-archiver": {
+    "version_specifier": "==0.8.2"
+  }
+}

--- a/pytorch/inference/docker/2.1/py3/cu118/Dockerfile.ec2.gpu.core_packages.json
+++ b/pytorch/inference/docker/2.1/py3/cu118/Dockerfile.ec2.gpu.core_packages.json
@@ -1,0 +1,40 @@
+{
+  "captum": {
+    "version_specifier": "==0.6.0",
+    "skip": "True"
+  },
+  "torchaudio": {
+    "version_specifier": "==2.1.0+cu118",
+    "skip": "True"
+  },
+  "torchdata": {
+    "version_specifier": "==0.7.0+7c7597b",
+    "skip": "True"
+  },
+  "torchtext": {
+    "version_specifier": "==0.16.0+cu118",
+    "skip": "True"
+  },
+  "torchvision": {
+    "version_specifier": "==0.16.0+cu118",
+    "skip": "True"
+  },
+  "pyopenssl": {
+    "version_specifier": ">=24.0.0"
+  },
+  "cryptography": {
+    "version_specifier": ">=42.0.5"
+  },
+  "ipython": {
+    "version_specifier": ">=8.10.0,<9.0"
+  },
+  "urllib3": {
+    "version_specifier": ">=1.26.18,<2"
+  },
+  "torchserve": {
+    "version_specifier": "==0.8.2"
+  },
+  "torch-model-archiver": {
+    "version_specifier": "==0.8.2"
+  }
+}

--- a/pytorch/inference/docker/2.1/py3/cu118/Dockerfile.gpu
+++ b/pytorch/inference/docker/2.1/py3/cu118/Dockerfile.gpu
@@ -26,7 +26,7 @@ ARG SM_TOOLKIT_VERSION
 # |_____\____|_____| |___|_| |_| |_|\__,_|\__, |\___|
 #                                         |___/
 #  ____           _
-# |  _ \ ___  ___(_)_ __   ___ 
+# |  _ \ ___  ___(_)_ __   ___
 # | |_) / _ \/ __| | '_ \ / _ \
 # |  _ <  __/ (__| | |_) |  __/
 # |_| \_\___|\___|_| .__/ \___|
@@ -181,10 +181,10 @@ RUN pip install --no-cache-dir -U \
     opencv-python \
     # "nvgpu" is a dependency of TS but is disabled in SM DLC build,
     # via ENV Variable "TS_DISABLE_SYSTEM_METRICS=true" in the SM section of this file.
-    # due to incompatibility with SM hosts 
+    # due to incompatibility with SM hosts
     nvgpu \
-    pyOpenSSL \
-    cryptography \
+    "pyOpenSSL>=24.0.0" \
+    "cryptography>=42.0.5" \
     "ipython>=8.10.0,<9.0" \
     "urllib3>=1.26.18,<2"
 
@@ -207,8 +207,8 @@ RUN pip install --no-cache-dir -U \
 # NOTE: This also brings in unnecessary cpu dependencies like nvgpu
 # -> Numpy is higer version as required by torch
 RUN pip install --no-cache-dir -U -r https://raw.githubusercontent.com/pytorch/serve/v${TORCHSERVE_VERSION}/requirements/common.txt \
- && pip install --no-cache-dir -U \ 
-    "numpy>=1.22.2,<1.23" \
+ && pip install --no-cache-dir -U \
+    numpy \
     torchserve==${TORCHSERVE_VERSION} \
     torch-model-archiver==${TORCHSERVE_VERSION}
 

--- a/pytorch/training/buildspec-2-1-ec2.yml
+++ b/pytorch/training/buildspec-2-1-ec2.yml
@@ -1,16 +1,20 @@
 account_id: &ACCOUNT_ID <set-$ACCOUNT_ID-in-environment>
+prod_account_id: &PROD_ACCOUNT_ID 763104351884
 region: &REGION <set-$REGION-in-environment>
 framework: &FRAMEWORK pytorch
 version: &VERSION 2.1.0
 short_version: &SHORT_VERSION "2.1"
 arch_type: x86
+autopatch_build: "True"
 
 repository_info:
   training_repository: &TRAINING_REPOSITORY
     image_type: &TRAINING_IMAGE_TYPE training
     root: !join [ *FRAMEWORK, "/", *TRAINING_IMAGE_TYPE ]
-    repository_name: &REPOSITORY_NAME !join [pr, "-", *FRAMEWORK, "-", *TRAINING_IMAGE_TYPE]
+    repository_name: &REPOSITORY_NAME !join [ pr, "-", *FRAMEWORK, "-", *TRAINING_IMAGE_TYPE ]
     repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ]
+    release_repository_name: &RELEASE_REPOSITORY_NAME !join [ *FRAMEWORK, "-", *TRAINING_IMAGE_TYPE ]
+    release_repository: &RELEASE_REPOSITORY !join [ *PROD_ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *RELEASE_REPOSITORY_NAME ]
 
 context:
   training_context: &TRAINING_CONTEXT
@@ -37,6 +41,7 @@ images:
     tag_python_version: &TAG_PYTHON_VERSION py310
     os_version: &OS_VERSION ubuntu20.04
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
+    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
     target: ec2
     context:
@@ -51,23 +56,24 @@ images:
     cuda_version: &CUDA_VERSION cu121
     os_version: &OS_VERSION ubuntu20.04
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
+    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
                          *DEVICE_TYPE ]
     target: ec2
     context:
       <<: *TRAINING_CONTEXT
-  BuildPyTorchExampleGPUTrainPy3cu121DockerImage:
-    <<: *TRAINING_REPOSITORY
-    build: &PYTORCH_GPU_TRAINING_PY3 false
-    image_size_baseline: 19700
-    base_image_name: BuildEC2GPUPTTrainPy3cu121DockerImage
-    device_type: &DEVICE_TYPE gpu
-    python_version: &DOCKER_PYTHON_VERSION py3
-    tag_python_version: &TAG_PYTHON_VERSION py310
-    cuda_version: &CUDA_VERSION cu121
-    os_version: &OS_VERSION ubuntu20.04
-    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION,
-                 "-ec2-example" ]
-    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /example, /Dockerfile., *DEVICE_TYPE ]
-    context:
-      <<: *TRAINING_CONTEXT
+  # BuildPyTorchExampleGPUTrainPy3cu121DockerImage:
+  #   <<: *TRAINING_REPOSITORY
+  #   build: &PYTORCH_GPU_TRAINING_PY3 false
+  #   image_size_baseline: 19700
+  #   base_image_name: BuildEC2GPUPTTrainPy3cu121DockerImage
+  #   device_type: &DEVICE_TYPE gpu
+  #   python_version: &DOCKER_PYTHON_VERSION py3
+  #   tag_python_version: &TAG_PYTHON_VERSION py310
+  #   cuda_version: &CUDA_VERSION cu121
+  #   os_version: &OS_VERSION ubuntu20.04
+  #   tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION,
+  #                "-ec2-example" ]
+  #   docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /example, /Dockerfile., *DEVICE_TYPE ]
+  #   context:
+  #     <<: *TRAINING_CONTEXT

--- a/pytorch/training/docker/2.1/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/2.1/py3/Dockerfile.cpu
@@ -114,9 +114,9 @@ RUN /opt/conda/bin/mamba install -y --override-channels \
     -c conda-forge \
     conda=23.1.0 \
     # patch CVE
-    "cryptography>=42.0.2" \
+    "cryptography>=42.0.5" \
     # patch CVE
-    "pyopenssl>=21.0.0" \
+    "pyopenssl>=24.0.0" \
     cmake \
     requests \
     python=$PYTHON_VERSION \

--- a/pytorch/training/docker/2.1/py3/Dockerfile.ec2.cpu.core_packages.json
+++ b/pytorch/training/docker/2.1/py3/Dockerfile.ec2.cpu.core_packages.json
@@ -1,0 +1,44 @@
+{
+  "accelerate": {
+    "version_specifier": "==0.22.0",
+    "skip": "True"
+  },
+  "fastai": {
+    "version_specifier": "==2.7.13",
+    "skip": "True"
+  },
+  "torchaudio": {
+    "version_specifier": "==2.1.0",
+    "skip": "True"
+  },
+  "torchdata": {
+    "version_specifier": "==0.7.0",
+    "skip": "True"
+  },
+  "torchtext": {
+    "version_specifier": "==0.16.0",
+    "skip": "True"
+  },
+  "torchvision": {
+    "version_specifier": "==0.16.0",
+    "skip": "True"
+  },
+  "cryptography": {
+    "version_specifier": ">=42.0.5"
+  },
+  "pyopenssl": {
+    "version_specifier": ">=24.0.0"
+  },
+  "mpi4py": {
+    "version_specifier": ">=3.1.4,<3.2"
+  },
+  "urllib3": {
+    "version_specifier": ">=1.26.18,<2"
+  },
+  "pyyaml": {
+    "version_specifier": ">=6.0.1"
+  },
+  "requests": {
+    "version_specifier": ">=2.31.0"
+  }
+}

--- a/pytorch/training/docker/2.1/py3/cu121/Dockerfile.ec2.gpu.core_packages.json
+++ b/pytorch/training/docker/2.1/py3/cu121/Dockerfile.ec2.gpu.core_packages.json
@@ -1,0 +1,53 @@
+{
+  "accelerate": {
+    "version_specifier": "==0.22.0",
+    "skip": "True"
+  },
+  "fastai": {
+    "version_specifier": "==2.7.13",
+    "skip": "True"
+  },
+  "flash-attn": {
+    "version_specifier": "==2.0.4",
+    "skip": "True"
+  },
+  "torchaudio": {
+    "version_specifier": "==2.1.0",
+    "skip": "True"
+  },
+  "torchdata": {
+    "version_specifier": "==0.7.0",
+    "skip": "True"
+  },
+  "torchtext": {
+    "version_specifier": "==0.16.0",
+    "skip": "True"
+  },
+  "torchtnt": {
+    "version_specifier": "==0.2.1",
+    "skip": "True"
+  },
+  "torchvision": {
+    "version_specifier": "==0.16.0",
+    "skip": "True"
+  },
+  "transformer-engine": {
+    "version_specifier": "==0.12.0+170797",
+    "skip": "True"
+  },
+  "pyopenssl": {
+    "version_specifier": ">=24.0.0"
+  },
+  "cryptography": {
+    "version_specifier": ">=42.0.5"
+  },
+  "mpi4py": {
+    "version_specifier": ">=3.1.4,<3.2"
+  },
+  "urllib3": {
+    "version_specifier": ">=1.26.18,<2"
+  },
+  "requests": {
+    "version_specifier": ">=2.31.0"
+  }
+}

--- a/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
+++ b/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
@@ -138,9 +138,9 @@ RUN /opt/conda/bin/mamba install -y -c conda-forge \
     # Adding package for studio kernels
     ipykernel \
     # patch CVE
-    "pyopenssl>=21.0.0" \
+    "pyopenssl>=24.0.0" \
     # patch CVE
-    "cryptography>=42.0.2" \
+    "cryptography>=42.0.5" \
     # patch CVE
     "urllib3>=1.26.18,<2" \
     pillow \

--- a/test/dlc_tests/container_tests/bin/gdrcopy/test_gdrcopy_dev.sh
+++ b/test/dlc_tests/container_tests/bin/gdrcopy/test_gdrcopy_dev.sh
@@ -12,21 +12,11 @@
 # language governing permissions and limitations under the License.
 
 #!/usr/bin/env bash
-gdrcopy_sanity > tmp_out
+# NOTE: This test script is used for GDRCopy v2.3 and below.
+# For GDRCopy v2.4 and above, use `test_gdrcopy.sh`
+sanity | grep 'Failures: 0, Error: 0' &> /dev/null
 if [ $? != 0 ]; then
     echo "GDRCopy Sanity check failed!"
     exit 1
 fi
-
-# NOTE: A grep guard clause is added because the old GDRCopy test (which is now moved to `test_gdrcopy_dev.sh`)
-# was checking an exit status of grep instead of the sanity test itself.
-# We are now moving towards checking the exit status of the sanity test,
-# but as a safety check we will continue to check the test output as well.
-cat tmp_out | grep 'Failed: 0' &> /dev/null
-if [ $? != 0 ]; then
-    echo "GDRCopy Sanity check passed but failed at grep output check!"
-    echo "Please examine the gdrcopy_sanity output to ensure the tests are passing properly"
-    exit 1
-fi
-
 echo "GDRCopy Sanity check succeed!"

--- a/test/dlc_tests/container_tests/bin/gdrcopy/test_gdrcopy_dev.sh
+++ b/test/dlc_tests/container_tests/bin/gdrcopy/test_gdrcopy_dev.sh
@@ -14,7 +14,7 @@
 #!/usr/bin/env bash
 # NOTE: This test script is used for GDRCopy v2.3 and below.
 # For GDRCopy v2.4 and above, use `test_gdrcopy.sh`
-sanity | grep 'Failures: 0, Error: 0' &> /dev/null
+sanity | grep 'Failures: 0, Errors: 0' &> /dev/null
 if [ $? != 0 ]; then
     echo "GDRCopy Sanity check failed!"
     exit 1

--- a/test/dlc_tests/ec2/test_gdrcopy.py
+++ b/test/dlc_tests/ec2/test_gdrcopy.py
@@ -5,13 +5,17 @@ from packaging.version import Version
 from packaging.specifiers import SpecifierSet
 
 import test.test_utils as test_utils
-from test.test_utils import CONTAINER_TESTS_PREFIX, is_pr_context, is_efa_dedicated
+from test.test_utils import (
+    CONTAINER_TESTS_PREFIX,
+    is_pr_context,
+    get_framework_and_version_from_tag,
+)
+
 from test.test_utils.ec2 import (
     get_efa_ec2_instance_type,
     filter_efa_instance_type,
     execute_ec2_training_test,
     are_heavy_instance_ec2_tests_enabled,
-    get_framework_and_version_from_tag,
 )
 
 GDRCOPY_SANITY_TEST_CMD = os.path.join(CONTAINER_TESTS_PREFIX, "gdrcopy", "test_gdrcopy.sh")


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run
[42f7839](https://github.com/aws/deep-learning-containers/pull/3847/commits/42f783938397499c0828aeeeb5fb88e44915b143) - Both Training and Inference DLCs
- Passed ec2 test
- Passed eks test
- Passed ecs test
- Passed benchmark test
- Passed sanity test

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [ ] build_pytorch_training_latest
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
