### PR TITLE
Add codeowners back, remove PT 2.1 and TF 2.14 from yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,8 +10,8 @@
 
 # Common files that is managed by multiple owners
 available_images.md @aws/dl-containers @aws/dlc-autogluon-reviewers @aws/dlc-neuron-reviewers @aws/dlc-eia-reviewers @aws/dlc-trcomp-reviewers @aws/dlc-lmi-reviewers @aws/sagemaker-1p-algorithms @aws/dlc-pytorch-reviewers @aws/dlc-triton-reviewers
-# release_images_inference.yml @aws/dl-containers @aws/dlc-autogluon-reviewers @aws/dlc-neuron-reviewers @aws/dlc-eia-reviewers @aws/dlc-trcomp-reviewers @aws/dlc-lmi-reviewers @aws/sagemaker-1p-algorithms @aws/dlc-pytorch-reviewers @aws/dlc-triton-reviewers
-# release_images_training.yml @aws/dl-containers @aws/dlc-autogluon-reviewers @aws/dlc-neuron-reviewers @aws/dlc-eia-reviewers @aws/dlc-trcomp-reviewers @aws/sagemaker-1p-algorithms @aws/dlc-pytorch-reviewers
+release_images_inference.yml @aws/dl-containers @aws/dlc-autogluon-reviewers @aws/dlc-neuron-reviewers @aws/dlc-eia-reviewers @aws/dlc-trcomp-reviewers @aws/dlc-lmi-reviewers @aws/sagemaker-1p-algorithms @aws/dlc-pytorch-reviewers @aws/dlc-triton-reviewers
+release_images_training.yml @aws/dl-containers @aws/dlc-autogluon-reviewers @aws/dlc-neuron-reviewers @aws/dlc-eia-reviewers @aws/dlc-trcomp-reviewers @aws/sagemaker-1p-algorithms @aws/dlc-pytorch-reviewers
 .release_images_template.yml @aws/dl-containers @aws/dlc-autogluon-reviewers @aws/dlc-neuron-reviewers @aws/dlc-eia-reviewers @aws/dlc-trcomp-reviewers @aws/dlc-pytorch-reviewers @aws/dlc-triton-reviewers
 data/ignore_ids_safety_scan.json @aws/dl-containers @aws/sagemaker-1p-algorithms
 # Any files modified under autogluon/ will be assigned to the autogluon reviewer team

--- a/release_images_patches.yml
+++ b/release_images_patches.yml
@@ -55,12 +55,12 @@ release_images:
       disable_sm_tag: False
       force_release: False
 
-  # Pytorch 2.1 Images
+  # PyTorch 2.2 Images
   5:
     framework: "pytorch"
-    version: "2.1.0"
-    customer_type: "ec2"
+    version: "2.2.0"
     arch_type: "x86"
+    customer_type: "ec2"
     training:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
@@ -71,9 +71,9 @@ release_images:
       force_release: False
   6:
     framework: "pytorch"
-    version: "2.1.0"
-    customer_type: "sagemaker"
+    version: "2.2.0"
     arch_type: "x86"
+    customer_type: "sagemaker"
     training:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
@@ -84,7 +84,7 @@ release_images:
       force_release: False
   7:
     framework: "pytorch"
-    version: "2.1.0"
+    version: "2.2.0"
     arch_type: "x86"
     customer_type: "ec2"
     inference:
@@ -97,7 +97,7 @@ release_images:
       force_release: False
   8:
     framework: "pytorch"
-    version: "2.1.0"
+    version: "2.2.0"
     arch_type: "x86"
     customer_type: "sagemaker"
     inference:
@@ -110,84 +110,6 @@ release_images:
       force_release: False
   9:
     framework: "pytorch"
-    version: "2.1.0"
-    arch_type: "graviton"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  10:
-    framework: "pytorch"
-    version: "2.1.0"
-    arch_type: "graviton"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-
-  # PyTorch 2.2 Images
-  11:
-    framework: "pytorch"
-    version: "2.2.0"
-    arch_type: "x86"
-    customer_type: "ec2"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu121"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  12:
-    framework: "pytorch"
-    version: "2.2.0"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu121"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  13:
-    framework: "pytorch"
-    version: "2.2.0"
-    arch_type: "x86"
-    customer_type: "ec2"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  14:
-    framework: "pytorch"
-    version: "2.2.0"
-    arch_type: "x86"
-    customer_type: "sagemaker"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu118"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  15:
-    framework: "pytorch"
     version: "2.2.1"
     arch_type: "graviton"
     customer_type: "ec2"
@@ -198,7 +120,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  16:
+  10:
     framework: "pytorch"
     version: "2.2.1"
     arch_type: "graviton"
@@ -212,7 +134,7 @@ release_images:
       force_release: False
 
   # PyTorch 2.3 Images
-  17:
+  11:
     framework: "pytorch"
     version: "2.3.0"
     customer_type: "ec2"
@@ -225,7 +147,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  18:
+  12:
     framework: "pytorch"
     version: "2.3.0"
     customer_type: "sagemaker"
@@ -238,7 +160,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  19:
+  13:
     framework: "pytorch"
     version: "2.3.0"
     arch_type: "x86"
@@ -251,7 +173,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  20:
+  14:
     framework: "pytorch"
     version: "2.3.0"
     arch_type: "x86"
@@ -264,7 +186,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  21:
+  15:
     framework: "pytorch"
     version: "2.3.0"
     arch_type: "graviton"
@@ -276,7 +198,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  22:
+  16:
     framework: "pytorch"
     version: "2.3.0"
     arch_type: "graviton"
@@ -290,7 +212,7 @@ release_images:
       force_release: False
   
   # PyTorch 2.4 Images
-  23:
+  17:
     framework: "pytorch"
     version: "2.4.0"
     customer_type: "ec2"
@@ -303,7 +225,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  24:
+  18:
     framework: "pytorch"
     version: "2.4.0"
     customer_type: "sagemaker"
@@ -316,7 +238,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  25:
+  19:
     framework: "pytorch"
     version: "2.4.0"
     arch_type: "x86"
@@ -329,7 +251,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  26:
+  20:
     framework: "pytorch"
     version: "2.4.0"
     arch_type: "x86"
@@ -342,7 +264,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  27:
+  21:
     framework: "pytorch"
     version: "2.4.0"
     arch_type: "graviton"
@@ -355,7 +277,7 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
-  28:
+  22:
     framework: "pytorch"
     version: "2.4.0"
     arch_type: "graviton"
@@ -368,153 +290,73 @@ release_images:
       disable_sm_tag: False
       force_release: False
 
-  # TensorFlow 2.14 Images
-  29:
+  # TensorFlow 2.16 Images
+  23:
     framework: "tensorflow"
-    version: "2.14.1"
+    version: "2.16.2"
     customer_type: "ec2"
     arch_type: "x86"
     training:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
-      cuda_version: "cu118"
+      cuda_version: "cu123"
       example: False
       disable_sm_tag: False
       force_release: False
-  30:
+  24:
     framework: "tensorflow"
-    version: "2.14.1"
+    version: "2.16.2"
     customer_type: "sagemaker"
     arch_type: "x86"
     training:
       device_types: [ "cpu", "gpu" ]
       python_versions: [ "py310" ]
       os_version: "ubuntu20.04"
-      cuda_version: "cu118"
+      cuda_version: "cu123"
       example: False
       disable_sm_tag: False
       force_release: False
   # 25:
   #   framework: "tensorflow"
-  #   version: "2.14.1"
+  #   version: "2.16.1"
   #   arch_type: "x86"
   #   customer_type: "ec2"
   #   inference:
   #     device_types: [ "cpu", "gpu" ]
   #     python_versions: [ "py310" ]
   #     os_version: "ubuntu20.04"
-  #     cuda_version: "cu118"
+  #     cuda_version: "cu122"
   #     example: False
   #     disable_sm_tag: False
   #     force_release: False
   # 26:
   #   framework: "tensorflow"
-  #   version: "2.14.1"
+  #   version: "2.16.1"
   #   arch_type: "x86"
   #   customer_type: "sagemaker"
   #   inference:
   #     device_types: [ "cpu", "gpu" ]
   #     python_versions: [ "py310" ]
   #     os_version: "ubuntu20.04"
-  #     cuda_version: "cu118"
+  #     cuda_version: "cu122"
   #     example: False
   #     disable_sm_tag: False
   #     force_release: False
   # 27:
   #   framework: "tensorflow"
-  #   version: "2.14.1"
+  #   version: "2.16.1"
   #   arch_type: "graviton"
   #   customer_type: "ec2"
   #   inference:
   #     device_types: [ "cpu" ]
   #     python_versions: [ "py310" ]
   #     os_version: "ubuntu20.04"
-  #     cuda_version: "cu118"
+  #     cuda_version: "cu122"
   #     example: False
   #     disable_sm_tag: False
   #     force_release: False
   # 28:
-  #   framework: "tensorflow"
-  #   version: "2.14.1"
-  #   arch_type: "graviton"
-  #   customer_type: "sagemaker"
-  #   inference:
-  #     device_types: [ "cpu" ]
-  #     python_versions: [ "py310" ]
-  #     os_version: "ubuntu20.04"
-  #     cuda_version: "cu118"
-  #     example: False
-  #     disable_sm_tag: False
-  #     force_release: False
-
-  # TensorFlow 2.16 Images
-  31:
-    framework: "tensorflow"
-    version: "2.16.2"
-    customer_type: "ec2"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu123"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  32:
-    framework: "tensorflow"
-    version: "2.16.2"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu20.04"
-      cuda_version: "cu123"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  # 31:
-  #   framework: "tensorflow"
-  #   version: "2.16.1"
-  #   arch_type: "x86"
-  #   customer_type: "ec2"
-  #   inference:
-  #     device_types: [ "cpu", "gpu" ]
-  #     python_versions: [ "py310" ]
-  #     os_version: "ubuntu20.04"
-  #     cuda_version: "cu122"
-  #     example: False
-  #     disable_sm_tag: False
-  #     force_release: False
-  # 32:
-  #   framework: "tensorflow"
-  #   version: "2.16.1"
-  #   arch_type: "x86"
-  #   customer_type: "sagemaker"
-  #   inference:
-  #     device_types: [ "cpu", "gpu" ]
-  #     python_versions: [ "py310" ]
-  #     os_version: "ubuntu20.04"
-  #     cuda_version: "cu122"
-  #     example: False
-  #     disable_sm_tag: False
-  #     force_release: False
-  # 33:
-  #   framework: "tensorflow"
-  #   version: "2.16.1"
-  #   arch_type: "graviton"
-  #   customer_type: "ec2"
-  #   inference:
-  #     device_types: [ "cpu" ]
-  #     python_versions: [ "py310" ]
-  #     os_version: "ubuntu20.04"
-  #     cuda_version: "cu122"
-  #     example: False
-  #     disable_sm_tag: False
-  #     force_release: False
-  # 34:
   #   framework: "tensorflow"
   #   version: "2.16.1"
   #   arch_type: "graviton"


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

- Return codeowners to its original state for release yaml
- Remove PT 2.1 and TF 2.14 from patches yaml


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
