### PR TITLE
Update release yaml, add numbering test

### DIFF
--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -57,32 +57,6 @@ release_images:
       disable_sm_tag: False
       force_release: False
   5:
-    framework: "tensorflow"
-    version: "2.12.1"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  6:
-    framework: "tensorflow"
-    version: "2.12.1"
-    customer_type: "ec2"
-    arch_type: "x86"
-    inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  7:
     framework: "djl"
     version: "0.27.0"
     arch_type: "x86"
@@ -93,7 +67,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  8:
+  6:
     framework: "huggingface_pytorch"
     version: "2.1.0"
     hf_transformers: "4.37.0"
@@ -105,7 +79,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  9:
+  7:
     framework: "huggingface_pytorch"
     version: "2.1.0"
     hf_transformers: "4.37.0"
@@ -118,7 +92,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  10:
+  8:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -131,7 +105,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  11:
+  9:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -144,7 +118,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  12:
+  10:
     framework: "huggingface_pytorch"
     version: "2.1.2"
     arch_type: "x86"
@@ -157,7 +131,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  13:
+  11:
     framework: "autogluon"
     version: "1.0.0"
     arch_type: "x86"
@@ -169,7 +143,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  14:
+  12:
     framework: "autogluon"
     version: "1.1.0"
     arch_type: "x86"

--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -44,19 +44,6 @@ release_images:
       disable_sm_tag: False
       force_release: False
   4:
-    framework: "pytorch"
-    version: "1.13.1"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py39" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu117"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  5:
     framework: "huggingface_pytorch"
     version: "2.0.0"
     hf_transformers: "4.28.1"
@@ -69,7 +56,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  6:
+  5:
     framework: "tensorflow"
     version: "2.12.1"
     customer_type: "sagemaker"
@@ -82,7 +69,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  7:
+  6:
     framework: "tensorflow"
     version: "2.12.1"
     customer_type: "ec2"
@@ -95,20 +82,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  8:
-    framework: "pytorch"
-    version: "1.13.1"
-    arch_type: "x86"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py39" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu117"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  9:
+  7:
     framework: "djl"
     version: "0.27.0"
     arch_type: "x86"
@@ -119,7 +93,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  10:
+  8:
     framework: "huggingface_pytorch"
     version: "2.1.0"
     hf_transformers: "4.37.0"
@@ -131,7 +105,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  11:
+  9:
     framework: "huggingface_pytorch"
     version: "2.1.0"
     hf_transformers: "4.37.0"
@@ -144,7 +118,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  12:
+  10:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -157,7 +131,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  13:
+  11:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -170,109 +144,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  14:
-    framework: "pytorch"
-    version: "2.1.0"
-    arch_type: "x86"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  15:
-    framework: "pytorch"
-    version: "2.1.0"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  16:
-    framework: "pytorch"
-    version: "2.1.0"
-    arch_type: "graviton"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  17:
-    framework: "pytorch"
-    version: "2.1.0"
-    arch_type: "graviton"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  18:
-    framework: "tensorflow"
-    version: "2.13.0"
-    arch_type: "x86"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  19:
-    framework: "tensorflow"
-    version: "2.13.0"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  20:
-    framework: "tensorflow"
-    version: "2.13.0"
-    arch_type: "graviton"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  21:
-    framework: "tensorflow"
-    version: "2.13.0"
-    arch_type: "graviton"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  22:
+  12:
     framework: "huggingface_pytorch"
     version: "2.1.2"
     arch_type: "x86"
@@ -285,7 +157,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  23:
+  13:
     framework: "autogluon"
     version: "1.0.0"
     arch_type: "x86"
@@ -297,7 +169,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  24:
+  14:
     framework: "autogluon"
     version: "1.1.0"
     arch_type: "x86"

--- a/release_images_patches.yml
+++ b/release_images_patches.yml
@@ -1,172 +1,172 @@
 ---
 # DLC images to patch - force_release is not allowed in this file
 release_images:
-  # PyTorch 2.2 Images
+  # PyTorch 1.13 Images
   1:
     framework: "pytorch"
-    version: "2.2.0"
+    version: "1.13.1"
+    customer_type: "ec2"
     arch_type: "x86"
-    customer_type: "sagemaker"
     training:
       device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
+      python_versions: [ "py39" ]
       os_version: "ubuntu20.04"
-      cuda_version: "cu121"
+      cuda_version: "cu117"
       example: False
       disable_sm_tag: False
       force_release: False
   2:
     framework: "pytorch"
-    version: "2.2.0"
+    version: "1.13.1"
+    customer_type: "sagemaker"
     arch_type: "x86"
-    customer_type: "ec2"
     training:
       device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
+      python_versions: [ "py39" ]
       os_version: "ubuntu20.04"
-      cuda_version: "cu121"
+      cuda_version: "cu117"
       example: False
       disable_sm_tag: False
       force_release: False
   3:
     framework: "pytorch"
-    version: "2.2.0"
+    version: "1.13.1"
     arch_type: "x86"
-    customer_type: "sagemaker"
+    customer_type: "ec2"
     inference:
       device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
+      python_versions: [ "py39" ]
       os_version: "ubuntu20.04"
-      cuda_version: "cu118"
+      cuda_version: "cu117"
       example: False
       disable_sm_tag: False
       force_release: False
   4:
     framework: "pytorch"
-    version: "2.2.0"
+    version: "1.13.1"
     arch_type: "x86"
-    customer_type: "ec2"
+    customer_type: "sagemaker"
     inference:
       device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
+      python_versions: [ "py39" ]
       os_version: "ubuntu20.04"
-      cuda_version: "cu118"
+      cuda_version: "cu117"
       example: False
       disable_sm_tag: False
       force_release: False
+
+  # Pytorch 2.1 Images
   5:
     framework: "pytorch"
-    version: "2.2.1"
-    arch_type: "graviton"
+    version: "2.1.0"
     customer_type: "ec2"
-    inference:
-      device_types: [ "cpu" ]
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
+      cuda_version: "cu121"
       example: False
       disable_sm_tag: False
       force_release: False
   6:
     framework: "pytorch"
-    version: "2.2.1"
-    arch_type: "graviton"
+    version: "2.1.0"
     customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-
-  # PT 2.3 images
-  7:
-    framework: "pytorch"
-    version: "2.3.0"
-    customer_type: "ec2"
     arch_type: "x86"
     training:
       device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py311" ]
+      python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
       cuda_version: "cu121"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  7:
+    framework: "pytorch"
+    version: "2.1.0"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
       example: False
       disable_sm_tag: False
       force_release: False
   8:
     framework: "pytorch"
-    version: "2.3.0"
-    customer_type: "sagemaker"
+    version: "2.1.0"
     arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  9:
+    framework: "pytorch"
+    version: "2.1.0"
+    arch_type: "graviton"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  10:
+    framework: "pytorch"
+    version: "2.1.0"
+    arch_type: "graviton"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+
+  # PyTorch 2.2 Images
+  11:
+    framework: "pytorch"
+    version: "2.2.0"
+    arch_type: "x86"
+    customer_type: "sagemaker"
     training:
       device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py311" ]
+      python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
       cuda_version: "cu121"
       example: False
       disable_sm_tag: False
       force_release: False
-
-  # TF 2.14 images
-  9:
-    framework: "tensorflow"
-    version: "2.14.1"
-    customer_type: "ec2"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  10:
-    framework: "tensorflow"
-    version: "2.14.1"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  11:
-    framework: "tensorflow"
-    version: "2.14.1"
-    arch_type: "x86"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
   12:
-    framework: "tensorflow"
-    version: "2.14.1"
+    framework: "pytorch"
+    version: "2.2.0"
     arch_type: "x86"
-    customer_type: "sagemaker"
-    inference:
+    customer_type: "ec2"
+    training:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
-      cuda_version: "cu118"
+      cuda_version: "cu121"
       example: False
       disable_sm_tag: False
       force_release: False
   13:
-    framework: "tensorflow"
-    version: "2.14.1"
-    arch_type: "graviton"
-    customer_type: "ec2"
+    framework: "pytorch"
+    version: "2.2.0"
+    arch_type: "x86"
+    customer_type: "sagemaker"
     inference:
-      device_types: [ "cpu" ]
+      device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
@@ -174,6 +174,218 @@ release_images:
       disable_sm_tag: False
       force_release: False
   14:
+    framework: "pytorch"
+    version: "2.2.0"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  15:
+    framework: "pytorch"
+    version: "2.2.1"
+    arch_type: "graviton"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  16:
+    framework: "pytorch"
+    version: "2.2.1"
+    arch_type: "graviton"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+
+  # PyTorch 2.3 Images
+  17:
+    framework: "pytorch"
+    version: "2.3.0"
+    customer_type: "ec2"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py311" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu121"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  18:
+    framework: "pytorch"
+    version: "2.3.0"
+    customer_type: "sagemaker"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py311" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu121"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+
+  # TensorFlow 2.13 Images
+  19:
+    framework: "tensorflow"
+    version: "2.13.0"
+    customer_type: "ec2"
+    arch_type: "x86"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  20:
+    framework: "tensorflow"
+    version: "2.13.0"
+    customer_type: "sagemaker"
+    arch_type: "x86"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  21:
+    framework: "tensorflow"
+    version: "2.13.0"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  22:
+    framework: "tensorflow"
+    version: "2.13.0"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  23:
+    framework: "tensorflow"
+    version: "2.13.0"
+    arch_type: "graviton"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  24:
+    framework: "tensorflow"
+    version: "2.13.0"
+    arch_type: "graviton"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+
+  # TensorFlow 2.14 Images
+  25:
+    framework: "tensorflow"
+    version: "2.14.1"
+    customer_type: "ec2"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  26:
+    framework: "tensorflow"
+    version: "2.14.1"
+    customer_type: "sagemaker"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  27:
+    framework: "tensorflow"
+    version: "2.14.1"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  28:
+    framework: "tensorflow"
+    version: "2.14.1"
+    arch_type: "x86"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  29:
+    framework: "tensorflow"
+    version: "2.14.1"
+    arch_type: "graviton"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  30:
     framework: "tensorflow"
     version: "2.14.1"
     arch_type: "graviton"

--- a/release_images_training.yml
+++ b/release_images_training.yml
@@ -14,19 +14,6 @@ release_images:
       disable_sm_tag: False
       force_release: False
   2:
-    framework: "tensorflow"
-    version: "2.13.0"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  3:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -39,7 +26,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  4:
+  3:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -52,46 +39,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  5:
-    framework: "tensorflow"
-    version: "2.13.0"
-    customer_type: "ec2"
-    arch_type: "x86"
-    training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  6:
-    framework: "pytorch"
-    version: "2.1.0"
-    customer_type: "ec2"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu121"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  7:
-    framework: "pytorch"
-    version: "2.1.0"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu121"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  8:
+  4:
     framework: "autogluon"
     version: "1.0.0"
     arch_type: "x86"
@@ -103,7 +51,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  9:
+  5:
     framework: "autogluon"
     version: "1.1.0"
     arch_type: "x86"
@@ -112,32 +60,6 @@ release_images:
       python_versions: ["py310"]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  10:
-    framework: "pytorch"
-    version: "1.13.1"
-    customer_type: "ec2"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py39" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu117"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  11:
-    framework: "pytorch"
-    version: "1.13.1"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py39" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu117"
       example: False
       disable_sm_tag: False
       force_release: False

--- a/release_images_training.yml
+++ b/release_images_training.yml
@@ -1,19 +1,6 @@
 ---
 release_images:
   1:
-    framework: "tensorflow"
-    version: "2.12.0"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  2:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -26,7 +13,7 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
-  3:
+  2:
     framework: "huggingface_pytorch"
     version: "1.13.1"
     arch_type: "x86"
@@ -39,7 +26,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  4:
+  3:
     framework: "autogluon"
     version: "1.0.0"
     arch_type: "x86"
@@ -51,7 +38,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  5:
+  4:
     framework: "autogluon"
     version: "1.1.0"
     arch_type: "x86"

--- a/test/dlc_tests/sanity/quick_checks/test_yml_config.py
+++ b/test/dlc_tests/sanity/quick_checks/test_yml_config.py
@@ -86,6 +86,36 @@ def test_release_images_numbering():
                     )
 
 
+@pytest.mark.quick_checks
+@pytest.mark.model("N/A")
+@pytest.mark.integration("release_images_no_overlaps")
+@pytest.mark.skipif(
+    not is_pr_context(),
+    reason="This test is only needed to validate release_images configs in PRs.",
+)
+def test_release_images_no_overlaps():
+    release_yamls = [
+        "release_images_patches.yml",
+        "release_images_training.yml",
+        "release_images_inference.yml",
+    ]
+    dlc_base_dir = get_repository_local_path()
+
+    configs = []
+
+    for release_yaml in release_yamls:
+        yaml_path = os.path.join(dlc_base_dir, release_yaml)
+
+        with open(yaml_path, "r") as rf:
+            contents = yaml.safe_load(rf)
+            for num, imgs in contents["release_images"].items():
+                if imgs in configs:
+                    raise RuntimeError(
+                        f"Found duplicate configs for {imgs} in {release_yaml}. These could be coming from another release yaml or the same file - please double check."
+                    )
+                configs.append(imgs)
+
+
 def _release_images_yml_verifier(image_type, excluded_image_type):
     """
     Simple test to ensure release images yml file is loadable

--- a/test/dlc_tests/sanity/quick_checks/test_yml_config.py
+++ b/test/dlc_tests/sanity/quick_checks/test_yml_config.py
@@ -4,7 +4,7 @@ import re
 import pytest
 import yaml
 
-from test.test_utils import is_pr_context, get_repository_local_path
+from test.test_utils import is_pr_context, get_repository_local_path, LOGGER
 
 
 @pytest.mark.quick_checks
@@ -46,6 +46,44 @@ def test_release_images_patches_yml():
             assert (
                 "force_release: True" not in line
             ), f"Force release is not permitted in patch file {release_images_yml_file}."
+
+
+@pytest.mark.quick_checks
+@pytest.mark.model("N/A")
+@pytest.mark.integration("release_images_numbering")
+@pytest.mark.skipif(
+    not is_pr_context(),
+    reason="This test is only needed to validate release_images configs in PRs.",
+)
+def test_release_images_numbering():
+    release_yamls = [
+        "release_images_patches.yml",
+        "release_images_training.yml",
+        "release_images_inference.yml",
+    ]
+    dlc_base_dir = get_repository_local_path()
+
+    for release_yaml in release_yamls:
+        yaml_path = os.path.join(dlc_base_dir, release_yaml)
+
+        with open(yaml_path, "r") as rf:
+            contents = yaml.safe_load(rf)
+            for i, (num, imgs) in enumerate(contents["release_images"].items()):
+                if i + 1 != int(num):
+                    LOGGER.error(
+                        f"Numbering seems incorrect in {release_yaml}. Try updating to the following:"
+                    )
+                    counter = 1
+                    with open(yaml_path, "r") as debugger:
+                        for line in debugger:
+                            if re.match(r"^\s{2}\d+:", line):
+                                LOGGER.info(f"  {counter}:"),
+                                counter += 1
+                            else:
+                                LOGGER.info(line.strip("\n") if line else line),
+                    raise RuntimeError(
+                        f"Line {i+1} in {release_yaml} is numbered incorrectly as {num}. Please correct the ordering."
+                    )
 
 
 def _release_images_yml_verifier(image_type, excluded_image_type):

--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -37,9 +37,8 @@ from test.test_utils import (
     get_cuda_version_from_tag,
     get_labels_from_ecr_image,
     get_buildspec_path,
-    is_tf_version,
+    get_all_the_tags_of_an_image_from_ecr,
     is_nightly_context,
-    get_processor_from_image_uri,
     execute_env_variables_test,
     UL20_CPU_ARM64_US_WEST_2,
     UBUNTU_18_HPU_DLAMI_US_WEST_2,
@@ -189,6 +188,13 @@ def test_ubuntu_version(image):
 
     assert "Ubuntu" in container_ubuntu_version
     assert ubuntu_version in container_ubuntu_version
+
+
+@pytest.mark.usefixtures("sagemaker")
+@pytest.mark.model("N/A")
+def test_image_tags(image, ecr_client):
+    all_tags = get_all_the_tags_of_an_image_from_ecr(ecr_client, image)
+    assert not any("benchmark-tested" in tag for tag in all_tags)
 
 
 @pytest.mark.usefixtures("sagemaker")


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
- Add remaining images to release yaml patches file

### Tests run
- Add additional test to ensure numbering is correct in release yaml files

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Fill out the template and click the checkbox of the builds you'd like to execute

*Note: Replace with <X.Y> with the major.minor framework version (i.e. 2.2) you would like to start.*

- [ ] build_pytorch_training_<X.Y>_sm
- [ ] build_pytorch_training_<X.Y>_ec2

- [ ] build_pytorch_inference_<X.Y>_sm
- [ ] build_pytorch_inference_<X.Y>_ec2
- [ ] build_pytorch_inference_<X.Y>_graviton

- [ ] build_tensorflow_training_<X.Y>_sm
- [ ] build_tensorflow_training_<X.Y>_ec2

- [ ] build_tensorflow_inference_<X.Y>_sm
- [ ] build_tensorflow_inference_<X.Y>_ec2
- [ ] build_tensorflow_inference_<X.Y>_graviton
</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
