### PR TITLE
Add condition to check instance type for VLLM EC2

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,7 +37,7 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["vllm"]
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,7 +37,7 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["vllm"]
+build_frameworks = []
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.

--- a/test/testrunner.py
+++ b/test/testrunner.py
@@ -428,7 +428,6 @@ def main():
                 try:
                     LOGGER.info(f"Running vLLM EKS EC2 tests with image: {all_image_list[0]}")
                     test_vllm()
-                    LOGGER.info("vLLM EKS EC2 tests completed successfully")
                     # Exit function after vLLM tests
                     return
                 except Exception as e:

--- a/test/vllm/trigger_test.py
+++ b/test/vllm/trigger_test.py
@@ -16,8 +16,9 @@ def run_platform_tests(platform: str, images: List[str], commit_id: str, ipv6_en
     """
     Run tests for a specific platform
     """
-    LOGGER.info(f"Running {platform} tests")
-    if platform == "ec2":
+    instance_type = os.getenv("EC2_GPU_INSTANCE_TYPE")
+    print(f"Running {platform} tests on {instance_type}")
+    if platform == "ec2" and instance_type == "p4d.24xlarge":
         try:
             ec2_resources = setup()
             print(ec2_resources)

--- a/test/vllm/trigger_test.py
+++ b/test/vllm/trigger_test.py
@@ -24,7 +24,6 @@ def run_platform_tests(platform: str, images: List[str]):
 
     if platform == "ec2":
         try:
-            print(f"Running {platform} tests on {instance_type}")
             ec2_resources = setup()
             print(ec2_resources)
             print("Finished gathering resources required for VLLM EC2 Tests")

--- a/test/vllm/trigger_test.py
+++ b/test/vllm/trigger_test.py
@@ -2,7 +2,7 @@ import os, sys
 import logging
 from typing import List
 
-from test.test_utils import get_dlc_images
+from test.test_utils import get_dlc_images, is_pr_context
 from test.vllm.eks.eks_test import test_vllm_on_eks
 from test.vllm.ec2.infra.setup_ec2 import setup
 from test.vllm.ec2.test_artifacts.test_ec2 import test_vllm_on_ec2
@@ -12,14 +12,19 @@ LOGGER.setLevel(logging.DEBUG)
 LOGGER.addHandler(logging.StreamHandler(sys.stdout))
 
 
-def run_platform_tests(platform: str, images: List[str], commit_id: str, ipv6_enabled: bool):
+def run_platform_tests(platform: str, images: List[str]):
     """
     Run tests for a specific platform
     """
     instance_type = os.getenv("EC2_GPU_INSTANCE_TYPE")
-    print(f"Running {platform} tests on {instance_type}")
-    if platform == "ec2" and instance_type == "p4d.24xlarge":
+
+    if instance_type == "p4d.24xlarge":
+        LOGGER.info(f"Skipping tests on {instance_type} instance type")
+        return
+
+    if platform == "ec2":
         try:
+            print(f"Running {platform} tests on {instance_type}")
             ec2_resources = setup()
             print(ec2_resources)
             print("Finished gathering resources required for VLLM EC2 Tests")
@@ -61,8 +66,6 @@ def test():
     run_platform_tests(
         platform=test_type,
         images=standard_images_list,
-        commit_id=commit_id,
-        ipv6_enabled=ipv6_enabled,
     )
 
 


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**: 
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right. 

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests Run
By default, docker image builds and tests are disabled. Two ways to run builds and tests:
1. Using dlc_developer_config.toml
2. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...
  
- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**
- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`
</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used. 
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list> 
```

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### PR Checklist 
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
