### PR TITLE
Onboard PyTorch 2.1 Training EC2/SM to Autopatch

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,11 +34,11 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ['pytorch']
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -60,26 +60,26 @@ ecs_tests = true
 eks_tests = true
 ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
-ec2_benchmark_tests = false
+ec2_benchmark_tests = true
 
 ### Set ec2_tests_on_heavy_instances = true to be able to run any EC2 tests that use large/expensive instance types by
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = false
+ec2_tests_on_heavy_instances = true
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = false
+sagemaker_local_tests = true
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = false
+sagemaker_remote_tests = true
 # run efa sagemaker tests
-sagemaker_efa_tests = false
+sagemaker_efa_tests = true
 # run release_candidate_integration tests
-sagemaker_rc_tests = false
+sagemaker_rc_tests = true
 # run sagemaker benchmark tests
-sagemaker_benchmark_tests = false
+sagemaker_benchmark_tests = true
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""
@@ -101,7 +101,7 @@ use_scheduler = false
 
 # Standard Framework Training
 dlc-pr-mxnet-training = ""
-dlc-pr-pytorch-training = ""
+dlc-pr-pytorch-training = "pytorch/training/buildspec-1-13.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/pytorch/training/buildspec-1-13.yml
+++ b/pytorch/training/buildspec-1-13.yml
@@ -1,16 +1,20 @@
 account_id: &ACCOUNT_ID <set-$ACCOUNT_ID-in-environment>
+prod_account_id: &PROD_ACCOUNT_ID 763104351884
 region: &REGION <set-$REGION-in-environment>
 framework: &FRAMEWORK pytorch
 version: &VERSION 1.13.1
 short_version: &SHORT_VERSION "1.13"
 arch_type: x86
+autopatch_build: "True"
 
 repository_info:
   training_repository: &TRAINING_REPOSITORY
     image_type: &TRAINING_IMAGE_TYPE training
     root: !join [ *FRAMEWORK, "/", *TRAINING_IMAGE_TYPE ]
-    repository_name: &REPOSITORY_NAME !join [pr, "-", *FRAMEWORK, "-", *TRAINING_IMAGE_TYPE]
+    repository_name: &REPOSITORY_NAME !join [ pr, "-", *FRAMEWORK, "-", *TRAINING_IMAGE_TYPE ]
     repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ]
+    release_repository_name: &RELEASE_REPOSITORY_NAME !join [ *FRAMEWORK, "-", *TRAINING_IMAGE_TYPE ]
+    release_repository: &RELEASE_REPOSITORY !join [ *PROD_ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *RELEASE_REPOSITORY_NAME ]
 
 context:
   training_context: &TRAINING_CONTEXT
@@ -28,34 +32,36 @@ context:
       target: deep_learning_container.py
 
 images:
-  # BuildEC2CPUPTTrainPy3DockerImage:
-  #   <<: *TRAINING_REPOSITORY
-  #   build: &PYTORCH_CPU_TRAINING_PY3 false
-  #   image_size_baseline: 5000
-  #   device_type: &DEVICE_TYPE cpu
-  #   python_version: &DOCKER_PYTHON_VERSION py3
-  #   tag_python_version: &TAG_PYTHON_VERSION py39
-  #   os_version: &OS_VERSION ubuntu20.04
-  #   tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
-  #   docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
-  #   target: ec2
-  #   context:
-  #     <<: *TRAINING_CONTEXT
-  # BuildEC2GPUPTTrainPy3DockerImage:
-  #   <<: *TRAINING_REPOSITORY
-  #   build: &PYTORCH_GPU_TRAINING_PY3 false
-  #   image_size_baseline: 14000
-  #   device_type: &DEVICE_TYPE gpu
-  #   python_version: &DOCKER_PYTHON_VERSION py3
-  #   tag_python_version: &TAG_PYTHON_VERSION py39
-  #   cuda_version: &CUDA_VERSION cu117
-  #   os_version: &OS_VERSION ubuntu20.04
-  #   tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
-  #   docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
-  #                        *DEVICE_TYPE ]
-  #   target: ec2
-  #   context:
-  #     <<: *TRAINING_CONTEXT
+  BuildEC2CPUPTTrainPy3DockerImage:
+    <<: *TRAINING_REPOSITORY
+    build: &PYTORCH_CPU_TRAINING_PY3 false
+    image_size_baseline: 5000
+    device_type: &DEVICE_TYPE cpu
+    python_version: &DOCKER_PYTHON_VERSION py3
+    tag_python_version: &TAG_PYTHON_VERSION py39
+    os_version: &OS_VERSION ubuntu20.04
+    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
+    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
+    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
+    target: ec2
+    context:
+      <<: *TRAINING_CONTEXT
+  BuildEC2GPUPTTrainPy3DockerImage:
+    <<: *TRAINING_REPOSITORY
+    build: &PYTORCH_GPU_TRAINING_PY3 false
+    image_size_baseline: 14000
+    device_type: &DEVICE_TYPE gpu
+    python_version: &DOCKER_PYTHON_VERSION py3
+    tag_python_version: &TAG_PYTHON_VERSION py39
+    cuda_version: &CUDA_VERSION cu117
+    os_version: &OS_VERSION ubuntu20.04
+    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
+    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
+    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
+                         *DEVICE_TYPE ]
+    target: ec2
+    context:
+      <<: *TRAINING_CONTEXT
   BuildSageMakerCPUPTTrainPy3DockerImage:
     <<: *TRAINING_REPOSITORY
     build: &PYTORCH_CPU_TRAINING_PY3 false
@@ -65,25 +71,27 @@ images:
     tag_python_version: &TAG_PYTHON_VERSION py39
     os_version: &OS_VERSION ubuntu20.04
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
+    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
     target: sagemaker
     context:
       <<: *TRAINING_CONTEXT
-  # BuildSageMakerGPUPTTrainPy3DockerImage:
-  #   <<: *TRAINING_REPOSITORY
-  #   build: &PYTORCH_GPU_TRAINING_PY3 false
-  #   image_size_baseline: 14000
-  #   device_type: &DEVICE_TYPE gpu
-  #   python_version: &DOCKER_PYTHON_VERSION py3
-  #   tag_python_version: &TAG_PYTHON_VERSION py39
-  #   cuda_version: &CUDA_VERSION cu117
-  #   os_version: &OS_VERSION ubuntu20.04
-  #   tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-  #   docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
-  #                        *DEVICE_TYPE ]
-  #   target: sagemaker
-  #   context:
-  #     <<: *TRAINING_CONTEXT
+  BuildSageMakerGPUPTTrainPy3DockerImage:
+    <<: *TRAINING_REPOSITORY
+    build: &PYTORCH_GPU_TRAINING_PY3 false
+    image_size_baseline: 14000
+    device_type: &DEVICE_TYPE gpu
+    python_version: &DOCKER_PYTHON_VERSION py3
+    tag_python_version: &TAG_PYTHON_VERSION py39
+    cuda_version: &CUDA_VERSION cu117
+    os_version: &OS_VERSION ubuntu20.04
+    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
+    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
+    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
+                         *DEVICE_TYPE ]
+    target: sagemaker
+    context:
+      <<: *TRAINING_CONTEXT
   # BuildPyTorchExampleGPUTrainPy3DockerImage:
   #   <<: *TRAINING_REPOSITORY
   #   build: &PYTORCH_GPU_TRAINING_PY3 false

--- a/pytorch/training/docker/1.13/py3/Dockerfile.ec2.cpu.core_packages.json
+++ b/pytorch/training/docker/1.13/py3/Dockerfile.ec2.cpu.core_packages.json
@@ -1,0 +1,47 @@
+{
+  "accelerate": {
+    "version_specifier": "==0.22.0",
+    "skip": "True"
+  },
+  "fastai": {
+    "version_specifier": "==2.7.14",
+    "skip": "True"
+  },
+  "torchaudio": {
+    "version_specifier": "==2.2.0",
+    "skip": "True"
+  },
+  "torchdata": {
+    "version_specifier": "==0.7.1",
+    "skip": "True"
+  },
+  "torchtext": {
+    "version_specifier": "==0.17.0",
+    "skip": "True"
+  },
+  "torchvision": {
+    "version_specifier": "==0.17.0",
+    "skip": "True"
+  },
+  "cryptography": {
+    "version_specifier": ">=42.0.5"
+  },
+  "pyopenssl": {
+    "version_specifier": ">=24.0.0"
+  },
+  "mpi4py": {
+    "version_specifier": ">=3.1.4,<3.2"
+  },
+  "urllib3": {
+    "version_specifier": ">=1.26.18,<2"
+  },
+  "pyyaml": {
+    "version_specifier": ">=6.0.1"
+  },
+  "requests": {
+    "version_specifier": ">=2.31.0"
+  },
+  "idna": {
+    "version_specifier": ">=3.7"
+  }
+}

--- a/pytorch/training/docker/1.13/py3/Dockerfile.sagemaker.cpu.core_packages.json
+++ b/pytorch/training/docker/1.13/py3/Dockerfile.sagemaker.cpu.core_packages.json
@@ -1,0 +1,53 @@
+{
+  "accelerate": {
+    "version_specifier": "==0.22.0",
+    "skip": "True"
+  },
+  "fastai": {
+    "version_specifier": "==2.7.14",
+    "skip": "True"
+  },
+  "torchaudio": {
+    "version_specifier": "==2.2.0",
+    "skip": "True"
+  },
+  "torchdata": {
+    "version_specifier": "==0.7.1",
+    "skip": "True"
+  },
+  "torchtext": {
+    "version_specifier": "==0.17.0",
+    "skip": "True"
+  },
+  "torchvision": {
+    "version_specifier": "==0.17.0",
+    "skip": "True"
+  },
+  "cryptography": {
+    "version_specifier": ">=42.0.5"
+  },
+  "pyopenssl": {
+    "version_specifier": ">=24.0.0"
+  },
+  "mpi4py": {
+    "version_specifier": ">=3.1.4,<3.2"
+  },
+  "urllib3": {
+    "version_specifier": ">=1.26.18,<2"
+  },
+  "pyyaml": {
+    "version_specifier": ">=6.0.1"
+  },
+  "requests": {
+    "version_specifier": ">=2.31.0"
+  },
+  "sagemaker": {
+    "version_specifier": ">=2,<3"
+  },
+  "sagemaker-experiments": {
+    "version_specifier": "<1"
+  },
+  "idna": {
+    "version_specifier": ">=3.7"
+  }
+}

--- a/pytorch/training/docker/1.13/py3/cu117/Dockerfile.ec2.gpu.core_packages.json
+++ b/pytorch/training/docker/1.13/py3/cu117/Dockerfile.ec2.gpu.core_packages.json
@@ -1,0 +1,56 @@
+{
+  "accelerate": {
+    "version_specifier": "==0.22.0",
+    "skip": "True"
+  },
+  "fastai": {
+    "version_specifier": "==2.7.14",
+    "skip": "True"
+  },
+  "flash-attn": {
+    "version_specifier": "==2.0.4",
+    "skip": "True"
+  },
+  "torchaudio": {
+    "version_specifier": "==2.2.0",
+    "skip": "True"
+  },
+  "torchdata": {
+    "version_specifier": "==0.7.1",
+    "skip": "True"
+  },
+  "torchtext": {
+    "version_specifier": "==0.17.0",
+    "skip": "True"
+  },
+  "torchtnt": {
+    "version_specifier": "==0.2.3",
+    "skip": "True"
+  },
+  "torchvision": {
+    "version_specifier": "==0.17.0",
+    "skip": "True"
+  },
+  "transformer-engine": {
+    "version_specifier": "==0.12.0+170797",
+    "skip": "True"
+  },
+  "pyopenssl": {
+    "version_specifier": ">=24.0.0"
+  },
+  "cryptography": {
+    "version_specifier": ">=42.0.5"
+  },
+  "mpi4py": {
+    "version_specifier": ">=3.1.4,<3.2"
+  },
+  "urllib3": {
+    "version_specifier": ">=1.26.18,<2"
+  },
+  "requests": {
+    "version_specifier": ">=2.31.0"
+  },
+  "idna": {
+    "version_specifier": ">=3.7"
+  }
+}

--- a/pytorch/training/docker/1.13/py3/cu117/Dockerfile.sagemaker.gpu.core_packages.json
+++ b/pytorch/training/docker/1.13/py3/cu117/Dockerfile.sagemaker.gpu.core_packages.json
@@ -1,0 +1,62 @@
+{
+  "accelerate": {
+    "version_specifier": "==0.22.0",
+    "skip": "True"
+  },
+  "fastai": {
+    "version_specifier": "==2.7.14",
+    "skip": "True"
+  },
+  "flash-attn": {
+    "version_specifier": "==2.0.4",
+    "skip": "True"
+  },
+  "torchaudio": {
+    "version_specifier": "==2.2.0",
+    "skip": "True"
+  },
+  "torchdata": {
+    "version_specifier": "==0.7.1",
+    "skip": "True"
+  },
+  "torchtext": {
+    "version_specifier": "==0.17.0",
+    "skip": "True"
+  },
+  "torchtnt": {
+    "version_specifier": "==0.2.3",
+    "skip": "True"
+  },
+  "torchvision": {
+    "version_specifier": "==0.17.0",
+    "skip": "True"
+  },
+  "transformer-engine": {
+    "version_specifier": "==0.12.0+170797",
+    "skip": "True"
+  },
+  "pyopenssl": {
+    "version_specifier": ">=24.0.0"
+  },
+  "cryptography": {
+    "version_specifier": ">=42.0.5"
+  },
+  "mpi4py": {
+    "version_specifier": ">=3.1.4,<3.2"
+  },
+  "urllib3": {
+    "version_specifier": ">=1.26.18,<2"
+  },
+  "requests": {
+    "version_specifier": ">=2.31.0"
+  },
+  "sagemaker": {
+    "version_specifier": ">=2,<3"
+  },
+  "sagemaker-experiments": {
+    "version_specifier": "<1"
+  },
+  "idna": {
+    "version_specifier": ">=3.7"
+  }
+}


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [ ] build_pytorch_training_latest
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
