### PR TITLE
docs: Add Base v1 and v2 AL2023 release notes

### DIFF
--- a/docs/src/data/base/v1.0.0-gpu-ec2.yml
+++ b/docs/src/data/base/v1.0.0-gpu-ec2.yml
@@ -1,0 +1,27 @@
+framework: Base
+version: "1.0.0"
+accelerator: gpu
+python: py313
+cuda: cu129
+os: amzn2023
+platform: ec2
+public_registry: true
+
+tags:
+  - "devel-cuda-v1.0.0"
+  - "devel-cuda-v1.0"
+  - "devel-cuda-v1"
+  - "devel-cuda"
+  - "runtime-cuda-v1.0.0"
+  - "runtime-cuda-v1.0"
+  - "runtime-cuda-v1"
+  - "runtime-cuda"
+
+announcements:
+  - "Introduced lightweight Base containers on Amazon Linux 2023 with CUDA 12.9.1 for EC2, ECS, EKS"
+  - "Available in `devel-cuda` (with build tools) and `runtime-cuda` (minimal runtime) variants"
+
+packages:
+  python: "3.13.12"
+  cuda: "12.9.1"
+  os: "Amazon Linux 2023"

--- a/docs/src/data/base/v2.0.0-gpu-ec2.yml
+++ b/docs/src/data/base/v2.0.0-gpu-ec2.yml
@@ -1,0 +1,25 @@
+framework: Base
+version: "2.0.0"
+accelerator: gpu
+python: py313
+cuda: cu130
+os: amzn2023
+platform: ec2
+public_registry: true
+
+tags:
+  - "devel-cuda-v2.0.0"
+  - "devel-cuda-v2.0"
+  - "devel-cuda-v2"
+  - "runtime-cuda-v2.0.0"
+  - "runtime-cuda-v2.0"
+  - "runtime-cuda-v2"
+
+announcements:
+  - "Introduced lightweight Base containers on Amazon Linux 2023 with CUDA 13.0.2 for EC2, ECS, EKS"
+  - "Available in `devel-cuda` (with build tools) and `runtime-cuda` (minimal runtime) variants"
+
+packages:
+  python: "3.13.12"
+  cuda: "13.0.2"
+  os: "Amazon Linux 2023"

--- a/docs/src/generate.py
+++ b/docs/src/generate.py
@@ -96,9 +96,8 @@ def _generate_framework_index(
     # Build ordered version list: AL2023 versions first (descending), then legacy (descending)
     amzn2023_by_version = _group_by_version(amzn2023_images)
     legacy_by_version = _group_by_version(legacy_images)
-    sorted_versions = (
-        sorted(amzn2023_by_version.keys(), key=parse_version, reverse=True)
-        + sorted(legacy_by_version.keys(), key=parse_version, reverse=True)
+    sorted_versions = sorted(amzn2023_by_version.keys(), key=parse_version, reverse=True) + sorted(
+        legacy_by_version.keys(), key=parse_version, reverse=True
     )
     images_by_version = {**amzn2023_by_version, **legacy_by_version}
 

--- a/docs/src/generate.py
+++ b/docs/src/generate.py
@@ -80,15 +80,27 @@ def _generate_framework_index(
     columns = table_config["columns"]
     headers = [col["header"] for col in columns]
 
-    # Group images by major.minor version
-    images_by_version: dict[str, list[ImageConfig]] = {}
-    for img in images:
-        ver = parse_version(img.version)
-        major_minor = f"{ver.major}.{ver.minor}"
-        images_by_version.setdefault(major_minor, []).append(img)
+    # Split images by OS: AL2023 images first, then legacy (Ubuntu etc.)
+    amzn2023_images = [img for img in images if img.get("os", "") == "amzn2023"]
+    legacy_images = [img for img in images if img.get("os", "") != "amzn2023"]
 
-    # Sort framework versions descending
-    sorted_versions = sorted(images_by_version.keys(), key=parse_version, reverse=True)
+    # Group images by major.minor version within each OS group
+    def _group_by_version(img_list):
+        by_version: dict[str, list[ImageConfig]] = {}
+        for img in img_list:
+            ver = parse_version(img.version)
+            major_minor = f"{ver.major}.{ver.minor}"
+            by_version.setdefault(major_minor, []).append(img)
+        return by_version
+
+    # Build ordered version list: AL2023 versions first (descending), then legacy (descending)
+    amzn2023_by_version = _group_by_version(amzn2023_images)
+    legacy_by_version = _group_by_version(legacy_images)
+    sorted_versions = (
+        sorted(amzn2023_by_version.keys(), key=parse_version, reverse=True)
+        + sorted(legacy_by_version.keys(), key=parse_version, reverse=True)
+    )
+    images_by_version = {**amzn2023_by_version, **legacy_by_version}
 
     # Build version-separated content for supported and deprecated
     supported_sections, deprecated_sections = [], []
@@ -105,16 +117,27 @@ def _generate_framework_index(
         supported = [img for img in sorted_images if img.is_supported]
         deprecated = [img for img in sorted_images if not img.is_supported]
 
+        # Add OS label to header if images have mixed OS types in this framework
+        os_label = ""
+        version_display = version
+        if amzn2023_images and legacy_images:
+            sample_os = sorted_images[0].get("os", "")
+            if sample_os == "amzn2023":
+                os_label = " (Amazon Linux 2023)"
+                version_display = f"v{version.split('.')[0]}"
+            else:
+                os_label = " (Ubuntu)"
+
         if supported:
             table = render_table(headers, [build_image_row(img, columns) for img in supported])
             supported_sections.append(
-                f"{RELEASE_NOTES_TABLE_HEADER} {framework_display} {version}\n\n{table}"
+                f"{RELEASE_NOTES_TABLE_HEADER} {framework_display} {version_display}{os_label}\n\n{table}"
             )
 
         if deprecated:
             table = render_table(headers, [build_image_row(img, columns) for img in deprecated])
             deprecated_sections.append(
-                f"{RELEASE_NOTES_TABLE_HEADER} {framework_display} {version}\n\n{table}"
+                f"{RELEASE_NOTES_TABLE_HEADER} {framework_display} {version_display}{os_label}\n\n{table}"
             )
 
     content = template.render(


### PR DESCRIPTION
## Purpose
Add release notes for the new Base v1 (CUDA 12.9.1) and Base v2 (CUDA 13.0.2) containers built on Amazon Linux 2023. Also updates the doc generator to display AL2023 images above legacy Ubuntu images on the index page, with OS labels for clarity.

## Test Plan
Run mkdocs serve locally

## Test Result
Local preview confirmed correct rendering at /releasenotes/base/

<img width="2870" height="1462" alt="image" src="https://github.com/user-attachments/assets/158d4d10-1c36-4622-845a-4e6ea2bfbfbd" />
<img width="2870" height="1462" alt="image" src="https://github.com/user-attachments/assets/cc2e15fe-5175-4a75-ac77-61d10ccccc9b" />
<img width="2870" height="1462" alt="image" src="https://github.com/user-attachments/assets/534db720-fc3c-4049-9b30-3eb4f9048809" />


______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
