### PR TITLE
Release PT 1.13.1 training

### DIFF
--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -1,242 +1,6 @@
 ---
 release_images:
-  # #############################
-  # Autopatch Releases
-  # #############################
   1:
-    framework: "pytorch"
-    version: "1.13.1"
-    customer_type: "ec2"
-    arch_type: "x86"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py39" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu117"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  2:
-    framework: "pytorch"
-    version: "1.13.1"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py39" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu117"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  3:
-    framework: "pytorch"
-    version: "2.1.0"
-    customer_type: "ec2"
-    arch_type: "x86"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  4:
-    framework: "pytorch"
-    version: "2.1.0"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  5:
-    framework: "pytorch"
-    version: "2.1.0"
-    customer_type: "ec2"
-    arch_type: "graviton"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  6:
-    framework: "pytorch"
-    version: "2.1.0"
-    customer_type: "sagemaker"
-    arch_type: "graviton"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  7:
-    framework: "pytorch"
-    version: "2.2.0"
-    customer_type: "ec2"
-    arch_type: "x86"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  8:
-    framework: "pytorch"
-    version: "2.2.0"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  9:
-    framework: "pytorch"
-    version: "2.2.1"
-    customer_type: "ec2"
-    arch_type: "graviton"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  10:
-    framework: "pytorch"
-    version: "2.2.1"
-    customer_type: "sagemaker"
-    arch_type: "graviton"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  11:
-    framework: "tensorflow"
-    version: "2.13.0"
-    customer_type: "ec2"
-    arch_type: "x86"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  12:
-    framework: "tensorflow"
-    version: "2.13.0"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  13:
-    framework: "tensorflow"
-    version: "2.13.0"
-    customer_type: "ec2"
-    arch_type: "graviton"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  14:
-    framework: "tensorflow"
-    version: "2.13.0"
-    customer_type: "sagemaker"
-    arch_type: "graviton"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  15:
-    framework: "tensorflow"
-    version: "2.14.1"
-    customer_type: "ec2"
-    arch_type: "x86"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  16:
-    framework: "tensorflow"
-    version: "2.14.1"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  17:
-    framework: "tensorflow"
-    version: "2.14.1"
-    customer_type: "ec2"
-    arch_type: "graviton"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  18:
-    framework: "tensorflow"
-    version: "2.14.1"
-    customer_type: "sagemaker"
-    arch_type: "graviton"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  # #############################
-  # Regular Releases
-  # #############################
-  19:
     framework: "huggingface_tensorflow"
     version: "2.11.1"
     arch_type: "x86"
@@ -251,7 +15,7 @@ release_images:
       # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-  20:
+  2:
     framework: "triton"
     version: "24.03"
     arch_type: "x86"
@@ -265,21 +29,34 @@ release_images:
       # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-  21:
+  3:
     framework: "stabilityai_pytorch"
     version: "2.0.1"
     arch_type: "x86"
     customer_type: "sagemaker"
     inference:
-      device_types: [ "gpu" ]
-      python_versions: [ "py310" ]
+      device_types: ["gpu"]
+      python_versions: ["py310"]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
       sgm_version: "0.1.0"
       example: False
       disable_sm_tag: False
       force_release: False
-  22:
+  4:
+    framework: "pytorch"
+    version: "1.13.1"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py39" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu117"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  5:
     framework: "huggingface_pytorch"
     version: "2.0.0"
     hf_transformers: "4.28.1"
@@ -292,7 +69,46 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  23:
+  6:
+    framework: "tensorflow"
+    version: "2.12.1"
+    customer_type: "sagemaker"
+    arch_type: "x86"
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  7:
+    framework: "tensorflow"
+    version: "2.12.1"
+    customer_type: "ec2"
+    arch_type: "x86"
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  8:
+    framework: "pytorch"
+    version: "1.13.1"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py39" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu117"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  9:
     framework: "djl"
     version: "0.27.0"
     arch_type: "x86"
@@ -303,32 +119,45 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  24:
+  10:
     framework: "huggingface_pytorch"
     version: "2.1.0"
     hf_transformers: "4.37.0"
     arch_type: "x86"
     inference:
-      device_types: [ "cpu" ]
+      device_types: ["cpu"]
       python_versions: [ "py310" ]
       os_version: "ubuntu22.04"
       example: False
       disable_sm_tag: False
       force_release: False
-  25:
+  11:
     framework: "huggingface_pytorch"
     version: "2.1.0"
     hf_transformers: "4.37.0"
     arch_type: "x86"
     inference:
-      device_types: [ "gpu" ]
+      device_types: ["gpu"]
       python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
       example: False
       disable_sm_tag: False
       force_release: False
-  26:
+  12:
+    framework: "pytorch"
+    version: "2.2.0"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  13:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -341,7 +170,46 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  27:
+  14:
+    framework: "tensorflow"
+    version: "2.14.1"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  15:
+    framework: "tensorflow"
+    version: "2.14.1"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  16:
+    framework: "pytorch"
+    version: "2.2.0"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  17:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -354,7 +222,159 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
+  18:
+    framework: "tensorflow"
+    version: "2.14.1"
+    arch_type: "graviton"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  19:
+    framework: "tensorflow"
+    version: "2.14.1"
+    arch_type: "graviton"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  20:
+    framework: "pytorch"
+    version: "2.2.1"
+    arch_type: "graviton"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  21:
+    framework: "pytorch"
+    version: "2.2.1"
+    arch_type: "graviton"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  22:
+    framework: "pytorch"
+    version: "2.1.0"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  23:
+    framework: "pytorch"
+    version: "2.1.0"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  24:
+    framework: "pytorch"
+    version: "2.1.0"
+    arch_type: "graviton"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  25:
+    framework: "pytorch"
+    version: "2.1.0"
+    arch_type: "graviton"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  26:
+    framework: "tensorflow"
+    version: "2.13.0"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  27:
+    framework: "tensorflow"
+    version: "2.13.0"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
   28:
+    framework: "tensorflow"
+    version: "2.13.0"
+    arch_type: "graviton"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  29:
+    framework: "tensorflow"
+    version: "2.13.0"
+    arch_type: "graviton"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  30:
     framework: "huggingface_pytorch"
     version: "2.1.2"
     arch_type: "x86"
@@ -367,13 +387,25 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  29:
+  31:
     framework: "autogluon"
     version: "1.0.0"
     arch_type: "x86"
     inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  32:
+    framework: "autogluon"
+    version: "1.1.0"
+    arch_type: "x86"
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
       example: False

--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -271,8 +271,8 @@ release_images:
     arch_type: "x86"
     customer_type: "sagemaker"
     inference:
-      device_types: ["gpu"]
-      python_versions: ["py310"]
+      device_types: [ "gpu" ]
+      python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
       sgm_version: "0.1.0"
@@ -309,7 +309,7 @@ release_images:
     hf_transformers: "4.37.0"
     arch_type: "x86"
     inference:
-      device_types: ["cpu"]
+      device_types: [ "cpu" ]
       python_versions: [ "py310" ]
       os_version: "ubuntu22.04"
       example: False
@@ -321,7 +321,7 @@ release_images:
     hf_transformers: "4.37.0"
     arch_type: "x86"
     inference:
-      device_types: ["gpu"]
+      device_types: [ "gpu" ]
       python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
@@ -372,8 +372,8 @@ release_images:
     version: "1.0.0"
     arch_type: "x86"
     inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
       example: False

--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -1,7 +1,7 @@
 ---
 release_images:
   # #############################
-  # Autopatch Onboarded
+  # Autopatch Releases
   # #############################
   1:
     framework: "pytorch"
@@ -234,7 +234,7 @@ release_images:
       disable_sm_tag: False
       force_release: False
   # #############################
-  # Release Images
+  # Regular Releases
   # #############################
   19:
     framework: "huggingface_tensorflow"

--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -1,6 +1,242 @@
 ---
 release_images:
+  # #############################
+  # Autopatch Onboarded
+  # #############################
   1:
+    framework: "pytorch"
+    version: "1.13.1"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py39" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu117"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  2:
+    framework: "pytorch"
+    version: "1.13.1"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py39" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu117"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  3:
+    framework: "pytorch"
+    version: "2.1.0"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  4:
+    framework: "pytorch"
+    version: "2.1.0"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  5:
+    framework: "pytorch"
+    version: "2.1.0"
+    arch_type: "graviton"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  6:
+    framework: "pytorch"
+    version: "2.1.0"
+    arch_type: "graviton"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  7:
+    framework: "pytorch"
+    version: "2.2.0"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  8:
+    framework: "pytorch"
+    version: "2.2.0"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  9:
+    framework: "pytorch"
+    version: "2.2.1"
+    arch_type: "graviton"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  10:
+    framework: "pytorch"
+    version: "2.2.1"
+    arch_type: "graviton"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  11:
+    framework: "tensorflow"
+    version: "2.13.0"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  12:
+    framework: "tensorflow"
+    version: "2.13.0"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  13:
+    framework: "tensorflow"
+    version: "2.13.0"
+    arch_type: "graviton"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  14:
+    framework: "tensorflow"
+    version: "2.13.0"
+    arch_type: "graviton"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  15:
+    framework: "tensorflow"
+    version: "2.14.1"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  16:
+    framework: "tensorflow"
+    version: "2.14.1"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  17:
+    framework: "tensorflow"
+    version: "2.14.1"
+    arch_type: "graviton"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  18:
+    framework: "tensorflow"
+    version: "2.14.1"
+    arch_type: "graviton"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  # #############################
+  # Release Images
+  # #############################
+  19:
     framework: "huggingface_tensorflow"
     version: "2.11.1"
     arch_type: "x86"
@@ -15,7 +251,7 @@ release_images:
       # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-  2:
+  20:
     framework: "triton"
     version: "24.03"
     arch_type: "x86"
@@ -29,7 +265,7 @@ release_images:
       # to images being published.
       force_release: False  # [Default: False] Set to True to force images to be published even if the same image
       # has already been published. Re-released image will have minor version incremented by 1.
-  3:
+  21:
     framework: "stabilityai_pytorch"
     version: "2.0.1"
     arch_type: "x86"
@@ -43,20 +279,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  4:
-    framework: "pytorch"
-    version: "1.13.1"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py39" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu117"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  5:
+  22:
     framework: "huggingface_pytorch"
     version: "2.0.0"
     hf_transformers: "4.28.1"
@@ -69,46 +292,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  6:
-    framework: "tensorflow"
-    version: "2.12.1"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  7:
-    framework: "tensorflow"
-    version: "2.12.1"
-    customer_type: "ec2"
-    arch_type: "x86"
-    inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  8:
-    framework: "pytorch"
-    version: "1.13.1"
-    arch_type: "x86"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py39" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu117"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  9:
+  23:
     framework: "djl"
     version: "0.27.0"
     arch_type: "x86"
@@ -119,7 +303,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  10:
+  24:
     framework: "huggingface_pytorch"
     version: "2.1.0"
     hf_transformers: "4.37.0"
@@ -131,7 +315,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  11:
+  25:
     framework: "huggingface_pytorch"
     version: "2.1.0"
     hf_transformers: "4.37.0"
@@ -144,20 +328,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  12:
-    framework: "pytorch"
-    version: "2.2.0"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  13:
+  26:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -170,46 +341,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  14:
-    framework: "tensorflow"
-    version: "2.14.1"
-    arch_type: "x86"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  15:
-    framework: "tensorflow"
-    version: "2.14.1"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  16:
-    framework: "pytorch"
-    version: "2.2.0"
-    arch_type: "x86"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  17:
+  27:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -222,159 +354,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  18:
-    framework: "tensorflow"
-    version: "2.14.1"
-    arch_type: "graviton"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  19:
-    framework: "tensorflow"
-    version: "2.14.1"
-    arch_type: "graviton"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  20:
-    framework: "pytorch"
-    version: "2.2.1"
-    arch_type: "graviton"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  21:
-    framework: "pytorch"
-    version: "2.2.1"
-    arch_type: "graviton"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  22:
-    framework: "pytorch"
-    version: "2.1.0"
-    arch_type: "x86"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  23:
-    framework: "pytorch"
-    version: "2.1.0"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  24:
-    framework: "pytorch"
-    version: "2.1.0"
-    arch_type: "graviton"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  25:
-    framework: "pytorch"
-    version: "2.1.0"
-    arch_type: "graviton"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  26:
-    framework: "tensorflow"
-    version: "2.13.0"
-    arch_type: "x86"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  27:
-    framework: "tensorflow"
-    version: "2.13.0"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
   28:
-    framework: "tensorflow"
-    version: "2.13.0"
-    arch_type: "graviton"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  29:
-    framework: "tensorflow"
-    version: "2.13.0"
-    arch_type: "graviton"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  30:
     framework: "huggingface_pytorch"
     version: "2.1.2"
     arch_type: "x86"
@@ -387,21 +367,9 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  31:
+  29:
     framework: "autogluon"
     version: "1.0.0"
-    arch_type: "x86"
-    inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  32:
-    framework: "autogluon"
-    version: "1.1.0"
     arch_type: "x86"
     inference:
       device_types: ["cpu", "gpu"]

--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -6,8 +6,8 @@ release_images:
   1:
     framework: "pytorch"
     version: "1.13.1"
-    arch_type: "x86"
     customer_type: "ec2"
+    arch_type: "x86"
     inference:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py39" ]
@@ -19,8 +19,8 @@ release_images:
   2:
     framework: "pytorch"
     version: "1.13.1"
-    arch_type: "x86"
     customer_type: "sagemaker"
+    arch_type: "x86"
     inference:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py39" ]
@@ -32,8 +32,8 @@ release_images:
   3:
     framework: "pytorch"
     version: "2.1.0"
-    arch_type: "x86"
     customer_type: "ec2"
+    arch_type: "x86"
     inference:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
@@ -45,8 +45,8 @@ release_images:
   4:
     framework: "pytorch"
     version: "2.1.0"
-    arch_type: "x86"
     customer_type: "sagemaker"
+    arch_type: "x86"
     inference:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
@@ -58,8 +58,8 @@ release_images:
   5:
     framework: "pytorch"
     version: "2.1.0"
-    arch_type: "graviton"
     customer_type: "ec2"
+    arch_type: "graviton"
     inference:
       device_types: [ "cpu" ]
       python_versions: [ "py310" ]
@@ -70,8 +70,8 @@ release_images:
   6:
     framework: "pytorch"
     version: "2.1.0"
-    arch_type: "graviton"
     customer_type: "sagemaker"
+    arch_type: "graviton"
     inference:
       device_types: [ "cpu" ]
       python_versions: [ "py310" ]
@@ -82,8 +82,8 @@ release_images:
   7:
     framework: "pytorch"
     version: "2.2.0"
-    arch_type: "x86"
     customer_type: "ec2"
+    arch_type: "x86"
     inference:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
@@ -95,8 +95,8 @@ release_images:
   8:
     framework: "pytorch"
     version: "2.2.0"
-    arch_type: "x86"
     customer_type: "sagemaker"
+    arch_type: "x86"
     inference:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
@@ -108,8 +108,8 @@ release_images:
   9:
     framework: "pytorch"
     version: "2.2.1"
-    arch_type: "graviton"
     customer_type: "ec2"
+    arch_type: "graviton"
     inference:
       device_types: [ "cpu" ]
       python_versions: [ "py310" ]
@@ -120,8 +120,8 @@ release_images:
   10:
     framework: "pytorch"
     version: "2.2.1"
-    arch_type: "graviton"
     customer_type: "sagemaker"
+    arch_type: "graviton"
     inference:
       device_types: [ "cpu" ]
       python_versions: [ "py310" ]
@@ -132,8 +132,8 @@ release_images:
   11:
     framework: "tensorflow"
     version: "2.13.0"
-    arch_type: "x86"
     customer_type: "ec2"
+    arch_type: "x86"
     inference:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
@@ -145,8 +145,8 @@ release_images:
   12:
     framework: "tensorflow"
     version: "2.13.0"
-    arch_type: "x86"
     customer_type: "sagemaker"
+    arch_type: "x86"
     inference:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
@@ -158,8 +158,8 @@ release_images:
   13:
     framework: "tensorflow"
     version: "2.13.0"
-    arch_type: "graviton"
     customer_type: "ec2"
+    arch_type: "graviton"
     inference:
       device_types: [ "cpu" ]
       python_versions: [ "py310" ]
@@ -171,8 +171,8 @@ release_images:
   14:
     framework: "tensorflow"
     version: "2.13.0"
-    arch_type: "graviton"
     customer_type: "sagemaker"
+    arch_type: "graviton"
     inference:
       device_types: [ "cpu" ]
       python_versions: [ "py310" ]
@@ -184,8 +184,8 @@ release_images:
   15:
     framework: "tensorflow"
     version: "2.14.1"
-    arch_type: "x86"
     customer_type: "ec2"
+    arch_type: "x86"
     inference:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
@@ -197,8 +197,8 @@ release_images:
   16:
     framework: "tensorflow"
     version: "2.14.1"
-    arch_type: "x86"
     customer_type: "sagemaker"
+    arch_type: "x86"
     inference:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
@@ -210,8 +210,8 @@ release_images:
   17:
     framework: "tensorflow"
     version: "2.14.1"
-    arch_type: "graviton"
     customer_type: "ec2"
+    arch_type: "graviton"
     inference:
       device_types: [ "cpu" ]
       python_versions: [ "py310" ]
@@ -223,8 +223,8 @@ release_images:
   18:
     framework: "tensorflow"
     version: "2.14.1"
-    arch_type: "graviton"
     customer_type: "sagemaker"
+    arch_type: "graviton"
     inference:
       device_types: [ "cpu" ]
       python_versions: [ "py310" ]

--- a/release_images_training.yml
+++ b/release_images_training.yml
@@ -10,9 +10,9 @@ release_images:
     arch_type: "x86"
     training:
       device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py3999999999" ]
+      python_versions: [ "py39" ]
       os_version: "ubuntu20.04"
-      cuda_version: "cu121"
+      cuda_version: "cu117"
       example: False
       disable_sm_tag: False
       force_release: False
@@ -87,8 +87,8 @@ release_images:
     customer_type: "ec2"
     arch_type: "x86"
     training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
       example: False
@@ -100,8 +100,8 @@ release_images:
     customer_type: "sagemaker"
     arch_type: "x86"
     training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
       example: False
@@ -167,8 +167,8 @@ release_images:
     version: "1.1.0"
     arch_type: "x86"
     training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
       example: False

--- a/release_images_training.yml
+++ b/release_images_training.yml
@@ -1,7 +1,7 @@
 ---
 release_images:
   # #############################
-  # Autopatch Onboarded
+  # Autopatch Releases
   # #############################
   1:
     framework: "pytorch"
@@ -134,7 +134,7 @@ release_images:
       disable_sm_tag: False
       force_release: False
   # #############################
-  # Release Images
+  # Regular Releases
   # #############################
   11:
     framework: "huggingface_pytorch"

--- a/release_images_training.yml
+++ b/release_images_training.yml
@@ -141,7 +141,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  15:
+  12:
     framework: "pytorch"
     version: "1.13.1"
     customer_type: "ec2"
@@ -154,7 +154,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  16:
+  13:
     framework: "pytorch"
     version: "1.13.1"
     customer_type: "sagemaker"

--- a/release_images_training.yml
+++ b/release_images_training.yml
@@ -1,39 +1,36 @@
 ---
 release_images:
-  # #############################
-  # Autopatch Releases
-  # #############################
   1:
-    framework: "pytorch"
-    version: "1.13.1"
-    customer_type: "ec2"
+    framework: "tensorflow"
+    version: "2.12.0"
+    customer_type: "sagemaker"
     arch_type: "x86"
     training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py39" ]
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
       os_version: "ubuntu20.04"
-      cuda_version: "cu117"
+      cuda_version: "cu118"
       example: False
       disable_sm_tag: False
       force_release: False
   2:
-    framework: "pytorch"
-    version: "1.13.1"
+    framework: "tensorflow"
+    version: "2.13.0"
     customer_type: "sagemaker"
     arch_type: "x86"
     training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py39" ]
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
       os_version: "ubuntu20.04"
-      cuda_version: "cu117"
+      cuda_version: "cu118"
       example: False
       disable_sm_tag: False
       force_release: False
   3:
     framework: "pytorch"
-    version: "2.1.0"
-    customer_type: "ec2"
+    version: "2.2.0"
     arch_type: "x86"
+    customer_type: "sagemaker"
     training:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
@@ -44,9 +41,9 @@ release_images:
       force_release: False
   4:
     framework: "pytorch"
-    version: "2.1.0"
-    customer_type: "sagemaker"
+    version: "2.2.0"
     arch_type: "x86"
+    customer_type: "ec2"
     training:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
@@ -57,86 +54,18 @@ release_images:
       force_release: False
   5:
     framework: "pytorch"
-    version: "2.2.0"
+    version: "2.0.1"
+    customer_type: "sagemaker"
     arch_type: "x86"
-    customer_type: "ec2"
     training:
-      device_types: [ "cpu", "gpu" ]
+      device_types: [ "gpu" ]
       python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
-      cuda_version: "cu121"
+      cuda_version: "cu118"
       example: False
       disable_sm_tag: False
       force_release: False
   6:
-    framework: "pytorch"
-    version: "2.2.0"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu121"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  7:
-    framework: "tensorflow"
-    version: "2.13.0"
-    customer_type: "ec2"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  8:
-    framework: "tensorflow"
-    version: "2.13.0"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  9:
-    framework: "tensorflow"
-    version: "2.14.1"
-    customer_type: "ec2"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  10:
-    framework: "tensorflow"
-    version: "2.14.1"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  # #############################
-  # Regular Releases
-  # #############################
-  11:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -149,7 +78,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  12:
+  7:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -162,15 +91,118 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  13:
-    framework: "autogluon"
-    version: "1.1.0"
+  8:
+    framework: "tensorflow"
+    version: "2.14.1"
+    customer_type: "ec2"
     arch_type: "x86"
     training:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  9:
+    framework: "tensorflow"
+    version: "2.14.1"
+    customer_type: "sagemaker"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  10:
+    framework: "tensorflow"
+    version: "2.13.0"
+    customer_type: "ec2"
+    arch_type: "x86"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  11:
+    framework: "pytorch"
+    version: "2.1.0"
+    customer_type: "ec2"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu121"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  12:
+    framework: "pytorch"
+    version: "2.1.0"
+    customer_type: "sagemaker"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu121"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  13:
+    framework: "autogluon"
+    version: "1.0.0"
+    arch_type: "x86"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  14:
+    framework: "autogluon"
+    version: "1.1.0"
+    arch_type: "x86"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  15:
+    framework: "pytorch"
+    version: "1.13.1"
+    customer_type: "ec2"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py39" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu117"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  16:
+    framework: "pytorch"
+    version: "1.13.1"
+    customer_type: "sagemaker"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py39" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu117"
       example: False
       disable_sm_tag: False
       force_release: False

--- a/release_images_training.yml
+++ b/release_images_training.yml
@@ -1,36 +1,39 @@
 ---
 release_images:
+  # #############################
+  # Autopatch Onboarded
+  # #############################
   1:
-    framework: "tensorflow"
-    version: "2.12.0"
-    customer_type: "sagemaker"
+    framework: "pytorch"
+    version: "1.13.1"
+    customer_type: "ec2"
     arch_type: "x86"
     training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py3999999999" ]
       os_version: "ubuntu20.04"
-      cuda_version: "cu118"
+      cuda_version: "cu121"
       example: False
       disable_sm_tag: False
       force_release: False
   2:
-    framework: "tensorflow"
-    version: "2.13.0"
+    framework: "pytorch"
+    version: "1.13.1"
     customer_type: "sagemaker"
     arch_type: "x86"
     training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py39" ]
       os_version: "ubuntu20.04"
-      cuda_version: "cu118"
+      cuda_version: "cu117"
       example: False
       disable_sm_tag: False
       force_release: False
   3:
     framework: "pytorch"
-    version: "2.2.0"
+    version: "2.1.0"
+    customer_type: "ec2"
     arch_type: "x86"
-    customer_type: "sagemaker"
     training:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
@@ -40,6 +43,19 @@ release_images:
       disable_sm_tag: False
       force_release: False
   4:
+    framework: "pytorch"
+    version: "2.1.0"
+    customer_type: "sagemaker"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu121"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  5:
     framework: "pytorch"
     version: "2.2.0"
     arch_type: "x86"
@@ -52,20 +68,75 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  5:
+  6:
     framework: "pytorch"
-    version: "2.0.1"
+    version: "2.2.0"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu121"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  7:
+    framework: "tensorflow"
+    version: "2.13.0"
+    customer_type: "ec2"
+    arch_type: "x86"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  8:
+    framework: "tensorflow"
+    version: "2.13.0"
     customer_type: "sagemaker"
     arch_type: "x86"
     training:
-      device_types: [ "gpu" ]
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  9:
+    framework: "tensorflow"
+    version: "2.14.1"
+    customer_type: "ec2"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
       example: False
       disable_sm_tag: False
       force_release: False
-  6:
+  10:
+    framework: "tensorflow"
+    version: "2.14.1"
+    customer_type: "sagemaker"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  # #############################
+  # Release Images
+  # #############################
+  11:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -78,7 +149,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  7:
+  12:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -91,84 +162,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  8:
-    framework: "tensorflow"
-    version: "2.14.1"
-    customer_type: "ec2"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  9:
-    framework: "tensorflow"
-    version: "2.14.1"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  10:
-    framework: "tensorflow"
-    version: "2.13.0"
-    customer_type: "ec2"
-    arch_type: "x86"
-    training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  11:
-    framework: "pytorch"
-    version: "2.1.0"
-    customer_type: "ec2"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu121"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  12:
-    framework: "pytorch"
-    version: "2.1.0"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu121"
-      example: False
-      disable_sm_tag: False
-      force_release: False
   13:
-    framework: "autogluon"
-    version: "1.0.0"
-    arch_type: "x86"
-    training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  14:
     framework: "autogluon"
     version: "1.1.0"
     arch_type: "x86"


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [ ] build_pytorch_training_latest
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
