### PR TITLE
docs: add vLLM 0.15.1 and Base 12.9.1 to available images

### DIFF
--- a/docs/src/data/base/12.9.1-gpu-ec2.yml
+++ b/docs/src/data/base/12.9.1-gpu-ec2.yml
@@ -1,0 +1,22 @@
+framework: Base
+version: "12.9.1"
+accelerator: gpu
+python: py312
+cuda: cu129
+os: ubuntu22.04
+platform: ec2
+public_registry: true
+
+tags:
+  - "12.9.1-gpu-py312-cu129-ubuntu22.04-ec2"
+  - "12.9-gpu-py312-cu129-ubuntu22.04-ec2-v1"
+  - "12.9.1-gpu-py312-ubuntu22.04-ec2"
+  - "12.9-gpu-py312-ubuntu22.04-ec2"
+
+announcements:
+  - "Introduced Base containers with CUDA 12.9.1 for EC2, ECS, EKS"
+  - "Added Python 3.12 support"
+
+packages:
+  python: "3.12"
+  cuda: "12.9.1"

--- a/docs/src/data/vllm/0.15.1-gpu-ec2.yml
+++ b/docs/src/data/vllm/0.15.1-gpu-ec2.yml
@@ -1,0 +1,26 @@
+framework: vLLM
+version: "0.15.1"
+accelerator: gpu
+python: py312
+cuda: cu129
+os: ubuntu22.04
+platform: ec2
+public_registry: true
+
+tags:
+  - "0.15.1-gpu-py312-cu129-ubuntu22.04-ec2"
+  - "0.15-gpu-py312-cu129-ubuntu22.04-ec2-v1"
+  - "0.15.1-gpu-py312-ec2"
+  - "0.15-gpu-py312-ec2"
+
+announcements:
+  - "Introduced vLLM 0.15.1 containers for EC2, ECS, EKS"
+
+packages:
+  vllm: "0.15.1"
+  pytorch: "2.9.1"
+  torchvision: "0.24.1"
+  torchaudio: "2.9.1"
+  cuda: "12.9"
+  nccl: "2.28.3"
+  efa: "1.46.0"

--- a/docs/src/data/vllm/0.15.1-gpu-sagemaker.yml
+++ b/docs/src/data/vllm/0.15.1-gpu-sagemaker.yml
@@ -1,0 +1,26 @@
+framework: vLLM
+version: "0.15.1"
+accelerator: gpu
+python: py312
+cuda: cu129
+os: ubuntu22.04
+platform: sagemaker
+public_registry: true
+
+tags:
+  - "0.15.1-gpu-py312-cu129-ubuntu22.04-sagemaker"
+  - "0.15-gpu-py312-cu129-ubuntu22.04-sagemaker-v1"
+  - "0.15.1-gpu-py312"
+  - "0.15-gpu-py312"
+
+announcements:
+  - "Introduced vLLM 0.15.1 containers for SageMaker"
+
+packages:
+  vllm: "0.15.1"
+  pytorch: "2.9.1"
+  torchvision: "0.24.1"
+  torchaudio: "2.9.1"
+  cuda: "12.9"
+  nccl: "2.28.3"
+  efa: "1.46.0"


### PR DESCRIPTION
Backfill missing documentation YAML files for vLLM 0.15.1 and Base 12.9.1.

This updates the available images documentation to include:
- vLLM 0.15.1 (EC2 and SageMaker platforms) - released on 2026-02-07
- Base 12.9.1 (EC2 platform) - released on 2026-02-10

Fixes stale documentation issues.

Supersedes #5683, #5684