### PR TITLE
docs: Update CONTRIBUTING.md to disable external contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,65 +1,29 @@
 # Contributing Guidelines
 
-Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
-documentation, we greatly value feedback and contributions from our community.
+We appreciate your interest in this project.\
+At this time, **we are not accepting external contributions** (including pull requests or new feature submissions).
 
-Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
-information to effectively respond to your bug report or contribution.
+Our team is still in the early stages of establishing contribution workflows, code ownership, and testing standards.\
+Once we are ready to open the project for community participation, we will announce it publicly and update this document with detailed contribution procedures.
 
+In the meantime:
 
-## Reporting Bugs/Feature Requests
+- You are welcome to **open issues** for **bug reports, questions, or feedback**.\
+  Please keep issue reports focused and include relevant context (environment, version, steps to reproduce, etc.).
+- Please **do not open pull requests** — they will be closed without review until contribution is re-enabled.
+- Security issues should continue to be reported through the [AWS/Amazon Security vulnerability reporting page](https://aws.amazon.com/security/vulnerability-reporting/).
 
-We welcome you to use the GitHub issue tracker to report bugs or suggest features.
-
-When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
-reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
-
-* A reproducible test case or series of steps
-* The version of our code being used
-* Any modifications you've made relevant to the bug
-* Anything unusual about your environment or deployment
-
-
-## Contributing via Pull Requests
-Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
-
-1. You are working against the latest source on the *master* branch.
-2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
-3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
-
-To send us a pull request, please:
-
-1. Fork the repository.
-2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
-3. Ensure local tests pass.
-4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
-
-We require python formatting standards enforced by https://black.readthedocs.io/en/stable/getting_started.html - please run `black -l 100` on all python code prior to merge, or else you may experience automated check failures.
-
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
-[creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
-
-
-## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
-
+______________________________________________________________________
 
 ## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.
 
+This project follows the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).\
+For more information, see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact\
+with questions.
 
-## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
-
+______________________________________________________________________
 
 ## Licensing
 
-See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
-
-The licenses for all dependencies included in the image must be on the Apache Software Foundation Third Party License Policy Category A or Category B license list.  See [https://www.apache.org/legal/resolved.html](https://www.apache.org/legal/resolved.html).
-
-We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.
+See the [LICENSE](LICENSE) file for licensing information.\
+When external contributions are accepted, contributors will be asked to confirm license compliance and may be required to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement).


### PR DESCRIPTION
## Purpose

The `master` branch CONTRIBUTING.md still welcomes external pull requests, but the repo is not ready for external contributions. The `main` branch already has the updated version.

This PR syncs the `master` branch CONTRIBUTING.md to match `main`, clarifying that external PRs are not currently accepted.

## PR Checklist
- [x] I ran `pre-commit run --all-files` locally before creating this PR.