### PR TITLE
remove cache_from_tag

### DIFF
--- a/src/image.py
+++ b/src/image.py
@@ -39,7 +39,6 @@ class DockerImage:
         tag,
         to_build,
         stage,
-        cache_from_tag,
         context=None,
         to_push=True,
         additional_tags=[],
@@ -53,7 +52,6 @@ class DockerImage:
         self.build_args = {}
         self.labels = {}
         self.stage = stage
-        self.cache_from_tag = cache_from_tag
         self.dockerfile = dockerfile
         self.context = context
         self.to_push = to_push
@@ -205,7 +203,6 @@ class DockerImage:
         """
         response = [f"Starting the Build Process for {self.repository}:{self.tag}"]
         LOGGER.info(f"Starting the Build Process for {self.repository}:{self.tag}")
-        LOGGER.info(f"Using cache_from {self.repository}:{self.cache_from_tag}")
 
         line_counter = 0
         line_interval = 50
@@ -220,7 +217,6 @@ class DockerImage:
             buildargs=self.build_args,
             labels=self.labels,
             target=self.target,
-            cache_from=[f"{self.repository}:{self.cache_from_tag}"],  # Add cache source
         ):
             # print the log line during build for every line_interval lines for debugging
             if line_counter % line_interval == 0:

--- a/src/image_builder.py
+++ b/src/image_builder.py
@@ -134,10 +134,8 @@ def image_builder(buildspec, image_types=[], device_types=[]):
             ARTIFACTS.update(image_config["context"])
 
         if build_context == "PR":
-            cache_from_tag = tag_image_with_pr_number(image_config["tag"])
             image_tag = tag_image_with_pr_number(image_config["tag"])
         else:
-            cache_from_tag = image_config["tag"]
             image_tag = image_config["tag"]
 
         if is_autopatch_build_enabled(buildspec_path=buildspec):
@@ -361,7 +359,6 @@ def image_builder(buildspec, image_types=[], device_types=[]):
             tag=append_tag(image_tag, "pre-push"),
             to_build=image_config["build"],
             stage=constants.PRE_PUSH_STAGE,
-            cache_from_tag=cache_from_tag,
             context=context,
             additional_tags=additional_image_tags,
             target=target,
@@ -373,7 +370,7 @@ def image_builder(buildspec, image_types=[], device_types=[]):
         # inside function get_common_stage_image_object we make pre_push_stage_image_object non pushable.
         if image_config.get("enable_common_stage_build", True):
             common_stage_image_object = generate_common_stage_image_object(
-                pre_push_stage_image_object, image_tag, cache_from_tag
+                pre_push_stage_image_object, image_tag
             )
             COMMON_STAGE_IMAGES.append(common_stage_image_object)
 
@@ -477,7 +474,7 @@ def process_images(pre_push_image_list, pre_push_image_type="Pre-push", buildspe
     return images_to_push
 
 
-def generate_common_stage_image_object(pre_push_stage_image_object, image_tag, cache_from_tag):
+def generate_common_stage_image_object(pre_push_stage_image_object, image_tag):
     """
     Creates a common stage image object for a pre_push stage image. If for a pre_push stage image we create a common
     stage image, then we do not push the pre_push stage image to the repository. Instead, we just push its common stage
@@ -499,7 +496,6 @@ def generate_common_stage_image_object(pre_push_stage_image_object, image_tag, c
         tag=append_tag(image_tag, "multistage-common"),
         to_build=pre_push_stage_image_object.to_build,
         stage=constants.COMMON_STAGE,
-        cache_from_tag=cache_from_tag,
         additional_tags=pre_push_stage_image_object.additional_tags,
     )
     pre_push_stage_image_object.to_push = False


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

<details>
<summary>Confused on how to run tests? Try using the helper utility...</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...
  
- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`
</details>

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Fill out the template and click the checkbox of the builds you'd like to execute

*Note: Replace with <X.Y> with the major.minor framework version (i.e. 2.2) you would like to start.*

- [ ] build_pytorch_training_<X.Y>_sm
- [ ] build_pytorch_training_<X.Y>_ec2

- [ ] build_pytorch_inference_<X.Y>_sm
- [ ] build_pytorch_inference_<X.Y>_ec2
- [ ] build_pytorch_inference_<X.Y>_graviton

- [ ] build_tensorflow_training_<X.Y>_sm
- [ ] build_tensorflow_training_<X.Y>_ec2

- [ ] build_tensorflow_inference_<X.Y>_sm
- [ ] build_tensorflow_inference_<X.Y>_ec2
- [ ] build_tensorflow_inference_<X.Y>_graviton
</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
