### PR TITLE
[vLLM] Build AL2023 image with DeepseekV4 support (vllm PR #40760)

### DIFF
--- a/.github/config/image/vllm-ec2-amzn2023.yml
+++ b/.github/config/image/vllm-ec2-amzn2023.yml
@@ -7,10 +7,12 @@ image:
   description: "vLLM for EC2 instances (AL2023, built from source)"
 
 # Build configuration
+# NOTE: keep framework_version and vllm_ref in sync with docker/vllm/versions.env
+#       (VLLM_VERSION, VLLM_REF). They are used here for image tags/labels/wheel-cache keys.
 common:
   framework: "vllm"
-  framework_version: "0.18.0"
-  vllm_ref: "v0.18.0"
+  framework_version: "0.20.1.dev0"
+  vllm_ref: "434b1bdb67515a07843dedb59477f681ff326e46"
   job_type: "general"
   python_version: "py312"
   cuda_version: "cu129"

--- a/.github/config/image/vllm-sagemaker-amzn2023.yml
+++ b/.github/config/image/vllm-sagemaker-amzn2023.yml
@@ -2,10 +2,12 @@
 image:
   name: "vllm-sagemaker-amzn2023"
   description: "vLLM for SageMaker on Amazon Linux 2023"
+# NOTE: keep framework_version and vllm_ref in sync with docker/vllm/versions.env
+#       (VLLM_VERSION, VLLM_REF). They are used here for image tags/labels/wheel-cache keys.
 common:
   framework: "vllm"
-  framework_version: "0.18.0"
-  vllm_ref: "v0.18.0"
+  framework_version: "0.20.1.dev0"
+  vllm_ref: "434b1bdb67515a07843dedb59477f681ff326e46"
   job_type: "general"
   python_version: "py312"
   cuda_version: "cu129"

--- a/.github/scripts/build_image.sh
+++ b/.github/scripts/build_image.sh
@@ -88,6 +88,16 @@ if [[ -n "${USE_PREBUILT_WHEEL:-}" ]]; then
   --build-arg USE_PREBUILT_WHEEL=\"${USE_PREBUILT_WHEEL}\""
 fi
 
+# Forward any extra build-args listed in EXTRA_BUILD_ARGS (space-separated
+# env var names). Keeps build_image.sh framework-agnostic — callers declare
+# what they want forwarded (e.g. `EXTRA_BUILD_ARGS="VLLM_REF VLLM_VERSION ..."`)
+# set by the workflow when sourcing a versions.env file.
+for v in ${EXTRA_BUILD_ARGS:-}; do
+  if [[ -n "${!v:-}" ]]; then
+    BUILD_CMD="${BUILD_CMD} --build-arg ${v}=\"${!v}\""
+  fi
+done
+
 # Add SageMaker labels if customer-type is 'sagemaker'
 if [[ "${CUSTOMER_TYPE}" == "sagemaker" ]]; then
   BUILD_CMD="${BUILD_CMD} \

--- a/.github/workflows/pr-vllm-ec2-amzn2023.yml
+++ b/.github/workflows/pr-vllm-ec2-amzn2023.yml
@@ -77,6 +77,14 @@ jobs:
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "vllm-ref=$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)" >> $GITHUB_OUTPUT
+          # Short form for image tag: truncate raw commit SHAs to 8 chars, sanitise other refs.
+          VLLM_REF="$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)"
+          if echo "$VLLM_REF" | grep -qE '^[0-9a-f]{12,}$'; then
+            VLLM_REF_SHORT=$(echo "$VLLM_REF" | cut -c1-8)
+          else
+            VLLM_REF_SHORT=$(echo "$VLLM_REF" | sed -E 's/[^A-Za-z0-9]/_/g')
+          fi
+          echo "vllm-ref-short=${VLLM_REF_SHORT}" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
           echo "cuda-version=$(jq -r '.common.cuda_version' config.json)" >> $GITHUB_OUTPUT
           echo "os-version=$(jq -r '.common.os_version' config.json)" >> $GITHUB_OUTPUT
@@ -180,6 +188,18 @@ jobs:
         run: |
           mkdir -p docker/vllm/prebuilt_wheels
           mkdir -p docker/vllm/sccache-cache
+
+      - name: Load pinned vLLM versions
+        run: |
+          # Capture vars introduced by sourcing the env file and forward them
+          # to $GITHUB_ENV. EXTRA_BUILD_ARGS is auto-derived (no manual list).
+          before=$(compgen -v | sort)
+          set -a; source docker/vllm/versions.env; set +a
+          new=$(comm -13 <(echo "$before") <(compgen -v | sort) | grep -Ev '^(before|PIPESTATUS|_)$')
+          for v in $new; do
+            [ -n "${!v:-}" ] && echo "${v}=$(echo "${!v}" | xargs)" >> "$GITHUB_ENV"
+          done
+          echo "EXTRA_BUILD_ARGS=$(echo $new | xargs)" >> "$GITHUB_ENV"
 
       - name: Build image
         id: build

--- a/.github/workflows/pr-vllm-sagemaker-amzn2023.yml
+++ b/.github/workflows/pr-vllm-sagemaker-amzn2023.yml
@@ -79,6 +79,14 @@ jobs:
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "vllm-ref=$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)" >> $GITHUB_OUTPUT
+          # Short form for image tag: truncate raw commit SHAs to 8 chars, sanitise other refs.
+          VLLM_REF="$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)"
+          if echo "$VLLM_REF" | grep -qE '^[0-9a-f]{12,}$'; then
+            VLLM_REF_SHORT=$(echo "$VLLM_REF" | cut -c1-8)
+          else
+            VLLM_REF_SHORT=$(echo "$VLLM_REF" | sed -E 's/[^A-Za-z0-9]/_/g')
+          fi
+          echo "vllm-ref-short=${VLLM_REF_SHORT}" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
           echo "cuda-version=$(jq -r '.common.cuda_version' config.json)" >> $GITHUB_OUTPUT
           echo "os-version=$(jq -r '.common.os_version' config.json)" >> $GITHUB_OUTPUT
@@ -178,6 +186,18 @@ jobs:
         run: |
           mkdir -p docker/vllm/prebuilt_wheels
           mkdir -p docker/vllm/sccache-cache
+
+      - name: Load pinned vLLM versions
+        run: |
+          # Capture vars introduced by sourcing the env file and forward them
+          # to $GITHUB_ENV. EXTRA_BUILD_ARGS is auto-derived (no manual list).
+          before=$(compgen -v | sort)
+          set -a; source docker/vllm/versions.env; set +a
+          new=$(comm -13 <(echo "$before") <(compgen -v | sort) | grep -Ev '^(before|PIPESTATUS|_)$')
+          for v in $new; do
+            [ -n "${!v:-}" ] && echo "${v}=$(echo "${!v}" | xargs)" >> "$GITHUB_ENV"
+          done
+          echo "EXTRA_BUILD_ARGS=$(echo $new | xargs)" >> "$GITHUB_ENV"
 
       - name: Build image
         id: build

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -87,7 +87,10 @@ ENV NVCC_THREADS=${nvcc_threads}
 ENV VLLM_TARGET_DEVICE=cuda
 ARG VLLM_REF
 ARG VLLM_VERSION
-ENV SETUPTOOLS_SCM_PRETEND_VERSION="${VLLM_VERSION}+amzn2023"
+# Wheel version tag — pass via --build-arg from workflow (see docker/vllm/versions.env).
+# Example: 0.20.1.dev0+amzn2023.dsv4.bc34b25e
+ARG SETUPTOOLS_SCM_PRETEND_VERSION
+ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION:-${VLLM_VERSION}+amzn2023}
 
 # --- Pre-built wheel support ---
 # Fetch wheels from S3 into docker/vllm/prebuilt_wheels/ BEFORE docker build:

--- a/docker/vllm/versions.env
+++ b/docker/vllm/versions.env
@@ -1,0 +1,27 @@
+# versions.env — Pinned build-args for the vLLM AL2023 image.
+# Source this file: source docker/vllm/versions.env
+#
+# These override the Dockerfile ARG defaults at build time. Every var
+# exported here is auto-forwarded as --build-arg to docker buildx by the
+# workflow (via EXTRA_BUILD_ARGS).
+#
+# NOTE: when bumping VLLM_REF / VLLM_VERSION, also update
+#   .github/config/image/vllm-ec2-amzn2023.yml
+#   .github/config/image/vllm-sagemaker-amzn2023.yml
+# (framework_version and vllm_ref) — these drive image tags and wheel-cache keys.
+
+# ── vLLM source & version ──────────────────────────────────────
+# Custom vLLM source from https://github.com/vllm-project/vllm/pull/40760
+# [New Model] Support DeepseekV4 (fork: zyongye/vllm, branch: dsv4)
+export VLLM_REPO="https://github.com/zyongye/vllm.git"
+export VLLM_REF="434b1bdb67515a07843dedb59477f681ff326e46"
+export VLLM_VERSION="0.20.1.dev0"
+
+# Wheel version tag — PEP 440: {version}+amzn2023.dsv4.{8-char SHA}
+# The commit SHA suffix ensures rebuilds on new commits are distinguishable.
+export SETUPTOOLS_SCM_PRETEND_VERSION="${VLLM_VERSION}+amzn2023.dsv4.$(echo "${VLLM_REF}" | cut -c1-8)"
+
+# ── Accelerator libraries ──────────────────────────────────────
+export FLASHINFER_VERSION="0.6.6"
+export DEEPGEMM_GIT_REF="477618cd51baffca09c4b0b87e97c03fe827ef03"
+export DEEPEP_COMMIT_HASH="73b6ea4"


### PR DESCRIPTION
Build AL2023 vLLM image with DeepseekV4 model support.

Source: `zyongye/vllm@434b1bdb`
Wheel version: `0.20.1.dev0+amzn2023.dsv4.434b1bdb`

## Changes
- Add `docker/vllm/versions.env` with custom `VLLM_REPO`/`VLLM_REF`
- Update image configs (`vllm-ec2-amzn2023.yml`, `vllm-sagemaker-amzn2023.yml`) with the custom commit ref
- Add `EXTRA_BUILD_ARGS` forwarding in `build_image.sh`
- Add `SETUPTOOLS_SCM_PRETEND_VERSION` build-arg support in Dockerfile
- Update EC2 and SageMaker workflows to source `versions.env` and include `vllm-ref-short` in tags

## Test Plan

```
# /buildspec vllm/inference/buildspec-vllm-ec2-amzn2023.yml
# /tests sanity security
```