### PR TITLE
Temporarily restrict release yaml file ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,8 +10,8 @@
 
 # Common files that is managed by multiple owners
 available_images.md @aws/dl-containers @aws/dlc-autogluon-reviewers @aws/dlc-neuron-reviewers @aws/dlc-eia-reviewers @aws/dlc-trcomp-reviewers @aws/dlc-lmi-reviewers @aws/sagemaker-1p-algorithms @aws/dlc-pytorch-reviewers @aws/dlc-triton-reviewers
-release_images_inference.yml @aws/dl-containers @aws/dlc-autogluon-reviewers @aws/dlc-neuron-reviewers @aws/dlc-eia-reviewers @aws/dlc-trcomp-reviewers @aws/dlc-lmi-reviewers @aws/sagemaker-1p-algorithms @aws/dlc-pytorch-reviewers @aws/dlc-triton-reviewers
-release_images_training.yml @aws/dl-containers @aws/dlc-autogluon-reviewers @aws/dlc-neuron-reviewers @aws/dlc-eia-reviewers @aws/dlc-trcomp-reviewers @aws/sagemaker-1p-algorithms @aws/dlc-pytorch-reviewers
+# release_images_inference.yml @aws/dl-containers @aws/dlc-autogluon-reviewers @aws/dlc-neuron-reviewers @aws/dlc-eia-reviewers @aws/dlc-trcomp-reviewers @aws/dlc-lmi-reviewers @aws/sagemaker-1p-algorithms @aws/dlc-pytorch-reviewers @aws/dlc-triton-reviewers
+# release_images_training.yml @aws/dl-containers @aws/dlc-autogluon-reviewers @aws/dlc-neuron-reviewers @aws/dlc-eia-reviewers @aws/dlc-trcomp-reviewers @aws/sagemaker-1p-algorithms @aws/dlc-pytorch-reviewers
 .release_images_template.yml @aws/dl-containers @aws/dlc-autogluon-reviewers @aws/dlc-neuron-reviewers @aws/dlc-eia-reviewers @aws/dlc-trcomp-reviewers @aws/dlc-pytorch-reviewers @aws/dlc-triton-reviewers
 data/ignore_ids_safety_scan.json @aws/dl-containers @aws/sagemaker-1p-algorithms
 # Any files modified under autogluon/ will be assigned to the autogluon reviewer team


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
- Temp comment out release yaml files from codeowners


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
