### PR TITLE
update model-hosting-container-standards

### DIFF
--- a/vllm/x86_64/gpu/Dockerfile
+++ b/vllm/x86_64/gpu/Dockerfile
@@ -66,6 +66,10 @@ RUN dpkg -l | grep -E "cuda|nvidia|libnv" | awk '{print $2}' | xargs apt-mark ho
     apt-get upgrade -y && \
     apt-get clean
 
+RUN uv pip install --system model-hosting-container-standards==0.1.9 \
+  && uv pip freeze | grep model-hosting-container-standards | grep "0.1.9" \
+  && uv cache clean
+
 COPY dockerd_entrypoint.sh /usr/local/bin/dockerd_entrypoint.sh
 RUN chmod +x /usr/local/bin/dockerd_entrypoint.sh 
 
@@ -78,6 +82,10 @@ RUN dpkg -l | grep -E "cuda|nvidia|libnv" | awk '{print $2}' | xargs apt-mark ho
     apt-get update && \
     apt-get upgrade -y && \
     apt-get clean
+
+RUN uv pip install --system model-hosting-container-standards==0.1.9 \
+  && uv pip freeze | grep model-hosting-container-standards | grep "0.1.9" \
+  && uv cache clean
 
 COPY sagemaker_entrypoint.sh /usr/local/bin/sagemaker_entrypoint.sh
 RUN chmod +x /usr/local/bin/sagemaker_entrypoint.sh


### PR DESCRIPTION
### Build
```
/buildspec vllm/buildspec-sm.yml
```

### Test
https://github.com/aws/deep-learning-containers/actions/runs/19521765247
```
# regression test
pytest -v -s test_regression.py

# cuda test
pytest -v -s cuda/test_cuda_context.py

# sagemaker related test
pytest tests/entrypoints/sagemaker/test_sagemaker_lora_adapters.py -v
pytest tests/entrypoints/sagemaker/test_sagemaker_stateful_sessions.py -v
pytest tests/entrypoints/sagemaker/test_sagemaker_middleware_integration.py -v
pytest tests/entrypoints/sagemaker/test_sagemaker_handler_overrides.py -v
pytest tests/entrypoints/openai/test_lora_adapters.py -v
SAGEMAKER_CONTAINER_LOG_LEVEL=20 python3 offline_inference/basic/generate.py --model facebook/opt-125m
# python3 offline_inference/basic/generate.py --model meta-llama/Llama-2-13b-chat-hf --cpu-offload-gb 10
SAGEMAKER_CONTAINER_LOG_LEVEL=INFO python3 offline_inference/basic/chat.py

# example test
python3 offline_inference/prefix_caching.py
python3 offline_inference/llm_engine_example.py
python3 offline_inference/audio_language.py --seed 0
python3 offline_inference/vision_language.py --seed 0
python3 offline_inference/vision_language_pooling.py --seed 0
python3 offline_inference/vision_language_multi_image.py --seed 0
VLLM_USE_V1=0 python3 others/tensorize_vllm_model.py --model facebook/opt-125m serialize --serialized-directory /tmp/ --suffix v1 && python3 others/tensorize_vllm_model.py --model facebook/opt-125m deserialize --path-to-tensors /tmp/vllm/facebook/opt-125m/v1/model.tensors
python3 offline_inference/encoder_decoder_multimodal.py --model-type whisper --seed 0
python3 offline_inference/basic/classify.py
python3 offline_inference/basic/embed.py
python3 offline_inference/basic/score.py
python3 offline_inference/simple_profiling.py
```
