### PR TITLE
PyTorch 2.2 Graviton SM Inference Update inference toolkit to 2.0.24

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -42,7 +42,7 @@ build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
-do_build = true
+do_build = false
 
 [notify]
 ### Notify on test failures

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -42,7 +42,7 @@ build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
-do_build = false
+do_build = true
 
 [notify]
 ### Notify on test failures

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -12,7 +12,7 @@ neuron_mode = false
 neuronx_mode = false
 # Please only set it to true if you are preparing a GRAVITON related PR
 # Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = true
+graviton_mode = false
 # Please only set it to True if you are preparing a HABANA related PR
 # Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false
@@ -34,10 +34,10 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = false
+build_training = true
 build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
@@ -56,9 +56,9 @@ notify_test_failures = false
 sanity_tests = true
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = false
-eks_tests = false
-ec2_tests = false
+ecs_tests = true
+eks_tests = true
+ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
 
@@ -70,10 +70,10 @@ ec2_tests_on_heavy_instances = false
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = false
+sagemaker_local_tests = true
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = false
+sagemaker_remote_tests = true
 # run efa sagemaker tests
 sagemaker_efa_tests = false
 # run release_candidate_integration tests

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -12,7 +12,7 @@ neuron_mode = false
 neuronx_mode = false
 # Please only set it to true if you are preparing a GRAVITON related PR
 # Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = false
+graviton_mode = true
 # Please only set it to True if you are preparing a HABANA related PR
 # Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false
@@ -34,10 +34,10 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
+build_training = false
 build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
@@ -56,9 +56,9 @@ notify_test_failures = false
 sanity_tests = true
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = true
-eks_tests = true
-ec2_tests = true
+ecs_tests = false
+eks_tests = false
+ec2_tests = false
 # Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
 
@@ -70,10 +70,10 @@ ec2_tests_on_heavy_instances = false
 
 ### SM specific tests
 ### Off by default
-sagemaker_local_tests = true
+sagemaker_local_tests = false
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = true
+sagemaker_remote_tests = false
 # run efa sagemaker tests
 sagemaker_efa_tests = false
 # run release_candidate_integration tests

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -12,7 +12,7 @@ neuron_mode = false
 neuronx_mode = false
 # Please only set it to true if you are preparing a GRAVITON related PR
 # Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = true
+graviton_mode = false
 # Please only set it to True if you are preparing a HABANA related PR
 # Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false
@@ -34,10 +34,10 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = false
+build_training = true
 build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
@@ -60,13 +60,13 @@ ecs_tests = true
 eks_tests = true
 ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
-ec2_benchmark_tests = true
+ec2_benchmark_tests = false
 
 ### Set ec2_tests_on_heavy_instances = true to be able to run any EC2 tests that use large/expensive instance types by
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = true
+ec2_tests_on_heavy_instances = false
 
 ### SM specific tests
 ### Off by default
@@ -75,11 +75,11 @@ sagemaker_local_tests = true
 # run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = true
 # run efa sagemaker tests
-sagemaker_efa_tests = true
+sagemaker_efa_tests = false
 # run release_candidate_integration tests
-sagemaker_rc_tests = true
+sagemaker_rc_tests = false
 # run sagemaker benchmark tests
-sagemaker_benchmark_tests = true
+sagemaker_benchmark_tests = false
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -12,7 +12,7 @@ neuron_mode = false
 neuronx_mode = false
 # Please only set it to true if you are preparing a GRAVITON related PR
 # Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = false
+graviton_mode = true
 # Please only set it to True if you are preparing a HABANA related PR
 # Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false
@@ -34,10 +34,10 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
+build_training = false
 build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
@@ -60,13 +60,13 @@ ecs_tests = true
 eks_tests = true
 ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
-ec2_benchmark_tests = false
+ec2_benchmark_tests = true
 
 ### Set ec2_tests_on_heavy_instances = true to be able to run any EC2 tests that use large/expensive instance types by
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = false
+ec2_tests_on_heavy_instances = true
 
 ### SM specific tests
 ### Off by default
@@ -75,11 +75,11 @@ sagemaker_local_tests = true
 # run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = true
 # run efa sagemaker tests
-sagemaker_efa_tests = false
+sagemaker_efa_tests = true
 # run release_candidate_integration tests
-sagemaker_rc_tests = false
+sagemaker_rc_tests = true
 # run sagemaker benchmark tests
-sagemaker_benchmark_tests = false
+sagemaker_benchmark_tests = true
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/pytorch/inference/buildspec-graviton-2-2.yml
+++ b/pytorch/inference/buildspec-graviton-2-2.yml
@@ -5,7 +5,7 @@ framework: &FRAMEWORK pytorch
 version: &VERSION 2.2.1
 short_version: &SHORT_VERSION "2.2"
 arch_type: graviton
-autopatch_build: "True"
+autopatch_build: "False"
 
 repository_info:
   inference_repository: &INFERENCE_REPOSITORY
@@ -55,7 +55,7 @@ images:
     device_type: &DEVICE_TYPE cpu
     os_version: &OS_VERSION ubuntu20.04
     torch_serve_version: &TORCHSERVE_VERSION 0.11.0
-    tool_kit_version: &SM_TOOLKIT_VERSION 2.0.23
+    tool_kit_version: &SM_TOOLKIT_VERSION 2.0.24
     python_version: &DOCKER_PYTHON_VERSION py3
     tag_python_version: &TAG_PYTHON_VERSION py310
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION , "-sagemaker"]

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.ec2.graviton.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.ec2.graviton.cpu.core_packages.json
@@ -23,7 +23,7 @@
     "version_specifier": "<2"
   },
   "requests": {
-    "version_specifier": ">=2.32.2"
+    "version_specifier": ">=2.32.3"
   },
   "pyopenssl": {
     "version_specifier": ">=24.1.0"

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.ec2.graviton.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.ec2.graviton.cpu.core_packages.json
@@ -22,6 +22,9 @@
   "awscli": {
     "version_specifier": "<2"
   },
+  "requests": {
+    "version_specifier": ">=2.32.2"
+  },
   "pyopenssl": {
     "version_specifier": ">=24.1.0"
   },

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.ec2.graviton.cpu.py_scan_allowlist.json
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.ec2.graviton.cpu.py_scan_allowlist.json
@@ -1,6 +1,5 @@
 {
   "65213": "From OpenSSL: Due to the low severity of this issue we are not issuing new releases of OpenSSL at this time. The fix will be included in the next releases when they become available.",
   "67599": "It has been reported that this is intended functionality and the user is responsible for using --extra-index-url securely",
-  "70612": "This Jinja2 CVE is disputed and has no fix.",
-  "71064": "Requests >=2.32.0 fixes CVE-2024-35195, but it causes https://github.com/psf/requests/issues/6707. So we allowlist this finding for now."
+  "70612": "This Jinja2 CVE is disputed and has no fix."
 }

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.graviton.cpu
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.graviton.cpu
@@ -19,7 +19,7 @@ ARG SM_TOOLKIT_VERSION
 # |_____\____|_____| |___|_| |_| |_|\__,_|\__, |\___|
 #                                         |___/
 #  ____           _
-# |  _ \ ___  ___(_)_ __   ___ 
+# |  _ \ ___  ___(_)_ __   ___
 # | |_) / _ \/ __| | '_ \ / _ \
 # |  _ <  __/ (__| | |_) |  __/
 # |_| \_\___|\___|_| .__/ \___|
@@ -121,7 +121,7 @@ RUN curl -L -o ~/miniforge3.sh https://github.com/conda-forge/miniforge/releases
     # Below 2 are included in miniconda base, but not mamba so need to install
     conda-content-trust \
     charset-normalizer \
-    requests \
+    "requests>=2.32.2" \
  && conda clean -ya
 
 # Install Common python packages

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.graviton.cpu
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.graviton.cpu
@@ -159,6 +159,7 @@ RUN pip install --no-cache-dir -U -r https://raw.githubusercontent.com/pytorch/s
     torch-model-archiver==${TORCHSERVE_VERSION}
 
 # Patches
+# py-vuln: 71064
 RUN pip install --no-cache-dir -U "requests>=2.32.3"
 
 # add necessary certificate for aws sdk cpp download

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.graviton.cpu
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.graviton.cpu
@@ -131,7 +131,6 @@ RUN ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
     scipy \
     numpy \
     opencv-python \
-    "requests>=2.32.3" \
     "pyopenssl>=24.1.0" \
     "cryptography>=41.0.2" \
     "ipython>=8.10.0,<9.0" \
@@ -157,6 +156,9 @@ RUN pip install --no-cache-dir -U -r https://raw.githubusercontent.com/pytorch/s
  && pip install --no-cache-dir -U \
     torchserve==${TORCHSERVE_VERSION} \
     torch-model-archiver==${TORCHSERVE_VERSION}
+
+# Patches
+RUN pip install --no-cache-dir -U "requests>=2.32.3"
 
 # add necessary certificate for aws sdk cpp download
 RUN mkdir -p /etc/pki/tls/certs && cp /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.graviton.cpu
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.graviton.cpu
@@ -121,6 +121,7 @@ RUN curl -L -o ~/miniforge3.sh https://github.com/conda-forge/miniforge/releases
     # Below 2 are included in miniconda base, but not mamba so need to install
     conda-content-trust \
     charset-normalizer \
+    requests \
  && conda clean -ya
 
 # Install Common python packages

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.graviton.cpu
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.graviton.cpu
@@ -121,7 +121,6 @@ RUN curl -L -o ~/miniforge3.sh https://github.com/conda-forge/miniforge/releases
     # Below 2 are included in miniconda base, but not mamba so need to install
     conda-content-trust \
     charset-normalizer \
-    "requests>=2.32.3" \
  && conda clean -ya
 
 # Install Common python packages
@@ -132,6 +131,7 @@ RUN ln -s /opt/conda/bin/pip /usr/local/bin/pip3 \
     scipy \
     numpy \
     opencv-python \
+    "requests>=2.32.3" \
     "pyopenssl>=24.1.0" \
     "cryptography>=41.0.2" \
     "ipython>=8.10.0,<9.0" \

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.graviton.cpu
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.graviton.cpu
@@ -121,7 +121,7 @@ RUN curl -L -o ~/miniforge3.sh https://github.com/conda-forge/miniforge/releases
     # Below 2 are included in miniconda base, but not mamba so need to install
     conda-content-trust \
     charset-normalizer \
-    "requests>=2.32.2" \
+    "requests>=2.32.3" \
  && conda clean -ya
 
 # Install Common python packages

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
@@ -23,7 +23,7 @@
     "version_specifier": "<2"
   },
   "requests": {
-    "version_specifier": ">=2.32.2"
+    "version_specifier": ">=2.32.3"
   },
   "pyopenssl": {
     "version_specifier": ">=24.1.0"

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
@@ -22,6 +22,9 @@
   "awscli": {
     "version_specifier": "<2"
   },
+  "requests": {
+    "version_specifier": ">=2.32.2"
+  },
   "pyopenssl": {
     "version_specifier": ">=24.1.0"
   },

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.sagemaker.graviton.cpu.core_packages.json
@@ -47,6 +47,6 @@
     "version_specifier": "==0.11.0"
   },
   "sagemaker-pytorch-inference": {
-    "version_specifier": "==2.0.23"
+    "version_specifier": "==2.0.24"
   }
 }

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.sagemaker.graviton.cpu.py_scan_allowlist.json
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.sagemaker.graviton.cpu.py_scan_allowlist.json
@@ -2,5 +2,4 @@
   "65213": "From OpenSSL: Due to the low severity of this issue we are not issuing new releases of OpenSSL at this time. The fix will be included in the next releases when they become available.",
   "67599": "It has been reported that this is intended functionality and the user is responsible for using --extra-index-url securely",
   "70612": "This Jinja2 CVE is disputed and has no fix.",
-  "71064": "Requests >=2.32.0 fixes CVE-2024-35195, but it causes https://github.com/psf/requests/issues/6707. So we allowlist this finding for now."
 }

--- a/pytorch/inference/docker/2.2/py3/Dockerfile.sagemaker.graviton.cpu.py_scan_allowlist.json
+++ b/pytorch/inference/docker/2.2/py3/Dockerfile.sagemaker.graviton.cpu.py_scan_allowlist.json
@@ -1,5 +1,5 @@
 {
   "65213": "From OpenSSL: Due to the low severity of this issue we are not issuing new releases of OpenSSL at this time. The fix will be included in the next releases when they become available.",
   "67599": "It has been reported that this is intended functionality and the user is responsible for using --extra-index-url securely",
-  "70612": "This Jinja2 CVE is disputed and has no fix.",
+  "70612": "This Jinja2 CVE is disputed and has no fix."
 }


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run
- [3f2851e](https://github.com/aws/deep-learning-containers/pull/3985/commits/3f2851ebd44dcea698288d570f7a858343b75b60)
  - Passed ec2, eks, ecs, benchmark, sm remote, sm local, sm efa, sm rc, sm benchmark tests

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Fill out the template and click the checkbox of the builds you'd like to execute

*Note: Replace with <X.Y> with the major.minor framework version (i.e. 2.2) you would like to start.*

- [ ] build_pytorch_training_<X.Y>_sm
- [ ] build_pytorch_training_<X.Y>_ec2

- [ ] build_pytorch_inference_<X.Y>_sm
- [ ] build_pytorch_inference_<X.Y>_ec2
- [x] build_pytorch_inference_2.2_graviton

- [ ] build_tensorflow_training_<X.Y>_sm
- [ ] build_tensorflow_training_<X.Y>_ec2

- [ ] build_tensorflow_inference_<X.Y>_sm
- [ ] build_tensorflow_inference_<X.Y>_ec2
- [ ] build_tensorflow_inference_<X.Y>_graviton
</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
