### PR TITLE
add huggingface pytorch training 2.7.1 release config

### DIFF
--- a/release_images_training.yml
+++ b/release_images_training.yml
@@ -91,3 +91,16 @@ release_images:
       example: False
       disable_sm_tag: False
       force_release: False
+  8:
+    framework: "huggingface_pytorch"
+    version: "2.7.1"
+    hf_transformers: "4.55.0"
+    arch_type: "x86"
+    training:
+      device_types: ["gpu"]
+      python_versions: [ "py312" ]
+      os_version: "ubuntu22.04"
+      cuda_version: "cu128"
+      example: False
+      disable_sm_tag: False
+      force_release: False


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**:
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right.

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests Run

By default, docker image builds and tests are disabled. Two ways to run builds and tests:
1. Using dlc_developer_config.toml
2. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**
- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`
</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### PR Checklist
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
