### PR TITLE
Patch PyTorch 2.7 sagemaker package

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -86,7 +86,7 @@ enable_ipv6 = false
 ###    b. Configure the default security group to allow SSH traffic using IPv4
 ###
 ### 3. Create an EFA-enabled security group:
-###    a. Follow 'Step 1: Prepare an EFA-enabled security group' in:
+###    a. Follow 'Step 1: Prepare an EFA-enabled security group' in: 
 ###       https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-security
 ###    b. Configure this security group to also allow SSH traffic via IPv4
 ipv6_vpc_name = ""
@@ -119,7 +119,7 @@ use_scheduler = false
 ### TRAINING PR JOBS ###
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-7-sm.yml"
+dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -86,7 +86,7 @@ enable_ipv6 = false
 ###    b. Configure the default security group to allow SSH traffic using IPv4
 ###
 ### 3. Create an EFA-enabled security group:
-###    a. Follow 'Step 1: Prepare an EFA-enabled security group' in: 
+###    a. Follow 'Step 1: Prepare an EFA-enabled security group' in:
 ###       https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-security
 ###    b. Configure this security group to also allow SSH traffic via IPv4
 ipv6_vpc_name = ""
@@ -119,7 +119,7 @@ use_scheduler = false
 ### TRAINING PR JOBS ###
 
 # Standard Framework Training
-dlc-pr-pytorch-training = ""
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-7-sm.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/miscellaneous_scripts/dockerfile_patch_script.sh
+++ b/miscellaneous_scripts/dockerfile_patch_script.sh
@@ -44,7 +44,7 @@ chmod +x $PATCHING_INFO_PATH/patch-details/install_script_language.sh && \
 $PATCHING_INFO_PATH/patch-details/install_script_language.sh
 
 # Upgrade sagemaker-training
-if [[ $LATEST_RELEASED_IMAGE_URI =~ ^763104351884\.dkr\.ecr\.us-west-2\.amazonaws\.com/pytorch-training:2\.[4-6](.+)sagemaker ]]; then
+if [[ $LATEST_RELEASED_IMAGE_URI =~ ^763104351884\.dkr\.ecr\.us-west-2\.amazonaws\.com/pytorch-training:2\.[4-7](.+)sagemaker ]]; then
     pip install -U "sagemaker-training>4.7.4" "protobuf>=4.25.8,<6"
 fi
 

--- a/miscellaneous_scripts/dockerfile_patch_script.sh
+++ b/miscellaneous_scripts/dockerfile_patch_script.sh
@@ -54,9 +54,9 @@ fi
 
 # Upgrade sagemaker-training
 if [[ $LATEST_RELEASED_IMAGE_URI =~ ^763104351884\.dkr\.ecr\.us-west-2\.amazonaws\.com/pytorch-training:2\.[4-6](.+)sagemaker ]]; then
-    pip install -U "sagemaker-training>4.7.4" "protobuf>=4.25.8,<6" "sagemaker-pytorch-training>=2.9.0"
+    pip install -U "sagemaker-training>4.7.4" "protobuf>=4.25.8,<6"
 elif [[ $LATEST_RELEASED_IMAGE_URI =~ ^763104351884\.dkr\.ecr\.us-west-2\.amazonaws\.com/pytorch-training:2\.7(.+)sagemaker ]]; then
-    pip install -U "sagemaker-training>4.7.4,<5"
+    pip install -U "sagemaker-training>4.7.4,<5" "sagemaker-pytorch-training>=2.9.0"
 fi
 
 # For PT inference gpu sagemaker images, replace start_cuda_compat.sh

--- a/miscellaneous_scripts/dockerfile_patch_script.sh
+++ b/miscellaneous_scripts/dockerfile_patch_script.sh
@@ -45,7 +45,7 @@ $PATCHING_INFO_PATH/patch-details/install_script_language.sh
 
 # Upgrade sagemaker-training
 if [[ $LATEST_RELEASED_IMAGE_URI =~ ^763104351884\.dkr\.ecr\.us-west-2\.amazonaws\.com/pytorch-training:2\.[4-7](.+)sagemaker ]]; then
-    pip install -U "sagemaker-training>4.7.4" "protobuf>=4.25.8,<6"
+    pip install -U "sagemaker-training>4.7.4" "protobuf>=4.25.8,<6" "sagemaker-pytorch-training>=2.9.0"
 fi
 
 # For PT inference sagemaker images, replace torchserve-entrypoint.py with the latest one

--- a/miscellaneous_scripts/dockerfile_patch_script.sh
+++ b/miscellaneous_scripts/dockerfile_patch_script.sh
@@ -46,7 +46,6 @@ $PATCHING_INFO_PATH/patch-details/install_script_language.sh
 # Upgrade sagemaker-training
 if [[ $LATEST_RELEASED_IMAGE_URI =~ ^763104351884\.dkr\.ecr\.us-west-2\.amazonaws\.com/pytorch-training:2\.[4-6](.+)sagemaker ]]; then
     pip install -U "sagemaker-training>4.7.4" "protobuf>=4.25.8,<6" "sagemaker-pytorch-training>=2.9.0"
-fi
 elif [[ $LATEST_RELEASED_IMAGE_URI =~ ^763104351884\.dkr\.ecr\.us-west-2\.amazonaws\.com/pytorch-training:2\.7(.+)sagemaker ]]; then
     pip install -U "sagemaker-training>4.7.4,<5"
 fi

--- a/miscellaneous_scripts/dockerfile_patch_script.sh
+++ b/miscellaneous_scripts/dockerfile_patch_script.sh
@@ -44,8 +44,11 @@ chmod +x $PATCHING_INFO_PATH/patch-details/install_script_language.sh && \
 $PATCHING_INFO_PATH/patch-details/install_script_language.sh
 
 # Upgrade sagemaker-training
-if [[ $LATEST_RELEASED_IMAGE_URI =~ ^763104351884\.dkr\.ecr\.us-west-2\.amazonaws\.com/pytorch-training:2\.[4-7](.+)sagemaker ]]; then
+if [[ $LATEST_RELEASED_IMAGE_URI =~ ^763104351884\.dkr\.ecr\.us-west-2\.amazonaws\.com/pytorch-training:2\.[4-6](.+)sagemaker ]]; then
     pip install -U "sagemaker-training>4.7.4" "protobuf>=4.25.8,<6" "sagemaker-pytorch-training>=2.9.0"
+fi
+elif [[ $LATEST_RELEASED_IMAGE_URI =~ ^763104351884\.dkr\.ecr\.us-west-2\.amazonaws\.com/pytorch-training:2\.7(.+)sagemaker ]]; then
+    pip install -U "sagemaker-training>4.7.4,<5"
 fi
 
 # For PT inference sagemaker images, replace torchserve-entrypoint.py with the latest one

--- a/pytorch/training/docker/2.7/py3/Dockerfile.sagemaker.cpu.core_packages.json
+++ b/pytorch/training/docker/2.7/py3/Dockerfile.sagemaker.cpu.core_packages.json
@@ -45,7 +45,7 @@
     "version_specifier": "<1"
   },
   "sagemaker-training": {
-    "version_specifier": "<=4.8.3"
+    "version_specifier": ">=4.8.3"
   },
   "tqdm": {
     "version_specifier": ">=4.66.3"

--- a/pytorch/training/docker/2.7/py3/Dockerfile.sagemaker.cpu.py_scan_allowlist.json
+++ b/pytorch/training/docker/2.7/py3/Dockerfile.sagemaker.cpu.py_scan_allowlist.json
@@ -1,0 +1,3 @@
+{
+  "77740": "Package: protobuf is required by sagemaker-training-toolkit. Advisory: Affected versions of this package are vulnerable to a potential Denial of Service (DoS) attack due to unbounded recursion when parsing untrusted Protocol Buffers data. The pure-Python implementation fails to enforce recursion depth limits when processing recursive groups, recursive messages, or a series of SGROUP tags, leading to stack overflow conditions that can crash the application by exceeding Python's recursion limit."
+}

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.sagemaker.gpu.core_packages.json
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.sagemaker.gpu.core_packages.json
@@ -46,7 +46,7 @@
     "version_specifier": ">=6.5.1"
   },
    "sagemaker-training": {
-    "version_specifier": "<=4.8.3"
+    "version_specifier": ">=4.8.3"
   },
    "sagemaker": {
     "version_specifier": ">=2,<3"

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.sagemaker.gpu.py_scan_allowlist.json
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.sagemaker.gpu.py_scan_allowlist.json
@@ -1,0 +1,3 @@
+{
+  "77740": "Package: protobuf is required by sagemaker-training-toolkit. Advisory: Affected versions of this package are vulnerable to a potential Denial of Service (DoS) attack due to unbounded recursion when parsing untrusted Protocol Buffers data. The pure-Python implementation fails to enforce recursion depth limits when processing recursive groups, recursive messages, or a series of SGROUP tags, leading to stack overflow conditions that can crash the application by exceeding Python's recursion limit."
+}


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests run
- [e8062aa](https://github.com/aws/deep-learning-containers/pull/4976/commits/e8062aa4533e8b50d08bb05eb6c12abd2a02be4e) Passed all tests

**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.

<details>
<summary>Confused on how to run tests? Try using the helper utility...</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...
  
- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`
</details>

**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
<details>
<summary>Expand</summary>

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`

**Additionally, please run the sagemaker local tests in at least one revision:**
- [ ] `sagemaker_local_tests = true`

</details>

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### DLC image/dockerfile

#### Builds to Execute
<details>
<summary>Expand</summary>

Fill out the template and click the checkbox of the builds you'd like to execute

*Note: Replace with <X.Y> with the major.minor framework version (i.e. 2.2) you would like to start.*

- [ ] build_pytorch_training_<X.Y>_sm
- [ ] build_pytorch_training_<X.Y>_ec2

- [ ] build_pytorch_inference_<X.Y>_sm
- [ ] build_pytorch_inference_<X.Y>_ec2
- [ ] build_pytorch_inference_<X.Y>_graviton

- [ ] build_tensorflow_training_<X.Y>_sm
- [ ] build_tensorflow_training_<X.Y>_ec2

- [ ] build_tensorflow_inference_<X.Y>_sm
- [ ] build_tensorflow_inference_<X.Y>_ec2
- [ ] build_tensorflow_inference_<X.Y>_graviton
</details>

### Additional context

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.

#### NEURON/GRAVITON Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`

#### Benchmark Testing Checklist
* When creating a PR:
- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
