### PR TITLE
[Fix] Make is_huggingface_image env variable agnostic

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -34,10 +34,10 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
+build_training = false
 build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
@@ -56,9 +56,9 @@ notify_test_failures = false
 sanity_tests = true
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = true
-eks_tests = true
-ec2_tests = true
+ecs_tests = false
+eks_tests = false
+ec2_tests = false
 # Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
 
@@ -70,10 +70,10 @@ ec2_tests_on_heavy_instances = false
 
 ### SM specific tests
 ### On by default
-sagemaker_local_tests = true
+sagemaker_local_tests = false
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = true
+sagemaker_remote_tests = false
 # run efa sagemaker tests
 sagemaker_efa_tests = false
 # run release_candidate_integration tests
@@ -130,7 +130,7 @@ dlc-pr-tensorflow-2-habana-training = ""
 
 # Standard Framework Inference
 dlc-pr-mxnet-inference = ""
-dlc-pr-pytorch-inference = ""
+dlc-pr-pytorch-inference = "pytorch/inference/buildspec-2-3-sm.yml"
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
 

--- a/pytorch/inference/buildspec-2-3-sm.yml
+++ b/pytorch/inference/buildspec-2-3-sm.yml
@@ -44,7 +44,7 @@ images:
     tool_kit_version: &SM_TOOLKIT_VERSION 2.0.24
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
     latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-    # build_tag_override: "beta:2.3.0-cpu-py311-ubuntu20.04-sagemaker"
+    build_tag_override: "beta:2.3.0-cpu-py311-ubuntu20.04-sagemaker"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
     target: sagemaker
     context:
@@ -62,7 +62,7 @@ images:
     tool_kit_version: &SM_TOOLKIT_VERSION 2.0.24
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
     latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-    # build_tag_override: "beta:2.3.0-gpu-py311-cu121-ubuntu20.04-sagemaker"
+    build_tag_override: "beta:2.3.0-gpu-py311-cu121-ubuntu20.04-sagemaker"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
                          *DEVICE_TYPE ]
     target: sagemaker

--- a/test/dlc_tests/sanity/test_telemetry.py
+++ b/test/dlc_tests/sanity/test_telemetry.py
@@ -9,6 +9,7 @@ from packaging.version import Version
 from packaging.specifiers import SpecifierSet
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("sagemaker", "huggingface")
 @pytest.mark.model("N/A")
@@ -23,6 +24,7 @@ def test_telemetry_instance_tag_failure_gpu(
     _run_tag_failure_IMDSv2_disabled_as_hop_limit_1(gpu, ec2_client, ec2_instance, ec2_connection)
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("sagemaker", "huggingface")
 @pytest.mark.model("N/A")
@@ -37,6 +39,7 @@ def test_telemetry_instance_tag_failure_cpu(
     _run_tag_failure_IMDSv2_disabled_as_hop_limit_1(cpu, ec2_client, ec2_instance, ec2_connection)
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("sagemaker")
 @pytest.mark.model("N/A")
@@ -55,6 +58,7 @@ def test_telemetry_instance_tag_failure_graviton_gpu(
     _run_tag_failure_IMDSv2_disabled_as_hop_limit_1(gpu, ec2_client, ec2_instance, ec2_connection)
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("sagemaker")
 @pytest.mark.model("N/A")
@@ -73,6 +77,7 @@ def test_telemetry_instance_tag_failure_graviton_cpu(
     _run_tag_failure_IMDSv2_disabled_as_hop_limit_1(cpu, ec2_client, ec2_instance, ec2_connection)
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("sagemaker")
 @pytest.mark.model("N/A")
@@ -88,6 +93,7 @@ def test_telemetry_instance_tag_failure_neuron(neuron, ec2_client, ec2_instance,
     )
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("feature_aws_framework_present")
 @pytest.mark.usefixtures("sagemaker")
@@ -110,6 +116,7 @@ def test_telemetry_instance_tag_success_gpu(
     _run_tag_success_IMDSv2_hop_limit_2(gpu, ec2_client, ec2_instance, ec2_connection)
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("feature_aws_framework_present")
 @pytest.mark.usefixtures("sagemaker")
@@ -132,6 +139,7 @@ def test_telemetry_instance_tag_success_cpu(
     _run_tag_success_IMDSv2_hop_limit_2(cpu, ec2_client, ec2_instance, ec2_connection)
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("sagemaker")
 @pytest.mark.model("N/A")
@@ -147,6 +155,7 @@ def test_telemetry_instance_tag_success_graviton_gpu(
     _run_tag_success_IMDSv2_hop_limit_2(gpu, ec2_client, ec2_instance, ec2_connection)
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("sagemaker")
 @pytest.mark.model("N/A")
@@ -162,6 +171,7 @@ def test_telemetry_instance_tag_success_graviton_cpu(
     _run_tag_success_IMDSv2_hop_limit_2(cpu, ec2_client, ec2_instance, ec2_connection)
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("sagemaker")
 @pytest.mark.model("N/A")
@@ -177,6 +187,7 @@ def test_telemetry_instance_tag_success_neuron(
     _run_tag_success_IMDSv2_hop_limit_2(neuron, ec2_client, ec2_instance, ec2_connection)
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("feature_aws_framework_present")
 @pytest.mark.usefixtures("sagemaker")
@@ -197,6 +208,7 @@ def test_telemetry_s3_query_bucket_success_gpu(
     _run_s3_query_bucket_success(gpu, ec2_client, ec2_instance, ec2_connection)
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("feature_aws_framework_present")
 @pytest.mark.usefixtures("sagemaker")
@@ -218,6 +230,7 @@ def test_telemetry_s3_query_bucket_success_cpu(
     _run_s3_query_bucket_success(cpu, ec2_client, ec2_instance, ec2_connection)
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("sagemaker")
 @pytest.mark.model("N/A")
@@ -232,6 +245,7 @@ def test_telemetry_s3_query_bucket_success_graviton_gpu(
     _run_s3_query_bucket_success(gpu, ec2_client, ec2_instance, ec2_connection)
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("sagemaker")
 @pytest.mark.model("N/A")
@@ -246,6 +260,7 @@ def test_telemetry_s3_query_bucket_success_graviton_cpu(
     _run_s3_query_bucket_success(cpu, ec2_client, ec2_instance, ec2_connection)
 
 
+@pytest.mark.skip("temp")
 @pytest.mark.flaky(reruns=2)
 @pytest.mark.usefixtures("sagemaker")
 @pytest.mark.model("N/A")

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -738,10 +738,6 @@ def is_rc_test_context():
     return config.is_sm_rc_test_enabled()
 
 
-def is_huggingface_image():
-    return os.getenv("FRAMEWORK_BUILD_SPEC_FILE").startswith("huggingface")
-
-
 def is_covered_by_ec2_sm_split(image_uri):
     ec2_sm_split_images = {
         "pytorch": SpecifierSet(">=1.10.0"),
@@ -773,10 +769,6 @@ def is_ec2_image(image_uri):
 
 def is_sagemaker_image(image_uri):
     return "-sagemaker" in image_uri
-
-
-def is_trcomp_image(image_uri):
-    return "-trcomp" in image_uri
 
 
 def is_time_for_canary_safety_scan():
@@ -1843,6 +1835,11 @@ def get_framework_from_image_uri(image_uri):
 def is_trcomp_image(image_uri):
     framework = get_framework_from_image_uri(image_uri)
     return "trcomp" in framework
+
+
+def is_huggingface_image(image_uri):
+    framework = get_framework_from_image_uri(image_uri)
+    return "huggingface" in framework
 
 
 def get_all_the_tags_of_an_image_from_ecr(ecr_client, image_uri):


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
- `is_huggingface_image` function from https://github.com/aws/deep-learning-containers/pull/4287 fails in RC Pipeline but passes in PR job due to difference in environment variable between the two jobs. This function leverages the same logic as `is_trcomp_image` to check whether an image is huggingface based on `image_uri`.
- This PR also removes duplicate `is_trcomp_image` function.

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

<details>
<summary>Confused on how to run tests? Try using the helper utility...</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...
  
- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`
</details>

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Fill out the template and click the checkbox of the builds you'd like to execute

*Note: Replace with <X.Y> with the major.minor framework version (i.e. 2.2) you would like to start.*

- [ ] build_pytorch_training_<X.Y>_sm
- [ ] build_pytorch_training_<X.Y>_ec2

- [ ] build_pytorch_inference_<X.Y>_sm
- [ ] build_pytorch_inference_<X.Y>_ec2
- [ ] build_pytorch_inference_<X.Y>_graviton

- [ ] build_tensorflow_training_<X.Y>_sm
- [ ] build_tensorflow_training_<X.Y>_ec2

- [ ] build_tensorflow_inference_<X.Y>_sm
- [ ] build_tensorflow_inference_<X.Y>_ec2
- [ ] build_tensorflow_inference_<X.Y>_graviton
</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
