### PR TITLE
DLC Buildx engine full migration

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,7 +37,7 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "autogluon", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["autogluon"]
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
@@ -58,12 +58,12 @@ notify_test_failures = false
 [test]
 ### On by default
 sanity_tests = true
-security_tests = true
+security_tests = false
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = true
-eks_tests = true
-ec2_tests = true
+ecs_tests = false
+eks_tests = false
+ec2_tests = false
 # Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
 
@@ -74,7 +74,7 @@ ec2_benchmark_tests = false
 ec2_tests_on_heavy_instances = false
 ### SM specific tests
 ### On by default
-sagemaker_local_tests = true
+sagemaker_local_tests = false
 ### Set enable_ipv6 = true to run tests with IPv6-enabled resources
 ### Off by default (set to false)
 enable_ipv6 = false
@@ -92,7 +92,7 @@ enable_ipv6 = false
 ipv6_vpc_name = ""
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = true
+sagemaker_remote_tests = false
 # run efa sagemaker tests
 sagemaker_efa_tests = false
 # run release_candidate_integration tests

--- a/src/image.py
+++ b/src/image.py
@@ -198,45 +198,6 @@ class DockerImage:
 
     def docker_build(self, context_path, custom_context=False):
         """
-        Uses Docker Buildx for vLLM images, falls back to legacy Docker API for others
-
-        :param context_path: str, Path to build context
-        :param custom_context: bool, Whether to use custom context from stdin (default: False)
-        :return: int, Build status
-        """
-        if self._is_vllm_image() or self._is_pytorch_training_image():
-            LOGGER.info(
-                f"Using Buildx for vLLM and PyTorch Training image: {self.repository}:{self.tag}"
-            )
-            return self._buildx_build(context_path, custom_context)
-        else:
-            LOGGER.info(
-                f"Using legacy Docker API for non-vLLM and non-PyTorch Training image: {self.repository}:{self.tag}"
-            )
-            return self._legacy_docker_build(context_path, custom_context)
-
-    def _is_vllm_image(self):
-        """
-        Determine if current image is a vLLM image
-
-        :return: bool, True if this is a vLLM image
-        """
-        return (
-            self.info.get("framework") == "vllm"
-            or "vllm" in self.repository.lower()
-            or "vllm" in str(self.info.get("name", "")).lower()
-        )
-
-    def _is_pytorch_training_image(self):
-        """
-        Determine if current image is a PyTorch Training image
-
-        :return: bool, True if this is a PyTorch Training image
-        """
-        return self.info.get("framework") == "pytorch" and self.info.get("image_type") == "training"
-
-    def _buildx_build(self, context_path, custom_context=False):
-        """
         Uses Docker Buildx CLI for building with real-time streaming and advanced caching.
 
 
@@ -325,79 +286,6 @@ class DockerImage:
 
         self.log.append(response)
         return self.build_status
-
-    def _legacy_docker_build(self, context_path, custom_context=False):
-        """
-        Uses legacy Docker API Client to build the image (for non-vLLM images).
-
-        :param context_path: str, Path to build context
-        :param custom_context: bool, Whether to use custom context from stdin (default: False)
-        :return: int, Build Status
-        """
-        response = [f"Starting Legacy Docker Build Process for {self.repository}:{self.tag}"]
-        LOGGER.info(f"Starting Legacy Docker Build Process for {self.repository}:{self.tag}")
-
-        # Open context tarball for legacy API
-        fileobj = open(context_path, "rb") if custom_context else None
-
-        line_counter = 0
-        line_interval = 50
-
-        try:
-            for line in self.client.build(
-                fileobj=fileobj,
-                path=self.dockerfile if not custom_context else None,
-                custom_context=custom_context,
-                rm=True,
-                decode=True,
-                tag=self.ecr_url,
-                buildargs=self.build_args,
-                labels=self.labels,
-                target=self.target,
-            ):
-                # print the log line during build for every line_interval lines
-                if line_counter % line_interval == 0:
-                    LOGGER.info(line)
-                line_counter += 1
-
-                if line.get("error") is not None:
-                    response.append(line["error"])
-                    self.log.append(response)
-                    self.build_status = constants.FAIL
-                    self.summary["status"] = constants.STATUS_MESSAGE[self.build_status]
-                    self.summary["end_time"] = datetime.now()
-
-                    LOGGER.info(f"Docker Build Logs: \n {self.get_tail_logs_in_pretty_format(100)}")
-                    LOGGER.error("ERROR during Docker BUILD")
-                    LOGGER.error(
-                        f"Error message received for {self.dockerfile} while docker build: {line}"
-                    )
-
-                    return self.build_status
-
-                if line.get("stream") is not None:
-                    response.append(line["stream"])
-                elif line.get("status") is not None:
-                    response.append(line["status"])
-                else:
-                    response.append(str(line))
-
-            self.log.append(response)
-
-            LOGGER.info(f"DOCKER BUILD LOGS: \n{self.get_tail_logs_in_pretty_format()}")
-            LOGGER.info(f"Completed Legacy Build for {self.repository}:{self.tag}")
-
-            self.build_status = constants.SUCCESS
-            return self.build_status
-
-        except Exception as e:
-            response.append(f"Legacy Docker build error: {str(e)}")
-            self.build_status = constants.FAIL
-            LOGGER.error(f"Legacy Docker build exception: {str(e)}")
-            return self.build_status
-        finally:
-            if fileobj:
-                fileobj.close()
 
     def image_size_check(self):
         """


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**:
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right.

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

feat: Migrate all DLC image builds to Buildx engine

- Replace legacy Docker build with Buildx for all image types
- Previously only vLLM images used Buildx


### Tests Run

By default, docker image builds and tests are disabled. Two ways to run builds and tests:
1. Using dlc_developer_config.toml
2. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**
- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`
</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

### Formatting
- [x] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### PR Checklist
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
