### PR TITLE
Allowlisting CVE-2025-6297 as it is not patchable

### DIFF
--- a/pytorch/inference/docker/2.5/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.5/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
@@ -89,5 +89,67 @@
       "title": "CVE-2025-32434 - torch",
       "reason_to_ignore": "N/A"
     }
+  ],
+  "dpkg": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "dpkg",
+      "package_details": {
+        "file_path": null,
+        "name": "dpkg",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "libdpkg-perl": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "libdpkg-perl",
+      "package_details": {
+        "file_path": null,
+        "name": "libdpkg-perl",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
+    }
   ]
 }

--- a/pytorch/inference/docker/2.5/py3/cu124/Dockerfile.ec2.arm64.gpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.5/py3/cu124/Dockerfile.ec2.arm64.gpu.os_scan_allowlist.json
@@ -29,5 +29,67 @@
       "title": "CVE-2025-32434 - torch",
       "reason_to_ignore": "N/A"
     }
+  ],
+  "dpkg": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "dpkg",
+      "package_details": {
+        "file_path": null,
+        "name": "dpkg",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "libdpkg-perl": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "libdpkg-perl",
+      "package_details": {
+        "file_path": null,
+        "name": "libdpkg-perl",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
+    }
   ]
 }

--- a/pytorch/inference/docker/2.5/py3/cu124/Dockerfile.ec2.gpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.5/py3/cu124/Dockerfile.ec2.gpu.os_scan_allowlist.json
@@ -89,5 +89,68 @@
       "title": "CVE-2025-32434 - torch",
       "reason_to_ignore": "N/A"
     }
+  ],
+
+  "dpkg": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "dpkg",
+      "package_details": {
+        "file_path": null,
+        "name": "dpkg",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "libdpkg-perl": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "libdpkg-perl",
+      "package_details": {
+        "file_path": null,
+        "name": "libdpkg-perl",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
+    }
   ]
 }

--- a/pytorch/inference/docker/2.5/py3/cu124/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.5/py3/cu124/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
@@ -89,5 +89,67 @@
       "title": "CVE-2025-32434 - torch",
       "reason_to_ignore": "N/A"
     }
+  ],
+  "dpkg": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "dpkg",
+      "package_details": {
+        "file_path": null,
+        "name": "dpkg",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "libdpkg-perl": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "libdpkg-perl",
+      "package_details": {
+        "file_path": null,
+        "name": "libdpkg-perl",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
+    }
   ]
 }

--- a/pytorch/inference/docker/2.6/py3/Dockerfile.ec2.arm64.cpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.6/py3/Dockerfile.ec2.arm64.cpu.os_scan_allowlist.json
@@ -1,35 +1,4 @@
 {
-  "torch": [
-    {
-      "description": "PyTorch is a Python package that provides tensor computation with strong GPU acceleration and deep neural networks built on a tape-based autograd system. In version 2.5.1 and prior, a Remote Command Execution (RCE) vulnerability exists in PyTorch when loading a model using torch.load with weights_only=True. This issue has been patched in version 2.6.0.",
-      "vulnerability_id": "CVE-2025-32434",
-      "name": "CVE-2025-32434",
-      "package_name": "torch",
-      "package_details": {
-        "file_path": "/opt/conda/lib/python3.11/site-packages/torch-2.4.0+cpu.dist-info/METADATA",
-        "name": "torch",
-        "package_manager": "PYTHON",
-        "version": "2.4.0+cpu",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 9.8,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 9.8,
-      "cvss_v2_score": 0.0,
-      "cvss_v3_severity": "CRITICAL",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-32434",
-      "source": "NVD",
-      "severity": "CRITICAL",
-      "status": "ACTIVE",
-      "title": "CVE-2025-32434 - torch",
-      "reason_to_ignore": "N/A"
-    }
-  ],
   "dpkg": [
     {
       "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",

--- a/pytorch/inference/docker/2.6/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.6/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
@@ -1,35 +1,4 @@
 {
-  "torch": [
-    {
-      "description": "PyTorch is a Python package that provides tensor computation with strong GPU acceleration and deep neural networks built on a tape-based autograd system. In version 2.5.1 and prior, a Remote Command Execution (RCE) vulnerability exists in PyTorch when loading a model using torch.load with weights_only=True. This issue has been patched in version 2.6.0.",
-      "vulnerability_id": "CVE-2025-32434",
-      "name": "CVE-2025-32434",
-      "package_name": "torch",
-      "package_details": {
-        "file_path": "/opt/conda/lib/python3.11/site-packages/torch-2.4.0+cpu.dist-info/METADATA",
-        "name": "torch",
-        "package_manager": "PYTHON",
-        "version": "2.4.0+cpu",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 9.8,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 9.8,
-      "cvss_v2_score": 0.0,
-      "cvss_v3_severity": "CRITICAL",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-32434",
-      "source": "NVD",
-      "severity": "CRITICAL",
-      "status": "ACTIVE",
-      "title": "CVE-2025-32434 - torch",
-      "reason_to_ignore": "N/A"
-    }
-  ],
   "dpkg": [
     {
       "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",

--- a/pytorch/inference/docker/2.6/py3/Dockerfile.sagemaker.arm64.cpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.6/py3/Dockerfile.sagemaker.arm64.cpu.os_scan_allowlist.json
@@ -1,0 +1,64 @@
+{
+  "dpkg": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.", 
+      "vulnerability_id": "CVE-2025-6297", 
+      "name": "CVE-2025-6297", 
+      "package_name": "dpkg", 
+      "package_details": {
+        "file_path": null, 
+        "name": "dpkg", 
+        "package_manager": "OS", 
+        "version": "1.21.1ubuntu2.3", 
+        "release": null
+        }, 
+        "remediation": {
+          "recommendation": {
+            "text": "None Provided"
+          }
+        }, 
+        "cvss_v3_score": 8.2, 
+        "cvss_v30_score": 0.0, 
+        "cvss_v31_score": 8.2, 
+        "cvss_v2_score": 0.0, 
+        "cvss_v3_severity": "HIGH", 
+        "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html", 
+        "source": "UBUNTU_CVE", 
+        "severity": "HIGH", 
+        "status": "ACTIVE", 
+        "title": "CVE-2025-6297 - dpkg, libdpkg-perl", 
+        "reason_to_ignore": "N/A"
+    }
+  ], 
+  "libdpkg-perl": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.", 
+      "vulnerability_id": "CVE-2025-6297", 
+      "name": "CVE-2025-6297", 
+      "package_name": "libdpkg-perl", 
+      "package_details": {
+        "file_path": null, 
+        "name": "libdpkg-perl", 
+        "package_manager": "OS", 
+        "version": "1.21.1ubuntu2.3", 
+        "release": null
+        }, 
+        "remediation": {
+          "recommendation": {
+            "text": "None Provided"
+          }
+        }, 
+        "cvss_v3_score": 8.2, 
+        "cvss_v30_score": 0.0, 
+        "cvss_v31_score": 8.2, 
+        "cvss_v2_score": 0.0, 
+        "cvss_v3_severity": "HIGH", 
+        "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html", 
+        "source": "UBUNTU_CVE", 
+        "severity": "HIGH", 
+        "status": "ACTIVE", 
+        "title": "CVE-2025-6297 - dpkg, libdpkg-perl", 
+        "reason_to_ignore": "N/A"
+    }
+  ]
+}

--- a/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.ec2.arm64.gpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.ec2.arm64.gpu.os_scan_allowlist.json
@@ -1,35 +1,4 @@
 {
-  "torch": [
-    {
-      "description": "PyTorch is a Python package that provides tensor computation with strong GPU acceleration and deep neural networks built on a tape-based autograd system. In version 2.5.1 and prior, a Remote Command Execution (RCE) vulnerability exists in PyTorch when loading a model using torch.load with weights_only=True. This issue has been patched in version 2.6.0.",
-      "vulnerability_id": "CVE-2025-32434",
-      "name": "CVE-2025-32434",
-      "package_name": "torch",
-      "package_details": {
-        "file_path": "/opt/conda/lib/python3.11/site-packages/torch-2.4.0+cpu.dist-info/METADATA",
-        "name": "torch",
-        "package_manager": "PYTHON",
-        "version": "2.4.0+cpu",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 9.8,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 9.8,
-      "cvss_v2_score": 0.0,
-      "cvss_v3_severity": "CRITICAL",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-32434",
-      "source": "NVD",
-      "severity": "CRITICAL",
-      "status": "ACTIVE",
-      "title": "CVE-2025-32434 - torch",
-      "reason_to_ignore": "N/A"
-    }
-  ],
   "dpkg": [
     {
       "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",

--- a/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.ec2.gpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.ec2.gpu.os_scan_allowlist.json
@@ -1,35 +1,4 @@
 {
-  "torch": [
-    {
-      "description": "PyTorch is a Python package that provides tensor computation with strong GPU acceleration and deep neural networks built on a tape-based autograd system. In version 2.5.1 and prior, a Remote Command Execution (RCE) vulnerability exists in PyTorch when loading a model using torch.load with weights_only=True. This issue has been patched in version 2.6.0.",
-      "vulnerability_id": "CVE-2025-32434",
-      "name": "CVE-2025-32434",
-      "package_name": "torch",
-      "package_details": {
-        "file_path": "/opt/conda/lib/python3.11/site-packages/torch-2.4.0+cpu.dist-info/METADATA",
-        "name": "torch",
-        "package_manager": "PYTHON",
-        "version": "2.4.0+cpu",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 9.8,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 9.8,
-      "cvss_v2_score": 0.0,
-      "cvss_v3_severity": "CRITICAL",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-32434",
-      "source": "NVD",
-      "severity": "CRITICAL",
-      "status": "ACTIVE",
-      "title": "CVE-2025-32434 - torch",
-      "reason_to_ignore": "N/A"
-    }
-  ],
   "dpkg": [
     {
       "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",

--- a/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
@@ -1,35 +1,4 @@
 {
-  "torch": [
-    {
-      "description": "PyTorch is a Python package that provides tensor computation with strong GPU acceleration and deep neural networks built on a tape-based autograd system. In version 2.5.1 and prior, a Remote Command Execution (RCE) vulnerability exists in PyTorch when loading a model using torch.load with weights_only=True. This issue has been patched in version 2.6.0.",
-      "vulnerability_id": "CVE-2025-32434",
-      "name": "CVE-2025-32434",
-      "package_name": "torch",
-      "package_details": {
-        "file_path": "/opt/conda/lib/python3.11/site-packages/torch-2.4.0+cpu.dist-info/METADATA",
-        "name": "torch",
-        "package_manager": "PYTHON",
-        "version": "2.4.0+cpu",
-        "release": null
-      },
-      "remediation": {
-        "recommendation": {
-          "text": "None Provided"
-        }
-      },
-      "cvss_v3_score": 9.8,
-      "cvss_v30_score": 0.0,
-      "cvss_v31_score": 9.8,
-      "cvss_v2_score": 0.0,
-      "cvss_v3_severity": "CRITICAL",
-      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-32434",
-      "source": "NVD",
-      "severity": "CRITICAL",
-      "status": "ACTIVE",
-      "title": "CVE-2025-32434 - torch",
-      "reason_to_ignore": "N/A"
-    }
-  ],
   "dpkg": [
     {
       "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",

--- a/pytorch/training/docker/2.5/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.5/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
@@ -441,5 +441,68 @@
       "title": "CVE-2025-30167 - jupyter_core",
       "reason_to_ignore": "N/A"
     }
+  ],
+
+  "dpkg": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "dpkg",
+      "package_details": {
+        "file_path": null,
+        "name": "dpkg",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "libdpkg-perl": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "libdpkg-perl",
+      "package_details": {
+        "file_path": null,
+        "name": "libdpkg-perl",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
+    }
   ]
 }

--- a/pytorch/training/docker/2.5/py3/cu124/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.5/py3/cu124/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
@@ -1290,5 +1290,68 @@
       "title": "CVE-2025-30167 - jupyter_core",
       "reason_to_ignore": "N/A"
     }
+  ],
+
+  "dpkg": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "dpkg",
+      "package_details": {
+        "file_path": null,
+        "name": "dpkg",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "libdpkg-perl": [
+    {
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "libdpkg-perl",
+      "package_details": {
+        "file_path": null,
+        "name": "libdpkg-perl",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
+    }
   ]
 }


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**:
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right.

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests Run

By default, docker image builds and tests are disabled. Two ways to run builds and tests:
1. Using dlc_developer_config.toml
2. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**
- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`
</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### PR Checklist
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
