### PR TITLE
Try uv

### DIFF
--- a/pytorch/training/buildspec-2-7-ec2.yml
+++ b/pytorch/training/buildspec-2-7-ec2.yml
@@ -38,21 +38,21 @@ context:
       target: deep_learning_container.py
 
 images:
-  BuildEC2CPUPTTrainPy3DockerImage:
-    <<: *TRAINING_REPOSITORY
-    build: &PYTORCH_CPU_TRAINING_PY3 false
-    image_size_baseline: 6500
-    device_type: &DEVICE_TYPE cpu
-    python_version: &DOCKER_PYTHON_VERSION py3
-    tag_python_version: &TAG_PYTHON_VERSION py312
-    os_version: &OS_VERSION ubuntu22.04
-    tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
-    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
-    # skip_build: "False"
-    docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
-    target: ec2
-    context:
-      <<: *TRAINING_CONTEXT
+  # BuildEC2CPUPTTrainPy3DockerImage:
+  #   <<: *TRAINING_REPOSITORY
+  #   build: &PYTORCH_CPU_TRAINING_PY3 false
+  #   image_size_baseline: 6500
+  #   device_type: &DEVICE_TYPE cpu
+  #   python_version: &DOCKER_PYTHON_VERSION py3
+  #   tag_python_version: &TAG_PYTHON_VERSION py312
+  #   os_version: &OS_VERSION ubuntu22.04
+  #   tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
+  #   latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
+  #   # skip_build: "False"
+  #   docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
+  #   target: ec2
+  #   context:
+  #     <<: *TRAINING_CONTEXT
   BuildEC2GPUPTTrainPy3cu128DockerImage:
     <<: *TRAINING_REPOSITORY
     build: &PYTORCH_GPU_TRAINING_PY3 false

--- a/pytorch/training/buildspec-2-7-ec2.yml
+++ b/pytorch/training/buildspec-2-7-ec2.yml
@@ -37,8 +37,11 @@ context:
       source: ../../src/deep_learning_container.py
       target: deep_learning_container.py
     pytorch_27_gpu_requirements:
-      source: docker/build_artifacts/pytorch_2_7_gpu.txt
-      target: pytorch_2_7_gpu.txt
+      source: docker/build_artifacts/torch27_gpu.txt
+      target: torch27_gpu.txt
+    pytorch_common_requirements:
+      source: docker/build_artifacts/torch_common.txt
+      target: torch_common.txt
 
 
 images:

--- a/pytorch/training/buildspec-2-7-ec2.yml
+++ b/pytorch/training/buildspec-2-7-ec2.yml
@@ -5,7 +5,7 @@ framework: &FRAMEWORK pytorch
 version: &VERSION 2.7.1
 short_version: &SHORT_VERSION "2.7"
 arch_type: x86
-autopatch_build: "True"
+autopatch_build: "False"
 
 repository_info:
   training_repository: &TRAINING_REPOSITORY

--- a/pytorch/training/buildspec-2-7-ec2.yml
+++ b/pytorch/training/buildspec-2-7-ec2.yml
@@ -36,6 +36,10 @@ context:
     deep_learning_container:
       source: ../../src/deep_learning_container.py
       target: deep_learning_container.py
+    pytorch_27_gpu_requirements:
+      source: docker/build_artifacts/pytorch_2_7_gpu.txt
+      target: pytorch_2_7_gpu.txt
+
 
 images:
   # BuildEC2CPUPTTrainPy3DockerImage:

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -285,7 +285,7 @@ RUN cd /tmp \
  && rm -rf /tmp/nccl
 
 # Install flash attn
-RUN MAX_JOBS=24 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation \
+RUN MAX_JOBS=20 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation \
     && pip cache purge \
     && uv cache clean
 
@@ -293,7 +293,7 @@ RUN MAX_JOBS=24 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-b
 # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
 # Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
 ENV NVTE_FRAMEWORK=pytorch
-RUN MAX_JOBS=24 uv pip install --system git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation \ 
+RUN MAX_JOBS=20 uv pip install --system git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation \ 
     && pip cache purge \
     && uv cache clean
 

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -285,13 +285,17 @@ RUN cd /tmp \
  && rm -rf /tmp/nccl
 
 # Install flash attn
-RUN MAX_JOBS=36 uv pip install --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
+RUN MAX_JOBS=36 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation \
+    && pip cache purge \
+    && uv cache clean
 
 # Install NVIDIA transformer engine.
 # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
 # Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
 ENV NVTE_FRAMEWORK=pytorch
-RUN MAX_JOBS=36 uv pip install --system --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
+RUN MAX_JOBS=36 uv pip install --system git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation \ 
+    && pip cache purge \
+    && uv cache clean
 
 COPY dockerd_entrypoint.sh /usr/local/bin/dockerd_entrypoint.sh
 RUN chmod +x /usr/local/bin/dockerd_entrypoint.sh

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -285,7 +285,7 @@ RUN cd /tmp \
  && rm -rf /tmp/nccl
 
 # Install flash attn
-RUN MAX_JOBS=20 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation \
+RUN MAX_JOBS=18 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation \
     && pip cache purge \
     && uv cache clean
 
@@ -293,7 +293,7 @@ RUN MAX_JOBS=20 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-b
 # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
 # Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
 ENV NVTE_FRAMEWORK=pytorch
-RUN MAX_JOBS=20 uv pip install --system git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation \ 
+RUN MAX_JOBS=18 uv pip install --system git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation \ 
     && pip cache purge \
     && uv cache clean
 

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -284,16 +284,14 @@ RUN cd /tmp \
  && make -j64 src.build BUILDDIR=/usr/local \
  && rm -rf /tmp/nccl
 
-RUN /bin/bash -c '\
-    # Install flash attn and NVIDIA transformer engine.
-    # Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
-    export NVTE_FRAMEWORK=pytorch \
-    export MAX_JOBS=$(nproc) && \
-    # Install flash-attn using instructions from https://github.com/Dao-AILab/flash-attention#installation-and-features
-    # Set MAX_JOBS=4 to avoid OOM issues in installation process
-    uv pip install --system --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation && \
-    # # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
-    uv pip install --system --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation'
+# Install flash attn
+RUN MAX_JOBS=36 uv pip install --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
+
+# Install NVIDIA transformer engine.
+# Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
+# Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
+ENV NVTE_FRAMEWORK=pytorch
+RUN MAX_JOBS=36 uv pip install --system --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
 
 COPY dockerd_entrypoint.sh /usr/local/bin/dockerd_entrypoint.sh
 RUN chmod +x /usr/local/bin/dockerd_entrypoint.sh

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -214,15 +214,14 @@ RUN cd /tmp/ \
 # Python Path
 ENV PATH="/usr/local/bin:${PATH}"
 
-# this will add pip systemlink to pip${PYTHON_SHORT_VERSION}
 # Install uv for faster pip installs
-RUN python3 -m pip install --upgrade pip uv \
-    --trusted-host pypi.org --trusted-host files.pythonhosted.org
+# this will add pip systemlink to pip${PYTHON_SHORT_VERSION}
+RUN python3 -m pip install --upgrade pip uv
 
 ENV UV_HTTP_TIMEOUT=500
-COPY pytorch_2_7_gpu.txt pytorch_2_7_gpu.txt
-RUN uv pip install --system -r pytorch_2_7_gpu.txt \
-    --extra-index-url https://download.pytorch.org/whl/cu128 \
+COPY torch_common.txt torch_common.txt
+COPY torch27_gpu.txt torch27_gpu.txt
+RUN uv pip install --system -r torch_common.txt -r torch27_gpu.txt \
     && pip uninstall -y dataclasses \
     && pip cache purge \
     && uv cache clean

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -285,7 +285,7 @@ RUN cd /tmp \
  && rm -rf /tmp/nccl
 
 # Install flash attn
-RUN MAX_JOBS=36 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation \
+RUN MAX_JOBS=18 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation \
     && pip cache purge \
     && uv cache clean
 
@@ -293,7 +293,7 @@ RUN MAX_JOBS=36 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-b
 # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
 # Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
 ENV NVTE_FRAMEWORK=pytorch
-RUN MAX_JOBS=36 uv pip install --system git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation \ 
+RUN uv pip install --system git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation \ 
     && pip cache purge \
     && uv cache clean
 

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -285,7 +285,7 @@ RUN cd /tmp \
  && rm -rf /tmp/nccl
 
 # Install flash attn
-RUN MAX_JOBS=30 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation \
+RUN MAX_JOBS=24 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation \
     && pip cache purge \
     && uv cache clean
 
@@ -293,7 +293,7 @@ RUN MAX_JOBS=30 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-b
 # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
 # Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
 ENV NVTE_FRAMEWORK=pytorch
-RUN MAX_JOBS=30 uv pip install --system git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation \ 
+RUN MAX_JOBS=24 uv pip install --system git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation \ 
     && pip cache purge \
     && uv cache clean
 

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -215,10 +215,15 @@ RUN cd /tmp/ \
 ENV PATH="/usr/local/bin:${PATH}"
 
 # this will add pip systemlink to pip${PYTHON_SHORT_VERSION}
-RUN python -m pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org
+RUN python -m pip install --upgrade pip \
+    --trusted-host pypi.org --trusted-host files.pythonhosted.org
+
+# Install uv for faster pip installs
+RUN  python3 -m pip install uv
+ENV UV_HTTP_TIMEOUT=500
 
 # Install common conda packages
-RUN pip install --no-cache-dir \
+RUN uv pip install --no-cache-dir \
     cython \
     cryptography \
     pyOpenSSL \
@@ -254,11 +259,11 @@ RUN pip install --no-cache-dir \
     tornado>=6.5.1
 
 # Install PyTorch
-RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
+RUN uv pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
     torchvision==${TORCHVISION_VERSION} \
     torchaudio==${TORCHAUDIO_VERSION} \
     --index-url https://download.pytorch.org/whl/cu128 \
-    && pip install --no-cache-dir -U torchtnt==${TORCHTNT_VERSION} \
+    && uv pip install --no-cache-dir -U torchtnt==${TORCHTNT_VERSION} \
     torchdata==${TORCHDATA_VERSION} \
     triton \
     s3torchconnector \
@@ -271,7 +276,7 @@ RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
     thinc==8.3.4 \
     blis \
     numpy \
- && pip uninstall -y dataclasses
+ && uv pip uninstall -y dataclasses
 
 RUN curl -o /license.txt https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.7/license.txt
 
@@ -338,9 +343,9 @@ RUN cd /tmp \
 ENV NVTE_FRAMEWORK=pytorch
 # Install flash-attn using instructions from https://github.com/Dao-AILab/flash-attention#installation-and-features
 # Set MAX_JOBS=4 to avoid OOM issues in installation process
-RUN MAX_JOBS=4 pip install --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
+RUN MAX_JOBS=4 uv pip install --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
 # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
-RUN pip install --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
+RUN uv pip install --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
 
 COPY dockerd_entrypoint.sh /usr/local/bin/dockerd_entrypoint.sh
 RUN chmod +x /usr/local/bin/dockerd_entrypoint.sh

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -223,7 +223,7 @@ RUN  python3 -m pip install uv
 ENV UV_HTTP_TIMEOUT=500
 
 # Install common conda packages
-RUN uv pip install --no-cache-dir \
+RUN uv pip install --system --no-cache-dir \
     cython \
     cryptography \
     pyOpenSSL \
@@ -259,11 +259,11 @@ RUN uv pip install --no-cache-dir \
     tornado>=6.5.1
 
 # Install PyTorch
-RUN uv pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
+RUN uv pip install --system --no-cache-dir -U torch==${PYTORCH_VERSION} \
     torchvision==${TORCHVISION_VERSION} \
     torchaudio==${TORCHAUDIO_VERSION} \
     --index-url https://download.pytorch.org/whl/cu128 \
-    && uv pip install --no-cache-dir -U torchtnt==${TORCHTNT_VERSION} \
+    && uv pip install --system --no-cache-dir -U torchtnt==${TORCHTNT_VERSION} \
     torchdata==${TORCHDATA_VERSION} \
     triton \
     s3torchconnector \
@@ -343,9 +343,9 @@ RUN cd /tmp \
 ENV NVTE_FRAMEWORK=pytorch
 # Install flash-attn using instructions from https://github.com/Dao-AILab/flash-attention#installation-and-features
 # Set MAX_JOBS=4 to avoid OOM issues in installation process
-RUN MAX_JOBS=4 uv pip install --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
+RUN MAX_JOBS=4 uv pip install --system --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
 # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
-RUN uv pip install --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
+RUN uv pip install --system --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
 
 COPY dockerd_entrypoint.sh /usr/local/bin/dockerd_entrypoint.sh
 RUN chmod +x /usr/local/bin/dockerd_entrypoint.sh

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -259,11 +259,11 @@ RUN uv pip install --system --no-cache-dir \
     tornado>=6.5.1
 
 # Install PyTorch
-RUN uv pip install --system --no-cache-dir -U torch==${PYTORCH_VERSION} \
+RUN uv pip install --system --no-cache-dir torch==${PYTORCH_VERSION} \
     torchvision==${TORCHVISION_VERSION} \
     torchaudio==${TORCHAUDIO_VERSION} \
     --index-url https://download.pytorch.org/whl/cu128 \
-    && uv pip install --system --no-cache-dir -U torchtnt==${TORCHTNT_VERSION} \
+    && uv pip install --system --no-cache-dir torchtnt==${TORCHTNT_VERSION} \
     torchdata==${TORCHDATA_VERSION} \
     triton \
     s3torchconnector \
@@ -276,7 +276,7 @@ RUN uv pip install --system --no-cache-dir -U torch==${PYTORCH_VERSION} \
     thinc==8.3.4 \
     blis \
     numpy \
- && uv pip uninstall -y dataclasses
+ && pip uninstall -y dataclasses
 
 RUN curl -o /license.txt https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.7/license.txt
 

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -285,7 +285,7 @@ RUN cd /tmp \
  && rm -rf /tmp/nccl
 
 # Install flash attn
-RUN MAX_JOBS=18 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation \
+RUN MAX_JOBS=36 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation \
     && pip cache purge \
     && uv cache clean
 
@@ -293,7 +293,7 @@ RUN MAX_JOBS=18 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-b
 # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
 # Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
 ENV NVTE_FRAMEWORK=pytorch
-RUN uv pip install --system git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation \ 
+RUN MAX_JOBS=36 uv pip install --system git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation \ 
     && pip cache purge \
     && uv cache clean
 

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -285,14 +285,16 @@ RUN cd /tmp \
  && make -j64 src.build BUILDDIR=/usr/local \
  && rm -rf /tmp/nccl
 
-# Install flash attn and NVIDIA transformer engine.
-# Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
-ENV NVTE_FRAMEWORK=pytorch
-# Install flash-attn using instructions from https://github.com/Dao-AILab/flash-attention#installation-and-features
-# Set MAX_JOBS=4 to avoid OOM issues in installation process
-RUN MAX_JOBS=4 uv pip install --system --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation
-# Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
-RUN uv pip install --system --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation
+RUN /bin/bash -c '\
+    # Install flash attn and NVIDIA transformer engine.
+    # Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
+    export NVTE_FRAMEWORK=pytorch \
+    export MAX_JOBS=$(nproc) && \
+    # Install flash-attn using instructions from https://github.com/Dao-AILab/flash-attention#installation-and-features
+    # Set MAX_JOBS=4 to avoid OOM issues in installation process
+    uv pip install --system --no-cache-dir flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation && \
+    # # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
+    uv pip install --system --no-cache-dir git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation'
 
 COPY dockerd_entrypoint.sh /usr/local/bin/dockerd_entrypoint.sh
 RUN chmod +x /usr/local/bin/dockerd_entrypoint.sh

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -285,7 +285,7 @@ RUN cd /tmp \
  && rm -rf /tmp/nccl
 
 # Install flash attn
-RUN MAX_JOBS=36 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation \
+RUN MAX_JOBS=30 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-build-isolation \
     && pip cache purge \
     && uv cache clean
 
@@ -293,7 +293,7 @@ RUN MAX_JOBS=36 uv pip install --system flash-attn==${FLASH_ATTN_VERSION} --no-b
 # Install TE using instructions from https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/installation.html
 # Optionally set NVTE_FRAMEWORK to avoid bringing in additional frameworks during TE install
 ENV NVTE_FRAMEWORK=pytorch
-RUN MAX_JOBS=36 uv pip install --system git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation \ 
+RUN MAX_JOBS=30 uv pip install --system git+https://github.com/NVIDIA/TransformerEngine.git@release_v${TE_VERSION} --no-build-isolation \ 
     && pip cache purge \
     && uv cache clean
 

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -222,7 +222,6 @@ ENV UV_HTTP_TIMEOUT=500
 COPY torch_common.txt torch_common.txt
 COPY torch27_gpu.txt torch27_gpu.txt
 RUN uv pip install --system -r torch_common.txt -r torch27_gpu.txt \
-    && pip uninstall -y dataclasses \
     && pip cache purge \
     && uv cache clean
 

--- a/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
+++ b/pytorch/training/docker/2.7/py3/cu128/Dockerfile.gpu
@@ -215,73 +215,21 @@ RUN cd /tmp/ \
 ENV PATH="/usr/local/bin:${PATH}"
 
 # this will add pip systemlink to pip${PYTHON_SHORT_VERSION}
-RUN python -m pip install --upgrade pip \
+# Install uv for faster pip installs
+RUN python3 -m pip install --upgrade pip uv \
     --trusted-host pypi.org --trusted-host files.pythonhosted.org
 
-# Install uv for faster pip installs
-RUN  python3 -m pip install uv
 ENV UV_HTTP_TIMEOUT=500
-
-# Install common conda packages
-RUN uv pip install --system --no-cache-dir \
-    cython \
-    cryptography \
-    pyOpenSSL \
-    pybind11 \
-    mkl \
-    mkl-include \
-    parso \
-    typing \
-    charset-normalizer \
-    packaging \
-    boto3 \
-    PyYAML \
-    numpy \
-    scipy \
-    click \
-    psutil \
-    ipython \
-    ipykernel \
-    pillow \
-    h5py \
-    fsspec \
-    "idna>=3.7" \
-    "tqdm>=4.66.3" \
-    "requests>=2.32.0" \
-    "setuptools>=70.0.0" \
-    "urllib3>=2.5.0" \
-    "awscli<2" \
-    ninja \
-    # pencv-python 4.12.0.88 reuqires numpy<2.3.0, which is not compatible with previous prod image(2.3.1)
-    opencv-python==4.11.0.86 \
-    mpi4py \
-    jinja2>=3.1.6 \
-    tornado>=6.5.1
-
-# Install PyTorch
-RUN uv pip install --system --no-cache-dir torch==${PYTORCH_VERSION} \
-    torchvision==${TORCHVISION_VERSION} \
-    torchaudio==${TORCHAUDIO_VERSION} \
-    --index-url https://download.pytorch.org/whl/cu128 \
-    && uv pip install --system --no-cache-dir torchtnt==${TORCHTNT_VERSION} \
-    torchdata==${TORCHDATA_VERSION} \
-    triton \
-    s3torchconnector \
-    fastai==2.8.2 \
-    accelerate \
-    # pin numpy requirement for fastai dependency
-    # requires explicit declaration of spacy, thic, blis
-    spacy \
-    #thinc 8.3.6 is not compatible with numpy 1.26.4 (sagemaker doesn't support latest numpy)
-    thinc==8.3.4 \
-    blis \
-    numpy \
- && pip uninstall -y dataclasses
+COPY pytorch_2_7_gpu.txt pytorch_2_7_gpu.txt
+RUN uv pip install --system -r pytorch_2_7_gpu.txt \
+    --extra-index-url https://download.pytorch.org/whl/cu128 \
+    && pip uninstall -y dataclasses \
+    && pip cache purge \
+    && uv cache clean
 
 RUN curl -o /license.txt https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.7/license.txt
 
 COPY deep_learning_container.py /usr/local/bin/deep_learning_container.py
-
 RUN chmod +x /usr/local/bin/deep_learning_container.py
 
 COPY start_cuda_compat.sh /usr/local/bin/start_cuda_compat.sh

--- a/pytorch/training/docker/build_artifacts/pytorch_2_7_gpu.txt
+++ b/pytorch/training/docker/build_artifacts/pytorch_2_7_gpu.txt
@@ -10,7 +10,6 @@ charset-normalizer
 packaging
 boto3
 PyYAML
-numpy
 scipy
 click
 psutil

--- a/pytorch/training/docker/build_artifacts/pytorch_2_7_gpu.txt
+++ b/pytorch/training/docker/build_artifacts/pytorch_2_7_gpu.txt
@@ -1,0 +1,49 @@
+cython
+cryptography
+pyOpenSSL
+pybind11
+mkl
+mkl-include
+parso
+typing
+charset-normalizer
+packaging
+boto3
+PyYAML
+numpy
+scipy
+click
+psutil
+ipython
+ipykernel
+pillow
+h5py
+fsspec
+idna >= 3.7
+tqdm >= 4.66.3
+requests >= 2.32.0
+setuptools >= 70.0.0
+urllib3 >= 2.5.0
+awscli <2
+ninja
+# pencv-python 4.12.0.88 reuqires numpy<2.3.0, which is not compatible with previous prod image(2.3.1)
+opencv-python==4.11.0.86
+mpi4py
+jinja2 >= 3.1.6
+tornado >= 6.5.1
+torch == 2.7.1
+torchvision == 0.22.1
+torchaudio == 2.7.1
+torchtnt == 0.2.4
+torchdata == 0.11.0
+triton
+s3torchconnector
+fastai == 2.8.2
+accelerate
+# pin numpy requirement for fastai dependency
+# requires explicit declaration of spacy, thic, blis
+spacy
+#thinc 8.3.6 is not compatible with numpy 1.26.4 (sagemaker doesn't support latest numpy)
+thinc == 8.3.4
+blis
+numpy

--- a/pytorch/training/docker/build_artifacts/torch27_gpu.txt
+++ b/pytorch/training/docker/build_artifacts/torch27_gpu.txt
@@ -1,0 +1,17 @@
+
+torch @ https://download.pytorch.org/whl/cu128/torch-2.7.1%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl#sha256=0b64f7d0a6f2a739ed052ba959f7b67c677028c9566ce51997f9f90fe573ddaa
+torchvision @ https://download.pytorch.org/whl/cu128/torchvision-0.22.1%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl#sha256=f64ef9bb91d71ab35d8384912a19f7419e35928685bc67544d58f45148334373
+torchaudio @ https://download.pytorch.org/whl/cu128/torchaudio-2.7.1%2Bcu128-cp312-cp312-manylinux_2_28_x86_64.whl#sha256=0c1d407f934d44f87935b139991d8872f81f88f8a6be9b7bd25918bf744e2be6
+torchtnt == 0.2.4
+torchdata == 0.11.0
+triton
+s3torchconnector
+fastai == 2.8.2
+accelerate
+# pin numpy requirement for fastai dependency
+# requires explicit declaration of spacy, thic, blis
+spacy
+#thinc 8.3.6 is not compatible with numpy 1.26.4 (sagemaker doesn't support latest numpy)
+thinc == 8.3.4
+blis
+numpy

--- a/pytorch/training/docker/build_artifacts/torch_common.txt
+++ b/pytorch/training/docker/build_artifacts/torch_common.txt
@@ -30,19 +30,3 @@ opencv-python==4.11.0.86
 mpi4py
 jinja2 >= 3.1.6
 tornado >= 6.5.1
-torch == 2.7.1
-torchvision == 0.22.1
-torchaudio == 2.7.1
-torchtnt == 0.2.4
-torchdata == 0.11.0
-triton
-s3torchconnector
-fastai == 2.8.2
-accelerate
-# pin numpy requirement for fastai dependency
-# requires explicit declaration of spacy, thic, blis
-spacy
-#thinc 8.3.6 is not compatible with numpy 1.26.4 (sagemaker doesn't support latest numpy)
-thinc == 8.3.4
-blis
-numpy


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**:
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right.

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests Run

By default, docker image builds and tests are disabled. Two ways to run builds and tests:
1. Using dlc_developer_config.toml
2. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**
- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`
</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
/buildspec pytorch/training/buildspec-2-7-ec2.yml
/tests sanity, security
```

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
