### PR TITLE
Add PT2.3 Inference to release_images_patches.yml

### DIFF
--- a/release_images_patches.yml
+++ b/release_images_patches.yml
@@ -238,42 +238,42 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-
-  # TensorFlow 2.13 Images
   19:
-    framework: "tensorflow"
-    version: "2.13.0"
-    customer_type: "ec2"
+    framework: "pytorch"
+    version: "2.3.0"
     arch_type: "x86"
-    training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py311" ]
       os_version: "ubuntu20.04"
-      cuda_version: "cu118"
+      cuda_version: "cu121"
       example: False
       disable_sm_tag: False
       force_release: False
   20:
-    framework: "tensorflow"
-    version: "2.13.0"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py310"]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  21:
-    framework: "tensorflow"
-    version: "2.13.0"
+    framework: "pytorch"
+    version: "2.3.0"
     arch_type: "x86"
     customer_type: "ec2"
     inference:
       device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
+      python_versions: [ "py311" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu121"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+
+  # TensorFlow 2.13 Images
+  21:
+    framework: "tensorflow"
+    version: "2.13.0"
+    customer_type: "ec2"
+    arch_type: "x86"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
       os_version: "ubuntu20.04"
       cuda_version: "cu118"
       example: False
@@ -282,6 +282,32 @@ release_images:
   22:
     framework: "tensorflow"
     version: "2.13.0"
+    customer_type: "sagemaker"
+    arch_type: "x86"
+    training:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py310"]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  23:
+    framework: "tensorflow"
+    version: "2.13.0"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  24:
+    framework: "tensorflow"
+    version: "2.13.0"
     arch_type: "x86"
     customer_type: "sagemaker"
     inference:
@@ -292,7 +318,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  23:
+  25:
     framework: "tensorflow"
     version: "2.13.0"
     arch_type: "graviton"
@@ -305,7 +331,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  24:
+  26:
     framework: "tensorflow"
     version: "2.13.0"
     arch_type: "graviton"
@@ -320,38 +346,12 @@ release_images:
       force_release: False
 
   # TensorFlow 2.14 Images
-  25:
-    framework: "tensorflow"
-    version: "2.14.1"
-    customer_type: "ec2"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  26:
-    framework: "tensorflow"
-    version: "2.14.1"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
   27:
     framework: "tensorflow"
     version: "2.14.1"
-    arch_type: "x86"
     customer_type: "ec2"
-    inference:
+    arch_type: "x86"
+    training:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
@@ -362,6 +362,32 @@ release_images:
   28:
     framework: "tensorflow"
     version: "2.14.1"
+    customer_type: "sagemaker"
+    arch_type: "x86"
+    training:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  29:
+    framework: "tensorflow"
+    version: "2.14.1"
+    arch_type: "x86"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu118"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  30:
+    framework: "tensorflow"
+    version: "2.14.1"
     arch_type: "x86"
     customer_type: "sagemaker"
     inference:
@@ -372,7 +398,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  29:
+  31:
     framework: "tensorflow"
     version: "2.14.1"
     arch_type: "graviton"
@@ -385,7 +411,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  30:
+  32:
     framework: "tensorflow"
     version: "2.14.1"
     arch_type: "graviton"


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Fill out the template and click the checkbox of the builds you'd like to execute

*Note: Replace with <X.Y> with the major.minor framework version (i.e. 2.2) you would like to start.*

- [ ] build_pytorch_training_<X.Y>_sm
- [ ] build_pytorch_training_<X.Y>_ec2

- [ ] build_pytorch_inference_<X.Y>_sm
- [ ] build_pytorch_inference_<X.Y>_ec2
- [ ] build_pytorch_inference_<X.Y>_graviton

- [ ] build_tensorflow_training_<X.Y>_sm
- [ ] build_tensorflow_training_<X.Y>_ec2

- [ ] build_tensorflow_inference_<X.Y>_sm
- [ ] build_tensorflow_inference_<X.Y>_ec2
- [ ] build_tensorflow_inference_<X.Y>_graviton
</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
