### PR TITLE
add basic development guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__
 .idea
 *.pyc
+.venv

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,5 @@
+{
+  "MD013": false, // disable line-length limit
+  "MD033": false, // allow inline HTML
+  "MD041": false  // allow first line not being top level
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+default_install_hook_types:
+  - pre-commit
+  - commit-msg
+
+default_stages:
+  - pre-commit
+  - manual
+
+repos:
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.38.1
+    hooks:
+    - id: typos
+      args: [--force-exclude]
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.45.0
+    hooks:
+      - id: markdownlint
+        args: [--fix]
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.3
+    hooks:
+      - id: ruff-check
+        args: [ --fix, --output-format=github ]
+      - id: ruff-format
+  - repo: local
+    hooks:
+      - id: signoff-commit
+        name: Sign-off Commit
+        entry: bash
+        args:
+          - -c
+          - |
+            if ! grep -q "^Signed-off-by: $(git config user.name) <$(git config user.email)>" "$(git rev-parse --git-path COMMIT_EDITMSG)"; then
+              printf "\nSigned-off-by: $(git config user.name) <$(git config user.email)>\n" >> "$(git rev-parse --git-path COMMIT_EDITMSG)"
+            fi
+        language: system
+        verbose: true
+        stages: [commit-msg]

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,4 +1,5 @@
 ## Code of Conduct
+
 This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
 For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.
+<opensource-codeofconduct@amazon.com> with any additional questions or comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,65 +1,29 @@
 # Contributing Guidelines
 
-Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
-documentation, we greatly value feedback and contributions from our community.
+We appreciate your interest in this project.  
+At this time, **we are not accepting external contributions** (including pull requests or new feature submissions).
 
-Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
-information to effectively respond to your bug report or contribution.
+Our team is still in the early stages of establishing contribution workflows, code ownership, and testing standards.  
+Once we are ready to open the project for community participation, we will announce it publicly and update this document with detailed contribution procedures.
 
+In the meantime:
 
-## Reporting Bugs/Feature Requests
+- You are welcome to **open issues** for **bug reports, questions, or feedback**.  
+  Please keep issue reports focused and include relevant context (environment, version, steps to reproduce, etc.).
+- Please **do not open pull requests** — they will be closed without review until contribution is re-enabled.
+- Security issues should continue to be reported through the [AWS/Amazon Security vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/).
 
-We welcome you to use the GitHub issue tracker to report bugs or suggest features.
-
-When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
-reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
-
-* A reproducible test case or series of steps
-* The version of our code being used
-* Any modifications you've made relevant to the bug
-* Anything unusual about your environment or deployment
-
-
-## Contributing via Pull Requests
-Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
-
-1. You are working against the latest source on the *master* branch.
-2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
-3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
-
-To send us a pull request, please:
-
-1. Fork the repository.
-2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
-
-We require python formatting standards enforced by https://black.readthedocs.io/en/stable/getting_started.html - please run `black -l 100` on all python code prior to merge, or else you may experience automated check failures.
-
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
-[creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
-
-
-## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
-
+---
 
 ## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.
 
+This project follows the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).  
+For more information, see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact  
+<opensource-codeofconduct@amazon.com> with questions.
 
-## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
-
+---
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
-
-The licenses for all dependencies included in the image must be on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
-
-We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.
+See the [LICENSE](LICENSE) file for licensing information.  
+When external contributions are accepted, contributors will be asked to confirm license compliance and may be required to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement).

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,43 @@
+# Developer Guide
+
+This document describes how to set up a local development environment, run checks, and contribute changes to the project.
+
+> 💡 All commands below assume a Unix-like environment (macOS or Linux).
+
+---
+
+## 1. Environment Setup
+
+Create and activate a virtual environment using **[uv](https://docs.astral.sh/uv/)** — a fast Python package manager and virtualenv tool:
+
+```bash
+uv venv --python 3.12
+source .venv/bin/activate
+```
+
+---
+
+## 2. Linting and Code Style
+
+This project enforces linting and formatting through [pre-commit](https://pre-commit.com/#usage) hooks.
+
+Install and configure:
+
+```bash
+uv pip install pre-commit
+pre-commit install
+```
+
+To manually run all linters:
+
+```bash
+pre-commit run --all-files
+```
+
+Before committing or pushing changes, make sure your local Git and GitHub environments are properly configured.
+Set your name and email — this is required for commit metadata and for the sign-off hook to work correctly.
+
+```bash
+git config --global user.name <YOUR NAME>
+git config --global user.email <YOUR EMAIL>
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,8 @@
+[tool.ruff]
+line-length = 100
+target-version = "py312"
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "lf"


### PR DESCRIPTION
- Add basic development instructions. 
- Enable use of `pre-commit` checks and require sign-off commits.