### PR TITLE
Release PyTorch 2.1 Inference Autopatch

### DIFF
--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -57,19 +57,6 @@ release_images:
       disable_sm_tag: False
       force_release: False
   5:
-    framework: "pytorch"
-    version: "2.1.0"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  6:
     framework: "huggingface_pytorch"
     version: "2.0.0"
     hf_transformers: "4.28.1"
@@ -82,7 +69,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  7:
+  6:
     framework: "tensorflow"
     version: "2.12.1"
     customer_type: "sagemaker"
@@ -95,7 +82,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  8:
+  7:
     framework: "tensorflow"
     version: "2.12.1"
     customer_type: "ec2"
@@ -108,7 +95,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  9:
+  8:
     framework: "pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -121,7 +108,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  10:
+  9:
     framework: "djl"
     version: "0.27.0"
     arch_type: "x86"
@@ -132,7 +119,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  11:
+  10:
     framework: "huggingface_pytorch"
     version: "2.1.0"
     hf_transformers: "4.37.0"
@@ -144,7 +131,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  12:
+  11:
     framework: "huggingface_pytorch"
     version: "2.1.0"
     hf_transformers: "4.37.0"
@@ -157,7 +144,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  13:
+  12:
     framework: "pytorch"
     version: "2.2.0"
     arch_type: "x86"
@@ -170,7 +157,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  14:
+  13:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -183,7 +170,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  15:
+  14:
     framework: "tensorflow"
     version: "2.14.1"
     arch_type: "x86"
@@ -196,7 +183,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  16:
+  15:
     framework: "tensorflow"
     version: "2.14.1"
     arch_type: "x86"
@@ -209,7 +196,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  17:
+  16:
     framework: "pytorch"
     version: "2.2.0"
     arch_type: "x86"
@@ -222,7 +209,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  18:
+  17:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -235,11 +222,24 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  19:
+  18:
     framework: "tensorflow"
     version: "2.14.1"
     arch_type: "graviton"
     customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  19:
+    framework: "tensorflow"
+    version: "2.14.1"
+    arch_type: "graviton"
+    customer_type: "sagemaker"
     inference:
       device_types: [ "cpu" ]
       python_versions: [ "py310" ]
@@ -249,19 +249,6 @@ release_images:
       disable_sm_tag: False
       force_release: False
   20:
-    framework: "tensorflow"
-    version: "2.14.1"
-    arch_type: "graviton"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  21:
     framework: "pytorch"
     version: "2.2.1"
     arch_type: "graviton"
@@ -273,7 +260,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  22:
+  21:
     framework: "pytorch"
     version: "2.2.1"
     arch_type: "graviton"
@@ -282,6 +269,32 @@ release_images:
       device_types: [ "cpu" ]
       python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  22:
+    framework: "pytorch"
+    version: "2.1.0"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  23:
+    framework: "pytorch"
+    version: "2.1.0"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
       example: False
       disable_sm_tag: False
       force_release: False


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [ ] build_pytorch_training_latest
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
