### PR TITLE
Fix builds that do not have buildspec env

### DIFF
--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -739,6 +739,8 @@ def is_rc_test_context():
 
 
 def is_huggingface_image():
+    if not os.getenv("FRAMEWORK_BUILDSPEC_FILE"):
+        return False
     return os.getenv("FRAMEWORK_BUILDSPEC_FILE").startswith("huggingface")
 
 


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
Fix HF utility function - if env is not present, assume false

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
