### PR TITLE
Patch TF 2.19 Training

### DIFF
--- a/tensorflow/training/docker/2.19/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
+++ b/tensorflow/training/docker/2.19/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
@@ -548,5 +548,160 @@
       "title": "CVE-2025-12758 - validator",
       "reason_to_ignore": "N/A"
     }
+  ],
+  "jaraco.context": [
+    {
+      "description": "jaraco.context, an open-source software package that provides some useful decorators and context managers, has a Zip Slip path traversal vulnerability in the `jaraco.context.tarball()` function starting in version 5.2.0 and prior to version 6.1.0. The vulnerability may allow attackers to extract files outside the intended extraction directory when malicious tar archives are processed. The strip_first_component filter splits the path on the first `/` and extracts the second component, while allowing `../` sequences. Paths like `dummy_dir/../../etc/passwd` become `../../etc/passwd`. Note that this suffers from a nested tarball attack as well with multi-level tar files such as `dummy_dir/inner.tar.gz`, where the inner.tar.gz includes a traversal `dummy_dir/../../config/.env` that also gets translated to `../../config/.env`. Version 6.1.0 contains a patch for the issue.",
+      "vulnerability_id": "CVE-2026-23949",
+      "name": "CVE-2026-23949",
+      "package_name": "jaraco.context",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/setuptools/_vendor/jaraco.context-5.3.0.dist-info/METADATA",
+        "name": "jaraco.context",
+        "package_manager": "PYTHON",
+        "version": "5.3.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.6,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.6,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23949",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-23949 - jaraco.context",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "qs": [
+    {
+      "description": "Improper Input Validation vulnerability in qs (parse modules) allows HTTP DoS.This issue affects qs: < 6.14.1.\n\nSummaryThe arrayLimit\u00a0option in qs does not enforce limits for bracket notation (a[]=1&a[]=2), allowing attackers to cause denial-of-service via memory exhaustion. Applications using arrayLimit\u00a0for DoS protection are vulnerable.\n\nDetailsThe arrayLimit\u00a0option only checks limits for indexed notation (a[0]=1&a[1]=2) but completely bypasses it for bracket notation (a[]=1&a[]=2).\n\nVulnerable code\u00a0(lib/parse.js:159-162):\n\nif (root === '[]' && options.parseArrays) { obj = utils.combine([], leaf); // No arrayLimit check }\n\nWorking code\u00a0(lib/parse.js:175):\n\nelse if (index <= options.arrayLimit) { // Limit checked here obj = []; obj[index] = leaf; }\n\nThe bracket notation handler at line 159 uses utils.combine([], leaf)\u00a0without validating against options.arrayLimit, while indexed notation at line 175 checks index <= options.arrayLimit\u00a0before creating arrays.\n\nPoCTest 1 - Basic bypass:\n\nnpm install qs\n\nconst qs",
+      "vulnerability_id": "CVE-2025-15284",
+      "name": "CVE-2025-15284",
+      "package_name": "qs",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/jupyterlab/staging/yarn.lock",
+        "name": "qs",
+        "package_manager": "NODE",
+        "version": "6.13.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-15284",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-15284 - qs",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "tar": [
+    {
+      "description": "node-tar,a Tar for Node.js, has a race condition vulnerability in versions up to and including 7.5.3. This is due to an incomplete handling of Unicode path collisions in the `path-reservations` system. On case-insensitive or normalization-insensitive filesystems (such as macOS APFS, In which it has been tested), the library fails to lock colliding paths (e.g., `\u00df` and `ss`), allowing them to be processed in parallel. This bypasses the library's internal concurrency safeguards and permits Symlink Poisoning attacks via race conditions. The library uses a `PathReservations` system to ensure that metadata checks and file operations for the same path are serialized. This prevents race conditions where one entry might clobber another concurrently. This is a Race Condition which enables Arbitrary File Overwrite. This vulnerability affects users and systems using node-tar on macOS (APFS/HFS+). Because of using `NFD` Unicode normalization (in which `\u00df` and `ss` are different), conflicting paths do not have their order",
+      "vulnerability_id": "CVE-2026-23950",
+      "name": "CVE-2026-23950",
+      "package_name": "tar",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/jupyterlab/staging/yarn.lock",
+        "name": "tar",
+        "package_manager": "NODE",
+        "version": "6.1.11",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23950",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-23950 - tar",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "vega-functions": [
+    {
+      "description": "vega-functions provides function implementations for the Vega expression language. Prior to version 6.1.1, for sites that allow users to supply untrusted user input, malicious use of an internal function (not part of the public API) could be used to run unintentional javascript (XSS). This issue is fixed in vega-functions `6.1.1`. There is no workaround besides upgrading. Using `vega.expressionInterpreter` as described in CSP safe mode does not prevent this issue.",
+      "vulnerability_id": "CVE-2025-66648",
+      "name": "CVE-2025-66648",
+      "package_name": "vega-functions",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/jupyterlab/staging/yarn.lock",
+        "name": "vega-functions",
+        "package_manager": "NODE",
+        "version": "5.18.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66648",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-66648 - vega-functions",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "vega-selections": [
+    {
+      "description": "Vega is a visualization grammar, a declarative format for creating, saving, and sharing interactive visualization designs. Prior to versions 6.1.2 and 5.6.3, applications meeting two conditions are at risk of arbitrary JavaScript code execution, even if \"safe mode\" expressionInterpreter is used. First, they use `vega` in an application that attaches both `vega` library and a `vega.View` instance similar to the Vega Editor to the global `window`, or has any other satisfactory function gadgets in the global scope. Second, they allow user-defined Vega `JSON` definitions (vs JSON that was is only provided through source code). This vulnerability allows for DOM XSS, potentially stored, potentially reflected, depending on how the library is being used. The vulnerability requires user interaction with the page to trigger. An attacker can exploit this issue by tricking a user into opening a malicious Vega specification. Successful exploitation allows the attacker to execute arbitrary JavaScript in the context of the ",
+      "vulnerability_id": "CVE-2025-65110",
+      "name": "CVE-2025-65110",
+      "package_name": "vega-selections",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/jupyterlab/staging/yarn.lock",
+        "name": "vega-selections",
+        "package_manager": "NODE",
+        "version": "5.6.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.1,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.1,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-65110",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-65110 - vega-selections",
+      "reason_to_ignore": "N/A"
+    }
   ]
 }

--- a/tensorflow/training/docker/2.19/py3/cu125/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
+++ b/tensorflow/training/docker/2.19/py3/cu125/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
@@ -548,5 +548,160 @@
       "title": "CVE-2025-12758 - validator",
       "reason_to_ignore": "N/A"
     }
+  ],
+  "jaraco.context": [
+    {
+      "description": "jaraco.context, an open-source software package that provides some useful decorators and context managers, has a Zip Slip path traversal vulnerability in the `jaraco.context.tarball()` function starting in version 5.2.0 and prior to version 6.1.0. The vulnerability may allow attackers to extract files outside the intended extraction directory when malicious tar archives are processed. The strip_first_component filter splits the path on the first `/` and extracts the second component, while allowing `../` sequences. Paths like `dummy_dir/../../etc/passwd` become `../../etc/passwd`. Note that this suffers from a nested tarball attack as well with multi-level tar files such as `dummy_dir/inner.tar.gz`, where the inner.tar.gz includes a traversal `dummy_dir/../../config/.env` that also gets translated to `../../config/.env`. Version 6.1.0 contains a patch for the issue.",
+      "vulnerability_id": "CVE-2026-23949",
+      "name": "CVE-2026-23949",
+      "package_name": "jaraco.context",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/setuptools/_vendor/jaraco.context-5.3.0.dist-info/METADATA",
+        "name": "jaraco.context",
+        "package_manager": "PYTHON",
+        "version": "5.3.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.6,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.6,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23949",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-23949 - jaraco.context",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "qs": [
+    {
+      "description": "Improper Input Validation vulnerability in qs (parse modules) allows HTTP DoS.This issue affects qs: < 6.14.1.\n\nSummaryThe arrayLimit\u00a0option in qs does not enforce limits for bracket notation (a[]=1&a[]=2), allowing attackers to cause denial-of-service via memory exhaustion. Applications using arrayLimit\u00a0for DoS protection are vulnerable.\n\nDetailsThe arrayLimit\u00a0option only checks limits for indexed notation (a[0]=1&a[1]=2) but completely bypasses it for bracket notation (a[]=1&a[]=2).\n\nVulnerable code\u00a0(lib/parse.js:159-162):\n\nif (root === '[]' && options.parseArrays) { obj = utils.combine([], leaf); // No arrayLimit check }\n\nWorking code\u00a0(lib/parse.js:175):\n\nelse if (index <= options.arrayLimit) { // Limit checked here obj = []; obj[index] = leaf; }\n\nThe bracket notation handler at line 159 uses utils.combine([], leaf)\u00a0without validating against options.arrayLimit, while indexed notation at line 175 checks index <= options.arrayLimit\u00a0before creating arrays.\n\nPoCTest 1 - Basic bypass:\n\nnpm install qs\n\nconst qs",
+      "vulnerability_id": "CVE-2025-15284",
+      "name": "CVE-2025-15284",
+      "package_name": "qs",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/jupyterlab/staging/yarn.lock",
+        "name": "qs",
+        "package_manager": "NODE",
+        "version": "6.13.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-15284",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-15284 - qs",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "tar": [
+    {
+      "description": "node-tar,a Tar for Node.js, has a race condition vulnerability in versions up to and including 7.5.3. This is due to an incomplete handling of Unicode path collisions in the `path-reservations` system. On case-insensitive or normalization-insensitive filesystems (such as macOS APFS, In which it has been tested), the library fails to lock colliding paths (e.g., `\u00df` and `ss`), allowing them to be processed in parallel. This bypasses the library's internal concurrency safeguards and permits Symlink Poisoning attacks via race conditions. The library uses a `PathReservations` system to ensure that metadata checks and file operations for the same path are serialized. This prevents race conditions where one entry might clobber another concurrently. This is a Race Condition which enables Arbitrary File Overwrite. This vulnerability affects users and systems using node-tar on macOS (APFS/HFS+). Because of using `NFD` Unicode normalization (in which `\u00df` and `ss` are different), conflicting paths do not have their order",
+      "vulnerability_id": "CVE-2026-23950",
+      "name": "CVE-2026-23950",
+      "package_name": "tar",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/jupyterlab/staging/yarn.lock",
+        "name": "tar",
+        "package_manager": "NODE",
+        "version": "6.1.11",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-23950",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-23950 - tar",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "vega-functions": [
+    {
+      "description": "vega-functions provides function implementations for the Vega expression language. Prior to version 6.1.1, for sites that allow users to supply untrusted user input, malicious use of an internal function (not part of the public API) could be used to run unintentional javascript (XSS). This issue is fixed in vega-functions `6.1.1`. There is no workaround besides upgrading. Using `vega.expressionInterpreter` as described in CSP safe mode does not prevent this issue.",
+      "vulnerability_id": "CVE-2025-66648",
+      "name": "CVE-2025-66648",
+      "package_name": "vega-functions",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/jupyterlab/staging/yarn.lock",
+        "name": "vega-functions",
+        "package_manager": "NODE",
+        "version": "5.18.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-66648",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-66648 - vega-functions",
+      "reason_to_ignore": "N/A"
+    }
+  ],
+  "vega-selections": [
+    {
+      "description": "Vega is a visualization grammar, a declarative format for creating, saving, and sharing interactive visualization designs. Prior to versions 6.1.2 and 5.6.3, applications meeting two conditions are at risk of arbitrary JavaScript code execution, even if \"safe mode\" expressionInterpreter is used. First, they use `vega` in an application that attaches both `vega` library and a `vega.View` instance similar to the Vega Editor to the global `window`, or has any other satisfactory function gadgets in the global scope. Second, they allow user-defined Vega `JSON` definitions (vs JSON that was is only provided through source code). This vulnerability allows for DOM XSS, potentially stored, potentially reflected, depending on how the library is being used. The vulnerability requires user interaction with the page to trigger. An attacker can exploit this issue by tricking a user into opening a malicious Vega specification. Successful exploitation allows the attacker to execute arbitrary JavaScript in the context of the ",
+      "vulnerability_id": "CVE-2025-65110",
+      "name": "CVE-2025-65110",
+      "package_name": "vega-selections",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/jupyterlab/staging/yarn.lock",
+        "name": "vega-selections",
+        "package_manager": "NODE",
+        "version": "5.6.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.1,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.1,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-65110",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-65110 - vega-selections",
+      "reason_to_ignore": "N/A"
+    }
   ]
 }


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**:
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right.

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests Run

By default, docker image builds and tests are disabled. Two ways to run builds and tests:
1. Using dlc_developer_config.toml
2. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**
- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`
</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### PR Checklist
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
