### PR TITLE
GPG/PGP key update

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,7 +34,7 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["tensorflow", "pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,7 +34,7 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["tensorflow", "pytorch"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true

--- a/miscellaneous_scripts/dockerfile_patch_script.sh
+++ b/miscellaneous_scripts/dockerfile_patch_script.sh
@@ -45,6 +45,14 @@ fi
 
 pip cache purge
 
+## Update GPG key in case Nginx exists
+VARIABLE=$(apt-key list 2>&1  |  { grep -c nginx || true; }) && \
+if [ $VARIABLE != 0 ]; then \
+    echo "Nginx exists, thus upgrade" && \
+    curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null && \
+    apt-key add /usr/share/keyrings/nginx-archive-keyring.gpg;
+fi
+
 chmod +x $PATCHING_INFO_PATH/patch-details/install_script_os.sh && \
 $PATCHING_INFO_PATH/patch-details/install_script_os.sh
 

--- a/src/patch_helper.py
+++ b/src/patch_helper.py
@@ -120,7 +120,8 @@ def trigger_enhanced_scan_patching(image_uri, patch_details_path, python_version
     container_id = run(f"{docker_run_cmd}", hide=True).stdout.strip()
     try:
         docker_exec_cmd = f"docker exec -i {container_id}"
-        container_setup_cmd = "apt-get update"
+        ## Update key in case nginx exists
+        container_setup_cmd = """VARIABLE=$(apt-key list 2>&1  |  { grep -c nginx || true; }) && if [ $VARIABLE != 0 ]; then echo "Nginx exists, thus upgrade" && curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null && apt-key add /usr/share/keyrings/nginx-archive-keyring.gpg; fi && apt-get update"""
         run(f"{docker_exec_cmd} {container_setup_cmd}", hide=True)
         save_file_name = "os_summary.json"
         script_run_cmd = f"""python /deep-learning-containers/miscellaneous_scripts/extract_apt_patch_data.py --save-result-path /image-specific-patch-folder/{save_file_name} --mode_type generate"""

--- a/src/patch_helper.py
+++ b/src/patch_helper.py
@@ -121,7 +121,7 @@ def trigger_enhanced_scan_patching(image_uri, patch_details_path, python_version
     try:
         docker_exec_cmd = f"docker exec -i {container_id}"
         ## Update key in case nginx exists
-        container_setup_cmd = """VARIABLE=$(apt-key list 2>&1  |  { grep -c nginx || true; }) && if [ $VARIABLE != 0 ]; then echo "Nginx exists, thus upgrade" && curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null && apt-key add /usr/share/keyrings/nginx-archive-keyring.gpg; fi && apt-get update"""
+        container_setup_cmd = """bash -c 'VARIABLE=$(apt-key list 2>&1  |  { grep -c nginx || true; }) && if [ "$VARIABLE" != 0 ]; then echo "Nginx exists, thus upgrade" && curl https://nginx.org/keys/nginx_signing.key | gpg --dearmor | tee /usr/share/keyrings/nginx-archive-keyring.gpg >/dev/null && apt-key add /usr/share/keyrings/nginx-archive-keyring.gpg; fi && apt-get update'"""
         run(f"{docker_exec_cmd} {container_setup_cmd}", hide=True)
         save_file_name = "os_summary.json"
         script_run_cmd = f"""python /deep-learning-containers/miscellaneous_scripts/extract_apt_patch_data.py --save-result-path /image-specific-patch-folder/{save_file_name} --mode_type generate"""


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
PGP keys are public encryption keys used to sign NGINX packages and the package repositories’ metadata. PGP key for NGINX expired on June 14, 2024. Consequently, we need to update to the new key which has its expiry due 2 years later.

In this PR, we check if we had any nginx key initially since that reflects we were using nginx packages. In case we had the nginx key, we update the key, otherwise we do not.

**Note:** Failures seen on the PR are unrelated and can be fixed in a separate PR

### Tests run
This was tested locally and on the PR for the builds. Earlier the builds were breaking. Post update of the key, the builds started to succeed.

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Fill out the template and click the checkbox of the builds you'd like to execute

*Note: Replace with <X.Y> with the major.minor framework version (i.e. 2.2) you would like to start.*

- [ ] build_pytorch_training_<X.Y>_sm
- [ ] build_pytorch_training_<X.Y>_ec2

- [ ] build_pytorch_inference_<X.Y>_sm
- [ ] build_pytorch_inference_<X.Y>_ec2
- [ ] build_pytorch_inference_<X.Y>_graviton

- [ ] build_tensorflow_training_<X.Y>_sm
- [ ] build_tensorflow_training_<X.Y>_ec2

- [ ] build_tensorflow_inference_<X.Y>_sm
- [ ] build_tensorflow_inference_<X.Y>_ec2
- [ ] build_tensorflow_inference_<X.Y>_graviton
</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
