### PR TITLE
HuggingFace PyTorch Training 2.1.0 GPU Test Fix

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -1,159 +1,74 @@
 [dev]
-# Set to "huggingface", for example, if you are a huggingface developer. Default is ""
 partner_developer = ""
-# Please only set it to true if you are preparing an EI related PR
-# Do remember to revert it back to false before merging any PR (including EI dedicated PR)
 ei_mode = false
-# Please only set it to true if you are preparing a NEURON related PR
-# Do remember to revert it back to false before merging any PR (including NEURON dedicated PR)
 neuron_mode = false
-# Please only set it to true if you are preparing a NEURONX related PR
-# Do remember to revert it back to false before merging any PR (including NEURONX dedicated PR)
 neuronx_mode = false
-# Please only set it to true if you are preparing a GRAVITON related PR
-# Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
 graviton_mode = false
-# Please only set it to True if you are preparing a HABANA related PR
-# Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false
-# Please only set it to True if you are preparing a HUGGINGFACE TRCOMP related PR
-# Do remember to revert it back to False before merging any PR (including HUGGINGFACE TRCOMP dedicated PR)
-# This mode is used to build TF 2.6 and PT1.11 DLC
 huggingface_trcomp_mode = false
-# Please only set it to True if you are preparing a TRCOMP related PR
-# Do remember to revert it back to False before merging any PR (including TRCOMP dedicated PR)
-# This mode is used to build PT1.12 and above DLC
 trcomp_mode = false
-# Set deep_canary_mode to true to simulate Deep Canary Test conditions on PR for all frameworks in the
-# build_frameworks list below. This will cause all image builds and non-deep-canary tests on the PR to be skipped,
-# regardless of whether they are enabled or disabled below.
-# Set graviton_mode to true to run Deep Canaries on Graviton images.
-# Do remember to revert it back to false before merging any PR.
 deep_canary_mode = false
 
 [build]
-# Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
-# available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
-
-# By default we build both training and inference containers. Set true/false values to determine which to build.
+build_frameworks = [ "huggingface_pytorch",]
 build_training = true
-build_inference = true
-
-# Set do_build to "false" to skip builds and test the latest image built by this PR
-# Note: at least one build is required to set do_build to "false"
+build_inference = false
 do_build = true
 
 [notify]
-### Notify on test failures
-### Off by default
 notify_test_failures = false
-  # Valid values: medium or high
-  notification_severity = "medium"
+notification_severity = "medium"
 
 [test]
-### On by default
 sanity_tests = true
-  safety_check_test = false
-  ecr_scan_allowlist_feature = false
+safety_check_test = false
+ecr_scan_allowlist_feature = false
 ecs_tests = true
 eks_tests = true
 ec2_tests = true
-# Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
-
-### Set ec2_tests_on_heavy_instances = true to be able to run any EC2 tests that use large/expensive instance types by
-### default. If false, these types of tests will be skipped while other tests will run as usual.
-### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
-### Off by default (set to false)
 ec2_tests_on_heavy_instances = false
-
-### SM specific tests
-### On by default
 sagemaker_local_tests = true
-
-# run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = true
-# run efa sagemaker tests
 sagemaker_efa_tests = false
-# run release_candidate_integration tests
 sagemaker_rc_tests = false
-# run sagemaker benchmark tests
 sagemaker_benchmark_tests = false
-
-# SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""
-
-# Run CI tests for nightly images
-# false by default
 nightly_pr_test_mode = false
-
 use_scheduler = false
 
 [buildspec_override]
-# Assign the path to the required buildspec file from the deep-learning-containers folder
-# For example:
-# dlc-pr-tensorflow-2-habana-training = "habana/tensorflow/training/buildspec-2-10.yml"
-# dlc-pr-pytorch-inference = "pytorch/inference/buildspec-1-12.yml"
-# Setting the buildspec file path to "" allows the image builder to choose the default buildspec file.
-
-### TRAINING PR JOBS ###
-
-# Standard Framework Training
 dlc-pr-mxnet-training = ""
 dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
-
-# HuggingFace Training
 dlc-pr-huggingface-tensorflow-training = ""
-dlc-pr-huggingface-pytorch-training = ""
-
-# Training Compiler
+dlc-pr-huggingface-pytorch-training = "huggingface/pytorch/training/buildspec.yml"
 dlc-pr-huggingface-pytorch-trcomp-training = ""
 dlc-pr-huggingface-tensorflow-2-trcomp-training = ""
 dlc-pr-pytorch-trcomp-training = ""
-
-# Neuron Training
 dlc-pr-mxnet-neuron-training = ""
 dlc-pr-pytorch-neuron-training = ""
 dlc-pr-tensorflow-2-neuron-training = ""
-
-# Stability AI Training
 dlc-pr-stabilityai-pytorch-training = ""
-
-# Habana Training
 dlc-pr-pytorch-habana-training = ""
 dlc-pr-tensorflow-2-habana-training = ""
-
-### INFERENCE PR JOBS ###
-
-# Standard Framework Inference
 dlc-pr-mxnet-inference = ""
 dlc-pr-pytorch-inference = ""
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
-
-# Neuron Inference
 dlc-pr-mxnet-neuron-inference = ""
 dlc-pr-pytorch-neuron-inference = ""
 dlc-pr-tensorflow-1-neuron-inference = ""
 dlc-pr-tensorflow-2-neuron-inference = ""
-
-# HuggingFace Inference
 dlc-pr-huggingface-tensorflow-inference = ""
 dlc-pr-huggingface-pytorch-inference = ""
 dlc-pr-huggingface-pytorch-neuron-inference = ""
-
-# Stability AI Inference
 dlc-pr-stabilityai-pytorch-inference = ""
-
-# Graviton Inference
 dlc-pr-mxnet-graviton-inference = ""
 dlc-pr-pytorch-graviton-inference = ""
 dlc-pr-tensorflow-2-graviton-inference = ""
-
-# EIA Inference
 dlc-pr-mxnet-eia-inference = ""
 dlc-pr-pytorch-eia-inference = ""
 dlc-pr-tensorflow-2-eia-inference = ""
+

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -1,74 +1,159 @@
 [dev]
+# Set to "huggingface", for example, if you are a huggingface developer. Default is ""
 partner_developer = ""
+# Please only set it to true if you are preparing an EI related PR
+# Do remember to revert it back to false before merging any PR (including EI dedicated PR)
 ei_mode = false
+# Please only set it to true if you are preparing a NEURON related PR
+# Do remember to revert it back to false before merging any PR (including NEURON dedicated PR)
 neuron_mode = false
+# Please only set it to true if you are preparing a NEURONX related PR
+# Do remember to revert it back to false before merging any PR (including NEURONX dedicated PR)
 neuronx_mode = false
+# Please only set it to true if you are preparing a GRAVITON related PR
+# Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
 graviton_mode = false
+# Please only set it to True if you are preparing a HABANA related PR
+# Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false
+# Please only set it to True if you are preparing a HUGGINGFACE TRCOMP related PR
+# Do remember to revert it back to False before merging any PR (including HUGGINGFACE TRCOMP dedicated PR)
+# This mode is used to build TF 2.6 and PT1.11 DLC
 huggingface_trcomp_mode = false
+# Please only set it to True if you are preparing a TRCOMP related PR
+# Do remember to revert it back to False before merging any PR (including TRCOMP dedicated PR)
+# This mode is used to build PT1.12 and above DLC
 trcomp_mode = false
+# Set deep_canary_mode to true to simulate Deep Canary Test conditions on PR for all frameworks in the
+# build_frameworks list below. This will cause all image builds and non-deep-canary tests on the PR to be skipped,
+# regardless of whether they are enabled or disabled below.
+# Set graviton_mode to true to run Deep Canaries on Graviton images.
+# Do remember to revert it back to false before merging any PR.
 deep_canary_mode = false
 
 [build]
-build_frameworks = [ "huggingface_pytorch",]
+# Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
+# available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
+build_frameworks = []
+
+# By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
+
+# Set do_build to "false" to skip builds and test the latest image built by this PR
+# Note: at least one build is required to set do_build to "false"
 do_build = true
 
 [notify]
+### Notify on test failures
+### Off by default
 notify_test_failures = false
-notification_severity = "medium"
+  # Valid values: medium or high
+  notification_severity = "medium"
 
 [test]
+### On by default
 sanity_tests = true
-safety_check_test = false
-ecr_scan_allowlist_feature = false
+  safety_check_test = false
+  ecr_scan_allowlist_feature = false
 ecs_tests = true
 eks_tests = true
 ec2_tests = true
+# Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
+
+### Set ec2_tests_on_heavy_instances = true to be able to run any EC2 tests that use large/expensive instance types by
+### default. If false, these types of tests will be skipped while other tests will run as usual.
+### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
+### Off by default (set to false)
 ec2_tests_on_heavy_instances = false
+
+### SM specific tests
+### On by default
 sagemaker_local_tests = true
+
+# run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = true
+# run efa sagemaker tests
 sagemaker_efa_tests = false
+# run release_candidate_integration tests
 sagemaker_rc_tests = false
+# run sagemaker benchmark tests
 sagemaker_benchmark_tests = false
+
+# SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""
+
+# Run CI tests for nightly images
+# false by default
 nightly_pr_test_mode = false
+
 use_scheduler = false
 
 [buildspec_override]
+# Assign the path to the required buildspec file from the deep-learning-containers folder
+# For example:
+# dlc-pr-tensorflow-2-habana-training = "habana/tensorflow/training/buildspec-2-10.yml"
+# dlc-pr-pytorch-inference = "pytorch/inference/buildspec-1-12.yml"
+# Setting the buildspec file path to "" allows the image builder to choose the default buildspec file.
+
+### TRAINING PR JOBS ###
+
+# Standard Framework Training
 dlc-pr-mxnet-training = ""
 dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
+
+# HuggingFace Training
 dlc-pr-huggingface-tensorflow-training = ""
-dlc-pr-huggingface-pytorch-training = "huggingface/pytorch/training/buildspec.yml"
+dlc-pr-huggingface-pytorch-training = ""
+
+# Training Compiler
 dlc-pr-huggingface-pytorch-trcomp-training = ""
 dlc-pr-huggingface-tensorflow-2-trcomp-training = ""
 dlc-pr-pytorch-trcomp-training = ""
+
+# Neuron Training
 dlc-pr-mxnet-neuron-training = ""
 dlc-pr-pytorch-neuron-training = ""
 dlc-pr-tensorflow-2-neuron-training = ""
+
+# Stability AI Training
 dlc-pr-stabilityai-pytorch-training = ""
+
+# Habana Training
 dlc-pr-pytorch-habana-training = ""
 dlc-pr-tensorflow-2-habana-training = ""
+
+### INFERENCE PR JOBS ###
+
+# Standard Framework Inference
 dlc-pr-mxnet-inference = ""
 dlc-pr-pytorch-inference = ""
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
+
+# Neuron Inference
 dlc-pr-mxnet-neuron-inference = ""
 dlc-pr-pytorch-neuron-inference = ""
 dlc-pr-tensorflow-1-neuron-inference = ""
 dlc-pr-tensorflow-2-neuron-inference = ""
+
+# HuggingFace Inference
 dlc-pr-huggingface-tensorflow-inference = ""
 dlc-pr-huggingface-pytorch-inference = ""
 dlc-pr-huggingface-pytorch-neuron-inference = ""
+
+# Stability AI Inference
 dlc-pr-stabilityai-pytorch-inference = ""
+
+# Graviton Inference
 dlc-pr-mxnet-graviton-inference = ""
 dlc-pr-pytorch-graviton-inference = ""
 dlc-pr-tensorflow-2-graviton-inference = ""
+
+# EIA Inference
 dlc-pr-mxnet-eia-inference = ""
 dlc-pr-pytorch-eia-inference = ""
 dlc-pr-tensorflow-2-eia-inference = ""
-

--- a/huggingface/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
+++ b/huggingface/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
@@ -31,7 +31,7 @@ RUN pip install --upgrade pip \
 
 # install Hugging Face libraries and its dependencies
 RUN pip install --no-cache-dir \
-	transformers[sklearn,sentencepiece,audio,vision]==${TRANSFORMERS_VERSION} \
+	transformers[sklearn,sentencepiece,audio,vision,pipelines]==${TRANSFORMERS_VERSION} \
 	datasets==${DATASETS_VERSION} \
 	diffusers==${DIFFUSERS_VERSION} \
 	Jinja2 \

--- a/huggingface/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
+++ b/huggingface/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
@@ -19,6 +19,8 @@ ARG FLASH_ATTN_VERSION=2.3.6
 ARG MULTIPROCESS_VERSION=0.70.16
 ARG DILL_VERSION=0.3.8
 ARG PYTHON=python3
+ARG SMD_MODEL_PARALLEL_URL=https://sagemaker-distributed-model-parallel.s3.us-west-2.amazonaws.com/pytorch-2.0.0/build-artifacts/2023-04-14-20-14/smdistributed_modelparallel-1.15.0-cp310-cp310-linux_x86_64.whl
+
 
 # TODO: Remove when the base image is updated
 RUN pip install --upgrade pip \
@@ -41,6 +43,9 @@ RUN pip install --no-cache-dir \
 	multiprocess==${MULTIPROCESS_VERSION} \
 	dill==${DILL_VERSION}
 
+# Install SM Distributed Modelparallel binary
+RUN pip install --no-cache-dir -U ${SMD_MODEL_PARALLEL_URL}
+
 RUN apt-get update \
  # TODO: Remove upgrade statements once packages are updated in base image
  && apt-get -y upgrade --only-upgrade systemd openssl cryptsetup \
@@ -56,3 +61,4 @@ RUN HOME_DIR=/root \
  && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
  && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
  && rm -rf ${HOME_DIR}/oss_compliance*
+

--- a/huggingface/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
+++ b/huggingface/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu
@@ -20,8 +20,6 @@ ARG MULTIPROCESS_VERSION=0.70.16
 ARG DILL_VERSION=0.3.8
 ARG NINJA_VERSION=1.11.1
 ARG PYTHON=python3
-ARG SMD_MODEL_PARALLEL_URL=https://sagemaker-distributed-model-parallel.s3.us-west-2.amazonaws.com/pytorch-2.0.0/build-artifacts/2023-04-14-20-14/smdistributed_modelparallel-1.15.0-cp310-cp310-linux_x86_64.whl
-
 
 # TODO: Remove when the base image is updated
 RUN pip install --upgrade pip \
@@ -45,9 +43,6 @@ RUN pip install --no-cache-dir \
 	multiprocess==${MULTIPROCESS_VERSION} \
 	dill==${DILL_VERSION} \
     ninja==${NINJA_VERSION}
-
-# Install SM Distributed Modelparallel binary
-RUN pip install --no-cache-dir -U ${SMD_MODEL_PARALLEL_URL}
 
 RUN apt-get update \
  # TODO: Remove upgrade statements once packages are updated in base image

--- a/huggingface/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu.os_scan_allowlist.json
+++ b/huggingface/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu.os_scan_allowlist.json
@@ -173,6 +173,35 @@
             "status": "ACTIVE",
             "title": "CVE-2024-36971 - linux",
             "reason_to_ignore": "N/A"
+        },
+        {
+            "description": " In the Linux kernel, the following vulnerability has been resolved: nilfs2: fix use-after-free of timer for log writer thread Patch series \"nilfs2: fix log writer related issues\". This bug fix series covers three nilfs2 log writer-related issues, including a timer use-after-free issue and potential deadlock issue on unmount, and a potential freeze issue in event synchronization found during their analysis. Details are described in each commit log. This patch (of 3): A use-after-free issue has been reported regarding the timer sc_timer on the nilfs_sc_info structure. The problem is that even though it is used to wake up a sleeping log writer thread, sc_timer is not shut down until the nilfs_sc_info structure is about to be freed, and is used regardless of the thread's lifetime. Fix this issue by limiting the use of sc_timer only while the log writer thread is alive.",
+            "vulnerability_id": "CVE-2024-38583",
+            "name": "CVE-2024-38583",
+            "package_name": "linux",
+            "package_details": {
+                "file_path": null,
+                "name": "linux",
+                "package_manager": "OS",
+                "version": "5.4.0",
+                "release": "190.210"
+            },
+            "remediation": {
+                "recommendation": {
+                "text": "None Provided"
+                }
+            },
+            "cvss_v3_score": 7.8,
+            "cvss_v30_score": 0,
+            "cvss_v31_score": 7.8,
+            "cvss_v2_score": 0,
+            "cvss_v3_severity": "HIGH",
+            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-38583.html",
+            "source": "UBUNTU_CVE",
+            "severity": "HIGH",
+            "status": "ACTIVE",
+            "title": "CVE-2024-38583 - linux",
+            "reason_to_ignore": "N/A"
         }
     ]
 }

--- a/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smdp.py
+++ b/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smdp.py
@@ -33,11 +33,6 @@ import re
 
 # configuration for running training on smdistributed Data Parallel
 distribution = {
-    "smdistributed": {
-        "dataparallel": {
-            "enabled": True,
-        }
-    },
     "torch_distributed": {
         "enabled": True,
     }

--- a/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smdp.py
+++ b/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smdp.py
@@ -32,7 +32,16 @@ import sagemaker
 import re
 
 # configuration for running training on smdistributed Data Parallel
-distribution = {"smdistributed": {"dataparallel": {"enabled": True}}}
+distribution = {
+    "smdistributed": {
+        "dataparallel": {
+            "enabled": True,
+        }
+    },
+    "torch_distributed": {
+        "enabled": True,
+    }
+}
 
 # hyperparameters, which are passed into the training job
 hyperparameters = {

--- a/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smdp.py
+++ b/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smdp.py
@@ -134,9 +134,7 @@ def _test_smdp_question_answering_function(
     )
 
     distribution = (
-        sm_distribution
-        if Version(transformers_version) < Version("4.6")
-        else torch_distribution
+        sm_distribution if Version(transformers_version) < Version("4.6") else torch_distribution
     )
 
     with timeout(minutes=DEFAULT_TIMEOUT):

--- a/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smdp.py
+++ b/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smdp.py
@@ -31,12 +31,14 @@ from ...integration.sagemaker.timeout import timeout
 import sagemaker
 import re
 
-# configuration for running training on smdistributed Data Parallel
-distribution = {
+# configurations for running training on smdistributed Data Parallel
+torch_distribution = {
     "torch_distributed": {
         "enabled": True,
     }
 }
+
+sm_distribution = {"smdistributed": {"dataparallel": {"enabled": True}}}
 
 # hyperparameters, which are passed into the training job
 hyperparameters = {
@@ -129,6 +131,12 @@ def _test_smdp_question_answering_function(
         "./examples/question-answering"
         if Version(transformers_version) < Version("4.6")
         else "./examples/pytorch/question-answering"
+    )
+
+    distribution = (
+        sm_distribution
+        if Version(transformers_version) < Version("4.6")
+        else torch_distribution
     )
 
     with timeout(minutes=DEFAULT_TIMEOUT):

--- a/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smmp.py
+++ b/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smmp.py
@@ -85,9 +85,7 @@ def can_run_modelparallel(ecr_image):
     framework_version = Version(image_framework_version)
     cuda_version = Version(image_cuda_version.strip("cu"))
 
-    return (Version("1.6") <= framework_version < Version("2.1")) and (
-        cuda_version == Version("110")
-    )
+    return (framework_version < Version("2.1")) and (cuda_version == Version("110"))
 
 
 @pytest.mark.processor("gpu")

--- a/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smmp.py
+++ b/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smmp.py
@@ -66,10 +66,12 @@ def get_transformers_version_from_image_uri(ecr_image):
         return transformers_version
     else:
         raise LookupError("HF transformers version not found in image URI")
-    
+
+
 def validate_or_skip_modelparallel(ecr_image):
     if not can_run_modelparallel(ecr_image):
         pytest.skip("Model Parallelism is supported on CUDA 11 with PyTorch v1.6 to v2.0")
+
 
 def can_run_modelparallel(ecr_image):
     image_framework, image_framework_version = get_framework_and_version_from_tag(ecr_image)
@@ -83,7 +85,9 @@ def can_run_modelparallel(ecr_image):
     framework_version = Version(image_framework_version)
     cuda_version = Version(image_cuda_version.strip("cu"))
 
-    return (Version("1.6") <= framework_version < Version("2.1")) and (cuda_version == Version("110"))
+    return (Version("1.6") <= framework_version < Version("2.1")) and (
+        cuda_version == Version("110")
+    )
 
 
 @pytest.mark.processor("gpu")

--- a/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smmp.py
+++ b/test/sagemaker_tests/huggingface_pytorch/training/integration/sagemaker/test_smmp.py
@@ -70,7 +70,7 @@ def get_transformers_version_from_image_uri(ecr_image):
 
 def validate_or_skip_modelparallel(ecr_image):
     if not can_run_modelparallel(ecr_image):
-        pytest.skip("Model Parallelism is supported on CUDA 11 with PyTorch v1.6 to v2.0")
+        pytest.skip("Model Parallelism is supported on CUDA 11 with PyTorch < v2.0")
 
 
 def can_run_modelparallel(ecr_image):


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

* HF PT tests failing in release pipeline due to ModuleNotFound for smprocessing.modelparallel (SMMP). After syncing with the SMMP team, I learned the following:
   * SMP v1 is supported only on PyTorch <2.0 and CUDA 11.
   * SMP v2 will work on PyTorch 2.1 and CUDA 12, but this version of SMP is used specifically on SMP distributed containers (not DLC), and therefore do not require coverage in this repo.
* Despite a lengthly investigation, I cannot confirm why these tests were passing 5 months ago.
*  HF PT tests for smprocessing.dataparallelprocessing were also failing with `RuntimeError: SMDDP does not support: _allgather_base` in the script. Following an investigation and a meeting with the SMDDB oncall, I was able to rootcause this and update the test.
   * Switching to `torch_distribution` from `sm_distribution`. These are both libraries providing the building blocks for distributed training. `torch_distribution` is essentially more generic while `sm_distribution` is tailored for SageMaker aplpications. `torch_distribution` however, supports `all_gather` while `sm_distribution` does not.

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

<details>
<summary>Confused on how to run tests? Try using the helper utility...</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...
  
- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`
</details>

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Fill out the template and click the checkbox of the builds you'd like to execute

*Note: Replace with <X.Y> with the major.minor framework version (i.e. 2.2) you would like to start.*

- [ ] build_pytorch_training_<X.Y>_sm
- [ ] build_pytorch_training_<X.Y>_ec2

- [ ] build_pytorch_inference_<X.Y>_sm
- [ ] build_pytorch_inference_<X.Y>_ec2
- [ ] build_pytorch_inference_<X.Y>_graviton

- [ ] build_tensorflow_training_<X.Y>_sm
- [ ] build_tensorflow_training_<X.Y>_ec2

- [ ] build_tensorflow_inference_<X.Y>_sm
- [ ] build_tensorflow_inference_<X.Y>_ec2
- [ ] build_tensorflow_inference_<X.Y>_graviton
</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
