### PR TITLE
fix: patch cryptography CVE-2026-39892 in vLLM Dockerfiles

### DIFF
--- a/docker/vllm/Dockerfile
+++ b/docker/vllm/Dockerfile
@@ -33,6 +33,7 @@ RUN uv pip install --system \
 # patch CVEs and sauron
 RUN uv pip install --system \
   "cbor2>=5.9.0" \
+  "cryptography>=46.0.7" \
   "pillow>=12.1.1" \
   "xgrammar>=0.1.32" \
   "PyJWT>=2.12.0" \

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -276,6 +276,7 @@ RUN uv pip install --no-cache-dir botocore
 
 # Patch CVEs
 RUN uv pip install --no-cache-dir \
+  "cryptography>=46.0.7" \
   "pillow>=12.1.1" \
   "xgrammar>=0.1.32" \
   "PyJWT>=2.12.0" \
@@ -408,6 +409,7 @@ RUN uv pip install --no-cache-dir botocore
 
 # Patch CVEs
 RUN uv pip install --no-cache-dir \
+  "cryptography>=46.0.7" \
   "pillow>=12.1.1" \
   "xgrammar>=0.1.32" \
   "PyJWT>=2.12.0" \


### PR DESCRIPTION
Upgrade cryptography>=46.0.7 to fix CVE-2026-39892 (CRITICAL, 3 days to SLA).

Applied to all vLLM image variants:
- docker/vllm/Dockerfile (Ubuntu v0.19)
- docker/vllm/Dockerfile.amzn2023 (AL2023 base + omni-base stages)

The other critical CVE (CVE-2026-33186, google.golang.org/grpc v1.59.0) is statically linked inside mooncake libetcd_wrapper.so and already allowlisted in the vllm framework_allowlist.json.

## Purpose

## Test Plan

## Test Result

______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
