### PR TITLE
docs: Add HuggingFace vLLM 0.14 GPU configuration for SageMaker

### DIFF
--- a/docs/src/data/huggingface-vllm/0.14-gpu-sagemaker.yml
+++ b/docs/src/data/huggingface-vllm/0.14-gpu-sagemaker.yml
@@ -1,0 +1,10 @@
+framework: vLLM
+version: "0.14"
+accelerator: gpu
+python: py312
+cuda: cu129
+os: ubuntu22.04
+platform: sagemaker
+
+tags:
+  - "0.14-gpu-py312-cu129-ubuntu22.04-v1"


### PR DESCRIPTION
## Purpose

HuggingFace vLLM image was released but the image entry is missing from the new [available images](https://aws.github.io/deep-learning-containers/reference/available_images/) docs page.

This PR adds the HuggingFace vLLM 0.14 GPU SageMaker configuration to the docs.

Based on #5713 by @ehcalabres.

## PR Checklist
- [x] I ran `pre-commit run --all-files` locally before creating this PR.