### PR TITLE
fix: pt 2.1 training scan allowlist

### DIFF
--- a/huggingface/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu.os_scan_allowlist.json
+++ b/huggingface/pytorch/training/docker/2.1/py3/cu121/Dockerfile.gpu.os_scan_allowlist.json
@@ -1,354 +1,6 @@
 {
     "linux": [
         {
-            "description": " In the Linux kernel, the following vulnerability has been resolved:  jfs: xattr: fix buffer overflow for invalid xattr  When an xattr size is not what is expected, it is printed out to the kernel log in hex format as a form of debugging.  But when that xattr size is bigger than the expected size, printing it out can cause an access off the end of the buffer.  Fix this all up by properly restricting the size of the debug hex dump in the kernel log.",
-            "vulnerability_id": "CVE-2024-40902",
-            "name": "CVE-2024-40902",
-            "package_name": "linux",
-            "package_details": {
-                "file_path": null,
-                "name": "linux",
-                "package_manager": "OS",
-                "version": "5.4.0",
-                "release": "190.210"
-            },
-            "remediation": {
-                "recommendation": {
-                "text": "None Provided"
-                }
-            },
-            "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0,
-            "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0,
-            "cvss_v3_severity": "HIGH",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-40902.html",
-            "source": "UBUNTU_CVE",
-            "severity": "HIGH",
-            "status": "ACTIVE",
-            "title": "CVE-2024-40902 - linux",
-            "reason_to_ignore": "N/A"
-        },
-        {
-            "description": " In the Linux kernel, the following vulnerability has been resolved:  net: dsa: mv88e6xxx: Correct check for empty list  Since commit a3c53be55c95 (\"net: dsa: mv88e6xxx: Support multiple MDIO busses\") mv88e6xxx_default_mdio_bus() has checked that the return value of list_first_entry() is non-NULL.  This appears to be intended to guard against the list chip->mdios being empty.  However, it is not the correct check as the implementation of list_first_entry is not designed to return NULL for empty lists.  Instead, use list_first_entry_or_null() which does return NULL if the list is empty.  Flagged by Smatch. Compile tested only.",
-            "vulnerability_id": "CVE-2024-42224",
-            "name": "CVE-2024-42224",
-            "package_name": "linux",
-            "package_details": {
-                "file_path": null,
-                "name": "linux",
-                "package_manager": "OS",
-                "version": "5.4.0",
-                "release": "190.210"
-            },
-            "remediation": {
-                "recommendation": {
-                "text": "None Provided"
-                }
-            },
-            "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0,
-            "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0,
-            "cvss_v3_severity": "HIGH",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-42224.html",
-            "source": "UBUNTU_CVE",
-            "severity": "HIGH",
-            "status": "ACTIVE",
-            "title": "CVE-2024-42224 - linux",
-            "reason_to_ignore": "N/A"
-        },
-        {
-            "description": " In the Linux kernel, the following vulnerability has been resolved: scsi: qla2xxx: Fix double free of fcport The server was crashing after LOGO because fcport was getting freed twice. -----------[ cut here ]----------- kernel BUG at mm/slub.c:371! invalid opcode: 0000 1 SMP PTI CPU: 35 PID: 4610 Comm: bash Kdump: loaded Tainted: G OE --------- - - 4.18.0-425.3.1.el8.x86_64 #1 Hardware name: HPE ProLiant DL360 Gen10/ProLiant DL360 Gen10, BIOS U32 09/03/2021 RIP: 0010:set_freepointer.part.57+0x0/0x10 RSP: 0018:ffffb07107027d90 EFLAGS: 00010246 RAX: ffff9cb7e3150000 RBX: ffff9cb7e332b9c0 RCX: ffff9cb7e3150400 RDX: 0000000000001f37 RSI: 0000000000000000 RDI: ffff9cb7c0005500 RBP: fffff693448c5400 R08: 0000000080000000 R09: 0000000000000009 R10: 0000000000000000 R11: 0000000000132af0 R12: ffff9cb7c0005500 R13: ffff9cb7e3150000 R14: ffffffffc06990e0 R15: ffff9cb7ea85ea58 FS: 00007ff6b79c2740(0000) GS:ffff9cb8f7ec0000(0000) knlGS:0000000000000000 CS: 0010 DS: 0000 ES: 0000 CR0: 0000000080050033 CR2: 000055b426b7d70",
-            "vulnerability_id": "CVE-2024-26929",
-            "name": "CVE-2024-26929",
-            "package_name": "linux",
-            "package_details": {
-                "file_path": null,
-                "name": "linux",
-                "package_manager": "OS",
-                "version": "5.4.0",
-                "release": "190.210"
-            },
-            "remediation": {
-                "recommendation": {
-                "text": "None Provided"
-                }
-            },
-            "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0,
-            "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0,
-            "cvss_v3_severity": "HIGH",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-26929.html",
-            "source": "UBUNTU_CVE",
-            "severity": "HIGH",
-            "status": "ACTIVE",
-            "title": "CVE-2024-26929 - linux",
-            "reason_to_ignore": "N/A"
-        },
-        {
-            "description": " In the Linux kernel, the following vulnerability has been resolved: firmware: arm_scmi: Harden accesses to the reset domains Accessing reset domains descriptors by the index upon the SCMI drivers requests through the SCMI reset operations interface can potentially lead to out-of-bound violations if the SCMI driver misbehave. Add an internal consistency check before any such domains descriptors accesses.",
-            "vulnerability_id": "CVE-2022-48655",
-            "name": "CVE-2022-48655",
-            "package_name": "linux",
-            "package_details": {
-                "file_path": null,
-                "name": "linux",
-                "package_manager": "OS",
-                "version": "5.4.0",
-                "release": "189.209"
-            },
-            "remediation": {
-                "recommendation": {
-                    "text": "None Provided"
-                }
-            },
-            "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0,
-            "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0,
-            "cvss_v3_severity": "HIGH",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-48655.html",
-            "source": "UBUNTU_CVE",
-            "severity": "HIGH",
-            "status": "ACTIVE",
-            "title": "CVE-2022-48655 - linux",
-            "reason_to_ignore": "N/A"
-        },
-        {
-            "description": " In the Linux kernel, the following vulnerability has been resolved:  greybus: Fix use-after-free bug in gb_interface_release due to race condition.  In gb_interface_create, &intf->mode_switch_completion is bound with gb_interface_mode_switch_work. Then it will be started by gb_interface_request_mode_switch. Here is the relevant code. if (!queue_work(system_long_wq, &intf->mode_switch_work)) { \t... }  If we call gb_interface_release to make cleanup, there may be an unfinished work. This function will call kfree to free the object \"intf\". However, if gb_interface_mode_switch_work is scheduled to run after kfree, it may cause use-after-free error as gb_interface_mode_switch_work will use the object \"intf\". The possible execution flow that may lead to the issue is as follows:  CPU0                            CPU1                              |   gb_interface_create                             |   gb_interface_request_mode_switch gb_interface_release        | kfree(intf) (free)          |                         ",
-            "vulnerability_id": "CVE-2024-39495",
-            "name": "CVE-2024-39495",
-            "package_name": "linux",
-            "package_details": {
-                "file_path": null,
-                "name": "linux",
-                "package_manager": "OS",
-                "version": "5.4.0",
-                "release": "190.210"
-            },
-            "remediation": {
-                "recommendation": {
-                "text": "None Provided"
-                }
-            },
-            "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0,
-            "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0,
-            "cvss_v3_severity": "HIGH",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-39495.html",
-            "source": "UBUNTU_CVE",
-            "severity": "HIGH",
-            "status": "ACTIVE",
-            "title": "CVE-2024-39495 - linux",
-            "reason_to_ignore": "N/A"
-        },
-        {
-            "description": " In the Linux kernel, the following vulnerability has been resolved: erofs: fix pcluster use-after-free on UP platforms During stress testing with CONFIG_SMP disabled, KASAN reports as below: ================================================================== BUG: KASAN: use-after-free in __mutex_lock+0xe5/0xc30 Read of size 8 at addr ffff8881094223f8 by task stress/7789 CPU: 0 PID: 7789 Comm: stress Not tainted 6.0.0-rc1-00002-g0d53d2e882f9 #3 Hardware name: Red Hat KVM, BIOS 0.5.1 01/01/2011 Call Trace: <TASK> .. __mutex_lock+0xe5/0xc30 .. z_erofs_do_read_page+0x8ce/0x1560 .. z_erofs_readahead+0x31c/0x580 .. Freed by task 7787 kasan_save_stack+0x1e/0x40 kasan_set_track+0x20/0x30 kasan_set_free_info+0x20/0x40 __kasan_slab_free+0x10c/0x190 kmem_cache_free+0xed/0x380 rcu_core+0x3d5/0xc90 __do_softirq+0x12d/0x389 Last potentially related work creation: kasan_save_stack+0x1e/0x40 __kasan_record_aux_stack+0x97/0xb0 call_rcu+0x3d/0x3f0 erofs_shrink_workstation+0x11f/0x210 erofs_shrink_scan+0xdc/0x170 shrink_slab.co",
-            "vulnerability_id": "CVE-2022-48674",
-            "name": "CVE-2022-48674",
-            "package_name": "linux",
-            "package_details": {
-                "file_path": null,
-                "name": "linux",
-                "package_manager": "OS",
-                "version": "5.4.0",
-                "release": "190.210"
-            },
-            "remediation": {
-                "recommendation": {
-                    "text": "None Provided"
-                }
-            },
-            "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0,
-            "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0,
-            "cvss_v3_severity": "HIGH",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-48674.html",
-            "source": "UBUNTU_CVE",
-            "severity": "HIGH",
-            "status": "ACTIVE",
-            "title": "CVE-2022-48674 - linux",
-            "reason_to_ignore": "N/A"
-        },
-        {
-            "description": " In the Linux kernel, the following vulnerability has been resolved: smb: client: fix use-after-free bug in cifs_debug_data_proc_show() Skip SMB sessions that are being teared down (e.g. @ses->ses_status == SES_EXITING) in cifs_debug_data_proc_show() to avoid use-after-free in @ses. This fixes the following GPF when reading from /proc/fs/cifs/DebugData while mounting and umounting [ 816.251274] general protection fault, probably for non-canonical address 0x6b6b6b6b6b6b6d81: 0000 [#1] PREEMPT SMP NOPTI ... [ 816.260138] Call Trace: [ 816.260329] <TASK> [ 816.260499] ? die_addr+0x36/0x90 [ 816.260762] ? exc_general_protection+0x1b3/0x410 [ 816.261126] ? asm_exc_general_protection+0x26/0x30 [ 816.261502] ? cifs_debug_tcon+0xbd/0x240 [cifs] [ 816.261878] ? cifs_debug_tcon+0xab/0x240 [cifs] [ 816.262249] cifs_debug_data_proc_show+0x516/0xdb0 [cifs] [ 816.262689] ? seq_read_iter+0x379/0x470 [ 816.262995] seq_read_iter+0x118/0x470 [ 816.263291] proc_reg_read_iter+0x53/0x90 [ 816.263596] ? srso_alias_return_thunk+0x5",
-            "vulnerability_id": "CVE-2023-52752",
-            "name": "CVE-2023-52752",
-            "package_name": "linux",
-            "package_details": {
-                "file_path": null,
-                "name": "linux",
-                "package_manager": "OS",
-                "version": "5.4.0",
-                "release": "190.210"
-            },
-            "remediation": {
-                "recommendation": {
-                "text": "None Provided"
-                }
-            },
-            "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0,
-            "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0,
-            "cvss_v3_severity": "HIGH",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2023/CVE-2023-52752.html",
-            "source": "UBUNTU_CVE",
-            "severity": "HIGH",
-            "status": "ACTIVE",
-            "title": "CVE-2023-52752 - linux",
-            "reason_to_ignore": "N/A"
-        },
-        {
-            "description": " In the Linux kernel, the following vulnerability has been resolved: gfs2: Fix slab-use-after-free in gfs2_qd_dealloc In gfs2_put_super(), whether withdrawn or not, the quota should be cleaned up by gfs2_quota_cleanup(). Otherwise, struct gfs2_sbd will be freed before gfs2_qd_dealloc (rcu callback) has run for all gfs2_quota_data objects, resulting in use-after-free. Also, gfs2_destroy_threads() and gfs2_quota_cleanup() is already called by gfs2_make_fs_ro(), so in gfs2_put_super(), after calling gfs2_make_fs_ro(), there is no need to call them again.",
-            "vulnerability_id": "CVE-2023-52760",
-            "name": "CVE-2023-52760",
-            "package_name": "linux",
-            "package_details": {
-                "file_path": null,
-                "name": "linux",
-                "package_manager": "OS",
-                "version": "5.4.0",
-                "release": "190.210"
-            },
-            "remediation": {
-                "recommendation": {
-                "text": "None Provided"
-                }
-            },
-            "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0,
-            "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0,
-            "cvss_v3_severity": "HIGH",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2023/CVE-2023-52760.html",
-            "source": "UBUNTU_CVE",
-            "severity": "HIGH",
-            "status": "ACTIVE",
-            "title": "CVE-2023-52760 - linux",
-            "reason_to_ignore": "N/A"
-        },
-        {
-            "description": " In the Linux kernel, the following vulnerability has been resolved: RDMA/mlx5: Fix fortify source warning while accessing Eth segment ------------[ cut here ]------------ memcpy: detected field-spanning write (size 56) of single field \"eseg->inline_hdr.start\" at /var/lib/dkms/mlnx-ofed-kernel/5.8/build/drivers/infiniband/hw/mlx5/wr.c:131 (size 2) WARNING: CPU: 0 PID: 293779 at /var/lib/dkms/mlnx-ofed-kernel/5.8/build/drivers/infiniband/hw/mlx5/wr.c:131 mlx5_ib_post_send+0x191b/0x1a60 [mlx5_ib] Modules linked in: 8021q garp mrp stp llc rdma_ucm(OE) rdma_cm(OE) iw_cm(OE) ib_ipoib(OE) ib_cm(OE) ib_umad(OE) mlx5_ib(OE) ib_uverbs(OE) ib_core(OE) mlx5_core(OE) pci_hyperv_intf mlxdevm(OE) mlx_compat(OE) tls mlxfw(OE) psample nft_fib_inet nft_fib_ipv4 nft_fib_ipv6 nft_fib nft_reject_inet nf_reject_ipv4 nf_reject_ipv6 nft_reject nft_ct nft_chain_nat nf_nat nf_conntrack nf_defrag_ipv6 nf_defrag_ipv4 ip_set nf_tables libcrc32c nfnetlink mst_pciconf(OE) knem(OE) vfio_pci vfio_pci_core vfio_iommu_type1 vfio iommufd irqby",
-            "vulnerability_id": "CVE-2024-26907",
-            "name": "CVE-2024-26907",
-            "package_name": "linux",
-            "package_details": {
-                "file_path": null,
-                "name": "linux",
-                "package_manager": "OS",
-                "version": "5.4.0",
-                "release": "189.209"
-            },
-            "remediation": {
-                "recommendation": {
-                    "text": "None Provided"
-                }
-            },
-            "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0,
-            "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0,
-            "cvss_v3_severity": "HIGH",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-26907.html",
-            "source": "UBUNTU_CVE",
-            "severity": "HIGH",
-            "status": "ACTIVE",
-            "title": "CVE-2024-26907 - linux",
-            "reason_to_ignore": "N/A"
-        },
-        {
-            "description": " In the Linux kernel, the following vulnerability has been resolved: smb: client: fix potential OOBs in smb2_parse_contexts() Validate offsets and lengths before dereferencing create contexts in smb2_parse_contexts(). This fixes following oops when accessing invalid create contexts from server: BUG: unable to handle page fault for address: ffff8881178d8cc3 #PF: supervisor read access in kernel mode #PF: error_code(0x0000) - not-present page PGD 4a01067 P4D 4a01067 PUD 0 Oops: 0000 [#1] PREEMPT SMP NOPTI CPU: 3 PID: 1736 Comm: mount.cifs Not tainted 6.7.0-rc4 #1 Hardware name: QEMU Standard PC (Q35 + ICH9, 2009), BIOS rel-1.16.2-3-gd478f380-rebuilt.opensuse.org 04/01/2014 RIP: 0010:smb2_parse_contexts+0xa0/0x3a0 [cifs] Code: f8 10 75 13 48 b8 93 ad 25 50 9c b4 11 e7 49 39 06 0f 84 d2 00 00 00 8b 45 00 85 c0 74 61 41 29 c5 48 01 c5 41 83 fd 0f 76 55 <0f> b7 7d 04 0f b7 45 06 4c 8d 74 3d 00 66 83 f8 04 75 bc ba 04 00 RSP: 0018:ffffc900007939e0 EFLAGS: 00010216 RAX: ffffc90000793c78 RBX: ffff8880180cc000 RCX: fff",
-            "vulnerability_id": "CVE-2023-52434",
-            "name": "CVE-2023-52434",
-            "package_name": "linux",
-            "package_details": {
-                "file_path": null,
-                "name": "linux",
-                "package_manager": "OS",
-                "version": "5.4.0",
-                "release": "190.210"
-            },
-            "remediation": {
-                "recommendation": {
-                    "text": "None Provided"
-                }
-            },
-            "cvss_v3_score": 8,
-            "cvss_v30_score": 0,
-            "cvss_v31_score": 8,
-            "cvss_v2_score": 0,
-            "cvss_v3_severity": "HIGH",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2023/CVE-2023-52434.html",
-            "source": "UBUNTU_CVE",
-            "severity": "HIGH",
-            "status": "ACTIVE",
-            "title": "CVE-2023-52434 - linux",
-            "reason_to_ignore": "N/A"
-        },
-        {
-            "description": " In the Linux kernel, the following vulnerability has been resolved: net: fix __dst_negative_advice() race __dst_negative_advice() does not enforce proper RCU rules when sk->dst_cache must be cleared, leading to possible UAF. RCU rules are that we must first clear sk->sk_dst_cache, then call dst_release(old_dst). Note that sk_dst_reset(sk) is implementing this protocol correctly, while __dst_negative_advice() uses the wrong order. Given that ip6_negative_advice() has special logic against RTF_CACHE, this means each of the three ->negative_advice() existing methods must perform the sk_dst_reset() themselves. Note the check against NULL dst is centralized in __dst_negative_advice(), there is no need to duplicate it in various callbacks. Many thanks to Clement Lecigne for tracking this issue. This old bug became visible after the blamed commit, using UDP sockets.",
-            "vulnerability_id": "CVE-2024-36971",
-            "name": "CVE-2024-36971",
-            "package_name": "linux",
-            "package_details": {
-                "file_path": null,
-                "name": "linux",
-                "package_manager": "OS",
-                "version": "5.4.0",
-                "release": "190.210"
-            },
-            "remediation": {
-                "recommendation": {
-                "text": "None Provided"
-                }
-            },
-            "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0,
-            "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0,
-            "cvss_v3_severity": "HIGH",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-36971.html",
-            "source": "UBUNTU_CVE",
-            "severity": "HIGH",
-            "status": "ACTIVE",
-            "title": "CVE-2024-36971 - linux",
-            "reason_to_ignore": "N/A"
-        },
-        {
-            "description": " In the Linux kernel, the following vulnerability has been resolved: nilfs2: fix use-after-free of timer for log writer thread Patch series \"nilfs2: fix log writer related issues\". This bug fix series covers three nilfs2 log writer-related issues, including a timer use-after-free issue and potential deadlock issue on unmount, and a potential freeze issue in event synchronization found during their analysis. Details are described in each commit log. This patch (of 3): A use-after-free issue has been reported regarding the timer sc_timer on the nilfs_sc_info structure. The problem is that even though it is used to wake up a sleeping log writer thread, sc_timer is not shut down until the nilfs_sc_info structure is about to be freed, and is used regardless of the thread's lifetime. Fix this issue by limiting the use of sc_timer only while the log writer thread is alive.",
-            "vulnerability_id": "CVE-2024-38583",
-            "name": "CVE-2024-38583",
-            "package_name": "linux",
-            "package_details": {
-                "file_path": null,
-                "name": "linux",
-                "package_manager": "OS",
-                "version": "5.4.0",
-                "release": "190.210"
-            },
-            "remediation": {
-                "recommendation": {
-                "text": "None Provided"
-                }
-            },
-            "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0,
-            "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0,
-            "cvss_v3_severity": "HIGH",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-38583.html",
-            "source": "UBUNTU_CVE",
-            "severity": "HIGH",
-            "status": "ACTIVE",
-            "title": "CVE-2024-38583 - linux",
-            "reason_to_ignore": "N/A"
-            },
-            {
             "description": "In the Linux kernel, the following vulnerability has been resolved: filelock: fix potential use-after-free in posix_lock_inode Light Hsieh reported a KASAN UAF warning in trace_posix_lock_inode(). The request pointer had been changed earlier to point to a lock entry that was added to the inode's list. However, before the tracepoint could fire, another task raced in and freed that lock. Fix this by moving the tracepoint inside the spinlock, which should ensure that this doesn't happen.",
             "vulnerability_id": "CVE-2024-41049",
             "name": "CVE-2024-41049",
@@ -366,9 +18,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-41049.html",
             "source": "UBUNTU_CVE",
@@ -376,7 +28,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-41049 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: nilfs2: add missing check for inode numbers on directory entries Syzbot reported that mounting and unmounting a specific pattern of corrupted nilfs2 filesystem images causes a use-after-free of metadata file inodes, which triggers a kernel bug in lru_add_fn(). As Jan Kara pointed out, this is because the link count of a metadata file gets corrupted to 0, and nilfs_evict_inode(), which is called from iput(), tries to delete that inode (ifile inode in this case). The inconsistency occurs because directories containing the inode numbers of these metadata files that should not be visible in the namespace are read without checking. Fix this issue by treating the inode numbers of these internal files as errors in the sanity check helper when reading directory folios/pages. Also thanks to Hillf Danton and Matthew Wilcox for their initial mm-layer analysis.",
             "vulnerability_id": "CVE-2024-42104",
             "name": "CVE-2024-42104",
@@ -394,9 +47,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-42104.html",
             "source": "UBUNTU_CVE",
@@ -404,7 +57,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-42104 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: net/iucv: Avoid explicit cpumask var allocation on stack For CONFIG_CPUMASK_OFFSTACK=y kernel, explicit allocation of cpumask variable on stack is not recommended since it can cause potential stack overflow. Instead, kernel code should always use *cpumask_var API(s) to allocate cpumask var in config-neutral way, leaving allocation strategy to CONFIG_CPUMASK_OFFSTACK. Use *cpumask_var API(s) to address it.",
             "vulnerability_id": "CVE-2024-42094",
             "name": "CVE-2024-42094",
@@ -422,9 +76,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-42094.html",
             "source": "UBUNTU_CVE",
@@ -432,7 +86,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-42094 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: gfs2: Fix potential glock use-after-free on unmount When a DLM lockspace is released and there ares still locks in that lockspace, DLM will unlock those locks automatically. Commit fb6791d100d1b started exploiting this behavior to speed up filesystem unmount: gfs2 would simply free glocks it didn't want to unlock and then release the lockspace. This didn't take the bast callbacks for asynchronous lock contention notifications into account, which remain active until until a lock is unlocked or its lockspace is released. To prevent those callbacks from accessing deallocated objects, put the glocks that should not be unlocked on the sd_dead_glocks list, release the lockspace, and only then free those glocks. As an additional measure, ignore unexpected ast and bast callbacks if the receiving glock is dead.",
             "vulnerability_id": "CVE-2024-38570",
             "name": "CVE-2024-38570",
@@ -450,9 +105,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-38570.html",
             "source": "UBUNTU_CVE",
@@ -460,7 +115,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-38570 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: scsi: pm8001: Fix use-after-free for aborted TMF sas_task Currently a use-after-free may occur if a TMF sas_task is aborted before we handle the IO completion in mpi_ssp_completion(). The abort occurs due to timeout. When the timeout occurs, the SAS_TASK_STATE_ABORTED flag is set and the sas_task is freed in pm8001_exec_internal_tmf_task(). However, if the I/O completion occurs later, the I/O completion still thinks that the sas_task is available. Fix this by clearing the ccb->task if the TMF times out - the I/O completion handler does nothing if this pointer is cleared.",
             "vulnerability_id": "CVE-2022-48791",
             "name": "CVE-2022-48791",
@@ -478,9 +134,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2022/CVE-2022-48791.html",
             "source": "UBUNTU_CVE",
@@ -488,7 +144,8 @@
             "status": "ACTIVE",
             "title": "CVE-2022-48791 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: ima: Fix use-after-free on a dentry's dname.name ->d_name.name can change on rename and the earlier value can be freed; there are conditions sufficient to stabilize it (->d_lock on dentry, ->d_lock on its parent, ->i_rwsem exclusive on the parent's inode, rename_lock), but none of those are met at any of the sites. Take a stable snapshot of the name instead.",
             "vulnerability_id": "CVE-2024-39494",
             "name": "CVE-2024-39494",
@@ -506,9 +163,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-39494.html",
             "source": "UBUNTU_CVE",
@@ -516,7 +173,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-39494 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: tcp_metrics: validate source addr length I don't see anything checking that TCP_METRICS_ATTR_SADDR_IPV4 is at least 4 bytes long, and the policy doesn't have an entry for this attribute at all (neither does it for IPv6 but v6 is manually validated).",
             "vulnerability_id": "CVE-2024-42154",
             "name": "CVE-2024-42154",
@@ -534,9 +192,9 @@
                 }
             },
             "cvss_v3_score": 9.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 9.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "CRITICAL",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-42154.html",
             "source": "UBUNTU_CVE",
@@ -544,7 +202,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-42154 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: bonding: Fix out-of-bounds read in bond_option_arp_ip_targets_set() In function bond_option_arp_ip_targets_set(), if newval->string is an empty string, newval->string+1 will point to the byte after the string, causing an out-of-bound read. BUG: KASAN: slab-out-of-bounds in strlen+0x7d/0xa0 lib/string.c:418 Read of size 1 at addr ffff8881119c4781 by task syz-executor665/8107 CPU: 1 PID: 8107 Comm: syz-executor665 Not tainted 6.7.0-rc7 #1 Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.15.0-1 04/01/2014 Call Trace: <TASK> __dump_stack lib/dump_stack.c:88 [inline] dump_stack_lvl+0xd9/0x150 lib/dump_stack.c:106 print_address_description mm/kasan/report.c:364 [inline] print_report+0xc1/0x5e0 mm/kasan/report.c:475 kasan_report+0xbe/0xf0 mm/kasan/report.c:588 strlen+0x7d/0xa0 lib/string.c:418 __fortify_strlen include/linux/fortify-string.h:210 [inline] in4_pton+0xa3/0x3f0 net/core/utils.c:130 bond_option_arp_ip_targets_set+0xc2/0x910 d",
             "vulnerability_id": "CVE-2024-39487",
             "name": "CVE-2024-39487",
@@ -562,9 +221,9 @@
                 }
             },
             "cvss_v3_score": 7.1,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.1,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-39487.html",
             "source": "UBUNTU_CVE",
@@ -572,7 +231,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-39487 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "It was discovered that the JFS file system contained an out-of-bounds read vulnerability when printing xattr debug information. A local attacker could use this to cause a denial of service (system crash).",
             "vulnerability_id": "CVE-2024-40902",
             "name": "CVE-2024-40902",
@@ -590,9 +250,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-40902.html",
             "source": "UBUNTU_CVE",
@@ -600,7 +260,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-40902 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: ata: libata-core: Fix double free on error If e.g. the ata_port_alloc() call in ata_host_alloc() fails, we will jump to the err_out label, which will call devres_release_group(). devres_release_group() will trigger a call to ata_host_release(). ata_host_release() calls kfree(host), so executing the kfree(host) in ata_host_alloc() will lead to a double free: kernel BUG at mm/slub.c:553! Oops: invalid opcode: 0000 [#1] PREEMPT SMP NOPTI CPU: 11 PID: 599 Comm: (udev-worker) Not tainted 6.10.0-rc5 #47 Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.16.3-2.fc40 04/01/2014 RIP: 0010:kfree+0x2cf/0x2f0 Code: 5d 41 5e 41 5f 5d e9 80 d6 ff ff 4d 89 f1 41 b8 01 00 00 00 48 89 d9 48 89 da RSP: 0018:ffffc90000f377f0 EFLAGS: 00010246 RAX: ffff888112b1f2c0 RBX: ffff888112b1f2c0 RCX: ffff888112b1f320 RDX: 000000000000400b RSI: ffffffffc02c9de5 RDI: ffff888112b1f2c0 RBP: ffffc90000f37830 R08: 0000000000000000 R09: 0000000000000000 R10: ffffc9000",
             "vulnerability_id": "CVE-2024-41087",
             "name": "CVE-2024-41087",
@@ -618,9 +279,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-41087.html",
             "source": "UBUNTU_CVE",
@@ -628,7 +289,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-41087 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: drm/amdgpu: Using uninitialized value *size when calling amdgpu_vce_cs_reloc Initialize the size before calling amdgpu_vce_cs_reloc, such as case 0x03000001. V2: To really improve the handling we would actually need to have a separate value of 0xffffffff.(Christian)",
             "vulnerability_id": "CVE-2024-42228",
             "name": "CVE-2024-42228",
@@ -645,10 +307,10 @@
                     "text": "None Provided"
                 }
             },
-            "cvss_v3_score": 7.0,
-            "cvss_v30_score": 0.0,
-            "cvss_v31_score": 7.0,
-            "cvss_v2_score": 0.0,
+            "cvss_v3_score": 7,
+            "cvss_v30_score": 0,
+            "cvss_v31_score": 7,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-42228.html",
             "source": "UBUNTU_CVE",
@@ -656,8 +318,9 @@
             "status": "ACTIVE",
             "title": "CVE-2024-42228 - linux",
             "reason_to_ignore": "N/A"
-        }, {
-            "description": "In the Linux kernel, the following vulnerability has been resolved: greybus: Fix use-after-free bug in gb_interface_release due to race condition. In gb_interface_create, &#38;intf->mode_switch_completion is bound with gb_interface_mode_switch_work. Then it will be started by gb_interface_request_mode_switch. Here is the relevant code. if (!queue_work(system_long_wq, &#38;intf->mode_switch_work)) { ... } If we call gb_interface_release to make cleanup, there may be an unfinished work. This function will call kfree to free the object \"intf\". However, if gb_interface_mode_switch_work is scheduled to run after kfree, it may cause use-after-free error as gb_interface_mode_switch_work will use the object \"intf\". The possible execution flow that may lead to the issue is as follows: CPU0 CPU1 | gb_interface_create | gb_interface_request_mode_switch gb_interface_release | kfree(intf) (free) | | gb_interface_mode_switch_work | mutex_lock(&#38;intf->mutex) (use) Fix it by canceling the work before kfree.",
+        },
+        {
+            "description": "In the Linux kernel, the following vulnerability has been resolved: greybus: Fix use-after-free bug in gb_interface_release due to race condition. In gb_interface_create, &intf->mode_switch_completion is bound with gb_interface_mode_switch_work. Then it will be started by gb_interface_request_mode_switch. Here is the relevant code. if (!queue_work(system_long_wq, &intf->mode_switch_work)) { ... } If we call gb_interface_release to make cleanup, there may be an unfinished work. This function will call kfree to free the object \"intf\". However, if gb_interface_mode_switch_work is scheduled to run after kfree, it may cause use-after-free error as gb_interface_mode_switch_work will use the object \"intf\". The possible execution flow that may lead to the issue is as follows: CPU0 CPU1 | gb_interface_create | gb_interface_request_mode_switch gb_interface_release | kfree(intf) (free) | | gb_interface_mode_switch_work | mutex_lock(&intf->mutex) (use) Fix it by canceling the work before kfree.",
             "vulnerability_id": "CVE-2024-39495",
             "name": "CVE-2024-39495",
             "package_name": "linux",
@@ -674,9 +337,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-39495.html",
             "source": "UBUNTU_CVE",
@@ -684,7 +347,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-39495 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: net: ethernet: lantiq_etop: fix double free in detach The number of the currently released descriptor is never incremented which results in the same skb being released multiple times.",
             "vulnerability_id": "CVE-2024-41046",
             "name": "CVE-2024-41046",
@@ -702,9 +366,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-41046.html",
             "source": "UBUNTU_CVE",
@@ -712,7 +376,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-41046 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: f2fs: check validation of fault attrs in f2fs_build_fault_attr() - It missed to check validation of fault attrs in parse_options(), let's fix to add check condition in f2fs_build_fault_attr(). - Use f2fs_build_fault_attr() in __sbi_store() to clean up code.",
             "vulnerability_id": "CVE-2024-42160",
             "name": "CVE-2024-42160",
@@ -730,9 +395,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-42160.html",
             "source": "UBUNTU_CVE",
@@ -740,7 +405,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-42160 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: net: dsa: mv88e6xxx: Correct check for empty list Since commit a3c53be55c95 (\"net: dsa: mv88e6xxx: Support multiple MDIO busses\") mv88e6xxx_default_mdio_bus() has checked that the return value of list_first_entry() is non-NULL. This appears to be intended to guard against the list chip->mdios being empty. However, it is not the correct check as the implementation of list_first_entry is not designed to return NULL for empty lists. Instead, use list_first_entry_or_null() which does return NULL if the list is empty. Flagged by Smatch. Compile tested only.",
             "vulnerability_id": "CVE-2024-42224",
             "name": "CVE-2024-42224",
@@ -758,9 +424,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-42224.html",
             "source": "UBUNTU_CVE",
@@ -768,7 +434,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-42224 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: bnx2x: Fix multiple UBSAN array-index-out-of-bounds Fix UBSAN warnings that occur when using a system with 32 physical cpu cores or more, or when the user defines a number of Ethernet queues greater than or equal to FP_SB_MAX_E1x using the num_queues module parameter. Currently there is a read/write out of bounds that occurs on the array \"struct stats_query_entry query\" present inside the \"bnx2x_fw_stats_req\" struct in \"drivers/net/ethernet/broadcom/bnx2x/bnx2x.h\". Looking at the definition of the \"struct stats_query_entry query\" array: struct stats_query_entry query[FP_SB_MAX_E1x+ BNX2X_FIRST_QUEUE_QUERY_IDX]; FP_SB_MAX_E1x is defined as the maximum number of fast path interrupts and has a value of 16, while BNX2X_FIRST_QUEUE_QUERY_IDX has a value of 3 meaning the array has a total size of 19. Since accesses to \"struct stats_query_entry query\" are offset-ted by BNX2X_FIRST_QUEUE_QUERY_IDX, that means that the total number of Ethernet queues ",
             "vulnerability_id": "CVE-2024-42148",
             "name": "CVE-2024-42148",
@@ -786,9 +453,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-42148.html",
             "source": "UBUNTU_CVE",
@@ -796,7 +463,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-42148 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: net/dpaa2: Avoid explicit cpumask var allocation on stack For CONFIG_CPUMASK_OFFSTACK=y kernel, explicit allocation of cpumask variable on stack is not recommended since it can cause potential stack overflow. Instead, kernel code should always use *cpumask_var API(s) to allocate cpumask var in config-neutral way, leaving allocation strategy to CONFIG_CPUMASK_OFFSTACK. Use *cpumask_var API(s) to address it.",
             "vulnerability_id": "CVE-2024-42093",
             "name": "CVE-2024-42093",
@@ -814,9 +482,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-42093.html",
             "source": "UBUNTU_CVE",
@@ -824,7 +492,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-42093 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: netns: Make get_net_ns() handle zero refcount net Syzkaller hit a warning: refcount_t: addition on 0; use-after-free. WARNING: CPU: 3 PID: 7890 at lib/refcount.c:25 refcount_warn_saturate+0xdf/0x1d0 Modules linked in: CPU: 3 PID: 7890 Comm: tun Not tainted 6.10.0-rc3-00100-gcaa4f9578aba-dirty #310 Hardware name: QEMU Standard PC (i440FX + PIIX, 1996), BIOS 1.15.0-1 04/01/2014 RIP: 0010:refcount_warn_saturate+0xdf/0x1d0 Code: 41 49 04 31 ff 89 de e8 9f 1e cd fe 84 db 75 9c e8 76 26 cd fe c6 05 b6 41 49 04 01 90 48 c7 c7 b8 8e 25 86 e8 d2 05 b5 fe 90 <0f> 0b 90 90 e9 79 ff ff ff e8 53 26 cd fe 0f b6 1 RSP: 0018:ffff8881067b7da0 EFLAGS: 00010286 RAX: 0000000000000000 RBX: 0000000000000000 RCX: ffffffff811c72ac RDX: ffff8881026a2140 RSI: ffffffff811c72b5 RDI: 0000000000000001 RBP: ffff8881067b7db0 R08: 0000000000000000 R09: 205b5d3730353139 R10: 0000000000000000 R11: 205d303938375420 R12: ffff8881086500c4 R13: ffff8881086500c4 R14: ffff8881086500",
             "vulnerability_id": "CVE-2024-40958",
             "name": "CVE-2024-40958",
@@ -842,9 +511,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-40958.html",
             "source": "UBUNTU_CVE",
@@ -852,7 +521,8 @@
             "status": "ACTIVE",
             "title": "CVE-2024-40958 - linux",
             "reason_to_ignore": "N/A"
-        }, {
+        },
+        {
             "description": "In the Linux kernel, the following vulnerability has been resolved: net: sched: sch_multiq: fix possible OOB write in multiq_tune() q->bands will be assigned to qopt->bands to execute subsequent code logic after kmalloc. So the old q->bands should not be used in kmalloc. Otherwise, an out-of-bounds write will occur.",
             "vulnerability_id": "CVE-2024-36978",
             "name": "CVE-2024-36978",
@@ -870,9 +540,9 @@
                 }
             },
             "cvss_v3_score": 7.8,
-            "cvss_v30_score": 0.0,
+            "cvss_v30_score": 0,
             "cvss_v31_score": 7.8,
-            "cvss_v2_score": 0.0,
+            "cvss_v2_score": 0,
             "cvss_v3_severity": "HIGH",
             "source_url": "https://people.canonical.com/~ubuntu-security/cve/2024/CVE-2024-36978.html",
             "source": "UBUNTU_CVE",


### PR DESCRIPTION
### Description
Pipeline blocked behind detected `linux` vulnerabilities that are not in the allowlist [isenlink](https://tiny.amazon.com/325qtpa4/IsenLink). Updated the allowlist based on the output of that failing test


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
