### PR TITLE
Onboard PyTorch 2.1 Graviton DLC to Autopatch

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -12,7 +12,7 @@ neuron_mode = false
 neuronx_mode = false
 # Please only set it to true if you are preparing a GRAVITON related PR
 # Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = true
+graviton_mode = false
 # Please only set it to True if you are preparing a HABANA related PR
 # Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false
@@ -34,10 +34,10 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ['pytorch']
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = false
+build_training = true
 build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
@@ -60,26 +60,26 @@ ecs_tests = true
 eks_tests = true
 ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
-ec2_benchmark_tests = true
+ec2_benchmark_tests = false
 
 ### Set ec2_tests_on_heavy_instances = true to be able to run any EC2 tests that use large/expensive instance types by
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = true
+ec2_tests_on_heavy_instances = false
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = true
+sagemaker_local_tests = false
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = true
+sagemaker_remote_tests = false
 # run efa sagemaker tests
-sagemaker_efa_tests = true
+sagemaker_efa_tests = false
 # run release_candidate_integration tests
-sagemaker_rc_tests = true
+sagemaker_rc_tests = false
 # run sagemaker benchmark tests
-sagemaker_benchmark_tests = true
+sagemaker_benchmark_tests = false
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""
@@ -150,7 +150,7 @@ dlc-pr-stabilityai-pytorch-inference = ""
 
 # Graviton Inference
 dlc-pr-mxnet-graviton-inference = ""
-dlc-pr-pytorch-graviton-inference = "pytorch/inference/buildspec-graviton-2-1.yml"
+dlc-pr-pytorch-graviton-inference = ""
 dlc-pr-tensorflow-2-graviton-inference = ""
 
 # EIA Inference

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -130,7 +130,7 @@ dlc-pr-tensorflow-2-habana-training = ""
 
 # Standard Framework Inference
 dlc-pr-mxnet-inference = ""
-dlc-pr-pytorch-inference = ""
+dlc-pr-pytorch-inference = "pytorch/inference/buildspec-graviton-2-1.yml"
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -12,7 +12,7 @@ neuron_mode = false
 neuronx_mode = false
 # Please only set it to true if you are preparing a GRAVITON related PR
 # Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = false
+graviton_mode = true
 # Please only set it to True if you are preparing a HABANA related PR
 # Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false
@@ -130,7 +130,7 @@ dlc-pr-tensorflow-2-habana-training = ""
 
 # Standard Framework Inference
 dlc-pr-mxnet-inference = ""
-dlc-pr-pytorch-inference = "pytorch/inference/buildspec-graviton-2-1.yml"
+dlc-pr-pytorch-inference = ""
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,10 +34,10 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ['pytorch']
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
+build_training = false
 build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
@@ -60,26 +60,26 @@ ecs_tests = true
 eks_tests = true
 ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
-ec2_benchmark_tests = false
+ec2_benchmark_tests = true
 
 ### Set ec2_tests_on_heavy_instances = true to be able to run any EC2 tests that use large/expensive instance types by
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = false
+ec2_tests_on_heavy_instances = true
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = false
+sagemaker_local_tests = true
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = false
+sagemaker_remote_tests = true
 # run efa sagemaker tests
-sagemaker_efa_tests = false
+sagemaker_efa_tests = true
 # run release_candidate_integration tests
-sagemaker_rc_tests = false
+sagemaker_rc_tests = true
 # run sagemaker benchmark tests
-sagemaker_benchmark_tests = false
+sagemaker_benchmark_tests = true
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""
@@ -150,7 +150,7 @@ dlc-pr-stabilityai-pytorch-inference = ""
 
 # Graviton Inference
 dlc-pr-mxnet-graviton-inference = ""
-dlc-pr-pytorch-graviton-inference = ""
+dlc-pr-pytorch-graviton-inference = "pytorch/inference/buildspec-graviton-2-1.yml"
 dlc-pr-tensorflow-2-graviton-inference = ""
 
 # EIA Inference

--- a/pytorch/inference/buildspec-graviton-2-1.yml
+++ b/pytorch/inference/buildspec-graviton-2-1.yml
@@ -1,16 +1,20 @@
 account_id: &ACCOUNT_ID <set-$ACCOUNT_ID-in-environment>
+prod_account_id: &PROD_ACCOUNT_ID 763104351884
 region: &REGION <set-$REGION-in-environment>
 framework: &FRAMEWORK pytorch
 version: &VERSION 2.1.0
 short_version: &SHORT_VERSION "2.1"
 arch_type: graviton
+autopatch_build: "True"
 
 repository_info:
   inference_repository: &INFERENCE_REPOSITORY
-      image_type: &INFERENCE_IMAGE_TYPE inference
-      root: !join [ *FRAMEWORK, "/", *INFERENCE_IMAGE_TYPE ]
-      repository_name: &REPOSITORY_NAME !join [pr, "-", *FRAMEWORK, "-", *INFERENCE_IMAGE_TYPE, "-", graviton]
-      repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ]
+    image_type: &INFERENCE_IMAGE_TYPE inference
+    root: !join [ *FRAMEWORK, "/", *INFERENCE_IMAGE_TYPE ]
+    repository_name: &REPOSITORY_NAME !join [ pr, "-", *FRAMEWORK, "-", *INFERENCE_IMAGE_TYPE, "-", graviton ]
+    repository: &REPOSITORY !join [ *ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *REPOSITORY_NAME ]
+    release_repository_name: &RELEASE_REPOSITORY_NAME !join [ *FRAMEWORK, "-", *INFERENCE_IMAGE_TYPE, "-", graviton]
+    release_repository: &RELEASE_REPOSITORY !join [ *PROD_ACCOUNT_ID, .dkr.ecr., *REGION, .amazonaws.com/, *RELEASE_REPOSITORY_NAME ]
 
 context:
   inference_context: &INFERENCE_CONTEXT
@@ -38,6 +42,7 @@ images:
     python_version: &DOCKER_PYTHON_VERSION py3
     tag_python_version: &TAG_PYTHON_VERSION py310
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION , "-ec2"]
+    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile.graviton., *DEVICE_TYPE ]
     target: ec2
     context:
@@ -53,6 +58,7 @@ images:
     python_version: &DOCKER_PYTHON_VERSION py3
     tag_python_version: &TAG_PYTHON_VERSION py310
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION , "-sagemaker"]
+    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile.graviton., *DEVICE_TYPE ]
     target: sagemaker
     context:

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.ec2.graviton.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.ec2.graviton.cpu.core_packages.json
@@ -35,9 +35,9 @@
     "version_specifier": ">=1.26.18,<2"
   },
   "torchserve": {
-    "version_specifier": "==0.10.0"
+    "version_specifier": "==0.9.0"
   },
   "torch-model-archiver": {
-    "version_specifier": "==0.10.0"
+    "version_specifier": "==0.9.0"
   }
 }

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.ec2.graviton.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.ec2.graviton.cpu.core_packages.json
@@ -1,0 +1,43 @@
+{
+  "captum": {
+    "version_specifier": "==0.6.0",
+    "skip": "True"
+  },
+  "torchaudio": {
+    "version_specifier": "==2.2.1+cpu",
+    "skip": "True"
+  },
+  "torchdata": {
+    "version_specifier": "==0.7.1",
+    "skip": "True"
+  },
+  "torchtext": {
+    "version_specifier": "==0.17.1+cpu",
+    "skip": "True"
+  },
+  "torchvision": {
+    "version_specifier": "==0.17.1+cpu",
+    "skip": "True"
+  },
+  "awscli": {
+    "version_specifier": "<2"
+  },
+  "pyopenssl": {
+    "version_specifier": ">=24.0.0"
+  },
+  "cryptography": {
+    "version_specifier": ">=41.0.2"
+  },
+  "ipython": {
+    "version_specifier": ">=8.10.0,<9.0"
+  },
+  "urllib3": {
+    "version_specifier": ">=1.26.18,<2"
+  },
+  "torchserve": {
+    "version_specifier": "==0.10.0"
+  },
+  "torch-model-archiver": {
+    "version_specifier": "==0.10.0"
+  }
+}

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.ec2.graviton.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.ec2.graviton.cpu.core_packages.json
@@ -4,35 +4,38 @@
     "skip": "True"
   },
   "torchaudio": {
-    "version_specifier": "==2.2.1+cpu",
+    "version_specifier": "==2.1.0+cpu",
     "skip": "True"
   },
   "torchdata": {
-    "version_specifier": "==0.7.1",
+    "version_specifier": "==0.7.0+7c7597b",
     "skip": "True"
   },
   "torchtext": {
-    "version_specifier": "==0.17.1+cpu",
+    "version_specifier": "==0.16.0+cpu",
     "skip": "True"
   },
   "torchvision": {
-    "version_specifier": "==0.17.1+cpu",
+    "version_specifier": "==0.16.0+cpu",
     "skip": "True"
-  },
-  "awscli": {
-    "version_specifier": "<2"
   },
   "pyopenssl": {
     "version_specifier": ">=24.0.0"
   },
   "cryptography": {
-    "version_specifier": ">=41.0.2"
+    "version_specifier": ">=42.0.5"
   },
   "ipython": {
     "version_specifier": ">=8.10.0,<9.0"
   },
+  "awscli": {
+    "version_specifier": "<2"
+  },
   "urllib3": {
     "version_specifier": ">=1.26.18,<2"
+  },
+  "numpy": {
+    "version_specifier": ">=1.22.2,<1.23"
   },
   "torchserve": {
     "version_specifier": "==0.10.0"

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.ec2.graviton.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.ec2.graviton.cpu.core_packages.json
@@ -34,9 +34,6 @@
   "urllib3": {
     "version_specifier": ">=1.26.18,<2"
   },
-  "numpy": {
-    "version_specifier": ">=1.22.2,<1.23"
-  },
   "torchserve": {
     "version_specifier": "==0.10.0"
   },

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.ec2.graviton.cpu.py_scan_allowlist.json
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.ec2.graviton.cpu.py_scan_allowlist.json
@@ -1,0 +1,3 @@
+{
+  "67599": "** DISPUTED ** An issue was discovered in pip (all versions) because it installs the version with the highest version number, even if the user had intended to obtain a private package from a private index. This only affects use of the --extra-index-url option, and exploitation requires that the package does not already exist in the public index (and thus the attacker can put the package there with an arbitrary version number). NOTE: it has been reported that this is intended functionality and the user is responsible for using --extra-index-url securely."
+}

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.graviton.cpu
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.graviton.cpu
@@ -155,7 +155,7 @@ RUN pip install --no-cache-dir -U \
 # -> Numpy is higer version as required by torch
 RUN pip install --no-cache-dir -U -r https://raw.githubusercontent.com/pytorch/serve/v${TORCHSERVE_VERSION}/requirements/common.txt \
  && pip install --no-cache-dir -U \
-    "numpy>=1.22.2,<1.23" \
+    numpy \
     torchserve==${TORCHSERVE_VERSION} \
     torch-model-archiver==${TORCHSERVE_VERSION}
 

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.graviton.cpu
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.graviton.cpu
@@ -20,7 +20,7 @@ ARG SM_TOOLKIT_VERSION
 # |_____\____|_____| |___|_| |_| |_|\__,_|\__, |\___|
 #                                         |___/
 #  ____           _
-# |  _ \ ___  ___(_)_ __   ___ 
+# |  _ \ ___  ___(_)_ __   ___
 # | |_) / _ \/ __| | '_ \ / _ \
 # |  _ <  __/ (__| | |_) |  __/
 # |_| \_\___|\___|_| .__/ \___|
@@ -133,8 +133,8 @@ RUN ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
     boto3 \
     scipy \
     opencv-python \
-    "pyOpenSSL>=23.2.0" \
-    "cryptography>=41.0.2" \
+    "pyOpenSSL>=24.0.0" \
+    "cryptography>=42.0.0" \
     "ipython>=8.10.0,<9.0" \
     "awscli<2" \
     "urllib3>=1.26.18,<2"

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
@@ -4,43 +4,46 @@
     "skip": "True"
   },
   "torchaudio": {
-    "version_specifier": "==2.2.1+cpu",
+    "version_specifier": "==2.1.0+cpu",
     "skip": "True"
   },
   "torchdata": {
-    "version_specifier": "==0.7.1",
+    "version_specifier": "==0.7.0+7c7597b",
     "skip": "True"
   },
   "torchtext": {
-    "version_specifier": "==0.17.1+cpu",
+    "version_specifier": "==0.16.0+cpu",
     "skip": "True"
   },
   "torchvision": {
-    "version_specifier": "==0.17.1+cpu",
+    "version_specifier": "==0.16.0+cpu",
     "skip": "True"
-  },
-  "awscli": {
-    "version_specifier": "<2"
   },
   "pyopenssl": {
     "version_specifier": ">=24.0.0"
   },
   "cryptography": {
-    "version_specifier": ">=41.0.2"
+    "version_specifier": ">=42.0.5"
   },
   "ipython": {
     "version_specifier": ">=8.10.0,<9.0"
   },
+  "awscli": {
+    "version_specifier": "<2"
+  },
   "urllib3": {
     "version_specifier": ">=1.26.18,<2"
   },
+  "numpy": {
+    "version_specifier": ">=1.22.2,<1.23"
+  },
   "torchserve": {
-    "version_specifier": "==0.10.0"
+    "version_specifier": "==0.8.2"
   },
   "torch-model-archiver": {
-    "version_specifier": "==0.10.0"
+    "version_specifier": "==0.8.2"
   },
   "sagemaker-pytorch-inference": {
-    "version_specifier": "==2.0.22"
+    "version_specifier": "==2.0.21"
   }
 }

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
@@ -34,9 +34,6 @@
   "urllib3": {
     "version_specifier": ">=1.26.18,<2"
   },
-  "numpy": {
-    "version_specifier": ">=1.22.2,<1.23"
-  },
   "torchserve": {
     "version_specifier": "==0.8.2"
   },

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
@@ -35,10 +35,10 @@
     "version_specifier": ">=1.26.18,<2"
   },
   "torchserve": {
-    "version_specifier": "==0.8.2"
+    "version_specifier": "==0.9.0"
   },
   "torch-model-archiver": {
-    "version_specifier": "==0.8.2"
+    "version_specifier": "==0.9.0"
   },
   "sagemaker-pytorch-inference": {
     "version_specifier": "==2.0.21"

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
@@ -1,0 +1,46 @@
+{
+  "captum": {
+    "version_specifier": "==0.6.0",
+    "skip": "True"
+  },
+  "torchaudio": {
+    "version_specifier": "==2.2.1+cpu",
+    "skip": "True"
+  },
+  "torchdata": {
+    "version_specifier": "==0.7.1",
+    "skip": "True"
+  },
+  "torchtext": {
+    "version_specifier": "==0.17.1+cpu",
+    "skip": "True"
+  },
+  "torchvision": {
+    "version_specifier": "==0.17.1+cpu",
+    "skip": "True"
+  },
+  "awscli": {
+    "version_specifier": "<2"
+  },
+  "pyopenssl": {
+    "version_specifier": ">=24.0.0"
+  },
+  "cryptography": {
+    "version_specifier": ">=41.0.2"
+  },
+  "ipython": {
+    "version_specifier": ">=8.10.0,<9.0"
+  },
+  "urllib3": {
+    "version_specifier": ">=1.26.18,<2"
+  },
+  "torchserve": {
+    "version_specifier": "==0.10.0"
+  },
+  "torch-model-archiver": {
+    "version_specifier": "==0.10.0"
+  },
+  "sagemaker-pytorch-inference": {
+    "version_specifier": "==2.0.22"
+  }
+}

--- a/pytorch/inference/docker/2.1/py3/Dockerfile.sagemaker.graviton.cpu.py_scan_allowlist.json
+++ b/pytorch/inference/docker/2.1/py3/Dockerfile.sagemaker.graviton.cpu.py_scan_allowlist.json
@@ -1,0 +1,3 @@
+{
+  "67599": "** DISPUTED ** An issue was discovered in pip (all versions) because it installs the version with the highest version number, even if the user had intended to obtain a private package from a private index. This only affects use of the --extra-index-url option, and exploitation requires that the package does not already exist in the public index (and thus the attacker can put the package there with an arbitrary version number). NOTE: it has been reported that this is intended functionality and the user is responsible for using --extra-index-url securely."
+}


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run
[543914a](https://github.com/aws/deep-learning-containers/pull/3859/commits/543914a8b2f1e72d19ec38ebb042a10e31165884) EC2 and SM Graviton DLC
- Passed ec2 test
- Passed eks test
- Passed ecs test
- Passed benchmark test
- Passed sanity test
- Passed sm test
- Passed sm local test
- Passed sm benchmark test
- Passed sm rc test
- Passed sm efa test

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [ ] build_pytorch_training_latest
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
