### PR TITLE
Re-enable TF 2.16 graviton images

### DIFF
--- a/release_images_patches.yml
+++ b/release_images_patches.yml
@@ -343,29 +343,29 @@ release_images:
   #     example: False
   #     disable_sm_tag: False
   #     force_release: False
-  # 27:
-  #   framework: "tensorflow"
-  #   version: "2.16.1"
-  #   arch_type: "graviton"
-  #   customer_type: "ec2"
-  #   inference:
-  #     device_types: [ "cpu" ]
-  #     python_versions: [ "py310" ]
-  #     os_version: "ubuntu20.04"
-  #     cuda_version: "cu122"
-  #     example: False
-  #     disable_sm_tag: False
-  #     force_release: False
-  # 28:
-  #   framework: "tensorflow"
-  #   version: "2.16.1"
-  #   arch_type: "graviton"
-  #   customer_type: "sagemaker"
-  #   inference:
-  #     device_types: [ "cpu" ]
-  #     python_versions: [ "py310" ]
-  #     os_version: "ubuntu20.04"
-  #     cuda_version: "cu122"
-  #     example: False
-  #     disable_sm_tag: False
-  #     force_release: False
+  25:
+    framework: "tensorflow"
+    version: "2.16.1"
+    arch_type: "graviton"
+    customer_type: "ec2"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu122"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  26:
+    framework: "tensorflow"
+    version: "2.16.1"
+    arch_type: "graviton"
+    customer_type: "sagemaker"
+    inference:
+      device_types: [ "cpu" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu20.04"
+      cuda_version: "cu122"
+      example: False
+      disable_sm_tag: False
+      force_release: False


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
Add back TF 2.16 graviton images to patches yaml


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
