### PR TITLE
Switch release logic to Python package and enable PR gamma testing

### DIFF
--- a/.github/actions/setup-release-package/action.yml
+++ b/.github/actions/setup-release-package/action.yml
@@ -13,7 +13,7 @@ inputs:
   release-package-s3-prefix:
     description: 'S3 prefix/folder path to the package'
     required: false
-    default: 'DLContainersReleaseLogicV2/DLContainersReleaseLogic'
+    default: 'DLContainersReleaseLogicPython/dlc_release_dist'
 
 runs:
   using: 'composite'

--- a/.github/workflows/auto-release-vllm-rayserve.yml
+++ b/.github/workflows/auto-release-vllm-rayserve.yml
@@ -6,11 +6,11 @@ on:
     # Runs at 10:00 AM PST/PDT on Monday and Wednesday
     - cron: '00 17 * * 1,3' # Monday and Wednesday at 10:00 AM PDT / 9:00 AM PST
 
-  # PR triggers for testing
-  pull_request:
-    paths:
-      - "**vllm**"
-      - "!docs/**"
+  # # PR triggers for testing
+  # pull_request:
+  #   paths:
+  #     - "**vllm**"
+  #     - "!docs/**"
 
   # Manual trigger
   workflow_dispatch:

--- a/.github/workflows/auto-release-vllm-rayserve.yml
+++ b/.github/workflows/auto-release-vllm-rayserve.yml
@@ -6,11 +6,11 @@ on:
     # Runs at 10:00 AM PST/PDT on Monday and Wednesday
     - cron: '00 17 * * 1,3' # Monday and Wednesday at 10:00 AM PDT / 9:00 AM PST
 
-  # # PR triggers for testing
-  # pull_request:
-  #   paths:
-  #     - "**vllm**"
-  #     - "!docs/**"
+  # PR triggers for testing
+  pull_request:
+    paths:
+      - "**vllm**"
+      - "!docs/**"
 
   # Manual trigger
   workflow_dispatch:


### PR DESCRIPTION
## Changes
- Update `setup-release-package` S3 prefix from `DLContainersReleaseLogicV2/DLContainersReleaseLogic` to `DLContainersReleaseLogicPython/dlc_release_dist`
- Uncomment `pull_request` trigger in `auto-release-vllm-rayserve.yml` to enable gamma release testing from PRs

## Testing
This PR will automatically trigger the `Auto Release - vLLM RayServe` workflow against the **gamma** environment using the new Python release package.