### PR TITLE
docs: add vLLM 0.15.1 to available images

### DIFF
--- a/docs/src/data/vllm/0.15.1-gpu-ec2.yml
+++ b/docs/src/data/vllm/0.15.1-gpu-ec2.yml
@@ -1,0 +1,26 @@
+framework: vLLM
+version: "0.15.1"
+accelerator: gpu
+python: py312
+cuda: cu129
+os: ubuntu22.04
+platform: ec2
+public_registry: true
+
+tags:
+  - "0.15.1-gpu-py312-cu129-ubuntu22.04-ec2"
+  - "0.15-gpu-py312-cu129-ubuntu22.04-ec2-v1"
+  - "0.15.1-gpu-py312-ec2"
+  - "0.15-gpu-py312-ec2"
+
+announcements:
+  - "Introduced vLLM 0.15.1 containers for EC2, ECS, EKS"
+
+packages:
+  vllm: "0.15.1"
+  pytorch: "2.9.1"
+  torchvision: "0.24.1"
+  torchaudio: "2.9.1"
+  cuda: "12.9"
+  nccl: "2.28.3"
+  efa: "1.46.0"

--- a/docs/src/data/vllm/0.15.1-gpu-sagemaker.yml
+++ b/docs/src/data/vllm/0.15.1-gpu-sagemaker.yml
@@ -1,0 +1,26 @@
+framework: vLLM
+version: "0.15.1"
+accelerator: gpu
+python: py312
+cuda: cu129
+os: ubuntu22.04
+platform: sagemaker
+public_registry: true
+
+tags:
+  - "0.15.1-gpu-py312-cu129-ubuntu22.04-sagemaker"
+  - "0.15-gpu-py312-cu129-ubuntu22.04-sagemaker-v1"
+  - "0.15.1-gpu-py312"
+  - "0.15-gpu-py312"
+
+announcements:
+  - "Introduced vLLM 0.15.1 containers for SageMaker"
+
+packages:
+  vllm: "0.15.1"
+  pytorch: "2.9.1"
+  torchvision: "0.24.1"
+  torchaudio: "2.9.1"
+  cuda: "12.9"
+  nccl: "2.28.3"
+  efa: "1.46.0"


### PR DESCRIPTION
Backfill missing vLLM 0.15.1 documentation YAML files for EC2 and SageMaker platforms.

This updates the available images documentation at https://aws.github.io/deep-learning-containers/reference/available_images/#vllm to include vLLM 0.15.1 which was released on 2026-02-07.

Fixes stale documentation issue.