### PR TITLE
Add "--buildspecs" feature to src/prepare_dlc_dev_environment.py

### DIFF
--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -124,42 +124,43 @@ class TomlOverrider:
         dev_modes = []
 
         for buildspec_path in buildspec_paths:
-            # define the expected file path syntax:
-            # <framework>/<framework>/<job_type>/buildspec-<version>-<version>.yml
-            buildspec_pattern = r"^(\S+)/(training|inference)/buildspec(\S*)\.yml$"
+            # Define the expected file path syntax:
+            # <framework>/<job_type>/buildspec-<additional_info>.yml
+            buildspec_pattern = r"^(\S+)/(training|inference)/buildspec(-\S*)?\.yml$"
 
             if not buildspec_path:
-                return
+                continue
 
-            # validate the buildspec_path format
+            # Match the buildspec_path format
             match = re.match(buildspec_pattern, buildspec_path)
             if not match:
-                raise ValueError(f"Invalid buildspec_path format: {buildspec_path}")
+                LOGGER.error(f"Invalid buildspec_path format: {buildspec_path}")
+                continue
 
-            # extract the framework, job_type, and version from the buildspec_path
+            # Extract the framework, job_type, and additional_info from the buildspec_path
             framework = match.group(1).replace("/", "_")
             frameworks.append(framework)
             framework_str = framework if framework != "tensorflow" else "tensorflow-2"
             job_type = match.group(2)
             job_types.append(job_type)
-            buildspec_info = match.group(3)
+            additional_info = match.group(3) or ""
 
             dev_mode = None
             for dm in VALID_DEV_MODES:
-                if dm.replace("_mode", "") in buildspec_info:
+                if dm.replace("_mode", "") in additional_info:
                     dev_mode = dm
                     break
             dev_modes.append(dev_mode)
 
-            # construct the build_job name using the extracted info
-            dev_mode_str = f"-{dev_mode. replace(' _mode', '')}" if dev_mode else ""
+            # Construct the build_job name using the extracted info
+            dev_mode_str = f"-{dev_mode.replace('_mode', '')}" if dev_mode else ""
             build_job = f"dlc-pr-{framework_str}{dev_mode_str}-{job_type}"
 
             self._overrides["buildspec_override"][build_job] = buildspec_path
 
         if len(set(dev_modes)) > 1:
             LOGGER.warning(
-                f"Hey only 1 dev mode is allowed, selecting the first mode I see {dev_modes[0] }"
+                f"Hey only 1 dev mode is allowed, selecting the first mode I see {dev_modes[0]}"
             )
         self.set_dev_mode(dev_mode=dev_modes[0])
         self.set_build_frameworks(frameworks=frameworks)

--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -88,14 +88,18 @@ class TomlOverrider:
         based on the provided test types. It assumes that all tests are enabled by default.
         The provided test types will be kept enabled.
         """
-        # Enable all tests by default
+        # Disable all tests
         for test_type in VALID_TEST_TYPES:
+            self._overrides["test"][test_type] = False
+
+        # Enable the provided test types
+        for test_type in test_types:
             self._overrides["test"][test_type] = True
 
-        # Disable the test types not present in the provided list
-        for test_type in VALID_TEST_TYPES:
-            if test_type not in test_types:
-                self._overrides["test"][test_type] = False
+        # Enable all tests if an empty list is provided
+        if not test_types:
+            for test_type in VALID_TEST_TYPES:
+                self._overrides["test"][test_type] = True
 
     def set_dev_mode(self, dev_mode):
         """

--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -88,9 +88,10 @@ class TomlOverrider:
         based on the provided test types. It assumes that all tests are enabled by default, except
         for ec2_benchmark_tests. The provided test types will be kept enabled.
         """
-        # disable all tests
-        for test_type in VALID_TEST_TYPES:
-            self._overrides["test"][test_type] = False
+        # disable all tests if list is not empty
+        if test_types:
+            for test_type in VALID_TEST_TYPES:
+                self._overrides["test"][test_type] = False
         # enable corresponding tests
         for test_type in test_types:
             self._overrides["test"][test_type] = True

--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -100,7 +100,10 @@ class TomlOverrider:
         Set the dev mode based on the user input.
         Valid choices are 'graviton_mode', 'neuronx_mode', and 'deep_canary_mode'.
         """
-        if dev_mode:
+        # Reset all dev modes to False
+        for mode in VALID_DEV_MODES:
+            self._overrides["dev"][mode] = False
+        if dev_mode and dev_mode in VALID_DEV_MODES:
             self._overrides["dev"][dev_mode] = True
 
     def set_buildspec(self, buildspec_paths):

--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -103,6 +103,8 @@ class TomlOverrider:
         # Reset all dev modes to False
         for mode in VALID_DEV_MODES:
             self._overrides["dev"][mode] = False
+        if isinstance(dev_mode, list):
+            raise ValueError("Only one dev mode is allowed at a time.")
         if dev_mode and dev_mode in VALID_DEV_MODES:
             self._overrides["dev"][dev_mode] = True
 

--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -85,7 +85,7 @@ class TomlOverrider:
     def set_test_types(self, test_types):
         """
         This method takes a list of test types as input and updates the test overrides dictionary
-        based on the provided test types. It assumes that all tests are enabled by default. 
+        based on the provided test types. It assumes that all tests are enabled by default.
         The provided test types will be kept enabled.
         """
         # Enable all tests by default

--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -173,7 +173,7 @@ class TomlOverrider:
 
         if len(set(dev_modes)) > 1:
             LOGGER.warning(
-                f"Hey only 1 dev mode is allowed, selecting the first mode I see {dev_modes[0]}"
+                f"Only 1 dev mode is allowed, selecting the first mode in the list: {dev_modes[0]}"
             )
 
         self.set_dev_mode(dev_mode=dev_modes[0])

--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -1,3 +1,4 @@
+import os
 import argparse
 import logging
 import sys
@@ -123,18 +124,21 @@ class TomlOverrider:
         job_types = []
         dev_modes = []
 
+        invalid_paths = []
+
+        # define the expected file path syntax:
+        # <framework>/<framework>/<job_type>/buildspec-<version>-<version>.yml
+        buildspec_pattern = r"^(\S+)/(training|inference)/buildspec(\S*)\.yml$"
+
         for buildspec_path in buildspec_paths:
-            # define the expected file path syntax:
-            # <framework>/<framework>/<job_type>/buildspec-<version>-<version>.yml
-            buildspec_pattern = r"^(\S+)/(training|inference)/buildspec(\S*)\.yml$"
-
-            if not buildspec_path:
-                return
-
             # validate the buildspec_path format
             match = re.match(buildspec_pattern, buildspec_path)
-            if not match:
-                raise ValueError(f"Invalid buildspec_path format: {buildspec_path}")
+            if not match or not os.path.exists(buildspec_path):
+                LOGGER.warning(
+                    f"WARNING! {buildspec_path} does not exist. Moving on to the next one..."
+                )
+                invalid_paths.append(buildspec_path)
+                continue
 
             # extract the framework, job_type, and version from the buildspec_path
             framework = match.group(1).replace("/", "_")
@@ -152,10 +156,17 @@ class TomlOverrider:
             dev_modes.append(dev_mode)
 
             # construct the build_job name using the extracted info
-            dev_mode_str = f"-{dev_mode. replace(' _mode', '')}" if dev_mode else ""
+            dev_mode_str = (
+                f"-{dev_mode.replace('_mode', '').replace('neuronx', 'neuron')}" if dev_mode else ""
+            )
             build_job = f"dlc-pr-{framework_str}{dev_mode_str}-{job_type}"
 
             self._overrides["buildspec_override"][build_job] = buildspec_path
+
+        if invalid_paths:
+            raise RuntimeError(
+                f"Found buildspecs that either do not match regex {buildspec_pattern} or do not exist: {invalid_paths}. Please retry, and use tab completion to find valid buildspecs."
+            )
 
         if len(set(dev_modes)) > 1:
             LOGGER.warning(

--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -2,8 +2,9 @@ import os
 import argparse
 import logging
 import sys
-import toml
 import re
+
+import toml
 
 from config import get_dlc_developer_config_path
 from codebuild_environment import get_cloned_folder_path
@@ -12,7 +13,6 @@ from codebuild_environment import get_cloned_folder_path
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.DEBUG)
 LOGGER.addHandler(logging.StreamHandler(sys.stdout))
-# LOGGER.addHandler(logging.StreamHandler(sys.stderr))
 
 
 VALID_TEST_TYPES = [
@@ -190,12 +190,12 @@ def write_toml(toml_path, overrides):
         loaded_toml = toml.load(toml_file_reader)
 
     for key, value in overrides.items():
-        if key == "buildspec_override":
-            for k, v in value.items():
-                loaded_toml["buildspec_override"][k] = v
-        else:
-            for k, v in value.items():
-                loaded_toml[key][k] = v
+        for k, v in value.items():
+            if loaded_toml.get(key, {}).get(k, None) is None:
+                LOGGER.warning(
+                    f"WARNING: Writing unrecognized key {key} {k} with value {v} to {toml_path}"
+                )
+            loaded_toml[key][k] = v
 
     with open(toml_path, "w") as toml_file_writer:
         output = toml.dumps(loaded_toml).split("\n")

--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -154,7 +154,7 @@ class TomlOverrider:
 
             # Construct the build_job name using the extracted info
             dev_mode_str = f"-{dev_mode.replace('_mode', '')}" if dev_mode else ""
-            build_job = f"dlc-pr-{framework_str}{dev_mode_str}-{job_type}"
+            build_job = f"dlc-pr-{framework_str}-{job_type}"
 
             self._overrides["buildspec_override"][build_job] = buildspec_path
 

--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -125,8 +125,10 @@ class TomlOverrider:
 
         for buildspec_path in buildspec_paths:
             # Define the expected file path syntax:
-            # <framework>/<job_type>/buildspec-<additional_info>.yml
-            buildspec_pattern = r"^(\S+)/(training|inference)/buildspec(-\S*)?\.yml$"
+            # <framework>/<job_type>/buildspec(-<additional_info>)?\.yml
+            buildspec_pattern = (
+                r"^(\S+)/(training|inference)/buildspec(-\S*(graviton|neuronx|dep\S*))?\.yml$"
+            )
 
             if not buildspec_path:
                 continue
@@ -146,14 +148,11 @@ class TomlOverrider:
             additional_info = match.group(3) or ""
 
             dev_mode = None
-            for dm in VALID_DEV_MODES:
-                if dm.replace("_mode", "") in additional_info:
-                    dev_mode = dm
-                    break
+            if "dep" in additional_info or "depcanary" in additional_info:
+                dev_mode = "deep_canary_mode"
             dev_modes.append(dev_mode)
 
             # Construct the build_job name using the extracted info
-            dev_mode_str = f"-{dev_mode.replace('_mode', '')}" if dev_mode else ""
             build_job = f"dlc-pr-{framework_str}-{job_type}"
 
             self._overrides["buildspec_override"][build_job] = buildspec_path

--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -106,7 +106,7 @@ class TomlOverrider:
         Set the dev mode based on the user input.
         Valid choices are 'graviton_mode', 'neuronx_mode', and 'deep_canary_mode'.
         """
-        # reset all dev modes to False
+        # Reset all dev modes to False
         for mode in VALID_DEV_MODES:
             self._overrides["dev"][mode] = False
         if isinstance(dev_mode, list):
@@ -115,63 +115,56 @@ class TomlOverrider:
             self._overrides["dev"][dev_mode] = True
 
     def set_buildspec(self, buildspec_paths):
+        """
+        This method takes a buildspec path as input and updates the corresponding key in the
+        buildspec_override section of the TOML file.
+        """
         frameworks = []
         job_types = []
-        dev_mode = None
+        dev_modes = []
 
         for buildspec_path in buildspec_paths:
+            # define the expected file path syntax:
+            # <framework>/<framework>/<job_type>/buildspec-<version>-<version>.yml
+            buildspec_pattern = r"^(\S+)/(training|inference)/buildspec(\S*)\.yml$"
+
             if not buildspec_path:
-                continue
+                return
 
-            # Validate the buildspec_path format
-            match = self._validate_buildspec_path(buildspec_path)
+            # validate the buildspec_path format
+            match = re.match(buildspec_pattern, buildspec_path)
             if not match:
-                continue
+                raise ValueError(f"Invalid buildspec_path format: {buildspec_path}")
 
-            framework, job_type, buildspec_info = self._extract_buildspec_info(match)
+            # extract the framework, job_type, and version from the buildspec_path
+            framework = match.group(1).replace("/", "_")
             frameworks.append(framework)
+            framework_str = framework if framework != "tensorflow" else "tensorflow-2"
+            job_type = match.group(2)
             job_types.append(job_type)
+            buildspec_info = match.group(3)
 
-            # Check for dev mode and use the first one encountered
-            if not dev_mode and buildspec_info:
-                dev_mode = self._get_dev_mode(buildspec_info)
+            dev_mode = None
+            for dm in VALID_DEV_MODES:
+                if dm.replace("_mode", "") in buildspec_info:
+                    dev_mode = dm
+                    break
+            dev_modes.append(dev_mode)
 
-            dev_mode_str = f"-{dev_mode.replace('_mode', '')}" if dev_mode else ""
-            build_job = f"dlc-pr-{framework}{dev_mode_str}-{job_type}"
+            # construct the build_job name using the extracted info
+            dev_mode_str = f"-{dev_mode. replace(' _mode', '')}" if dev_mode else ""
+            build_job = f"dlc-pr-{framework_str}{dev_mode_str}-{job_type}"
+
             self._overrides["buildspec_override"][build_job] = buildspec_path
 
-        # Reset all dev modes to False and set the first encountered dev mode to True
-        self._handle_dev_modes(dev_mode)
+        if len(set(dev_modes)) > 1:
+            LOGGER.warning(
+                f"Hey only 1 dev mode is allowed, selecting the first mode I see {dev_modes[0]}"
+            )
 
+        self.set_dev_mode(dev_mode=dev_modes[0])
         self.set_build_frameworks(frameworks=frameworks)
         self.set_job_type(job_types=job_types)
-
-    def _validate_buildspec_path(self, buildspec_path):
-        buildspec_pattern = r"^(\S+)/(training|inference)/buildspec(\S*)\.yml$"
-        return re.match(buildspec_pattern, buildspec_path)
-
-    def _extract_buildspec_info(self, match):
-        if not match:
-            return None, None, None
-
-        framework = match.group(1).replace("/", "_")
-        framework_str = f"{framework}-2" if framework == "tensorflow" else framework
-        job_type = match.group(2)
-        buildspec_info = match.group(3)
-        return framework_str, job_type, buildspec_info
-
-    def _get_dev_mode(self, buildspec_info):
-        for dm in VALID_DEV_MODES:
-            if dm.replace("_mode", "") in buildspec_info:
-                return dm
-        return None
-
-    def _handle_dev_modes(self, dev_mode):
-        if dev_mode is None:
-            return
-
-        for mode in VALID_DEV_MODES:
-            self._overrides["dev"][mode] = mode == dev_mode
 
     @property
     def overrides(self):

--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -171,7 +171,8 @@ class TomlOverrider:
             return
 
         for mode in VALID_DEV_MODES:
-            self._overrides["dev"][mode] = (mode == dev_mode)
+            self._overrides["dev"][mode] = mode == dev_mode
+
     @property
     def overrides(self):
         return self._overrides

--- a/src/prepare_dlc_dev_environment.py
+++ b/src/prepare_dlc_dev_environment.py
@@ -66,7 +66,7 @@ class TomlOverrider:
         dictionary is stored in the _overrides attribute of the TomlOverrider object
         """
         if frameworks:
-            unique_frameworks = list(set(frameworks))
+            unique_frameworks = list(dict.fromkeys(frameworks))
             self._overrides["build"]["build_frameworks"] = unique_frameworks
 
     def set_job_type(self, job_types):
@@ -85,16 +85,17 @@ class TomlOverrider:
     def set_test_types(self, test_types):
         """
         This method takes a list of test types as input and updates the test overrides dictionary
-        based on the provided test types. It assumes that all tests are enabled by default, except
-        for ec2_benchmark_tests. The provided test types will be kept enabled.
+        based on the provided test types. It assumes that all tests are enabled by default. 
+        The provided test types will be kept enabled.
         """
-        # disable all tests if list is not empty
-        if test_types:
-            for test_type in VALID_TEST_TYPES:
-                self._overrides["test"][test_type] = False
-        # enable corresponding tests
-        for test_type in test_types:
+        # Enable all tests by default
+        for test_type in VALID_TEST_TYPES:
             self._overrides["test"][test_type] = True
+
+        # Disable the test types not present in the provided list
+        for test_type in VALID_TEST_TYPES:
+            if test_type not in test_types:
+                self._overrides["test"][test_type] = False
 
     def set_dev_mode(self, dev_mode):
         """

--- a/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
+++ b/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
@@ -118,8 +118,8 @@ def test_set_buildspec_updates_buildspec_override():
 
     expected_buildspec_override = {
         "dlc-pr-huggingface-pytorch-training": "huggingface/pytorch/training/buildspec.yml",
-        "dlc-pr-pytorch-inference": "pytorch/inference/buildspec-graviton.yml",
-        "dlc-pr-tensorflow-2-inference": "tensorflow/inference/buildspec-neuronx.yml",
+        "dlc-pr-pytorch-graviton-inference": "pytorch/inference/buildspec-graviton.yml",
+        "dlc-pr-tensorflow-2-neuronx-inference": "tensorflow/inference/buildspec-neuronx.yml",
     }
 
     assert overrider.overrides["buildspec_override"] == expected_buildspec_override

--- a/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
+++ b/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
@@ -59,6 +59,16 @@ def test_set_test_types():
     assert overrider.overrides["test"]["sagemaker_local_tests"] == False
     assert overrider.overrides["test"]["sagemaker_remote_tests"] == True
 
+    # Test case with no test types (default behavior)
+    test_types = []
+    overrider.set_test_types(test_types)
+    assert overrider.overrides["test"]["sanity_tests"] == True
+    assert overrider.overrides["test"]["ecs_tests"] == True
+    assert overrider.overrides["test"]["eks_tests"] == True
+    assert overrider.overrides["test"]["ec2_tests"] == True
+    assert overrider.overrides["test"]["sagemaker_local_tests"] == True
+    assert overrider.overrides["test"]["sagemaker_remote_tests"] == True
+
 
 @pytest.mark.quick_checks
 @pytest.mark.model("N/A")
@@ -86,3 +96,7 @@ def test_set_dev_mode():
     assert overrider.overrides["dev"]["graviton_mode"] == False
     assert overrider.overrides["dev"]["neuronx_mode"] == False
     assert overrider.overrides["dev"]["deep_canary_mode"] == True
+
+    # Test case with multiple dev modes (error)
+    with pytest.raises(ValueError):
+        overrider.set_dev_mode(["graviton_mode", "neuronx_mode"])

--- a/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
+++ b/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
@@ -118,13 +118,12 @@ def test_set_buildspec_updates_buildspec_override():
     overrider.set_buildspec(valid_buildspec_paths)
 
     expected_buildspec_override = {
-        "dlc-pr-huggingface-depcanary-training": "huggingface/training/buildspec-aws-depcanary.yml",
-        "dlc-pr-pytorch-graviton_mode-training": "pytorch/training/buildspec-aws-graviton2.yml",
-        "dlc-pr-tensorflow-2-neuronx_mode-inference": "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
+        "dlc-pr-huggingface-training": "huggingface/training/buildspec-aws-depcanary.yml",
+        "dlc-pr-pytorch-training": "pytorch/training/buildspec-aws-graviton2.yml",
+        "dlc-pr-tensorflow-2-inference": "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
     }
 
     assert overrider.overrides["buildspec_override"] == expected_buildspec_override
-
 
 @pytest.mark.quick_checks
 @pytest.mark.model("N/A")
@@ -157,8 +156,8 @@ def test_set_buildspec_updates_dev_mode():
     overrider.set_buildspec(valid_buildspec_paths)
 
     assert overrider.overrides["dev"]["graviton_mode"] == True
-    assert overrider.overrides["dev"]["neuronx_mode"] == True
-    assert overrider.overrides["dev"]["deep_canary_mode"] == True
+    assert overrider.overrides["dev"]["neuronx_mode"] == False
+    assert overrider.overrides["dev"]["deep_canary_mode"] == False
 
 
 @pytest.mark.quick_checks

--- a/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
+++ b/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
@@ -109,17 +109,17 @@ def test_set_buildspec_updates_buildspec_override():
     overrider = prepare_dlc_dev_environment.TomlOverrider()
 
     valid_buildspec_paths = [
-        "pytorch/training/buildspec-aws-graviton2.yml",
-        "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
-        "huggingface/training/buildspec-aws-depcanary.yml",
+        "pytorch/inference/buildspec-graviton.yml",
+        "tensorflow/training/buildspec-neuronx.yml",
+        "huggingface/pytorch/training/buildspec.yml",
     ]
 
     overrider.set_buildspec(valid_buildspec_paths)
 
     expected_buildspec_override = {
-        "dlc-pr-huggingface-training": "huggingface/training/buildspec-aws-depcanary.yml",
-        "dlc-pr-pytorch-training": "pytorch/training/buildspec-aws-graviton2.yml",
-        "dlc-pr-tensorflow-2-inference": "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
+        "dlc-pr-huggingface-pytorch-training": "huggingface/pytorch/training/buildspec.yml",
+        "dlc-pr-pytorch-inference": "pytorch/inference/buildspec-graviton.yml",
+        "dlc-pr-tensorflow-2-training": "tensorflow/training/buildspec-neuronx.yml",
     }
 
     assert overrider.overrides["buildspec_override"] == expected_buildspec_override
@@ -148,13 +148,14 @@ def test_set_buildspec_updates_dev_mode():
     overrider = prepare_dlc_dev_environment.TomlOverrider()
 
     valid_buildspec_paths = [
-        "pytorch/training/buildspec-graviton.yml",
-        "tensorflow/inference/buildspec-neuronx.yml",
+        "pytorch/inference/buildspec-graviton.yml",
+        "tensorflow/training/buildspec-neuronx.yml",
     ]
 
     overrider.set_buildspec(valid_buildspec_paths)
 
     assert overrider.overrides["dev"]["graviton_mode"] is True
+    # Only the first dev mode is used, so neuronx is set to False
     assert overrider.overrides["dev"]["neuronx_mode"] is False
 
 
@@ -165,14 +166,14 @@ def test_set_buildspec_updates_build_frameworks():
     overrider = prepare_dlc_dev_environment.TomlOverrider()
 
     valid_buildspec_paths = [
-        "pytorch/training/buildspec-aws-graviton2.yml",
-        "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
-        "huggingface/training/buildspec-aws-depcanary.yml",
+        "pytorch/inference/buildspec-graviton.yml",
+        "tensorflow/training/buildspec-neuronx.yml",
+        "huggingface/pytorch/training/buildspec.yml",
     ]
 
     overrider.set_buildspec(valid_buildspec_paths)
 
-    expected_build_frameworks = ["pytorch", "tensorflow", "huggingface"]
+    expected_build_frameworks = ["pytorch", "tensorflow", "huggingface_pytorch"]
     assert overrider.overrides["build"]["build_frameworks"] == expected_build_frameworks
 
 
@@ -183,14 +184,14 @@ def test_set_buildspec_updates_build_training_only():
     overrider = prepare_dlc_dev_environment.TomlOverrider()
 
     buildspec_paths = [
-        "pytorch/training/buildspec-aws-graviton2.yml",
-        "huggingface/training/buildspec-aws-depcanary.yml",
+        "pytorch/training/buildspec.yml",
+        "huggingface/pytorch/inference/buildspec.yml",
     ]
 
     overrider.set_buildspec(buildspec_paths)
 
     assert overrider.overrides["build"]["build_training"] is True
-    assert overrider.overrides["build"]["build_inference"] is False
+    assert overrider.overrides["build"]["build_inference"] is True
 
 
 @pytest.mark.quick_checks
@@ -200,7 +201,7 @@ def test_set_buildspec_updates_build_inference_only():
     overrider = prepare_dlc_dev_environment.TomlOverrider()
 
     buildspec_paths = [
-        "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
+        "tensorflow/inference/buildspec-neuronx.yml",
     ]
 
     overrider.set_buildspec(buildspec_paths)

--- a/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
+++ b/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
@@ -1,7 +1,6 @@
 import pytest
 
 from src import prepare_dlc_dev_environment
-from unittest.mock import patch
 
 
 @pytest.mark.quick_checks
@@ -21,26 +20,26 @@ def test_build_job_types():
     overrider = prepare_dlc_dev_environment.TomlOverrider()
     overrider.set_job_type(("inference", "training"))
     assert (
-        overrider.overrides["build"]["build_training"] == True
-        and overrider.overrides["build"]["build_inference"] == True
+        overrider.overrides["build"]["build_training"] is True
+        and overrider.overrides["build"]["build_inference"] is True
     )
 
     overrider.set_job_type(["inference"])
     assert (
-        overrider.overrides["build"]["build_training"] == False
-        and overrider.overrides["build"]["build_inference"] == True
+        overrider.overrides["build"]["build_training"] is False
+        and overrider.overrides["build"]["build_inference"] is True
     )
 
     overrider.set_job_type(["training"])
     assert (
-        overrider.overrides["build"]["build_training"] == True
-        and overrider.overrides["build"]["build_inference"] == False
+        overrider.overrides["build"]["build_training"] is True
+        and overrider.overrides["build"]["build_inference"] is False
     )
 
     overrider.set_job_type([])
     assert (
-        overrider.overrides["build"]["build_training"] == False
-        and overrider.overrides["build"]["build_inference"] == False
+        overrider.overrides["build"]["build_training"] is False
+        and overrider.overrides["build"]["build_inference"] is False
     )
 
 
@@ -53,22 +52,22 @@ def test_set_test_types():
     # Test case with a subset of test types
     test_types = ["ec2_tests", "ecs_tests", "sagemaker_remote_tests"]
     overrider.set_test_types(test_types)
-    assert overrider.overrides["test"]["sanity_tests"] == False
-    assert overrider.overrides["test"]["ecs_tests"] == True
-    assert overrider.overrides["test"]["eks_tests"] == False
-    assert overrider.overrides["test"]["ec2_tests"] == True
-    assert overrider.overrides["test"]["sagemaker_local_tests"] == False
-    assert overrider.overrides["test"]["sagemaker_remote_tests"] == True
+    assert overrider.overrides["test"]["sanity_tests"] is False
+    assert overrider.overrides["test"]["ecs_tests"] is True
+    assert overrider.overrides["test"]["eks_tests"] is False
+    assert overrider.overrides["test"]["ec2_tests"] is True
+    assert overrider.overrides["test"]["sagemaker_local_tests"] is False
+    assert overrider.overrides["test"]["sagemaker_remote_tests"] is True
 
     # Test case with no test types (default behavior)
     test_types = []
     overrider.set_test_types(test_types)
-    assert overrider.overrides["test"]["sanity_tests"] == True
-    assert overrider.overrides["test"]["ecs_tests"] == True
-    assert overrider.overrides["test"]["eks_tests"] == True
-    assert overrider.overrides["test"]["ec2_tests"] == True
-    assert overrider.overrides["test"]["sagemaker_local_tests"] == True
-    assert overrider.overrides["test"]["sagemaker_remote_tests"] == True
+    assert overrider.overrides["test"]["sanity_tests"] is True
+    assert overrider.overrides["test"]["ecs_tests"] is True
+    assert overrider.overrides["test"]["eks_tests"] is True
+    assert overrider.overrides["test"]["ec2_tests"] is True
+    assert overrider.overrides["test"]["sagemaker_local_tests"] is True
+    assert overrider.overrides["test"]["sagemaker_remote_tests"] is True
 
 
 @pytest.mark.quick_checks
@@ -79,24 +78,24 @@ def test_set_dev_mode():
 
     # test with no dev mode provided
     overrider.set_dev_mode(None)
-    assert overrider.overrides["dev"]["graviton_mode"] == False
-    assert overrider.overrides["dev"]["neuronx_mode"] == False
-    assert overrider.overrides["dev"]["deep_canary_mode"] == False
+    assert overrider.overrides["dev"]["graviton_mode"] is False
+    assert overrider.overrides["dev"]["neuronx_mode"] is False
+    assert overrider.overrides["dev"]["deep_canary_mode"] is False
 
     overrider.set_dev_mode("graviton_mode")
-    assert overrider.overrides["dev"]["graviton_mode"] == True
-    assert overrider.overrides["dev"]["neuronx_mode"] == False
-    assert overrider.overrides["dev"]["deep_canary_mode"] == False
+    assert overrider.overrides["dev"]["graviton_mode"] is True
+    assert overrider.overrides["dev"]["neuronx_mode"] is False
+    assert overrider.overrides["dev"]["deep_canary_mode"] is False
 
     overrider.set_dev_mode("neuronx_mode")
-    assert overrider.overrides["dev"]["graviton_mode"] == False
-    assert overrider.overrides["dev"]["neuronx_mode"] == True
-    assert overrider.overrides["dev"]["deep_canary_mode"] == False
+    assert overrider.overrides["dev"]["graviton_mode"] is False
+    assert overrider.overrides["dev"]["neuronx_mode"] is True
+    assert overrider.overrides["dev"]["deep_canary_mode"] is False
 
     overrider.set_dev_mode("deep_canary_mode")
-    assert overrider.overrides["dev"]["graviton_mode"] == False
-    assert overrider.overrides["dev"]["neuronx_mode"] == False
-    assert overrider.overrides["dev"]["deep_canary_mode"] == True
+    assert overrider.overrides["dev"]["graviton_mode"] is False
+    assert overrider.overrides["dev"]["neuronx_mode"] is False
+    assert overrider.overrides["dev"]["deep_canary_mode"] is True
 
     # Test case with multiple dev modes (error)
     with pytest.raises(ValueError):
@@ -138,7 +137,7 @@ def test_set_buildspec_invalid_path():
         "tensorflow/inference/buildspec-aws-neuronx.yml",
     ]
 
-    with pytest.raises(ValueError):
+    with pytest.raises(RuntimeError):
         overrider.set_buildspec(invalid_buildspec_paths)
 
 
@@ -149,16 +148,14 @@ def test_set_buildspec_updates_dev_mode():
     overrider = prepare_dlc_dev_environment.TomlOverrider()
 
     valid_buildspec_paths = [
-        "pytorch/training/buildspec-aws-graviton2.yml",
-        "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
-        "huggingface/training/buildspec-aws-depcanary.yml",
+        "pytorch/training/buildspec-graviton.yml",
+        "tensorflow/inference/buildspec-neuronx.yml",
     ]
 
     overrider.set_buildspec(valid_buildspec_paths)
 
-    assert overrider.overrides["dev"]["graviton_mode"] == True
-    assert overrider.overrides["dev"]["neuronx_mode"] == False
-    assert overrider.overrides["dev"]["deep_canary_mode"] == False
+    assert overrider.overrides["dev"]["graviton_mode"] is True
+    assert overrider.overrides["dev"]["neuronx_mode"] is False
 
 
 @pytest.mark.quick_checks
@@ -192,8 +189,8 @@ def test_set_buildspec_updates_build_training_only():
 
     overrider.set_buildspec(buildspec_paths)
 
-    assert overrider.overrides["build"]["build_training"] == True
-    assert overrider.overrides["build"]["build_inference"] == False
+    assert overrider.overrides["build"]["build_training"] is True
+    assert overrider.overrides["build"]["build_inference"] is False
 
 
 @pytest.mark.quick_checks
@@ -208,5 +205,5 @@ def test_set_buildspec_updates_build_inference_only():
 
     overrider.set_buildspec(buildspec_paths)
 
-    assert overrider.overrides["build"]["build_training"] == False
-    assert overrider.overrides["build"]["build_inference"] == True
+    assert overrider.overrides["build"]["build_training"] is False
+    assert overrider.overrides["build"]["build_inference"] is True

--- a/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
+++ b/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src import prepare_dlc_dev_environment
+from unittest.mock import patch
 
 
 @pytest.mark.quick_checks
@@ -100,3 +101,112 @@ def test_set_dev_mode():
     # Test case with multiple dev modes (error)
     with pytest.raises(ValueError):
         overrider.set_dev_mode(["graviton_mode", "neuronx_mode"])
+
+
+@pytest.mark.quick_checks
+@pytest.mark.model("N/A")
+@pytest.mark.integration("set_buildspec")
+def test_set_buildspec_updates_buildspec_override():
+    overrider = prepare_dlc_dev_environment.TomlOverrider()
+
+    valid_buildspec_paths = [
+        "pytorch/training/buildspec-aws-graviton2.yml",
+        "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
+        "huggingface/training/buildspec-aws-depcanary.yml",
+    ]
+
+    overrider.set_buildspec(valid_buildspec_paths)
+
+    expected_buildspec_override = {
+        "dlc-pr-pytorch-training": "pytorch/training/buildspec-aws-graviton2.yml",
+        "dlc-pr-tensorflow-2-neuronx-inference": "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
+        "dlc-pr-huggingface-depcanary-training": "huggingface/training/buildspec-aws-depcanary.yml",
+    }
+
+    assert overrider.overrides["buildspec_override"] == expected_buildspec_override
+
+
+@pytest.mark.quick_checks
+@pytest.mark.model("N/A")
+@pytest.mark.integration("set_buildspec")
+def test_set_buildspec_invalid_path():
+    overrider = prepare_dlc_dev_environment.TomlOverrider()
+
+    invalid_buildspec_paths = [  # invalid path
+        "invalid/path/buildspec.yml",
+        "pytorch/invalid/buildspec-aws-graviton2.yml",
+        "tensorflow/inference/buildspec-aws-neuronx.yml",
+    ]
+
+    with pytest.raises(ValueError):
+        overrider.set_buildspec(invalid_buildspec_paths)
+
+
+@pytest.mark.quick_checks
+@pytest.mark.model("N/A")
+@pytest.mark.integration("set_buildspec")
+def test_set_buildspec_updates_dev_mode():
+    overrider = prepare_dlc_dev_environment.TomlOverrider()
+
+    valid_buildspec_paths = [
+        "pytorch/training/buildspec-aws-graviton2.yml",
+        "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
+        "huggingface/training/buildspec-aws-depcanary.yml",
+    ]
+
+    overrider.set_buildspec(valid_buildspec_paths)
+
+    assert overrider.overrides["dev"]["graviton_mode"] == True
+    assert overrider.overrides["dev"]["neuronx_mode"] == True
+    assert overrider.overrides["dev"]["deep_canary_mode"] == True
+
+
+@pytest.mark.quick_checks
+@pytest.mark.model("N/A")
+@pytest.mark.integration("set_buildspec")
+def test_set_buildspec_updates_build_frameworks():
+    overrider = prepare_dlc_dev_environment.TomlOverrider()
+
+    valid_buildspec_paths = [
+        "pytorch/training/buildspec-aws-graviton2.yml",
+        "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
+        "huggingface/training/buildspec-aws-depcanary.yml",
+    ]
+
+    overrider.set_buildspec(valid_buildspec_paths)
+
+    expected_build_frameworks = ["pytorch", "tensorflow", "huggingface"]
+    assert overrider.overrides["build"]["build_frameworks"] == expected_build_frameworks
+
+
+@pytest.mark.quick_checks
+@pytest.mark.model("N/A")
+@pytest.mark.integration("set_buildspec")
+def test_set_buildspec_updates_build_training_only():
+    overrider = prepare_dlc_dev_environment.TomlOverrider()
+
+    buildspec_paths = [
+        "pytorch/training/buildspec-aws-graviton2.yml",
+        "huggingface/training/buildspec-aws-depcanary.yml",
+    ]
+
+    overrider.set_buildspec(buildspec_paths)
+
+    assert overrider.overrides["build"]["build_training"] == True
+    assert overrider.overrides["build"]["build_inference"] == False
+
+
+@pytest.mark.quick_checks
+@pytest.mark.model("N/A")
+@pytest.mark.integration("set_buildspec")
+def test_set_buildspec_updates_build_inference_only():
+    overrider = prepare_dlc_dev_environment.TomlOverrider()
+
+    buildspec_paths = [
+        "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
+    ]
+
+    overrider.set_buildspec(buildspec_paths)
+
+    assert overrider.overrides["build"]["build_training"] == False
+    assert overrider.overrides["build"]["build_inference"] == True

--- a/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
+++ b/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
@@ -145,6 +145,29 @@ def test_set_buildspec_invalid_path():
 @pytest.mark.quick_checks
 @pytest.mark.model("N/A")
 @pytest.mark.integration("set_buildspec")
+def test_set_buildspec_updates_buildspec_override():
+    overrider = prepare_dlc_dev_environment.TomlOverrider()
+
+    valid_buildspec_paths = [
+        "pytorch/training/buildspec-aws-graviton2.yml",
+        "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
+        "huggingface/training/buildspec-aws-depcanary.yml",
+    ]
+
+    overrider.set_buildspec(valid_buildspec_paths)
+
+    expected_buildspec_override = {
+        "dlc-pr-pytorch-training": "pytorch/training/buildspec-aws-graviton2.yml",
+        "dlc-pr-tensorflow-2-inference": "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
+        "dlc-pr-huggingface-training": "huggingface/training/buildspec-aws-depcanary.yml",
+    }
+
+    assert overrider.overrides["buildspec_override"] == expected_buildspec_override
+
+
+@pytest.mark.quick_checks
+@pytest.mark.model("N/A")
+@pytest.mark.integration("set_buildspec")
 def test_set_buildspec_updates_dev_mode():
     overrider = prepare_dlc_dev_environment.TomlOverrider()
 

--- a/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
+++ b/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
@@ -110,7 +110,7 @@ def test_set_buildspec_updates_buildspec_override():
 
     valid_buildspec_paths = [
         "pytorch/inference/buildspec-graviton.yml",
-        "tensorflow/training/buildspec-neuronx.yml",
+        "tensorflow/inference/buildspec-neuronx.yml",
         "huggingface/pytorch/training/buildspec.yml",
     ]
 
@@ -119,7 +119,7 @@ def test_set_buildspec_updates_buildspec_override():
     expected_buildspec_override = {
         "dlc-pr-huggingface-pytorch-training": "huggingface/pytorch/training/buildspec.yml",
         "dlc-pr-pytorch-inference": "pytorch/inference/buildspec-graviton.yml",
-        "dlc-pr-tensorflow-2-training": "tensorflow/training/buildspec-neuronx.yml",
+        "dlc-pr-tensorflow-2-inference": "tensorflow/inference/buildspec-neuronx.yml",
     }
 
     assert overrider.overrides["buildspec_override"] == expected_buildspec_override
@@ -149,7 +149,7 @@ def test_set_buildspec_updates_dev_mode():
 
     valid_buildspec_paths = [
         "pytorch/inference/buildspec-graviton.yml",
-        "tensorflow/training/buildspec-neuronx.yml",
+        "tensorflow/inference/buildspec-neuronx.yml",
     ]
 
     overrider.set_buildspec(valid_buildspec_paths)
@@ -167,7 +167,7 @@ def test_set_buildspec_updates_build_frameworks():
 
     valid_buildspec_paths = [
         "pytorch/inference/buildspec-graviton.yml",
-        "tensorflow/training/buildspec-neuronx.yml",
+        "tensorflow/inference/buildspec-neuronx.yml",
         "huggingface/pytorch/training/buildspec.yml",
     ]
 

--- a/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
+++ b/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
@@ -125,6 +125,7 @@ def test_set_buildspec_updates_buildspec_override():
 
     assert overrider.overrides["buildspec_override"] == expected_buildspec_override
 
+
 @pytest.mark.quick_checks
 @pytest.mark.model("N/A")
 @pytest.mark.integration("set_buildspec")

--- a/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
+++ b/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
@@ -145,29 +145,6 @@ def test_set_buildspec_invalid_path():
 @pytest.mark.quick_checks
 @pytest.mark.model("N/A")
 @pytest.mark.integration("set_buildspec")
-def test_set_buildspec_updates_buildspec_override():
-    overrider = prepare_dlc_dev_environment.TomlOverrider()
-
-    valid_buildspec_paths = [
-        "pytorch/training/buildspec-aws-graviton2.yml",
-        "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
-        "huggingface/training/buildspec-aws-depcanary.yml",
-    ]
-
-    overrider.set_buildspec(valid_buildspec_paths)
-
-    expected_buildspec_override = {
-        "dlc-pr-pytorch-training": "pytorch/training/buildspec-aws-graviton2.yml",
-        "dlc-pr-tensorflow-2-inference": "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
-        "dlc-pr-huggingface-training": "huggingface/training/buildspec-aws-depcanary.yml",
-    }
-
-    assert overrider.overrides["buildspec_override"] == expected_buildspec_override
-
-
-@pytest.mark.quick_checks
-@pytest.mark.model("N/A")
-@pytest.mark.integration("set_buildspec")
 def test_set_buildspec_updates_dev_mode():
     overrider = prepare_dlc_dev_environment.TomlOverrider()
 
@@ -179,30 +156,8 @@ def test_set_buildspec_updates_dev_mode():
 
     overrider.set_buildspec(valid_buildspec_paths)
 
-    # Only the first dev mode should be set to True
     assert overrider.overrides["dev"]["graviton_mode"] == True
-    assert overrider.overrides["dev"]["neuronx_mode"] == False
-    assert overrider.overrides["dev"]["deep_canary_mode"] == False
-
-    # Test case with only graviton buildspec path
-    overrider = prepare_dlc_dev_environment.TomlOverrider()
-    overrider.set_buildspec(["pytorch/training/buildspec-aws-graviton2.yml"])
-    assert overrider.overrides["dev"]["graviton_mode"] == True
-    assert overrider.overrides["dev"]["neuronx_mode"] == False
-    assert overrider.overrides["dev"]["deep_canary_mode"] == False
-
-    # Test case with only neuronx buildspec path
-    overrider = prepare_dlc_dev_environment.TomlOverrider()
-    overrider.set_buildspec(["tensorflow/inference/buildspec-aws-neuronx-py38.yml"])
-    assert overrider.overrides["dev"]["graviton_mode"] == False
     assert overrider.overrides["dev"]["neuronx_mode"] == True
-    assert overrider.overrides["dev"]["deep_canary_mode"] == False
-
-    # Test case with only deep canary buildspec path
-    overrider = prepare_dlc_dev_environment.TomlOverrider()
-    overrider.set_buildspec(["huggingface/training/buildspec-aws-depcanary.yml"])
-    assert overrider.overrides["dev"]["graviton_mode"] == False
-    assert overrider.overrides["dev"]["neuronx_mode"] == False
     assert overrider.overrides["dev"]["deep_canary_mode"] == True
 
 

--- a/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
+++ b/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
@@ -156,8 +156,30 @@ def test_set_buildspec_updates_dev_mode():
 
     overrider.set_buildspec(valid_buildspec_paths)
 
+    # Only the first dev mode should be set to True
     assert overrider.overrides["dev"]["graviton_mode"] == True
+    assert overrider.overrides["dev"]["neuronx_mode"] == False
+    assert overrider.overrides["dev"]["deep_canary_mode"] == False
+
+    # Test case with only graviton buildspec path
+    overrider = prepare_dlc_dev_environment.TomlOverrider()
+    overrider.set_buildspec(["pytorch/training/buildspec-aws-graviton2.yml"])
+    assert overrider.overrides["dev"]["graviton_mode"] == True
+    assert overrider.overrides["dev"]["neuronx_mode"] == False
+    assert overrider.overrides["dev"]["deep_canary_mode"] == False
+
+    # Test case with only neuronx buildspec path
+    overrider = prepare_dlc_dev_environment.TomlOverrider()
+    overrider.set_buildspec(["tensorflow/inference/buildspec-aws-neuronx-py38.yml"])
+    assert overrider.overrides["dev"]["graviton_mode"] == False
     assert overrider.overrides["dev"]["neuronx_mode"] == True
+    assert overrider.overrides["dev"]["deep_canary_mode"] == False
+
+    # Test case with only deep canary buildspec path
+    overrider = prepare_dlc_dev_environment.TomlOverrider()
+    overrider.set_buildspec(["huggingface/training/buildspec-aws-depcanary.yml"])
+    assert overrider.overrides["dev"]["graviton_mode"] == False
+    assert overrider.overrides["dev"]["neuronx_mode"] == False
     assert overrider.overrides["dev"]["deep_canary_mode"] == True
 
 

--- a/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
+++ b/test/dlc_tests/sanity/quick_checks/test_prepare_dev_env.py
@@ -118,9 +118,9 @@ def test_set_buildspec_updates_buildspec_override():
     overrider.set_buildspec(valid_buildspec_paths)
 
     expected_buildspec_override = {
-        "dlc-pr-pytorch-training": "pytorch/training/buildspec-aws-graviton2.yml",
-        "dlc-pr-tensorflow-2-neuronx-inference": "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
         "dlc-pr-huggingface-depcanary-training": "huggingface/training/buildspec-aws-depcanary.yml",
+        "dlc-pr-pytorch-graviton_mode-training": "pytorch/training/buildspec-aws-graviton2.yml",
+        "dlc-pr-tensorflow-2-neuronx_mode-inference": "tensorflow/inference/buildspec-aws-neuronx-py38.yml",
     }
 
     assert overrider.overrides["buildspec_override"] == expected_buildspec_override


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
- Add "--buildspecs" feature, which allows a user to enter a path of a buildspec file, infer the build job associated with the buildspec, and update this key to the user provided value.
- Continue to support the tests options
- Add new quick checks unit tests to test the functionality of the script

### Tests run
- Execute unit tests

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [x] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [x] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Fill out the template and click the checkbox of the builds you'd like to execute

*Note: Replace with <X.Y> with the major.minor framework version (i.e. 2.2) you would like to start.*

- [ ] build_pytorch_training_<X.Y>_sm
- [ ] build_pytorch_training_<X.Y>_ec2

- [ ] build_pytorch_inference_<X.Y>_sm
- [ ] build_pytorch_inference_<X.Y>_ec2
- [ ] build_pytorch_inference_<X.Y>_graviton

- [ ] build_tensorflow_training_<X.Y>_sm
- [ ] build_tensorflow_training_<X.Y>_ec2

- [ ] build_tensorflow_inference_<X.Y>_sm
- [ ] build_tensorflow_inference_<X.Y>_ec2
- [ ] build_tensorflow_inference_<X.Y>_graviton
</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
