### PR TITLE
fix: Fix neuronx buildRC pipeline sanity check failure

### DIFF
--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -494,7 +494,7 @@ def test_framework_and_neuron_sdk_version(neuron):
         # temporary hack because transformers_neuronx reports its version as 0.6.x
         if package_name == "transformers-neuronx":
             version_list = [
-                ".".join(entry.split(".")[:-2]) + ".x" for entry in release_manifest[package_name]
+                ".".join(entry.split(".")[:2]) + ".x" for entry in release_manifest[package_name]
             ]
         assert installed_framework_version in version_list, (
             f"framework {framework} version {installed_framework_version} "


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
- Sanity check test is failing in the BuildRC pipeline, blocking the vulnerability resolution patch for one of the neuronx image container 
- the reason is the code expect transformers-neuronx to have 4 components in the version number, like the more recent ones ("name":"transformers-neuronx","version":"0.10.0.21") but version 0.9 still uses the old 3 components versioning ("name":"transformers-neuronx","version":"0.9.474")
- Updating the logic to create version_list to deal with this situation so that it would do 'keep first 2 version components (major/minor) and append x instead of removing last 2 version components
```
neuron = '669063966089.dkr.ecr.us-west-2.amazonaws.com/beta-huggingface-pytorch-inference:1.13.1-transformers4.36.2-neuronx-py310-sdk2.16.1-ubuntu20.04-2024-08-08-19-37-04'
    @pytest.mark.usefixtures("sagemaker", "huggingface")
    @pytest.mark.model("N/A")
    def test_framework_and_neuron_sdk_version(neuron):
        """
        Gets the neuron sdk tag from the image. For that neuron sdk and the frame work version from
        the image, it gets the expected frame work version. Then checks that the expected framework version
        same as the one on a running container.
        This function test only Neuron images.
    
        :param image: ECR image URI
        """
        image = neuron
    
        tested_framework, tag_framework_version = get_framework_and_version_from_tag(image)
        neuron_sdk_version = get_neuron_sdk_version_from_tag(image)
    
        assert neuron_sdk_version is not None, "missing Neuron SDK version"
    
        release_manifest = None
        if tested_framework == "tensorflow" and tag_framework_version == "1.15.5":
            release_manifest = get_neuron_release_manifest(
                "2.12.2"
            )  # last release where tf 1.15 has been listed
        else:
            release_manifest = get_neuron_release_manifest(neuron_sdk_version)
    
        # Framework name may include huggingface
        if tested_framework.startswith("huggingface_"):
            tested_framework = tested_framework[len("huggingface_") :]
    
        package_names = {}  # maps a package name to a framework name
        if tested_framework == "pytorch":
            if "training" in image or "neuronx" in image:
                package_names = {"torch-neuronx": "torch_neuronx"}
                # transformers is only available for the inference image
                if "training" not in image:
                    package_names["transformers-neuronx"] = "transformers_neuronx"
            else:
                package_names = {"torch-neuron": "torch_neuron"}
        elif tested_framework == "tensorflow":
            if "neuronx" in image:
                package_names = {"tensorflow-neuronx": "tensorflow_neuronx"}
            else:
                package_names = {"tensorflow-neuron": "tensorflow_neuron"}
        elif tested_framework == "mxnet":
            package_names = {"mxnet_neuron": "mxnet"}
    
        container_name = None
        ctx = None
    
        for package_name, framework in package_names.items():
            assert (
                package_name in release_manifest
            ), f"release_manifest does not contain package {package_name}:\n {json.dumps(release_manifest)}"
    
            if not container_name:
                container_name = get_container_name("framework-version-neuron", image)
                ctx = Context()
                start_container(container_name, image, ctx)
    
            output = run_cmd_on_container(
                container_name,
                ctx,
                f"import {framework}; print({framework}.__version__)",
                executable="python",
            )
    
            installed_framework_version = output.stdout.strip()
            version_list = release_manifest[package_name]
            # temporary hack because transformers_neuronx reports its version as 0.6.x
            if package_name == "transformers-neuronx":
                version_list = [
                    ".".join(entry.split(".")[:-2]) + ".x" for entry in release_manifest[package_name]
                ]
>           assert installed_framework_version in version_list, (
                f"framework {framework} version {installed_framework_version} "
                f"not found in released versions for that package: {version_list}"
            )
E           AssertionError: framework transformers_neuronx version 0.9.x not found in released versions for that package: ['0.x']
E           assert '0.9.x' in ['0.x']
```

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

<details>
<summary>Confused on how to run tests? Try using the helper utility...</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...
  
- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`
</details>

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Fill out the template and click the checkbox of the builds you'd like to execute

*Note: Replace with <X.Y> with the major.minor framework version (i.e. 2.2) you would like to start.*

- [ ] build_pytorch_training_<X.Y>_sm
- [ ] build_pytorch_training_<X.Y>_ec2

- [ ] build_pytorch_inference_<X.Y>_sm
- [ ] build_pytorch_inference_<X.Y>_ec2
- [ ] build_pytorch_inference_<X.Y>_graviton

- [ ] build_tensorflow_training_<X.Y>_sm
- [ ] build_tensorflow_training_<X.Y>_ec2

- [ ] build_tensorflow_inference_<X.Y>_sm
- [ ] build_tensorflow_inference_<X.Y>_ec2
- [ ] build_tensorflow_inference_<X.Y>_graviton
</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
