### PR TITLE
Disable PT 2.7 Autopatch and Onboard BuildX

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -122,7 +122,7 @@ use_scheduler = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = ""
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-7-sm.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,16 +37,16 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
-do_build = false
+do_build = true
 
 [notify]
 ### Notify on test failures
@@ -57,12 +57,12 @@ notify_test_failures = false
 
 [test]
 ### On by default
-sanity_tests = false
-security_tests = false
+sanity_tests = true
+security_tests = true
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = false
-eks_tests = false
+ecs_tests = true
+eks_tests = true
 ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
@@ -71,10 +71,10 @@ ec2_benchmark_tests = false
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = true
+ec2_tests_on_heavy_instances = false
 ### SM specific tests
 ### On by default
-sagemaker_local_tests = false
+sagemaker_local_tests = true
 ### Set enable_ipv6 = true to run tests with IPv6-enabled resources
 ### Off by default (set to false)
 enable_ipv6 = false
@@ -86,19 +86,19 @@ enable_ipv6 = false
 ###    b. Configure the default security group to allow SSH traffic using IPv4
 ###
 ### 3. Create an EFA-enabled security group:
-###    a. Follow 'Step 1: Prepare an EFA-enabled security group' in:
+###    a. Follow 'Step 1: Prepare an EFA-enabled security group' in: 
 ###       https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-security
 ###    b. Configure this security group to also allow SSH traffic via IPv4
 ipv6_vpc_name = ""
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = false
+sagemaker_remote_tests = true
 # run efa sagemaker tests
-sagemaker_efa_tests = true
+sagemaker_efa_tests = false
 # run release_candidate_integration tests
-sagemaker_rc_tests = true
+sagemaker_rc_tests = false
 # run sagemaker benchmark tests
-sagemaker_benchmark_tests = true
+sagemaker_benchmark_tests = false
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""
@@ -122,7 +122,7 @@ use_scheduler = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-7-sm.yml"
+dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,16 +37,16 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
-do_build = true
+do_build = false
 
 [notify]
 ### Notify on test failures
@@ -57,12 +57,12 @@ notify_test_failures = false
 
 [test]
 ### On by default
-sanity_tests = true
-security_tests = true
+sanity_tests = false
+security_tests = false
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = true
-eks_tests = true
+ecs_tests = false
+eks_tests = false
 ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
@@ -71,10 +71,10 @@ ec2_benchmark_tests = false
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = false
+ec2_tests_on_heavy_instances = true
 ### SM specific tests
 ### On by default
-sagemaker_local_tests = true
+sagemaker_local_tests = false
 ### Set enable_ipv6 = true to run tests with IPv6-enabled resources
 ### Off by default (set to false)
 enable_ipv6 = false
@@ -86,19 +86,19 @@ enable_ipv6 = false
 ###    b. Configure the default security group to allow SSH traffic using IPv4
 ###
 ### 3. Create an EFA-enabled security group:
-###    a. Follow 'Step 1: Prepare an EFA-enabled security group' in: 
+###    a. Follow 'Step 1: Prepare an EFA-enabled security group' in:
 ###       https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-security
 ###    b. Configure this security group to also allow SSH traffic via IPv4
 ipv6_vpc_name = ""
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = true
+sagemaker_remote_tests = false
 # run efa sagemaker tests
-sagemaker_efa_tests = false
+sagemaker_efa_tests = true
 # run release_candidate_integration tests
-sagemaker_rc_tests = false
+sagemaker_rc_tests = true
 # run sagemaker benchmark tests
-sagemaker_benchmark_tests = false
+sagemaker_benchmark_tests = true
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""

--- a/pytorch/training/buildspec-2-7-sm.yml
+++ b/pytorch/training/buildspec-2-7-sm.yml
@@ -5,7 +5,7 @@ framework: &FRAMEWORK pytorch
 version: &VERSION 2.7.1
 short_version: &SHORT_VERSION "2.7"
 arch_type: x86
-autopatch_build: "False"
+autopatch_build: "True"
 
 repository_info:
   training_repository: &TRAINING_REPOSITORY

--- a/pytorch/training/buildspec-2-7-sm.yml
+++ b/pytorch/training/buildspec-2-7-sm.yml
@@ -56,7 +56,7 @@ images:
   BuildSageMakerGPUPTTrainPy3DockerImage:
     <<: *TRAINING_REPOSITORY
     build: &PYTORCH_GPU_TRAINING_PY3 false
-    image_size_baseline: 24000
+    image_size_baseline: 30000
     device_type: &DEVICE_TYPE gpu
     python_version: &DOCKER_PYTHON_VERSION py3
     tag_python_version: &TAG_PYTHON_VERSION py312

--- a/pytorch/training/buildspec-2-7-sm.yml
+++ b/pytorch/training/buildspec-2-7-sm.yml
@@ -38,25 +38,25 @@ context:
       target: deep_learning_container.py
 
 images:
-  # BuildSageMakerCPUPTTrainPy3DockerImage:
-  #   <<: *TRAINING_REPOSITORY
-  #   build: &PYTORCH_CPU_TRAINING_PY3 false
-  #   image_size_baseline: 6500
-  #   device_type: &DEVICE_TYPE cpu
-  #   python_version: &DOCKER_PYTHON_VERSION py3
-  #   tag_python_version: &TAG_PYTHON_VERSION py312
-  #   os_version: &OS_VERSION ubuntu22.04
-  #   tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-  #   latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-  #   # skip_build: "False"
-  #   docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
-  #   target: sagemaker
-  #   context:
-  #     <<: *TRAINING_CONTEXT
+  BuildSageMakerCPUPTTrainPy3DockerImage:
+    <<: *TRAINING_REPOSITORY
+    build: &PYTORCH_CPU_TRAINING_PY3 false
+    image_size_baseline: 6500
+    device_type: &DEVICE_TYPE cpu
+    python_version: &DOCKER_PYTHON_VERSION py3
+    tag_python_version: &TAG_PYTHON_VERSION py312
+    os_version: &OS_VERSION ubuntu22.04
+    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
+    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
+    # skip_build: "False"
+    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
+    target: sagemaker
+    context:
+      <<: *TRAINING_CONTEXT
   BuildSageMakerGPUPTTrainPy3DockerImage:
     <<: *TRAINING_REPOSITORY
     build: &PYTORCH_GPU_TRAINING_PY3 false
-    image_size_baseline: 30000
+    image_size_baseline: 24000
     device_type: &DEVICE_TYPE gpu
     python_version: &DOCKER_PYTHON_VERSION py3
     tag_python_version: &TAG_PYTHON_VERSION py312

--- a/pytorch/training/buildspec-2-7-sm.yml
+++ b/pytorch/training/buildspec-2-7-sm.yml
@@ -5,7 +5,7 @@ framework: &FRAMEWORK pytorch
 version: &VERSION 2.7.1
 short_version: &SHORT_VERSION "2.7"
 arch_type: x86
-autopatch_build: "True"
+autopatch_build: "False"
 
 repository_info:
   training_repository: &TRAINING_REPOSITORY
@@ -38,21 +38,21 @@ context:
       target: deep_learning_container.py
 
 images:
-  BuildSageMakerCPUPTTrainPy3DockerImage:
-    <<: *TRAINING_REPOSITORY
-    build: &PYTORCH_CPU_TRAINING_PY3 false
-    image_size_baseline: 6500
-    device_type: &DEVICE_TYPE cpu
-    python_version: &DOCKER_PYTHON_VERSION py3
-    tag_python_version: &TAG_PYTHON_VERSION py312
-    os_version: &OS_VERSION ubuntu22.04
-    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-    # skip_build: "False"
-    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
-    target: sagemaker
-    context:
-      <<: *TRAINING_CONTEXT
+  # BuildSageMakerCPUPTTrainPy3DockerImage:
+  #   <<: *TRAINING_REPOSITORY
+  #   build: &PYTORCH_CPU_TRAINING_PY3 false
+  #   image_size_baseline: 6500
+  #   device_type: &DEVICE_TYPE cpu
+  #   python_version: &DOCKER_PYTHON_VERSION py3
+  #   tag_python_version: &TAG_PYTHON_VERSION py312
+  #   os_version: &OS_VERSION ubuntu22.04
+  #   tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
+  #   latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
+  #   # skip_build: "False"
+  #   docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
+  #   target: sagemaker
+  #   context:
+  #     <<: *TRAINING_CONTEXT
   BuildSageMakerGPUPTTrainPy3DockerImage:
     <<: *TRAINING_REPOSITORY
     build: &PYTORCH_GPU_TRAINING_PY3 false

--- a/pytorch/training/buildspec-2-7-sm.yml
+++ b/pytorch/training/buildspec-2-7-sm.yml
@@ -5,7 +5,7 @@ framework: &FRAMEWORK pytorch
 version: &VERSION 2.7.1
 short_version: &SHORT_VERSION "2.7"
 arch_type: x86
-autopatch_build: "True"
+autopatch_build: "False"
 
 repository_info:
   training_repository: &TRAINING_REPOSITORY

--- a/pytorch/training/docker/2.7/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/2.7/py3/Dockerfile.cpu
@@ -322,7 +322,7 @@ RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
 # Install SM packages
 RUN pip install --no-cache-dir -U \
     smclarify \
-    "sagemaker>=2,<3" \
+    "sagemaker>=2.9.0,<3" \
     "sagemaker-experiments<1" \
     sagemaker-pytorch-training \
     sagemaker-training
@@ -338,7 +338,7 @@ RUN pip install --no-cache-dir -U \
     seaborn \
     shap \
     # pinned for sagemaker==2.233.0
-    cloudpickle 
+    cloudpickle
 
 # Copy workaround script for incorrect hostname
 COPY changehostname.c /
@@ -361,4 +361,3 @@ RUN rm -rf /root/.cache | true
 
 ENTRYPOINT ["bash", "-m", "start_with_right_hostname.sh"]
 CMD ["/bin/bash"]
-

--- a/pytorch/training/docker/2.7/py3/Dockerfile.sagemaker.cpu.core_packages.json
+++ b/pytorch/training/docker/2.7/py3/Dockerfile.sagemaker.cpu.core_packages.json
@@ -18,13 +18,13 @@
     "version_specifier": "==0.2.4",
     "skip": "True"
   },
-    "s3torchconnector": {
-    "version_specifier": "==1.4.2",
-     "skip": "True"
+  "s3torchconnector": {
+    "version_specifier": "==1.4.3",
+    "skip": "True"
   },
   "accelerate": {
-    "version_specifier": "==1.9.0",
-     "skip": "True"
+    "version_specifier": "==1.10.0",
+    "skip": "True"
   },
   "thinc": {
     "version_specifier": "==8.3.4"
@@ -41,7 +41,7 @@
   "sagemaker": {
     "version_specifier": ">=2,<3"
   },
-   "sagemaker-experiments": {
+  "sagemaker-experiments": {
     "version_specifier": "<1"
   },
   "sagemaker-training": {
@@ -59,7 +59,7 @@
   "urllib3": {
     "version_specifier": ">=2.5.0"
   },
-   "awscli": {
+  "awscli": {
     "version_specifier": "<2"
   },
   "opencv-python": {

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -254,211 +254,211 @@ RUN pip install --no-cache-dir \
     tornado>=6.5.1
 
 # Install PyTorch
-RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
-    torchvision==${TORCHVISION_VERSION} \
-    torchaudio==${TORCHAUDIO_VERSION} \
-    --index-url https://download.pytorch.org/whl/cu128 \
-    && pip install --no-cache-dir -U torchtnt==${TORCHTNT_VERSION} \
-    torchdata==${TORCHDATA_VERSION} \
-    triton \
-    s3torchconnector \
-    fastai==2.8.2 \
-    accelerate \
-    # pin numpy requirement for fastai dependency
-    # requires explicit declaration of spacy, thic, blis
-    spacy \
-    #thinc 8.3.6 is not compatible with numpy 1.26.4 (sagemaker doesn't support latest numpy)
-    thinc==8.3.4 \
-    blis \
-    numpy \
- && pip uninstall -y dataclasses
-
-RUN curl -o /license.txt https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.7/license.txt
-
-COPY deep_learning_container.py /usr/local/bin/deep_learning_container.py
-
-RUN chmod +x /usr/local/bin/deep_learning_container.py
-
-COPY start_cuda_compat.sh /usr/local/bin/start_cuda_compat.sh
-RUN chmod +x /usr/local/bin/start_cuda_compat.sh
-
-COPY bash_telemetry.sh /usr/local/bin/bash_telemetry.sh
-RUN chmod +x /usr/local/bin/bash_telemetry.sh
-RUN echo 'source /usr/local/bin/bash_telemetry.sh' >> /etc/bash.bashrc
-
-# Removing the cache as it is needed for security verification
-RUN rm -rf /root/.cache | true
-
-########################################################
-#  _____ ____ ____    ___
-# | ____/ ___|___ \  |_ _|_ __ ___   __ _  __ _  ___
-# |  _|| |     __) |  | || '_ ` _ \ / _` |/ _` |/ _ \
-# | |__| |___ / __/   | || | | | | | (_| | (_| |  __/
-# |_____\____|_____| |___|_| |_| |_|\__,_|\__, |\___|
-#                                         |___/
-#  ____           _
-# |  _ \ ___  ___(_)_ __   ___
-# | |_) / _ \/ __| | '_ \ / _ \
-# |  _ <  __/ (__| | |_) |  __/
-# |_| \_\___|\___|_| .__/ \___|
-#                  |_|
-########################################################
-
-FROM common AS ec2
-
-ARG PYTHON
-ARG PYTHON_SHORT_VERSION
-ARG NCCL_VERSION
-ARG GDRCOPY_VERSION
-ARG TE_VERSION
-ARG FLASH_ATTN_VERSION
-
-WORKDIR /
-
-
-# Install GDRCopy which is a dependency of SM Distributed DataParallel binary
-# The test binaries requires cuda driver library which could be found in conda
-# So update the linker path to point to it to avoid -Lcuda not found
-RUN cd /tmp \
- && git clone https://github.com/NVIDIA/gdrcopy.git -b v${GDRCOPY_VERSION} \
- && cd gdrcopy \
- && sed -ie '12s@$@ -L $(CUDA)/lib64/stubs@' tests/Makefile \
- && CUDA=${CUDA_HOME} make install \
- && rm -rf /tmp/gdrcopy
-
-# Install NCCL
-RUN cd /tmp \
- && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION}-1 \
- && cd nccl \
- && make -j64 src.build BUILDDIR=/usr/local \
- && rm -rf /tmp/nccl
-
-# Install flash attn and NVIDIA transformer engine.
-# Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
-ENV NVTE_FRAMEWORK=pytorch
-# Install flash-attn using instructions from https://github.com/Dao-AILab/flash-attention#installation-and-features
-# Set MAX_JOBS=4 to avoid OOM issues in installation process
-RUN MAX_JOBS=4 pip install --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
-# Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
-RUN pip install --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
-
-COPY dockerd_entrypoint.sh /usr/local/bin/dockerd_entrypoint.sh
-RUN chmod +x /usr/local/bin/dockerd_entrypoint.sh
-
-RUN HOME_DIR=/root \
- && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
- && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
- && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
- && chmod +x /usr/local/bin/testOSSCompliance \
- && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
- && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
- && rm -rf ${HOME_DIR}/oss_compliance* \
- && rm -rf /tmp/tmp*
-
-# Removing the cache as it is needed for security verification
-RUN rm -rf /root/.cache | true
-
-ENTRYPOINT ["bash", "-m", "dockerd_entrypoint.sh"]
-CMD ["/bin/bash"]
-
-
-#################################################################
-#  ____                   __  __       _
-# / ___|  __ _  __ _  ___|  \/  | __ _| | _____ _ __
-# \___ \ / _` |/ _` |/ _ \ |\/| |/ _` | |/ / _ \ '__|
-#  ___) | (_| | (_| |  __/ |  | | (_| |   <  __/ |
-# |____/ \__,_|\__, |\___|_|  |_|\__,_|_|\_\___|_|
-#              |___/
-#  ___                              ____           _
-# |_ _|_ __ ___   __ _  __ _  ___  |  _ \ ___  ___(_)_ __   ___
-#  | || '_ ` _ \ / _` |/ _` |/ _ \ | |_) / _ \/ __| | '_ \ / _ \
-#  | || | | | | | (_| | (_| |  __/ |  _ <  __/ (__| | |_) |  __/
-# |___|_| |_| |_|\__,_|\__, |\___| |_| \_\___|\___|_| .__/ \___|
-#                      |___/                        |_|
-#################################################################
-
-FROM common AS sagemaker
-
-LABEL maintainer="Amazon AI"
-LABEL dlc_major_version="1"
-
-ENV SAGEMAKER_TRAINING_MODULE=sagemaker_pytorch_container.training:main
-
-ARG PYTHON
-ARG PYTHON_SHORT_VERSION
-ARG NCCL_VERSION
-ARG GDRCOPY_VERSION
-ARG TE_VERSION
-ARG FLASH_ATTN_VERSION
-
-WORKDIR /
-
-# Install GDRCopy which is a dependency of SM Distributed DataParallel binary
-# The test binaries requires cuda driver library which could be found in conda
-# So update the linker path to point to it to avoid -Lcuda not found
-RUN cd /tmp \
- && git clone https://github.com/NVIDIA/gdrcopy.git -b v${GDRCOPY_VERSION} \
- && cd gdrcopy \
- && sed -ie '12s@$@ -L $(CUDA)/lib64/stubs@' tests/Makefile \
- && CUDA=${CUDA_HOME} make install \
- && rm -rf /tmp/gdrcopy
-
-# Install NCCL
-RUN cd /tmp \
- && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION}-1 \
- && cd nccl \
- && make -j64 src.build BUILDDIR=/usr/local \
- && rm -rf /tmp/nccl
-
-RUN pip uninstall -y ninja && pip install ninja
-
-# Install flash attn and NVIDIA transformer engine.
-# Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
-ENV NVTE_FRAMEWORK=pytorch
-# Install flash-attn using instructions from https://github.com/Dao-AILab/flash-attention#installation-and-features
-# Set MAX_JOBS=4 to avoid OOM issues in installation process
-RUN MAX_JOBS=4 pip install --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
-# Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
-RUN pip install --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
-
-# Install SM packages
-RUN pip install --no-cache-dir -U \
-    smclarify \
-    "sagemaker>=2.9.0,<3" \
-    "sagemaker-experiments<1" \
-    sagemaker-pytorch-training \
-    sagemaker-training
-
-# Install extra packages
-RUN pip install --no-cache-dir -U \
-    bokeh \
-    imageio \
-    numba \
-    pandas \
-    plotly \
-    shap \
-    scikit-learn \
-    seaborn \
-    # pinned for sagemaker==2.233.0
-    cloudpickle
-
-RUN HOME_DIR=/root \
- && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
- && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
- && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
- && chmod +x /usr/local/bin/testOSSCompliance \
- && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
- && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
- && rm -rf ${HOME_DIR}/oss_compliance* \
- && rm -rf /tmp/tmp*
-
-# Removing the cache as it is needed for security verification
-RUN rm -rf /root/.cache | true
-
-# Copy workaround script for incorrect hostname
-COPY changehostname.c /
-COPY start_with_right_hostname.sh /usr/local/bin/start_with_right_hostname.sh
-RUN chmod +x /usr/local/bin/start_with_right_hostname.sh
-
-ENTRYPOINT ["bash", "-m", "start_with_right_hostname.sh"]
-CMD ["/bin/bash"]
+# RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
+#     torchvision==${TORCHVISION_VERSION} \
+#     torchaudio==${TORCHAUDIO_VERSION} \
+#     --index-url https://download.pytorch.org/whl/cu128 \
+#     && pip install --no-cache-dir -U torchtnt==${TORCHTNT_VERSION} \
+#     torchdata==${TORCHDATA_VERSION} \
+#     triton \
+#     s3torchconnector \
+#     fastai==2.8.2 \
+#     accelerate \
+#     # pin numpy requirement for fastai dependency
+#     # requires explicit declaration of spacy, thic, blis
+#     spacy \
+#     #thinc 8.3.6 is not compatible with numpy 1.26.4 (sagemaker doesn't support latest numpy)
+#     thinc==8.3.4 \
+#     blis \
+#     numpy \
+#  && pip uninstall -y dataclasses
+#
+# RUN curl -o /license.txt https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.7/license.txt
+#
+# COPY deep_learning_container.py /usr/local/bin/deep_learning_container.py
+#
+# RUN chmod +x /usr/local/bin/deep_learning_container.py
+#
+# COPY start_cuda_compat.sh /usr/local/bin/start_cuda_compat.sh
+# RUN chmod +x /usr/local/bin/start_cuda_compat.sh
+#
+# COPY bash_telemetry.sh /usr/local/bin/bash_telemetry.sh
+# RUN chmod +x /usr/local/bin/bash_telemetry.sh
+# RUN echo 'source /usr/local/bin/bash_telemetry.sh' >> /etc/bash.bashrc
+#
+# # Removing the cache as it is needed for security verification
+# RUN rm -rf /root/.cache | true
+#
+# ########################################################
+# #  _____ ____ ____    ___
+# # | ____/ ___|___ \  |_ _|_ __ ___   __ _  __ _  ___
+# # |  _|| |     __) |  | || '_ ` _ \ / _` |/ _` |/ _ \
+# # | |__| |___ / __/   | || | | | | | (_| | (_| |  __/
+# # |_____\____|_____| |___|_| |_| |_|\__,_|\__, |\___|
+# #                                         |___/
+# #  ____           _
+# # |  _ \ ___  ___(_)_ __   ___
+# # | |_) / _ \/ __| | '_ \ / _ \
+# # |  _ <  __/ (__| | |_) |  __/
+# # |_| \_\___|\___|_| .__/ \___|
+# #                  |_|
+# ########################################################
+#
+# FROM common AS ec2
+#
+# ARG PYTHON
+# ARG PYTHON_SHORT_VERSION
+# ARG NCCL_VERSION
+# ARG GDRCOPY_VERSION
+# ARG TE_VERSION
+# ARG FLASH_ATTN_VERSION
+#
+# WORKDIR /
+#
+#
+# # Install GDRCopy which is a dependency of SM Distributed DataParallel binary
+# # The test binaries requires cuda driver library which could be found in conda
+# # So update the linker path to point to it to avoid -Lcuda not found
+# RUN cd /tmp \
+#  && git clone https://github.com/NVIDIA/gdrcopy.git -b v${GDRCOPY_VERSION} \
+#  && cd gdrcopy \
+#  && sed -ie '12s@$@ -L $(CUDA)/lib64/stubs@' tests/Makefile \
+#  && CUDA=${CUDA_HOME} make install \
+#  && rm -rf /tmp/gdrcopy
+#
+# # Install NCCL
+# RUN cd /tmp \
+#  && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION}-1 \
+#  && cd nccl \
+#  && make -j64 src.build BUILDDIR=/usr/local \
+#  && rm -rf /tmp/nccl
+#
+# # Install flash attn and NVIDIA transformer engine.
+# # Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
+# ENV NVTE_FRAMEWORK=pytorch
+# # Install flash-attn using instructions from https://github.com/Dao-AILab/flash-attention#installation-and-features
+# # Set MAX_JOBS=4 to avoid OOM issues in installation process
+# RUN MAX_JOBS=4 pip install --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
+# # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
+# RUN pip install --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
+#
+# COPY dockerd_entrypoint.sh /usr/local/bin/dockerd_entrypoint.sh
+# RUN chmod +x /usr/local/bin/dockerd_entrypoint.sh
+#
+# RUN HOME_DIR=/root \
+#  && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
+#  && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
+#  && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
+#  && chmod +x /usr/local/bin/testOSSCompliance \
+#  && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
+#  && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
+#  && rm -rf ${HOME_DIR}/oss_compliance* \
+#  && rm -rf /tmp/tmp*
+#
+# # Removing the cache as it is needed for security verification
+# RUN rm -rf /root/.cache | true
+#
+# ENTRYPOINT ["bash", "-m", "dockerd_entrypoint.sh"]
+# CMD ["/bin/bash"]
+#
+#
+# #################################################################
+# #  ____                   __  __       _
+# # / ___|  __ _  __ _  ___|  \/  | __ _| | _____ _ __
+# # \___ \ / _` |/ _` |/ _ \ |\/| |/ _` | |/ / _ \ '__|
+# #  ___) | (_| | (_| |  __/ |  | | (_| |   <  __/ |
+# # |____/ \__,_|\__, |\___|_|  |_|\__,_|_|\_\___|_|
+# #              |___/
+# #  ___                              ____           _
+# # |_ _|_ __ ___   __ _  __ _  ___  |  _ \ ___  ___(_)_ __   ___
+# #  | || '_ ` _ \ / _` |/ _` |/ _ \ | |_) / _ \/ __| | '_ \ / _ \
+# #  | || | | | | | (_| | (_| |  __/ |  _ <  __/ (__| | |_) |  __/
+# # |___|_| |_| |_|\__,_|\__, |\___| |_| \_\___|\___|_| .__/ \___|
+# #                      |___/                        |_|
+# #################################################################
+#
+# FROM common AS sagemaker
+#
+# LABEL maintainer="Amazon AI"
+# LABEL dlc_major_version="1"
+#
+# ENV SAGEMAKER_TRAINING_MODULE=sagemaker_pytorch_container.training:main
+#
+# ARG PYTHON
+# ARG PYTHON_SHORT_VERSION
+# ARG NCCL_VERSION
+# ARG GDRCOPY_VERSION
+# ARG TE_VERSION
+# ARG FLASH_ATTN_VERSION
+#
+# WORKDIR /
+#
+# # Install GDRCopy which is a dependency of SM Distributed DataParallel binary
+# # The test binaries requires cuda driver library which could be found in conda
+# # So update the linker path to point to it to avoid -Lcuda not found
+# RUN cd /tmp \
+#  && git clone https://github.com/NVIDIA/gdrcopy.git -b v${GDRCOPY_VERSION} \
+#  && cd gdrcopy \
+#  && sed -ie '12s@$@ -L $(CUDA)/lib64/stubs@' tests/Makefile \
+#  && CUDA=${CUDA_HOME} make install \
+#  && rm -rf /tmp/gdrcopy
+#
+# # Install NCCL
+# RUN cd /tmp \
+#  && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION}-1 \
+#  && cd nccl \
+#  && make -j64 src.build BUILDDIR=/usr/local \
+#  && rm -rf /tmp/nccl
+#
+# RUN pip uninstall -y ninja && pip install ninja
+#
+# # Install flash attn and NVIDIA transformer engine.
+# # Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
+# ENV NVTE_FRAMEWORK=pytorch
+# # Install flash-attn using instructions from https://github.com/Dao-AILab/flash-attention#installation-and-features
+# # Set MAX_JOBS=4 to avoid OOM issues in installation process
+# RUN MAX_JOBS=4 pip install --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
+# # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
+# RUN pip install --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
+#
+# # Install SM packages
+# RUN pip install --no-cache-dir -U \
+#     smclarify \
+#     "sagemaker>=2.9.0,<3" \
+#     "sagemaker-experiments<1" \
+#     sagemaker-pytorch-training \
+#     sagemaker-training
+#
+# # Install extra packages
+# RUN pip install --no-cache-dir -U \
+#     bokeh \
+#     imageio \
+#     numba \
+#     pandas \
+#     plotly \
+#     shap \
+#     scikit-learn \
+#     seaborn \
+#     # pinned for sagemaker==2.233.0
+#     cloudpickle
+#
+# RUN HOME_DIR=/root \
+#  && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
+#  && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
+#  && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
+#  && chmod +x /usr/local/bin/testOSSCompliance \
+#  && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
+#  && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
+#  && rm -rf ${HOME_DIR}/oss_compliance* \
+#  && rm -rf /tmp/tmp*
+#
+# # Removing the cache as it is needed for security verification
+# RUN rm -rf /root/.cache | true
+#
+# # Copy workaround script for incorrect hostname
+# COPY changehostname.c /
+# COPY start_with_right_hostname.sh /usr/local/bin/start_with_right_hostname.sh
+# RUN chmod +x /usr/local/bin/start_with_right_hostname.sh
+#
+# ENTRYPOINT ["bash", "-m", "start_with_right_hostname.sh"]
+# CMD ["/bin/bash"]

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -272,23 +272,23 @@ RUN pip install --no-cache-dir \
 #     blis \
 #     numpy \
 #  && pip uninstall -y dataclasses
-#
-# RUN curl -o /license.txt https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.7/license.txt
-#
-# COPY deep_learning_container.py /usr/local/bin/deep_learning_container.py
-#
-# RUN chmod +x /usr/local/bin/deep_learning_container.py
-#
-# COPY start_cuda_compat.sh /usr/local/bin/start_cuda_compat.sh
-# RUN chmod +x /usr/local/bin/start_cuda_compat.sh
-#
-# COPY bash_telemetry.sh /usr/local/bin/bash_telemetry.sh
-# RUN chmod +x /usr/local/bin/bash_telemetry.sh
-# RUN echo 'source /usr/local/bin/bash_telemetry.sh' >> /etc/bash.bashrc
-#
-# # Removing the cache as it is needed for security verification
-# RUN rm -rf /root/.cache | true
-#
+
+RUN curl -o /license.txt https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.7/license.txt
+
+COPY deep_learning_container.py /usr/local/bin/deep_learning_container.py
+
+RUN chmod +x /usr/local/bin/deep_learning_container.py
+
+COPY start_cuda_compat.sh /usr/local/bin/start_cuda_compat.sh
+RUN chmod +x /usr/local/bin/start_cuda_compat.sh
+
+COPY bash_telemetry.sh /usr/local/bin/bash_telemetry.sh
+RUN chmod +x /usr/local/bin/bash_telemetry.sh
+RUN echo 'source /usr/local/bin/bash_telemetry.sh' >> /etc/bash.bashrc
+
+# Removing the cache as it is needed for security verification
+RUN rm -rf /root/.cache | true
+
 # ########################################################
 # #  _____ ____ ____    ___
 # # | ____/ ___|___ \  |_ _|_ __ ___   __ _  __ _  ___
@@ -360,39 +360,39 @@ RUN pip install --no-cache-dir \
 #
 # ENTRYPOINT ["bash", "-m", "dockerd_entrypoint.sh"]
 # CMD ["/bin/bash"]
-#
-#
-# #################################################################
-# #  ____                   __  __       _
-# # / ___|  __ _  __ _  ___|  \/  | __ _| | _____ _ __
-# # \___ \ / _` |/ _` |/ _ \ |\/| |/ _` | |/ / _ \ '__|
-# #  ___) | (_| | (_| |  __/ |  | | (_| |   <  __/ |
-# # |____/ \__,_|\__, |\___|_|  |_|\__,_|_|\_\___|_|
-# #              |___/
-# #  ___                              ____           _
-# # |_ _|_ __ ___   __ _  __ _  ___  |  _ \ ___  ___(_)_ __   ___
-# #  | || '_ ` _ \ / _` |/ _` |/ _ \ | |_) / _ \/ __| | '_ \ / _ \
-# #  | || | | | | | (_| | (_| |  __/ |  _ <  __/ (__| | |_) |  __/
-# # |___|_| |_| |_|\__,_|\__, |\___| |_| \_\___|\___|_| .__/ \___|
-# #                      |___/                        |_|
-# #################################################################
-#
-# FROM common AS sagemaker
-#
-# LABEL maintainer="Amazon AI"
-# LABEL dlc_major_version="1"
-#
-# ENV SAGEMAKER_TRAINING_MODULE=sagemaker_pytorch_container.training:main
-#
-# ARG PYTHON
-# ARG PYTHON_SHORT_VERSION
-# ARG NCCL_VERSION
-# ARG GDRCOPY_VERSION
-# ARG TE_VERSION
-# ARG FLASH_ATTN_VERSION
-#
-# WORKDIR /
-#
+
+
+#################################################################
+#  ____                   __  __       _
+# / ___|  __ _  __ _  ___|  \/  | __ _| | _____ _ __
+# \___ \ / _` |/ _` |/ _ \ |\/| |/ _` | |/ / _ \ '__|
+#  ___) | (_| | (_| |  __/ |  | | (_| |   <  __/ |
+# |____/ \__,_|\__, |\___|_|  |_|\__,_|_|\_\___|_|
+#              |___/
+#  ___                              ____           _
+# |_ _|_ __ ___   __ _  __ _  ___  |  _ \ ___  ___(_)_ __   ___
+#  | || '_ ` _ \ / _` |/ _` |/ _ \ | |_) / _ \/ __| | '_ \ / _ \
+#  | || | | | | | (_| | (_| |  __/ |  _ <  __/ (__| | |_) |  __/
+# |___|_| |_| |_|\__,_|\__, |\___| |_| \_\___|\___|_| .__/ \___|
+#                      |___/                        |_|
+#################################################################
+
+FROM common AS sagemaker
+
+LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="1"
+
+ENV SAGEMAKER_TRAINING_MODULE=sagemaker_pytorch_container.training:main
+
+ARG PYTHON
+ARG PYTHON_SHORT_VERSION
+ARG NCCL_VERSION
+ARG GDRCOPY_VERSION
+ARG TE_VERSION
+ARG FLASH_ATTN_VERSION
+
+WORKDIR /
+
 # # Install GDRCopy which is a dependency of SM Distributed DataParallel binary
 # # The test binaries requires cuda driver library which could be found in conda
 # # So update the linker path to point to it to avoid -Lcuda not found
@@ -429,36 +429,36 @@ RUN pip install --no-cache-dir \
 #     sagemaker-pytorch-training \
 #     sagemaker-training
 #
-# # Install extra packages
-# RUN pip install --no-cache-dir -U \
-#     bokeh \
-#     imageio \
-#     numba \
-#     pandas \
-#     plotly \
-#     shap \
-#     scikit-learn \
-#     seaborn \
-#     # pinned for sagemaker==2.233.0
-#     cloudpickle
-#
-# RUN HOME_DIR=/root \
-#  && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
-#  && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
-#  && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
-#  && chmod +x /usr/local/bin/testOSSCompliance \
-#  && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
-#  && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
-#  && rm -rf ${HOME_DIR}/oss_compliance* \
-#  && rm -rf /tmp/tmp*
-#
-# # Removing the cache as it is needed for security verification
-# RUN rm -rf /root/.cache | true
-#
-# # Copy workaround script for incorrect hostname
-# COPY changehostname.c /
-# COPY start_with_right_hostname.sh /usr/local/bin/start_with_right_hostname.sh
-# RUN chmod +x /usr/local/bin/start_with_right_hostname.sh
-#
-# ENTRYPOINT ["bash", "-m", "start_with_right_hostname.sh"]
-# CMD ["/bin/bash"]
+# Install extra packages
+RUN pip install --no-cache-dir -U \
+    bokeh \
+    imageio \
+    numba \
+    pandas \
+    plotly \
+    shap \
+    scikit-learn \
+    seaborn \
+    # pinned for sagemaker==2.233.0
+    cloudpickle
+
+RUN HOME_DIR=/root \
+ && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
+ && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
+ && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
+ && chmod +x /usr/local/bin/testOSSCompliance \
+ && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
+ && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
+ && rm -rf ${HOME_DIR}/oss_compliance* \
+ && rm -rf /tmp/tmp*
+
+# Removing the cache as it is needed for security verification
+RUN rm -rf /root/.cache | true
+
+# Copy workaround script for incorrect hostname
+COPY changehostname.c /
+COPY start_with_right_hostname.sh /usr/local/bin/start_with_right_hostname.sh
+RUN chmod +x /usr/local/bin/start_with_right_hostname.sh
+
+ENTRYPOINT ["bash", "-m", "start_with_right_hostname.sh"]
+CMD ["/bin/bash"]

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -289,77 +289,77 @@ RUN echo 'source /usr/local/bin/bash_telemetry.sh' >> /etc/bash.bashrc
 # Removing the cache as it is needed for security verification
 RUN rm -rf /root/.cache | true
 
-# ########################################################
-# #  _____ ____ ____    ___
-# # | ____/ ___|___ \  |_ _|_ __ ___   __ _  __ _  ___
-# # |  _|| |     __) |  | || '_ ` _ \ / _` |/ _` |/ _ \
-# # | |__| |___ / __/   | || | | | | | (_| | (_| |  __/
-# # |_____\____|_____| |___|_| |_| |_|\__,_|\__, |\___|
-# #                                         |___/
-# #  ____           _
-# # |  _ \ ___  ___(_)_ __   ___
-# # | |_) / _ \/ __| | '_ \ / _ \
-# # |  _ <  __/ (__| | |_) |  __/
-# # |_| \_\___|\___|_| .__/ \___|
-# #                  |_|
-# ########################################################
-#
-# FROM common AS ec2
-#
-# ARG PYTHON
-# ARG PYTHON_SHORT_VERSION
-# ARG NCCL_VERSION
-# ARG GDRCOPY_VERSION
-# ARG TE_VERSION
-# ARG FLASH_ATTN_VERSION
-#
-# WORKDIR /
-#
-#
-# # Install GDRCopy which is a dependency of SM Distributed DataParallel binary
-# # The test binaries requires cuda driver library which could be found in conda
-# # So update the linker path to point to it to avoid -Lcuda not found
-# RUN cd /tmp \
-#  && git clone https://github.com/NVIDIA/gdrcopy.git -b v${GDRCOPY_VERSION} \
-#  && cd gdrcopy \
-#  && sed -ie '12s@$@ -L $(CUDA)/lib64/stubs@' tests/Makefile \
-#  && CUDA=${CUDA_HOME} make install \
-#  && rm -rf /tmp/gdrcopy
-#
-# # Install NCCL
-# RUN cd /tmp \
-#  && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION}-1 \
-#  && cd nccl \
-#  && make -j64 src.build BUILDDIR=/usr/local \
-#  && rm -rf /tmp/nccl
-#
-# # Install flash attn and NVIDIA transformer engine.
-# # Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
-# ENV NVTE_FRAMEWORK=pytorch
-# # Install flash-attn using instructions from https://github.com/Dao-AILab/flash-attention#installation-and-features
-# # Set MAX_JOBS=4 to avoid OOM issues in installation process
-# RUN MAX_JOBS=4 pip install --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
-# # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
-# RUN pip install --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
-#
-# COPY dockerd_entrypoint.sh /usr/local/bin/dockerd_entrypoint.sh
-# RUN chmod +x /usr/local/bin/dockerd_entrypoint.sh
-#
-# RUN HOME_DIR=/root \
-#  && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
-#  && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
-#  && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
-#  && chmod +x /usr/local/bin/testOSSCompliance \
-#  && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
-#  && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
-#  && rm -rf ${HOME_DIR}/oss_compliance* \
-#  && rm -rf /tmp/tmp*
-#
-# # Removing the cache as it is needed for security verification
-# RUN rm -rf /root/.cache | true
-#
-# ENTRYPOINT ["bash", "-m", "dockerd_entrypoint.sh"]
-# CMD ["/bin/bash"]
+########################################################
+#  _____ ____ ____    ___
+# | ____/ ___|___ \  |_ _|_ __ ___   __ _  __ _  ___
+# |  _|| |     __) |  | || '_ ` _ \ / _` |/ _` |/ _ \
+# | |__| |___ / __/   | || | | | | | (_| | (_| |  __/
+# |_____\____|_____| |___|_| |_| |_|\__,_|\__, |\___|
+#                                         |___/
+#  ____           _
+# |  _ \ ___  ___(_)_ __   ___
+# | |_) / _ \/ __| | '_ \ / _ \
+# |  _ <  __/ (__| | |_) |  __/
+# |_| \_\___|\___|_| .__/ \___|
+#                  |_|
+########################################################
+
+FROM common AS ec2
+
+ARG PYTHON
+ARG PYTHON_SHORT_VERSION
+ARG NCCL_VERSION
+ARG GDRCOPY_VERSION
+ARG TE_VERSION
+ARG FLASH_ATTN_VERSION
+
+WORKDIR /
+
+
+# Install GDRCopy which is a dependency of SM Distributed DataParallel binary
+# The test binaries requires cuda driver library which could be found in conda
+# So update the linker path to point to it to avoid -Lcuda not found
+RUN cd /tmp \
+ && git clone https://github.com/NVIDIA/gdrcopy.git -b v${GDRCOPY_VERSION} \
+ && cd gdrcopy \
+ && sed -ie '12s@$@ -L $(CUDA)/lib64/stubs@' tests/Makefile \
+ && CUDA=${CUDA_HOME} make install \
+ && rm -rf /tmp/gdrcopy
+
+# Install NCCL
+RUN cd /tmp \
+ && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION}-1 \
+ && cd nccl \
+ && make -j64 src.build BUILDDIR=/usr/local \
+ && rm -rf /tmp/nccl
+
+# Install flash attn and NVIDIA transformer engine.
+# Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
+ENV NVTE_FRAMEWORK=pytorch
+# Install flash-attn using instructions from https://github.com/Dao-AILab/flash-attention#installation-and-features
+# Set MAX_JOBS=4 to avoid OOM issues in installation process
+RUN MAX_JOBS=4 pip install --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
+# Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
+RUN pip install --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
+
+COPY dockerd_entrypoint.sh /usr/local/bin/dockerd_entrypoint.sh
+RUN chmod +x /usr/local/bin/dockerd_entrypoint.sh
+
+RUN HOME_DIR=/root \
+ && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
+ && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
+ && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
+ && chmod +x /usr/local/bin/testOSSCompliance \
+ && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
+ && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
+ && rm -rf ${HOME_DIR}/oss_compliance* \
+ && rm -rf /tmp/tmp*
+
+# Removing the cache as it is needed for security verification
+RUN rm -rf /root/.cache | true
+
+ENTRYPOINT ["bash", "-m", "dockerd_entrypoint.sh"]
+CMD ["/bin/bash"]
 
 
 #################################################################

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -143,13 +143,13 @@ RUN mkdir -p /tmp/nvjpeg \
 && rm -rf /tmp/nvjpeg \
 # patch cuobjdump and nvdisasm
 && rm -rf /usr/local/cuda/bin/cuobjdump* \
-&& rm -rf /usr/local/cuda/bin/nvdisasm* 
+&& rm -rf /usr/local/cuda/bin/nvdisasm*
 
 # For EFA, below flags are needed to install EFA on docker image
 #  -n, --no-verify       Skip EFA device verification and test
 #  -l, --skip-limit-conf Skip EFA limit configuration
 #  -k, --skip-kmod       Skip EFA kmod installation
-# start from 0.38.0 EFA now bundles the AWS OFI NCCL plugin, 
+# start from 0.38.0 EFA now bundles the AWS OFI NCCL plugin,
 # which can now be found in /opt/amazon/ofi-nccl/lib/x86_64-linux-gnu rather than the original /opt/aws-ofi-nccl/.
 RUN mkdir /tmp/efa \
  && cd /tmp/efa \
@@ -424,7 +424,7 @@ RUN pip install --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.g
 # Install SM packages
 RUN pip install --no-cache-dir -U \
     smclarify \
-    "sagemaker>=2,<3" \
+    "sagemaker>=2.9.0,<3" \
     "sagemaker-experiments<1" \
     sagemaker-pytorch-training \
     sagemaker-training
@@ -440,7 +440,7 @@ RUN pip install --no-cache-dir -U \
     scikit-learn \
     seaborn \
     # pinned for sagemaker==2.233.0
-    cloudpickle 
+    cloudpickle
 
 RUN HOME_DIR=/root \
  && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -253,7 +253,7 @@ RUN pip install --no-cache-dir \
     jinja2>=3.1.6 \
     tornado>=6.5.1
 
-Install PyTorch
+# Install PyTorch
 RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
     torchvision==${TORCHVISION_VERSION} \
     torchaudio==${TORCHAUDIO_VERSION} \

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -253,25 +253,25 @@ RUN pip install --no-cache-dir \
     jinja2>=3.1.6 \
     tornado>=6.5.1
 
-# Install PyTorch
-# RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
-#     torchvision==${TORCHVISION_VERSION} \
-#     torchaudio==${TORCHAUDIO_VERSION} \
-#     --index-url https://download.pytorch.org/whl/cu128 \
-#     && pip install --no-cache-dir -U torchtnt==${TORCHTNT_VERSION} \
-#     torchdata==${TORCHDATA_VERSION} \
-#     triton \
-#     s3torchconnector \
-#     fastai==2.8.2 \
-#     accelerate \
-#     # pin numpy requirement for fastai dependency
-#     # requires explicit declaration of spacy, thic, blis
-#     spacy \
-#     #thinc 8.3.6 is not compatible with numpy 1.26.4 (sagemaker doesn't support latest numpy)
-#     thinc==8.3.4 \
-#     blis \
-#     numpy \
-#  && pip uninstall -y dataclasses
+Install PyTorch
+RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
+    torchvision==${TORCHVISION_VERSION} \
+    torchaudio==${TORCHAUDIO_VERSION} \
+    --index-url https://download.pytorch.org/whl/cu128 \
+    && pip install --no-cache-dir -U torchtnt==${TORCHTNT_VERSION} \
+    torchdata==${TORCHDATA_VERSION} \
+    triton \
+    s3torchconnector \
+    fastai==2.8.2 \
+    accelerate \
+    # pin numpy requirement for fastai dependency
+    # requires explicit declaration of spacy, thic, blis
+    spacy \
+    #thinc 8.3.6 is not compatible with numpy 1.26.4 (sagemaker doesn't support latest numpy)
+    thinc==8.3.4 \
+    blis \
+    numpy \
+ && pip uninstall -y dataclasses
 
 RUN curl -o /license.txt https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.7/license.txt
 
@@ -393,42 +393,42 @@ ARG FLASH_ATTN_VERSION
 
 WORKDIR /
 
-# # Install GDRCopy which is a dependency of SM Distributed DataParallel binary
-# # The test binaries requires cuda driver library which could be found in conda
-# # So update the linker path to point to it to avoid -Lcuda not found
-# RUN cd /tmp \
-#  && git clone https://github.com/NVIDIA/gdrcopy.git -b v${GDRCOPY_VERSION} \
-#  && cd gdrcopy \
-#  && sed -ie '12s@$@ -L $(CUDA)/lib64/stubs@' tests/Makefile \
-#  && CUDA=${CUDA_HOME} make install \
-#  && rm -rf /tmp/gdrcopy
-#
-# # Install NCCL
-# RUN cd /tmp \
-#  && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION}-1 \
-#  && cd nccl \
-#  && make -j64 src.build BUILDDIR=/usr/local \
-#  && rm -rf /tmp/nccl
-#
-# RUN pip uninstall -y ninja && pip install ninja
-#
-# # Install flash attn and NVIDIA transformer engine.
-# # Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
-# ENV NVTE_FRAMEWORK=pytorch
-# # Install flash-attn using instructions from https://github.com/Dao-AILab/flash-attention#installation-and-features
-# # Set MAX_JOBS=4 to avoid OOM issues in installation process
-# RUN MAX_JOBS=4 pip install --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
-# # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
-# RUN pip install --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
-#
-# # Install SM packages
-# RUN pip install --no-cache-dir -U \
-#     smclarify \
-#     "sagemaker>=2.9.0,<3" \
-#     "sagemaker-experiments<1" \
-#     sagemaker-pytorch-training \
-#     sagemaker-training
-#
+# Install GDRCopy which is a dependency of SM Distributed DataParallel binary
+# The test binaries requires cuda driver library which could be found in conda
+# So update the linker path to point to it to avoid -Lcuda not found
+RUN cd /tmp \
+ && git clone https://github.com/NVIDIA/gdrcopy.git -b v${GDRCOPY_VERSION} \
+ && cd gdrcopy \
+ && sed -ie '12s@$@ -L $(CUDA)/lib64/stubs@' tests/Makefile \
+ && CUDA=${CUDA_HOME} make install \
+ && rm -rf /tmp/gdrcopy
+
+# Install NCCL
+RUN cd /tmp \
+ && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION}-1 \
+ && cd nccl \
+ && make -j64 src.build BUILDDIR=/usr/local \
+ && rm -rf /tmp/nccl
+
+RUN pip uninstall -y ninja && pip install ninja
+
+# Install flash attn and NVIDIA transformer engine.
+# Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
+ENV NVTE_FRAMEWORK=pytorch
+# Install flash-attn using instructions from https://github.com/Dao-AILab/flash-attention#installation-and-features
+# Set MAX_JOBS=4 to avoid OOM issues in installation process
+RUN MAX_JOBS=4 pip install --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
+# Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
+RUN pip install --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
+
+# Install SM packages
+RUN pip install --no-cache-dir -U \
+    smclarify \
+    "sagemaker>=2.9.0,<3" \
+    "sagemaker-experiments<1" \
+    sagemaker-pytorch-training \
+    sagemaker-training
+
 # Install extra packages
 RUN pip install --no-cache-dir -U \
     bokeh \

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.sagemaker.gpu.core_packages.json
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.sagemaker.gpu.core_packages.json
@@ -1,5 +1,5 @@
 {
- "torch": {
+  "torch": {
     "version_specifier": "==2.7.1"
   },
   "torchvision": {
@@ -22,12 +22,12 @@
     "version_specifier": "==2.3",
     "skip": "True"
   },
-    "s3torchconnector": {
-    "version_specifier": "==1.4.2",
+  "s3torchconnector": {
+    "version_specifier": "==1.4.3",
     "skip": "True"
   },
   "accelerate": {
-    "version_specifier": "==1.9.0",
+    "version_specifier": "==1.10.0",
     "skip": "True"
   },
   "thinc": {
@@ -45,13 +45,13 @@
   "tornado": {
     "version_specifier": ">=6.5.1"
   },
-   "sagemaker-training": {
+  "sagemaker-training": {
     "version_specifier": ">=4.8.3"
   },
-   "sagemaker": {
+  "sagemaker": {
     "version_specifier": ">=2,<3"
   },
-   "sagemaker-experiments": {
+  "sagemaker-experiments": {
     "version_specifier": "<1"
   },
   "idna": {
@@ -69,7 +69,7 @@
   "urllib3": {
     "version_specifier": ">=2.5.0"
   },
-   "awscli": {
+  "awscli": {
     "version_specifier": "<2"
   },
   "sagemaker-pytorch-training": {

--- a/src/image.py
+++ b/src/image.py
@@ -205,12 +205,14 @@ class DockerImage:
         :param custom_context: bool, Whether to use custom context from stdin (default: False)
         :return: int, Build status
         """
-        if self._is_vllm_image():
-            LOGGER.info(f"Using Buildx for vLLM image: {self.repository}:{self.tag}")
-            return self._buildx_build(context_path, custom_context)
-        else:
-            LOGGER.info(f"Using legacy Docker API for non-vLLM image: {self.repository}:{self.tag}")
-            return self._legacy_docker_build(context_path, custom_context)
+        # NOTE: TEMP change, enforce buildx usage
+        return self._buildx_build(context_path, custom_context)
+        # if self._is_vllm_image():
+        #     LOGGER.info(f"Using Buildx for vLLM image: {self.repository}:{self.tag}")
+        #     return self._buildx_build(context_path, custom_context)
+        # else:
+        #     LOGGER.info(f"Using legacy Docker API for non-vLLM image: {self.repository}:{self.tag}")
+        #     return self._legacy_docker_build(context_path, custom_context)
 
     def _is_vllm_image(self):
         """

--- a/src/image.py
+++ b/src/image.py
@@ -13,14 +13,13 @@ ANY KIND, either express or implied. See the License for the specific
 language governing permissions and limitations under the License.
 """
 
-from datetime import datetime
-
-from docker import APIClient
-from docker import DockerClient
-
-import constants
 import logging
 import subprocess
+from datetime import datetime
+
+from docker import APIClient, DockerClient
+
+import constants
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
@@ -205,14 +204,16 @@ class DockerImage:
         :param custom_context: bool, Whether to use custom context from stdin (default: False)
         :return: int, Build status
         """
-        # NOTE: TEMP change, enforce buildx usage
-        return self._buildx_build(context_path, custom_context)
-        # if self._is_vllm_image():
-        #     LOGGER.info(f"Using Buildx for vLLM image: {self.repository}:{self.tag}")
-        #     return self._buildx_build(context_path, custom_context)
-        # else:
-        #     LOGGER.info(f"Using legacy Docker API for non-vLLM image: {self.repository}:{self.tag}")
-        #     return self._legacy_docker_build(context_path, custom_context)
+        if self._is_vllm_image() or self._is_pytorch_training_image():
+            LOGGER.info(
+                f"Using Buildx for vLLM and PyTorch Training image: {self.repository}:{self.tag}"
+            )
+            return self._buildx_build(context_path, custom_context)
+        else:
+            LOGGER.info(
+                f"Using legacy Docker API for non-vLLM and non-PyTorch Training image: {self.repository}:{self.tag}"
+            )
+            return self._legacy_docker_build(context_path, custom_context)
 
     def _is_vllm_image(self):
         """
@@ -225,6 +226,14 @@ class DockerImage:
             or "vllm" in self.repository.lower()
             or "vllm" in str(self.info.get("name", "")).lower()
         )
+
+    def _is_pytorch_training_image(self):
+        """
+        Determine if current image is a PyTorch Training image
+
+        :return: bool, True if this is a PyTorch Training image
+        """
+        return self.info.get("framework") == "pytorch" and self.info.get("image_type") == "training"
 
     def _buildx_build(self, context_path, custom_context=False):
         """


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description
- Disable autopatch for PT 2.7 and enable Buildx for PT Training

### Tests Run
- Passed efa tests [1a668bb](https://github.com/aws/deep-learning-containers/pull/5184/commits/1a668bb62494c33d01148bf4cba6f540df544ff6)
- Passed all tests [7a1924a](https://github.com/aws/deep-learning-containers/pull/5184/commits/7a1924a8513555a5df737ba7fd933fcdb30851dc)

By default, docker image builds and tests are disabled. Two ways to run builds and tests:
1. Using dlc_developer_config.toml
2. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...
  
- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**
- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`
</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used. 
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec pytorch/training/buildspec-2-7-sm.yml
# /tests <test_list> 
```

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
