### PR TITLE
[vllm] [cpu] [sagemaker] Add vLLM CPU inference image for SageMaker

### DIFF
--- a/vllm/buildspec-cpu-sm.yml
+++ b/vllm/buildspec-cpu-sm.yml
@@ -30,7 +30,7 @@ images:
     <<: *BUILD_REPOSITORY
     context:
       <<: *BUILD_CONTEXT
-    image_size_baseline: 15000
+    image_size_baseline: 5000
     device_type: &DEVICE_TYPE cpu
     python_version: &DOCKER_PYTHON_VERSION py3
     tag_python_version: &TAG_PYTHON_VERSION py312

--- a/vllm/x86_64/cpu/Dockerfile.cpu
+++ b/vllm/x86_64/cpu/Dockerfile.cpu
@@ -63,6 +63,8 @@ ENV UV_HTTP_TIMEOUT=500
 # Memory allocator + Intel OpenMP for x86_64 performance
 ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libtcmalloc_minimal.so.4:/opt/venv/lib/libiomp5.so"
 
+RUN echo 'ulimit -c 0' >> ~/.bashrc
+
 # ====================== vllm-build =========================================
 FROM base AS vllm-build
 


### PR DESCRIPTION
*GitHub Issue #, if available:* N/A

### Description

Add vLLM CPU-only inference image for SageMaker. Enables running vLLM on CPU instances for reranking, scoring, embeddings, and small generative models.

- `vllm/x86_64/cpu/Dockerfile.cpu` — Multi-stage build from `ubuntu:22.04`, compiles vLLM v0.15.1 with `VLLM_TARGET_DEVICE=cpu`. Uses tcmalloc + Intel OpenMP, Python 3.12 via uv, reuses shared `sagemaker_entrypoint.sh`.
- `vllm/buildspec-cpu-sm.yml` — Buildspec for CPU SageMaker target. Tag: `0.15.1-cpu-py312-ubuntu22.04-sagemaker`.

**Manual testing on EC2 (c5.4xlarge):**
- Image builds successfully (~3.5 GB)
- `/health`, `/ping` return 200
- `/v1/completions` works (facebook/opt-125m)
- `/score` and `/invocations` work with reranker (Alibaba-NLP/gte-multilingual-reranker-base)

### Tests Run

```
/buildspec vllm/buildspec-cpu-sm.yml
/tests sanity security
```

### Formatting
- [ ] N/A — No Python files in this PR (Dockerfile + YAML only)

### PR Checklist

- [x] I've prepended PR tag with frameworks/job this applies to : [vllm] | [cpu] | [sagemaker]
- [x] This PR is fully backward compatible with pre-existing code
- [x] I've documented the DLC image/dockerfile this relates to
- [x] I've documented the tests I've run on the DLC image
- [ ] I've reviewed the licenses of new binaries and dependencies

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.