### PR TITLE
Add support for AsimovBot PR parser

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,13 +7,13 @@
 
 ### Description
 
-### Tests run
-
-**NOTE: By default, docker builds are disabled. In order to build your container, please update dlc_developer_config.toml and specify the framework to build in "build_frameworks"**
-- [ ] I have run builds/tests on commit <INSERT COMMIT ID> for my changes.
+### Tests Run
+By default, docker image builds and tests are disabled. Two ways to run builds and tests:
+1. Using dlc_developer_config.toml
+2. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)
 
 <details>
-<summary>Confused on how to run tests? Try using the helper utility...</summary>
+<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>
 
 Assuming your remote is called `origin` (you can find out more with `git remote -v`)...
   
@@ -28,50 +28,26 @@ Assuming your remote is called `origin` (you can find out more with `git remote 
 - Restore TOML file when ready to merge
 
 `python src/prepare_dlc_dev_environment.py -rcp origin`
-</details>
 
-**NOTE: If you are creating a PR for a new framework version, please ensure success of the standard, rc, and efa sagemaker remote tests by updating the dlc_developer_config.toml file:**
-<details>
-<summary>Expand</summary>
-
+**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**
 - [ ] `sagemaker_remote_tests = true`
 - [ ] `sagemaker_efa_tests = true`
 - [ ] `sagemaker_rc_tests = true`
-
-**Additionally, please run the sagemaker local tests in at least one revision:**
 - [ ] `sagemaker_local_tests = true`
-
 </details>
+
+<details>
+<summary>How to use PR description</summary>
+In the code block below, uncomment the buildspec line to run the image build, and optionally the tests line to run specific tests other than the default set which will always run if the build succeeded. The default set is (sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local), which are the same ones turned on by default in dlc_developer_config.toml. Replace the arguments with your desired buildspec file path and specific tests. 
+</details>
+
+```
+# /buildspec pytorch/inference/buildspec.yml
+# /tests sanity security ec2
+```
 
 ### Formatting
 - [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)
-
-### DLC image/dockerfile
-
-#### Builds to Execute
-<details>
-<summary>Expand</summary>
-
-Fill out the template and click the checkbox of the builds you'd like to execute
-
-*Note: Replace with <X.Y> with the major.minor framework version (i.e. 2.2) you would like to start.*
-
-- [ ] build_pytorch_training_<X.Y>_sm
-- [ ] build_pytorch_training_<X.Y>_ec2
-
-- [ ] build_pytorch_inference_<X.Y>_sm
-- [ ] build_pytorch_inference_<X.Y>_ec2
-- [ ] build_pytorch_inference_<X.Y>_graviton
-
-- [ ] build_tensorflow_training_<X.Y>_sm
-- [ ] build_tensorflow_training_<X.Y>_ec2
-
-- [ ] build_tensorflow_inference_<X.Y>_sm
-- [ ] build_tensorflow_inference_<X.Y>_ec2
-- [ ] build_tensorflow_inference_<X.Y>_graviton
-</details>
-
-### Additional context
 
 ### PR Checklist 
 <details>
@@ -84,14 +60,6 @@ Fill out the template and click the checkbox of the builds you'd like to execute
 - [ ] (If applicable) I've documented below the tests I've run on the DLC image
 - [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
 - [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.
-
-#### NEURON/GRAVITON Testing Checklist
-* When creating a PR:
-- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `neuron_mode = true` or `graviton_mode = true`
-
-#### Benchmark Testing Checklist
-* When creating a PR:
-- [ ] I've modified `dlc_developer_config.toml` in my PR branch by setting `ec2_benchmark_tests = true` or `sagemaker_benchmark_tests = true`
 </details>
 
 ### Pytest Marker Checklist

--- a/src/main.py
+++ b/src/main.py
@@ -40,11 +40,15 @@ def main():
     # this build.
     utils.write_to_json_file(constants.TEST_TYPE_IMAGES_PATH, {})
 
-    # Skip tensorflow-1 PR jobs, as there are no longer patch releases being added for TF1
-    # Purposefully not including this in developer config to make this difficult to enable
-    # TODO: Remove when we remove these jobs completely
-    build_name = get_codebuild_project_name()
-    if build_context == "PR" and build_name == "dlc-pr-tensorflow-1":
+    # Only bypass TOML checks if buildspec comes from PR description
+    if os.getenv("FRAMEWORK_BUILDSPEC_FILE") and os.getenv("FROM_PR_DESCRIPTION") == "true":
+        utils.build_setup(
+            args.framework,
+            device_types=device_types,
+            image_types=image_types,
+            py_versions=py_versions,
+        )
+        image_builder(args.buildspec, image_types, device_types)
         return
 
     # A general build will work if build job and build mode are in non-EI, non-NEURON

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -441,6 +441,11 @@ def main():
             else:
                 raise Exception(f"EKS cluster {eks_cluster_name} is not in active state")
 
+        # Get specified tests if any
+        specified_tests = os.getenv("SPECIFIED_TESTS")
+        if specified_tests:
+            specified_tests = specified_tests.split()
+
         # Execute dlc_tests pytest command
         pytest_cmd = [
             "-s",
@@ -449,6 +454,9 @@ def main():
             f"--junitxml={report}",
             "-n=auto",
         ]
+        if specified_tests:
+            test_expr = " or ".join(f"test_{t}" for t in specified_tests)
+            pytest_cmd.extend(["-k", f"({test_expr})"])
 
         is_habana_image = any("habana" in image_uri for image_uri in all_image_list)
         if specific_test_type == "ec2":


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests Run
By default, docker image builds and tests are disabled. Two ways to run builds and tests:
1. Using dlc_developer_config.toml
2. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...
  
- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**
- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`
</details>

<details>
<summary>How to use PR description</summary>
In the code block below, uncomment the buildspec line to run the image build, and optionally the tests line to run specific tests other than the default set which will always run if the build succeeded. The default set is (sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local), which are the same ones turned on by default in dlc_developer_config.toml. Replace the arguments with your desired buildspec file path and specific tests. 
</details>

```
# /buildspec pytorch/inference/buildspec.yml
# /tests sanity security ec2
```

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
