### PR TITLE
fix: add awscli and black CVE-2026-32274 fix to PT 2.9 EC2 training images

### DIFF
--- a/pytorch/training/docker/2.9/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/2.9/py3/Dockerfile.cpu
@@ -248,6 +248,10 @@ RUN bash setup_oss_compliance.sh ${PYTHON} && rm setup_oss_compliance.sh
 
 COPY dockerd_entrypoint.sh /usr/local/bin/dockerd_entrypoint.sh
 RUN chmod +x /usr/local/bin/dockerd_entrypoint.sh
+
+# Install awscli, boto3 (expected by sanity tests) and upgrade black to fix CVE-2026-32274
+RUN pip install --no-cache-dir awscli boto3 "black>=26.3.1"
+
 ENTRYPOINT ["bash", "-m", "dockerd_entrypoint.sh"]
 
 # Starts framework

--- a/pytorch/training/docker/2.9/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
@@ -1,0 +1,33 @@
+{
+  "black": [
+    {
+      "description": "Black is the uncompromising Python code formatter. Prior to 26.3.1, Black writes a cache file, the name of which is computed from various formatting options. The value of the --python-cell-magics option was placed in the filename without sanitization, which allowed an attacker who controls the value of this argument to write cache files to arbitrary file system locations. Fixed in Black 26.3.1.",
+      "vulnerability_id": "CVE-2026-32274",
+      "name": "CVE-2026-32274",
+      "package_name": "black",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt",
+        "name": "black",
+        "package_manager": "PYTHON",
+        "version": "22.3.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32274",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-32274 - black",
+      "reason_to_ignore": "N/A"
+    }
+  ]
+}

--- a/pytorch/training/docker/2.9/py3/cu130/Dockerfile.ec2.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/cu130/Dockerfile.ec2.gpu.os_scan_allowlist.json
@@ -1,0 +1,33 @@
+{
+  "black": [
+    {
+      "description": "Black is the uncompromising Python code formatter. Prior to 26.3.1, Black writes a cache file, the name of which is computed from various formatting options. The value of the --python-cell-magics option was placed in the filename without sanitization, which allowed an attacker who controls the value of this argument to write cache files to arbitrary file system locations. Fixed in Black 26.3.1.",
+      "vulnerability_id": "CVE-2026-32274",
+      "name": "CVE-2026-32274",
+      "package_name": "black",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt",
+        "name": "black",
+        "package_manager": "PYTHON",
+        "version": "22.3.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-32274",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-32274 - black",
+      "reason_to_ignore": "N/A"
+    }
+  ]
+}

--- a/pytorch/training/docker/2.9/py3/cu130/Dockerfile.gpu
+++ b/pytorch/training/docker/2.9/py3/cu130/Dockerfile.gpu
@@ -217,6 +217,9 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
+# Upgrade black to fix CVE-2026-32274 in spacy bundled test requirements
+RUN pip install --no-cache-dir awscli "black>=26.3.1"
+
 ENTRYPOINT ["bash", "-m", "dockerd_entrypoint.sh"]
 CMD ["/bin/bash"]
 


### PR DESCRIPTION
## Description
This PR fixes two failures in the PyTorch 2.9 EC2 training pipelines (`BuildRCPipeline-pytorch-training-2-9-ec2`):

### 1. Sanity test failure — missing awscli in EC2 CPU image
- **Test**: `test_common_pytorch_utility_packages_using_import`
- **Error**: `ModuleNotFoundError: No module named awscli`
- **Root cause**: `awscli` was moved from the common stage to the SageMaker-only stage in #5856, but the sanity test still expects it in EC2 images.
- **Fix**: Add `pip install awscli` to the EC2 stage of `Dockerfile.cpu`.

### 2. Security test failure — CVE-2026-32274 in black
- **Test**: `test_ecr_enhanced_scan` on CPU image
- **Error**: `CVE-2026-32274 - black` (HIGH, CVSS 7.5) — `black==22.3.0` found in spacy bundled test requirements
- **Root cause**: The `black>=26.3.1` upgrade was only applied to the SageMaker stage in #5856, not the EC2 stage.
- **Fix**: Add `pip install black>=26.3.1` to the EC2 stage of both `Dockerfile.cpu` and `Dockerfile.gpu`.


## Test
[ce302cd](https://github.com/aws/deep-learning-containers/pull/5996/commits/ce302cd6fa6f0ab920f78056d666c74a309fe690) - EC2 tests passed with PT 2.9 EC2 build via PR CI with sanity and security tests enabled.