### PR TITLE
resolving idna vuln instead of ignoring

### DIFF
--- a/huggingface/pytorch/training/docker/1.13/py3/sdk2.15.0/Dockerfile.neuronx
+++ b/huggingface/pytorch/training/docker/1.13/py3/sdk2.15.0/Dockerfile.neuronx
@@ -26,7 +26,8 @@ RUN pip install -U \
 	"numpy>=1.22.2,<1.24" \
 	"Pillow==10.3.0" \
 	"urllib3>=1.26.17,<1.27" \
-	"pyarrow~=14.0.1"
+	"pyarrow~=14.0.1" \
+    "idna>=3.7"
 
 RUN apt-get update \
  && apt install -y git-lfs \

--- a/huggingface/pytorch/training/docker/1.13/py3/sdk2.15.0/Dockerfile.neuronx.os_scan_allowlist.json
+++ b/huggingface/pytorch/training/docker/1.13/py3/sdk2.15.0/Dockerfile.neuronx.os_scan_allowlist.json
@@ -328,41 +328,6 @@
       "reason_to_ignore": "N/A"
     }
   ],
-  "idna":
-  [
-    {
-      "description": "An issue was found in the idna library that allows an attacker to trigger a heap-buffer overflow vulnerability by passing a crafted argument to the idna.encode() function. This flaw could lead to a denial-of-service (DoS) attack.",
-      "vulnerability_id": "CVE-2024-3651",
-      "name": "CVE-2024-3651",
-      "package_name": "idna",
-      "package_details":
-      {
-        "file_path": null,
-        "name": "idna",
-        "package_manager": "pip",
-        "version": "3.4",
-        "release": null
-      },
-      "remediation":
-      {
-        "recommendation":
-        {
-          "text": "Upgrade to version 3.7 or later of the idna library, as it includes a fix for this vulnerability."
-        }
-      },
-      "cvss_v3_score": 7.5,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 7.5,
-      "cvss_v2_score": 0.0,
-      "cvss_v3_severity": "HIGH",
-      "source_url": "https://www.tenable.com/cve/CVE-2024-3651",
-      "source": "EXTERNAL",
-      "severity": "HIGH",
-      "status": "ACTIVE",
-      "title": "CVE-2024-3651 - idna",
-      "reason_to_ignore": "N/A"
-    }
-  ],
   "libc-bin":
   [
     {


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [ ] build_pytorch_training_latest
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
