### PR TITLE
update README and DEVELOPMENT for docs

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,14 +1,6 @@
-# Documentation Development Guide
+# Content Development Guide
 
-Guide for developers working with AWS Deep Learning Containers documentation.
-
-## Quick Start
-
-```bash
-cd /path/to/deep-learning-containers
-source .venv/bin/activate
-cd docs/src && python main.py --verbose
-```
+Guide for adding and modifying generated content in AWS Deep Learning Containers documentation. For site setup and local development, see [README.md](README.md).
 
 ## Directory Structure
 
@@ -42,7 +34,7 @@ docs/
 └── mkdocs.yml
 ```
 
-______________________________________________________________________
+---
 
 ## Adding a New Image
 
@@ -76,7 +68,7 @@ See `docs/src/data/template/image-template.yml` for all available fields.
 cd docs/src && python main.py --verbose
 ```
 
-______________________________________________________________________
+---
 
 ## Adding Support Policy Dates
 
@@ -94,7 +86,7 @@ eop: "2026-10-15"   # End of Patch date
 
 **Validation:** All images in the same framework group with the same full version (X.Y.Z) must have identical GA/EOP dates.
 
-______________________________________________________________________
+---
 
 ## Adding Release Notes
 
@@ -143,7 +135,7 @@ Section headers in optional sections are rendered via the section key.
 To format your optional section headers, add a new field in `docs/src/global.yml` under `display_names` section.
 Eg: deprecation_notice section will render its header as `## deprecation_notice` unless a formatted string is provided in `docs/src/global.yml`.
 
-______________________________________________________________________
+---
 
 ## Adding a New Repository
 
@@ -171,7 +163,7 @@ ______________________________________________________________________
      - my-repo
    ```
 
-______________________________________________________________________
+---
 
 ## Editing Table Columns
 
@@ -190,7 +182,7 @@ columns:
 To add additional fields, ensure that the image configuration YAML file contains said field of the same name.
 Additionally, if you require the field to be formatted, add an additional attribute in `ImageConfig` class of `display_<field_name>` to grab the formatted field.
 
-______________________________________________________________________
+---
 
 ## Legacy Support Data
 
@@ -205,7 +197,7 @@ pytorch:
 
 Generally, this is only required if an image configuration file does not already exist and the image is already past its support.
 
-______________________________________________________________________
+---
 
 ## Global Configuration
 
@@ -217,67 +209,18 @@ ______________________________________________________________________
 - **table_order:** Order of tables displayed within the documentations website (eg: available_images.md and support_policy.md)
 - **platforms/accelerators:** Display mappings
 
-______________________________________________________________________
+---
 
-## Running Generation
+## Tutorials Changes
 
-```bash
-# Help
-python main.py --help
+For any changes required to the tutorial pages, create a new PR in
+[aws-samples/sample-aws-deep-learning-containers](https://github.com/aws-samples/sample-aws-deep-learning-containers.git).
 
-# Full generation
-python main.py --verbose
+> **Important**: When making changes to the tutorials page, make sure that you update the tutorials
+> [index.md](https://github.com/aws-samples/sample-aws-deep-learning-containers/blob/main/index.md) and
+> [.nav.yaml](https://github.com/aws-samples/sample-aws-deep-learning-containers/blob/main/.nav.yml) accordingly.
 
-# Specific outputs
-python main.py --available-images-only
-python main.py --support-policy-only
-python main.py --release-notes-only
-
-# Preview site
-cd docs && mkdocs serve
-```
-
-______________________________________________________________________
-
-## Local Documentation Development
-
-### Generation Only (No Server)
-
-Run `main.py` to generate documentation without serving:
-
-```bash
-cd docs/src && python main.py --verbose
-```
-
-This automatically clones `tutorials/` repository and generates markdown files in `reference/` and `releasenotes/` directories without starting a web server.
-
-### Serving Locally
-
-Use `mkdocs serve` to automatically clone `tutorials/` and generate documentation in `reference/` and `releasenotes/` and serve the website:
-
-```bash
-cd docs && mkdocs serve
-```
-
-The site is typically available at `http://127.0.0.1:8000/deep-learning-containers/` - check the command output for the actual URL.
-
-### Live Reload
-
-Enable automatic reload on content changes:
-
-```bash
-mkdocs serve --livereload
-```
-
-**Note:** Live reload only detects changes to:
-
-- Markdown file content
-- `.nav.yml` content
-- `mkdocs.yml` content
-
-Live reload does **not** detect changes requiring documentation regeneration (e.g., image config YAML files, templates). To regenerate documentation, stop the server (`Ctrl+C`) and rerun `mkdocs serve`.
-
-______________________________________________________________________
+---
 
 ## Troubleshooting
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,25 +1,59 @@
-# Documentation Development Runbook
+# Documentation Website Guide
+
+Guide for setting up, running, and configuring the MkDocs documentation site. For adding or modifying generated content (images, release notes, support policy), see [DEVELOPMENT.md](DEVELOPMENT.md).
 
 ## Prerequisites
 
-Follow the environment setup instructions in [DEVELOPMENT.md](../DEVELOPMENT.md), then install documentation dependencies:
-
 ```bash
+# Set up virtual environment from repository root
+cd /path/to/deep-learning-containers
+python -m venv .venv
+source .venv/bin/activate
 pip install -r docs/requirements.txt
 ```
 
 ## Local Development
 
-Start the development server with live reload:
+### Generation Only
 
+Run the generation system without serving:
 ```bash
-mkdocs serve
+cd docs/src && python main.py --verbose
 ```
+This clones the `tutorials/` repository and generates markdown files in `reference/` and `releasenotes/` directories.
+
+Generation flags:
+```bash
+python main.py --available-images-only
+python main.py --support-policy-only
+python main.py --release-notes-only
+python main.py --index-only
+```
+
+### Serving
+
+Use `mkdocs serve` to generate documentation and serve the website:
+```bash
+cd docs && mkdocs serve
+```
+The site is typically available at `http://127.0.0.1:8000/deep-learning-containers/` - check the command output for the actual URL.
+
+### Live Reload
+
+Enable automatic reload on content changes:
+```bash
+mkdocs serve --livereload
+```
+**Note:** Live reload only detects changes to:
+- Markdown file content
+- `.nav.yml` content
+- `mkdocs.yml` content
+
+Live reload does **not** detect changes requiring documentation regeneration (e.g., image config YAML files, templates). To regenerate documentation, stop the server (`Ctrl+C`) and rerun `mkdocs serve`.
 
 ## Navigation
 
 Site navigation is managed centrally in `docs/.nav.yml` using the `awesome-nav` plugin. Structure:
-
 ```yaml
 nav:
   - Home: index.md
@@ -34,7 +68,6 @@ nav:
 Key settings in `mkdocs.yaml`:
 
 **Theme Palette** - Modify color scheme under `theme.palette`:
-
 ```yaml
 theme:
   palette:
@@ -44,7 +77,6 @@ theme:
 ```
 
 **Plugins** - Add/remove plugins under `plugins`:
-
 ```yaml
 plugins:
   - search
@@ -52,11 +84,3 @@ plugins:
   - awesome-nav
 ```
 
-## Tutorials Changes
-
-For any changes required to the tutorial pages, create a new PR in
-[aws-samples/sample-aws-deep-learning-containers](https://github.com/aws-samples/sample-aws-deep-learning-containers.git).
-
-> **Important**: When making changes to the tutorials page, make sure that you update the tutorials
-> [index.md](https://github.com/aws-samples/sample-aws-deep-learning-containers/blob/main/index.md) and
-> [.nav.yaml](https://github.com/aws-samples/sample-aws-deep-learning-containers/blob/main/.nav.yml) accordingly.


### PR DESCRIPTION
*GitHub Issue #, if available:*

**Note**:
- If merging this PR should also close the associated Issue, please also add that Issue # to the Linked Issues section on the right.

- All PR's are checked weekly for staleness. This PR will be closed if not updated in 30 days.

### Description

### Tests Run

By default, docker image builds and tests are disabled. Two ways to run builds and tests:
1. Using dlc_developer_config.toml
2. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**
- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`
</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

### Formatting
- [ ] I have run `black -l 100` on my code (formatting tool: https://black.readthedocs.io/en/stable/getting_started.html)

### PR Checklist
<details>
<summary>Expand</summary>

- [ ] I've prepended PR tag with frameworks/job this applies to : [mxnet, tensorflow, pytorch] | [ei/neuron/graviton] | [build] | [test] | [benchmark] | [ec2, ecs, eks, sagemaker]
- [ ] If the PR changes affects SM test, I've modified dlc_developer_config.toml in my PR branch by setting sagemaker_tests = true and efa_tests = true
- [ ] If this PR changes existing code, the change fully backward compatible with pre-existing code. (Non backward-compatible changes need special approval.)
- [ ] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [ ] (If applicable) I've documented below the tests I've run on the DLC image
- [ ] (If applicable) I've reviewed the licenses of updated and new binaries and their dependencies to make sure all licenses are on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
- [ ] (If applicable) I've scanned the updated and new binaries to make sure they do not have vulnerabilities associated with them.
</details>

### Pytest Marker Checklist
<details>
<summary>Expand</summary>

- [ ] (If applicable) I have added the marker `@pytest.mark.model("<model-type>")` to the new tests which I have added, to specify the Deep Learning model that is used in the test (use `"N/A"` if the test doesn't use a model)
- [ ] (If applicable) I have added the marker `@pytest.mark.integration("<feature-being-tested>")` to the new tests which I have added, to specify the feature that will be tested
- [ ] (If applicable) I have added the marker `@pytest.mark.multinode(<integer-num-nodes>)` to the new tests which I have added, to specify the number of nodes used on a multi-node test
- [ ] (If applicable) I have added the marker `@pytest.mark.processor(<"cpu"/"gpu"/"eia"/"neuron">)` to the new tests which I have added, if a test is specifically applicable to only one processor type
</details>


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
