### PR TITLE
 Update autopatch storage account in ecr test 

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -1,74 +1,159 @@
 [dev]
+# Set to "huggingface", for example, if you are a huggingface developer. Default is ""
 partner_developer = ""
+# Please only set it to true if you are preparing an EI related PR
+# Do remember to revert it back to false before merging any PR (including EI dedicated PR)
 ei_mode = false
+# Please only set it to true if you are preparing a NEURON related PR
+# Do remember to revert it back to false before merging any PR (including NEURON dedicated PR)
 neuron_mode = false
+# Please only set it to true if you are preparing a NEURONX related PR
+# Do remember to revert it back to false before merging any PR (including NEURONX dedicated PR)
 neuronx_mode = false
-graviton_mode = true
+# Please only set it to true if you are preparing a GRAVITON related PR
+# Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
+graviton_mode = false
+# Please only set it to True if you are preparing a HABANA related PR
+# Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
 habana_mode = false
+# Please only set it to True if you are preparing a HUGGINGFACE TRCOMP related PR
+# Do remember to revert it back to False before merging any PR (including HUGGINGFACE TRCOMP dedicated PR)
+# This mode is used to build TF 2.6 and PT1.11 DLC
 huggingface_trcomp_mode = false
+# Please only set it to True if you are preparing a TRCOMP related PR
+# Do remember to revert it back to False before merging any PR (including TRCOMP dedicated PR)
+# This mode is used to build PT1.12 and above DLC
 trcomp_mode = false
+# Set deep_canary_mode to true to simulate Deep Canary Test conditions on PR for all frameworks in the
+# build_frameworks list below. This will cause all image builds and non-deep-canary tests on the PR to be skipped,
+# regardless of whether they are enabled or disabled below.
+# Set graviton_mode to true to run Deep Canaries on Graviton images.
+# Do remember to revert it back to false before merging any PR.
 deep_canary_mode = false
 
 [build]
-build_frameworks = [ "pytorch",]
-build_training = false
+# Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
+# available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
+build_frameworks = []
+
+# By default we build both training and inference containers. Set true/false values to determine which to build.
+build_training = true
 build_inference = true
+
+# Set do_build to "false" to skip builds and test the latest image built by this PR
+# Note: at least one build is required to set do_build to "false"
 do_build = true
 
 [notify]
+### Notify on test failures
+### Off by default
 notify_test_failures = false
-notification_severity = "medium"
+  # Valid values: medium or high
+  notification_severity = "medium"
 
 [test]
+### On by default
 sanity_tests = true
-safety_check_test = false
-ecr_scan_allowlist_feature = false
+  safety_check_test = false
+  ecr_scan_allowlist_feature = false
 ecs_tests = true
 eks_tests = true
 ec2_tests = true
+# Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
+
+### Set ec2_tests_on_heavy_instances = true to be able to run any EC2 tests that use large/expensive instance types by
+### default. If false, these types of tests will be skipped while other tests will run as usual.
+### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
+### Off by default (set to false)
 ec2_tests_on_heavy_instances = false
+
+### SM specific tests
+### On by default
 sagemaker_local_tests = true
+
+# run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = true
+# run efa sagemaker tests
 sagemaker_efa_tests = false
+# run release_candidate_integration tests
 sagemaker_rc_tests = false
+# run sagemaker benchmark tests
 sagemaker_benchmark_tests = false
+
+# SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""
+
+# Run CI tests for nightly images
+# false by default
 nightly_pr_test_mode = false
+
 use_scheduler = false
 
 [buildspec_override]
+# Assign the path to the required buildspec file from the deep-learning-containers folder
+# For example:
+# dlc-pr-tensorflow-2-habana-training = "habana/tensorflow/training/buildspec-2-10.yml"
+# dlc-pr-pytorch-inference = "pytorch/inference/buildspec-1-12.yml"
+# Setting the buildspec file path to "" allows the image builder to choose the default buildspec file.
+
+### TRAINING PR JOBS ###
+
+# Standard Framework Training
 dlc-pr-mxnet-training = ""
 dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
+
+# HuggingFace Training
 dlc-pr-huggingface-tensorflow-training = ""
 dlc-pr-huggingface-pytorch-training = ""
+
+# Training Compiler
 dlc-pr-huggingface-pytorch-trcomp-training = ""
 dlc-pr-huggingface-tensorflow-2-trcomp-training = ""
 dlc-pr-pytorch-trcomp-training = ""
+
+# Neuron Training
 dlc-pr-mxnet-neuron-training = ""
 dlc-pr-pytorch-neuron-training = ""
 dlc-pr-tensorflow-2-neuron-training = ""
+
+# Stability AI Training
 dlc-pr-stabilityai-pytorch-training = ""
+
+# Habana Training
 dlc-pr-pytorch-habana-training = ""
 dlc-pr-tensorflow-2-habana-training = ""
+
+### INFERENCE PR JOBS ###
+
+# Standard Framework Inference
 dlc-pr-mxnet-inference = ""
 dlc-pr-pytorch-inference = ""
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
+
+# Neuron Inference
 dlc-pr-mxnet-neuron-inference = ""
 dlc-pr-pytorch-neuron-inference = ""
 dlc-pr-tensorflow-1-neuron-inference = ""
 dlc-pr-tensorflow-2-neuron-inference = ""
+
+# HuggingFace Inference
 dlc-pr-huggingface-tensorflow-inference = ""
 dlc-pr-huggingface-pytorch-inference = ""
 dlc-pr-huggingface-pytorch-neuron-inference = ""
+
+# Stability AI Inference
 dlc-pr-stabilityai-pytorch-inference = ""
+
+# Graviton Inference
 dlc-pr-mxnet-graviton-inference = ""
-dlc-pr-pytorch-graviton-inference = "pytorch/inference/buildspec-graviton-2-3.yml"
+dlc-pr-pytorch-graviton-inference = ""
 dlc-pr-tensorflow-2-graviton-inference = ""
+
+# EIA Inference
 dlc-pr-mxnet-eia-inference = ""
 dlc-pr-pytorch-eia-inference = ""
 dlc-pr-tensorflow-2-eia-inference = ""
-

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -1,159 +1,74 @@
 [dev]
-# Set to "huggingface", for example, if you are a huggingface developer. Default is ""
 partner_developer = ""
-# Please only set it to true if you are preparing an EI related PR
-# Do remember to revert it back to false before merging any PR (including EI dedicated PR)
 ei_mode = false
-# Please only set it to true if you are preparing a NEURON related PR
-# Do remember to revert it back to false before merging any PR (including NEURON dedicated PR)
 neuron_mode = false
-# Please only set it to true if you are preparing a NEURONX related PR
-# Do remember to revert it back to false before merging any PR (including NEURONX dedicated PR)
 neuronx_mode = false
-# Please only set it to true if you are preparing a GRAVITON related PR
-# Do remember to revert it back to false before merging any PR (including GRAVITON dedicated PR)
-graviton_mode = false
-# Please only set it to True if you are preparing a HABANA related PR
-# Do remember to revert it back to False before merging any PR (including HABANA dedicated PR)
+graviton_mode = true
 habana_mode = false
-# Please only set it to True if you are preparing a HUGGINGFACE TRCOMP related PR
-# Do remember to revert it back to False before merging any PR (including HUGGINGFACE TRCOMP dedicated PR)
-# This mode is used to build TF 2.6 and PT1.11 DLC
 huggingface_trcomp_mode = false
-# Please only set it to True if you are preparing a TRCOMP related PR
-# Do remember to revert it back to False before merging any PR (including TRCOMP dedicated PR)
-# This mode is used to build PT1.12 and above DLC
 trcomp_mode = false
-# Set deep_canary_mode to true to simulate Deep Canary Test conditions on PR for all frameworks in the
-# build_frameworks list below. This will cause all image builds and non-deep-canary tests on the PR to be skipped,
-# regardless of whether they are enabled or disabled below.
-# Set graviton_mode to true to run Deep Canaries on Graviton images.
-# Do remember to revert it back to false before merging any PR.
 deep_canary_mode = false
 
 [build]
-# Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
-# available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
-
-# By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
+build_frameworks = [ "pytorch",]
+build_training = false
 build_inference = true
-
-# Set do_build to "false" to skip builds and test the latest image built by this PR
-# Note: at least one build is required to set do_build to "false"
 do_build = true
 
 [notify]
-### Notify on test failures
-### Off by default
 notify_test_failures = false
-  # Valid values: medium or high
-  notification_severity = "medium"
+notification_severity = "medium"
 
 [test]
-### On by default
 sanity_tests = true
-  safety_check_test = false
-  ecr_scan_allowlist_feature = false
+safety_check_test = false
+ecr_scan_allowlist_feature = false
 ecs_tests = true
 eks_tests = true
 ec2_tests = true
-# Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
-
-### Set ec2_tests_on_heavy_instances = true to be able to run any EC2 tests that use large/expensive instance types by
-### default. If false, these types of tests will be skipped while other tests will run as usual.
-### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
-### Off by default (set to false)
 ec2_tests_on_heavy_instances = false
-
-### SM specific tests
-### On by default
 sagemaker_local_tests = true
-
-# run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = true
-# run efa sagemaker tests
 sagemaker_efa_tests = false
-# run release_candidate_integration tests
 sagemaker_rc_tests = false
-# run sagemaker benchmark tests
 sagemaker_benchmark_tests = false
-
-# SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""
-
-# Run CI tests for nightly images
-# false by default
 nightly_pr_test_mode = false
-
 use_scheduler = false
 
 [buildspec_override]
-# Assign the path to the required buildspec file from the deep-learning-containers folder
-# For example:
-# dlc-pr-tensorflow-2-habana-training = "habana/tensorflow/training/buildspec-2-10.yml"
-# dlc-pr-pytorch-inference = "pytorch/inference/buildspec-1-12.yml"
-# Setting the buildspec file path to "" allows the image builder to choose the default buildspec file.
-
-### TRAINING PR JOBS ###
-
-# Standard Framework Training
 dlc-pr-mxnet-training = ""
 dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
-
-# HuggingFace Training
 dlc-pr-huggingface-tensorflow-training = ""
 dlc-pr-huggingface-pytorch-training = ""
-
-# Training Compiler
 dlc-pr-huggingface-pytorch-trcomp-training = ""
 dlc-pr-huggingface-tensorflow-2-trcomp-training = ""
 dlc-pr-pytorch-trcomp-training = ""
-
-# Neuron Training
 dlc-pr-mxnet-neuron-training = ""
 dlc-pr-pytorch-neuron-training = ""
 dlc-pr-tensorflow-2-neuron-training = ""
-
-# Stability AI Training
 dlc-pr-stabilityai-pytorch-training = ""
-
-# Habana Training
 dlc-pr-pytorch-habana-training = ""
 dlc-pr-tensorflow-2-habana-training = ""
-
-### INFERENCE PR JOBS ###
-
-# Standard Framework Inference
 dlc-pr-mxnet-inference = ""
 dlc-pr-pytorch-inference = ""
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
-
-# Neuron Inference
 dlc-pr-mxnet-neuron-inference = ""
 dlc-pr-pytorch-neuron-inference = ""
 dlc-pr-tensorflow-1-neuron-inference = ""
 dlc-pr-tensorflow-2-neuron-inference = ""
-
-# HuggingFace Inference
 dlc-pr-huggingface-tensorflow-inference = ""
 dlc-pr-huggingface-pytorch-inference = ""
 dlc-pr-huggingface-pytorch-neuron-inference = ""
-
-# Stability AI Inference
 dlc-pr-stabilityai-pytorch-inference = ""
-
-# Graviton Inference
 dlc-pr-mxnet-graviton-inference = ""
-dlc-pr-pytorch-graviton-inference = ""
+dlc-pr-pytorch-graviton-inference = "pytorch/inference/buildspec-graviton-2-3.yml"
 dlc-pr-tensorflow-2-graviton-inference = ""
-
-# EIA Inference
 dlc-pr-mxnet-eia-inference = ""
 dlc-pr-pytorch-eia-inference = ""
 dlc-pr-tensorflow-2-eia-inference = ""
+

--- a/test/dlc_tests/sanity/test_ecr_scan.py
+++ b/test/dlc_tests/sanity/test_ecr_scan.py
@@ -102,7 +102,9 @@ def upload_json_to_image_data_storage_s3_bucket(
     )
     s3_resource = boto3.resource("s3")
     sts_client = boto3.client("sts")
-    account_id = sts_client.get_caller_identity().get("Account")
+    account_id = os.getenv("AUTOPATCH_STORAGE_ACCOUNT") or sts_client.get_caller_identity().get(
+        "Account"
+    )
     for to_upload in upload_list:
         s3_filepath = f"{image_sha}/{to_upload['s3_filename']}"
         upload_data = json.dumps(


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
- If available, read value from env variable
- This code is used in both sanity test and build - though a bit unconventional as it involves importing a test module into src; looks like the workaround was to use lazy imports (https://github.com/aws/deep-learning-containers/blob/ac36c40c7fa9a3a0c2b7c4a5b09b25a3cf9931a5/src/patch_helper.py#L78)

### Testing
- [x] Running builds/sanity test for pt graviton in ([705e5cb](https://github.com/aws/deep-learning-containers/pull/4236/commits/705e5cb2a27913e4e631fe510ca88224e9f28683)) to ensure no regression in existing process

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
