### PR TITLE
Fix vulnerabilities AutoGluon v1.2

### DIFF
--- a/autogluon/inference/docker/1.2/py3/Dockerfile.cpu.os_scan_allowlist.json
+++ b/autogluon/inference/docker/1.2/py3/Dockerfile.cpu.os_scan_allowlist.json
@@ -354,5 +354,36 @@
       "title": "CVE-2024-11394 - transformers",
       "reason_to_ignore": "N/A"
     }
+  ],
+  "lightgbm": [
+    {
+      "description": "LightGBM Remote Code Execution Vulnerability",
+      "vulnerability_id": "CVE-2024-43598",
+      "name": "CVE-2024-43598",
+      "package_name": "lightgbm",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.11/site-packages/lightgbm-4.5.0.dist-info/METADATA",
+        "name": "lightgbm",
+        "package_manager": "PYTHONPKG",
+        "version": "4.5.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.1,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 8.1,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43598",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2024-43598 - lightgbm",
+      "reason_to_ignore": "No fix provided"
+    }
   ]
 }

--- a/autogluon/inference/docker/1.2/py3/cu124/Dockerfile.gpu.os_scan_allowlist.json
+++ b/autogluon/inference/docker/1.2/py3/cu124/Dockerfile.gpu.os_scan_allowlist.json
@@ -354,5 +354,36 @@
       "title": "CVE-2024-11394 - transformers",
       "reason_to_ignore": "N/A"
     }
+  ],
+  "lightgbm": [
+    {
+      "description": "LightGBM Remote Code Execution Vulnerability",
+      "vulnerability_id": "CVE-2024-43598",
+      "name": "CVE-2024-43598",
+      "package_name": "lightgbm",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.11/site-packages/lightgbm-4.5.0.dist-info/METADATA",
+        "name": "lightgbm",
+        "package_manager": "PYTHONPKG",
+        "version": "4.5.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.1,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 8.1,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43598",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2024-43598 - lightgbm",
+      "reason_to_ignore": "No fix provided"
+    }
   ]
 }

--- a/autogluon/training/docker/1.2/py3/Dockerfile.cpu.os_scan_allowlist.json
+++ b/autogluon/training/docker/1.2/py3/Dockerfile.cpu.os_scan_allowlist.json
@@ -354,5 +354,36 @@
       "title": "CVE-2024-11394 - transformers",
       "reason_to_ignore": "N/A"
     }
+  ],
+  "lightgbm": [
+    {
+      "description": "LightGBM Remote Code Execution Vulnerability",
+      "vulnerability_id": "CVE-2024-43598",
+      "name": "CVE-2024-43598",
+      "package_name": "lightgbm",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.11/site-packages/lightgbm-4.5.0.dist-info/METADATA",
+        "name": "lightgbm",
+        "package_manager": "PYTHONPKG",
+        "version": "4.5.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.1,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 8.1,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43598",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2024-43598 - lightgbm",
+      "reason_to_ignore": "No fix provided"
+    }
   ]
 }

--- a/autogluon/training/docker/1.2/py3/cu124/Dockerfile.gpu.os_scan_allowlist.json
+++ b/autogluon/training/docker/1.2/py3/cu124/Dockerfile.gpu.os_scan_allowlist.json
@@ -354,5 +354,36 @@
       "title": "CVE-2024-11394 - transformers",
       "reason_to_ignore": "N/A"
     }
+  ],
+  "lightgbm": [
+    {
+      "description": "LightGBM Remote Code Execution Vulnerability",
+      "vulnerability_id": "CVE-2024-43598",
+      "name": "CVE-2024-43598",
+      "package_name": "lightgbm",
+      "package_details": {
+        "file_path": "opt/conda/lib/python3.11/site-packages/lightgbm-4.5.0.dist-info/METADATA",
+        "name": "lightgbm",
+        "package_manager": "PYTHONPKG",
+        "version": "4.5.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.1,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 8.1,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2024-43598",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2024-43598 - lightgbm",
+      "reason_to_ignore": "No fix provided"
+    }
   ]
 }

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,7 +37,7 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["autogluon"]
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
@@ -107,7 +107,7 @@ use_scheduler = false
 dlc-pr-mxnet-training = ""
 dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
-dlc-pr-autogluon-training = ""
+dlc-pr-autogluon-training = "autogluon/training/buildspec.yml"
 
 # HuggingFace Training
 dlc-pr-huggingface-tensorflow-training = ""
@@ -136,7 +136,7 @@ dlc-pr-tensorflow-2-habana-training = ""
 dlc-pr-mxnet-inference = ""
 dlc-pr-pytorch-inference = ""
 dlc-pr-tensorflow-2-inference = ""
-dlc-pr-autogluon-inference = ""
+dlc-pr-autogluon-inference = "autogluon/inference/buildspec.yml"
 
 # Neuron Inference
 dlc-pr-mxnet-neuron-inference = ""

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,7 +37,7 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "mxnet", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["autogluon"]
+build_frameworks = []
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
@@ -107,7 +107,7 @@ use_scheduler = false
 dlc-pr-mxnet-training = ""
 dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
-dlc-pr-autogluon-training = "autogluon/training/buildspec.yml"
+dlc-pr-autogluon-training = ""
 
 # HuggingFace Training
 dlc-pr-huggingface-tensorflow-training = ""
@@ -136,7 +136,7 @@ dlc-pr-tensorflow-2-habana-training = ""
 dlc-pr-mxnet-inference = ""
 dlc-pr-pytorch-inference = ""
 dlc-pr-tensorflow-2-inference = ""
-dlc-pr-autogluon-inference = "autogluon/inference/buildspec.yml"
+dlc-pr-autogluon-inference = ""
 
 # Neuron Inference
 dlc-pr-mxnet-neuron-inference = ""


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

Add exception for LightGBM vulnerability for AutoGluon training and inference images as autogluon uses LightGBM versions >=4.5.0

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

<details>
<summary>Confused on how to run tests? Try using the helper utility...</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...
  
- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`
</details>

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Fill out the template and click the checkbox of the builds you'd like to execute

*Note: Replace with <X.Y> with the major.minor framework version (i.e. 2.2) you would like to start.*

- [ ] build_pytorch_training_<X.Y>_sm
- [ ] build_pytorch_training_<X.Y>_ec2

- [ ] build_pytorch_inference_<X.Y>_sm
- [ ] build_pytorch_inference_<X.Y>_ec2
- [ ] build_pytorch_inference_<X.Y>_graviton

- [ ] build_tensorflow_training_<X.Y>_sm
- [ ] build_tensorflow_training_<X.Y>_ec2

- [ ] build_tensorflow_inference_<X.Y>_sm
- [ ] build_tensorflow_inference_<X.Y>_ec2
- [ ] build_tensorflow_inference_<X.Y>_graviton
</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
