### PR TITLE
Shorten initiator name for HF builds

### DIFF
--- a/src/image_builder.py
+++ b/src/image_builder.py
@@ -630,7 +630,9 @@ def tag_image_with_initiator(image_tag):
     """
     Add additional debug tags
     """
-    return f"{image_tag}-{os.getenv('CODEBUILD_INITIATOR', '').split('/')[-1]}-{os.getenv('CODEBUILD_RESOLVED_SOURCE_VERSION', '')[:7]}"
+    # Shorten huggingface name to avoid breaching 128 char tag limit
+    initiator = os.getenv("CODEBUILD_INITIATOR", "").split("/")[-1].replace("huggingface", "hf")
+    return f"{image_tag}-{initiator}-{os.getenv('CODEBUILD_RESOLVED_SOURCE_VERSION', '')[:7]}"
 
 
 def append_tag(image_tag, append_str):


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
- Shorten huggingface in initiator to circumvent breaching long tag names

#### Builds to Execute
<details>
<summary>Expand</summary>

Fill out the template and click the checkbox of the builds you'd like to execute

*Note: Replace with <X.Y> with the major.minor framework version (i.e. 2.2) you would like to start.*

- [ ] build_pytorch_training_<X.Y>_sm
- [ ] build_pytorch_training_<X.Y>_ec2

- [x] build_huggingface-pytorch_inference_latest_neuronx
- [ ] build_pytorch_inference_<X.Y>_ec2
- [ ] build_pytorch_inference_<X.Y>_graviton

- [ ] build_tensorflow_training_<X.Y>_sm
- [ ] build_tensorflow_training_<X.Y>_ec2

- [ ] build_tensorflow_inference_<X.Y>_sm
- [ ] build_tensorflow_inference_<X.Y>_ec2
- [ ] build_tensorflow_inference_<X.Y>_graviton
</details>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
