### PR TITLE
Fix SM Endpoint Error

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -42,7 +42,7 @@ build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
-do_build = true
+do_build = false
 
 [notify]
 ### Notify on test failures

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -42,7 +42,7 @@ build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
-do_build = false
+do_build = true
 
 [notify]
 ### Notify on test failures

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,8 +37,8 @@ deep_canary_mode = false
 build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
-build_inference = false
+build_training = false
+build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,15 +34,15 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = false
+build_training = true
 build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
-do_build = false
+do_build = true
 
 [notify]
 ### Notify on test failures
@@ -53,12 +53,12 @@ notify_test_failures = false
 
 [test]
 ### On by default
-sanity_tests = false
+sanity_tests = true
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = false
-eks_tests = false
-ec2_tests = false
+ecs_tests = true
+eks_tests = true
+ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
 
@@ -70,7 +70,7 @@ ec2_tests_on_heavy_instances = false
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = true
+sagemaker_local_tests = false
 
 # run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = false

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,15 +34,15 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
-do_build = true
+do_build = false
 
 [notify]
 ### Notify on test failures
@@ -53,12 +53,12 @@ notify_test_failures = false
 
 [test]
 ### On by default
-sanity_tests = true
+sanity_tests = false
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = true
-eks_tests = true
-ec2_tests = true
+ecs_tests = false
+eks_tests = false
+ec2_tests = false
 # Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
 
@@ -70,7 +70,7 @@ ec2_tests_on_heavy_instances = false
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = false
+sagemaker_local_tests = true
 
 # run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = false

--- a/pytorch/inference/buildspec.yml
+++ b/pytorch/inference/buildspec.yml
@@ -43,6 +43,7 @@ images:
     torch_serve_version: &TORCHSERVE_VERSION 0.11.0
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
     latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
+    build_tag_override: "beta:2.2.0-cpu-py310-ubuntu20.04-ec2"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
     target: ec2
     context:
@@ -59,6 +60,7 @@ images:
     torch_serve_version: &TORCHSERVE_VERSION 0.11.0
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
     latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
+    build_tag_override: "beta:2.2.0-gpu-py310-cu121-ubuntu20.04-ec2"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
                          *DEVICE_TYPE ]
     target: ec2
@@ -76,6 +78,7 @@ images:
     tool_kit_version: &SM_TOOLKIT_VERSION 2.0.23
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
     latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
+    build_tag_override: "beta:2.2.0-cpu-py310-ubuntu20.04-sagemaker"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
     target: sagemaker
     context:
@@ -93,6 +96,7 @@ images:
     tool_kit_version: &SM_TOOLKIT_VERSION 2.0.23
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
     latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
+    build_tag_override: "beta:2.2.0-cpu-py310-ubuntu20.04-sagemaker"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
                          *DEVICE_TYPE ]
     target: sagemaker

--- a/pytorch/inference/buildspec.yml
+++ b/pytorch/inference/buildspec.yml
@@ -60,7 +60,7 @@ images:
     torch_serve_version: &TORCHSERVE_VERSION 0.11.0
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
     latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
-    build_tag_override: "beta:2.2.0-gpu-py310-cu121-ubuntu20.04-ec2"
+    build_tag_override: "beta:2.2.0-gpu-py310-cu118-ubuntu20.04-ec2"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
                          *DEVICE_TYPE ]
     target: ec2
@@ -96,7 +96,7 @@ images:
     tool_kit_version: &SM_TOOLKIT_VERSION 2.0.23
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
     latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-    build_tag_override: "beta:2.2.0-cpu-py310-ubuntu20.04-sagemaker"
+    build_tag_override: "beta:2.2.0-gpu-py310-cu118-ubuntu20.04-sagemaker"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
                          *DEVICE_TYPE ]
     target: sagemaker

--- a/pytorch/inference/buildspec.yml
+++ b/pytorch/inference/buildspec.yml
@@ -43,7 +43,7 @@ images:
     torch_serve_version: &TORCHSERVE_VERSION 0.11.0
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
     latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
-    build_tag_override: "beta:2.2.0-cpu-py310-ubuntu20.04-ec2"
+    # build_tag_override: "beta:2.2.0-cpu-py310-ubuntu20.04-ec2"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
     target: ec2
     context:
@@ -60,7 +60,7 @@ images:
     torch_serve_version: &TORCHSERVE_VERSION 0.11.0
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
     latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
-    build_tag_override: "beta:2.2.0-gpu-py310-cu118-ubuntu20.04-ec2"
+    # build_tag_override: "beta:2.2.0-gpu-py310-cu118-ubuntu20.04-ec2"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
                          *DEVICE_TYPE ]
     target: ec2
@@ -78,7 +78,7 @@ images:
     tool_kit_version: &SM_TOOLKIT_VERSION 2.0.23
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
     latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-    build_tag_override: "beta:2.2.0-cpu-py310-ubuntu20.04-sagemaker"
+    # build_tag_override: "beta:2.2.0-cpu-py310-ubuntu20.04-sagemaker"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
     target: sagemaker
     context:
@@ -96,7 +96,7 @@ images:
     tool_kit_version: &SM_TOOLKIT_VERSION 2.0.23
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
     latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-    build_tag_override: "beta:2.2.0-gpu-py310-cu118-ubuntu20.04-sagemaker"
+    # build_tag_override: "beta:2.2.0-gpu-py310-cu118-ubuntu20.04-sagemaker"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
                          *DEVICE_TYPE ]
     target: sagemaker

--- a/test/sagemaker_tests/pytorch/inference/requirements.txt
+++ b/test/sagemaker_tests/pytorch/inference/requirements.txt
@@ -1,7 +1,7 @@
 boto3
 coverage
 # Docker v7.0.0 breaks compatibility with Docker Compose v1 (SageMaker Local)
-docker
+docker<7.0.0
 docker-compose
 Flask==1.1.1
 fabric

--- a/test/sagemaker_tests/pytorch/inference/requirements.txt
+++ b/test/sagemaker_tests/pytorch/inference/requirements.txt
@@ -1,7 +1,7 @@
 boto3
 coverage
 # Docker v7.0.0 breaks compatibility with Docker Compose v1 (SageMaker Local)
-docker<=6.1.3
+docker<=7.0.0
 docker-compose
 Flask==1.1.1
 fabric
@@ -20,7 +20,7 @@ pytest-xdist
 requests
 requests_mock
 retrying==1.3.3
-sagemaker>=2,<3
+sagemaker>=2,<2.220.0
 sagemaker-inference
 six
 tenacity

--- a/test/sagemaker_tests/pytorch/inference/requirements.txt
+++ b/test/sagemaker_tests/pytorch/inference/requirements.txt
@@ -17,10 +17,10 @@ pytest<8.1
 pytest-cov
 pytest-rerunfailures
 pytest-xdist
-requests
+requests<2.32.0
 requests_mock
 retrying==1.3.3
-sagemaker<=2.220.0
+sagemaker>=2,<3
 sagemaker-inference
 six
 tenacity

--- a/test/sagemaker_tests/pytorch/inference/requirements.txt
+++ b/test/sagemaker_tests/pytorch/inference/requirements.txt
@@ -1,7 +1,7 @@
 boto3
 coverage
 # Docker v7.0.0 breaks compatibility with Docker Compose v1 (SageMaker Local)
-docker<7.0.0
+docker<=6.1.3
 docker-compose
 Flask==1.1.1
 fabric
@@ -20,7 +20,7 @@ pytest-xdist
 requests
 requests_mock
 retrying==1.3.3
-sagemaker>=2,<3
+sagemaker<=2.220.0
 sagemaker-inference
 six
 tenacity

--- a/test/sagemaker_tests/pytorch/inference/requirements.txt
+++ b/test/sagemaker_tests/pytorch/inference/requirements.txt
@@ -1,7 +1,7 @@
 boto3
 coverage
 # Docker v7.0.0 breaks compatibility with Docker Compose v1 (SageMaker Local)
-docker<7.0.0
+docker
 docker-compose
 Flask==1.1.1
 fabric
@@ -20,7 +20,7 @@ pytest-xdist
 requests
 requests_mock
 retrying==1.3.3
-sagemaker==2.220.0
+sagemaker>=2,<3
 sagemaker-inference
 six
 tenacity

--- a/test/sagemaker_tests/pytorch/inference/requirements.txt
+++ b/test/sagemaker_tests/pytorch/inference/requirements.txt
@@ -1,7 +1,7 @@
 boto3
 coverage
 # Docker v7.0.0 breaks compatibility with Docker Compose v1 (SageMaker Local)
-docker<=7.0.0
+docker<7.0.0
 docker-compose
 Flask==1.1.1
 fabric

--- a/test/sagemaker_tests/pytorch/inference/requirements.txt
+++ b/test/sagemaker_tests/pytorch/inference/requirements.txt
@@ -20,7 +20,7 @@ pytest-xdist
 requests
 requests_mock
 retrying==1.3.3
-sagemaker>=2,<2.220.0
+sagemaker==2.220.0
 sagemaker-inference
 six
 tenacity


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

- New version of requests breaks docker-py and thus test requirements

### Tests run
- Tested with [e822f96](https://github.com/aws/deep-learning-containers/pull/3940/commits/e822f96a381c9b1eee60b1d53ebd0417c57dd869)

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>
Click the checkbox to enable a build to execute upon merge.

*Note: By default, pipelines are set to "latest". Replace with major.minor framework version if you do not want "latest".*

- [ ] build_pytorch_training_latest
- [ ] build_pytorch_inference_latest
- [ ] build_tensorflow_training_latest
- [ ] build_tensorflow_inference_latest

</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
