### PR TITLE
[PyTorch Migration] Add Release Workflow

### DIFF
--- a/.github/config/image/pytorch-ec2-cpu.yml
+++ b/.github/config/image/pytorch-ec2-cpu.yml
@@ -14,9 +14,9 @@ common:
   device_type: "cpu"
   contributor: "None"
 release:
-  release: false
+  release: true
   force_release: false
   public_registry: false
-  private_registry: false
+  private_registry: true
   enable_soci: false
   environment: production

--- a/.github/config/image/pytorch-ec2-cpu.yml
+++ b/.github/config/image/pytorch-ec2-cpu.yml
@@ -16,7 +16,7 @@ common:
 release:
   release: true
   force_release: false
-  public_registry: false
+  public_registry: true
   private_registry: true
-  enable_soci: false
+  enable_soci: true
   environment: production

--- a/.github/config/image/pytorch-ec2-cpu.yml
+++ b/.github/config/image/pytorch-ec2-cpu.yml
@@ -2,7 +2,7 @@ image:
   name: "pytorch-ec2-cpu"
   description: "PyTorch CPU training for EC2 instances"
 common:
-  framework: "pytorch"
+  framework: "pytorch_runtime"
   framework_version: "2.11.0"
   job_type: "training"
   python_version: "py312"
@@ -10,7 +10,7 @@ common:
   os_version: "amzn2023"
   customer_type: "ec2"
   arch_type: "x86"
-  prod_image: "pytorch:2.11-cpu-py312-ec2"
+  prod_image: "pytorch:2.11-cpu-amzn2023"
   device_type: "cpu"
   contributor: "None"
 release:

--- a/.github/config/image/pytorch-ec2-cuda.yml
+++ b/.github/config/image/pytorch-ec2-cuda.yml
@@ -2,7 +2,7 @@ image:
   name: "pytorch-ec2-cuda"
   description: "PyTorch CUDA training for EC2 instances"
 common:
-  framework: "pytorch"
+  framework: "pytorch_runtime"
   framework_version: "2.11.0"
   job_type: "training"
   python_version: "py312"
@@ -10,7 +10,7 @@ common:
   os_version: "amzn2023"
   customer_type: "ec2"
   arch_type: "x86"
-  prod_image: "pytorch:2.11-gpu-py312-ec2"
+  prod_image: "pytorch:2.11-cu130-amzn2023"
   device_type: "gpu"
   contributor: "None"
 release:

--- a/.github/config/image/pytorch-ec2-cuda.yml
+++ b/.github/config/image/pytorch-ec2-cuda.yml
@@ -14,9 +14,9 @@ common:
   device_type: "gpu"
   contributor: "None"
 release:
-  release: false
+  release: true
   force_release: false
   public_registry: false
-  private_registry: false
+  private_registry: true
   enable_soci: false
   environment: production

--- a/.github/config/image/pytorch-ec2-cuda.yml
+++ b/.github/config/image/pytorch-ec2-cuda.yml
@@ -16,7 +16,7 @@ common:
 release:
   release: true
   force_release: false
-  public_registry: false
+  public_registry: true
   private_registry: true
-  enable_soci: false
+  enable_soci: true
   environment: production

--- a/.github/config/image/pytorch-sagemaker-cpu.yml
+++ b/.github/config/image/pytorch-sagemaker-cpu.yml
@@ -2,15 +2,16 @@ image:
   name: "pytorch-sagemaker-cpu"
   description: "PyTorch CPU training for SageMaker"
 common:
-  framework: "pytorch"
+  framework: "pytorch_runtime"
   framework_version: "2.11.0"
   job_type: "training"
   python_version: "py312"
   cuda_version: ""
   os_version: "amzn2023"
   customer_type: "sagemaker"
+  platform: "sagemaker"
   arch_type: "x86"
-  prod_image: "pytorch:2.11-cpu-py312-sagemaker"
+  prod_image: "pytorch:2.11-cpu-amzn2023-sagemaker"
   device_type: "cpu"
   contributor: "None"
 release:

--- a/.github/config/image/pytorch-sagemaker-cpu.yml
+++ b/.github/config/image/pytorch-sagemaker-cpu.yml
@@ -14,9 +14,9 @@ common:
   device_type: "cpu"
   contributor: "None"
 release:
-  release: false
+  release: true
   force_release: false
   public_registry: false
-  private_registry: false
+  private_registry: true
   enable_soci: false
   environment: production

--- a/.github/config/image/pytorch-sagemaker-cpu.yml
+++ b/.github/config/image/pytorch-sagemaker-cpu.yml
@@ -17,7 +17,7 @@ common:
 release:
   release: true
   force_release: false
-  public_registry: false
+  public_registry: true
   private_registry: true
-  enable_soci: false
+  enable_soci: true
   environment: production

--- a/.github/config/image/pytorch-sagemaker-cuda.yml
+++ b/.github/config/image/pytorch-sagemaker-cuda.yml
@@ -17,7 +17,7 @@ common:
 release:
   release: true
   force_release: false
-  public_registry: false
+  public_registry: true
   private_registry: true
-  enable_soci: false
+  enable_soci: true
   environment: production

--- a/.github/config/image/pytorch-sagemaker-cuda.yml
+++ b/.github/config/image/pytorch-sagemaker-cuda.yml
@@ -14,9 +14,9 @@ common:
   device_type: "gpu"
   contributor: "None"
 release:
-  release: false
+  release: true
   force_release: false
   public_registry: false
-  private_registry: false
+  private_registry: true
   enable_soci: false
   environment: production

--- a/.github/config/image/pytorch-sagemaker-cuda.yml
+++ b/.github/config/image/pytorch-sagemaker-cuda.yml
@@ -2,15 +2,16 @@ image:
   name: "pytorch-sagemaker-cuda"
   description: "PyTorch CUDA training for SageMaker"
 common:
-  framework: "pytorch"
+  framework: "pytorch_runtime"
   framework_version: "2.11.0"
   job_type: "training"
   python_version: "py312"
   cuda_version: "cu130"
   os_version: "amzn2023"
   customer_type: "sagemaker"
+  platform: "sagemaker"
   arch_type: "x86"
-  prod_image: "pytorch:2.11-gpu-py312-sagemaker"
+  prod_image: "pytorch:2.11-cu130-amzn2023-sagemaker"
   device_type: "gpu"
   contributor: "None"
 release:

--- a/.github/workflows/autorelease-pytorch-ec2-cpu.yml
+++ b/.github/workflows/autorelease-pytorch-ec2-cpu.yml
@@ -95,6 +95,7 @@ jobs:
           CI_IMAGE_URI="${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:pytorch-cpu-runtime-${{ needs.load-config.outputs.framework-version }}-${{ needs.load-config.outputs.python-version }}-${{ needs.load-config.outputs.os-version }}-ec2-${{ github.run_id }}"
 
           docker buildx build --progress plain \
+            --build-arg FRAMEWORK=${{ needs.load-config.outputs.framework }} \
             --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
             --build-arg TORCH_VERSION=${TORCH_VERSION} \
             --build-arg DLC_MAJOR_VERSION=${DLC_MAJOR_VERSION} \

--- a/.github/workflows/autorelease-pytorch-ec2-cpu.yml
+++ b/.github/workflows/autorelease-pytorch-ec2-cpu.yml
@@ -1,0 +1,213 @@
+name: Auto Release - PyTorch EC2 CPU
+
+on:
+  schedule:
+    - cron: '00 17 * * 1,3'
+
+  # PR trigger for gamma release testing — disable after first successful gamma run
+  pull_request:
+    paths:
+      - ".github/workflows/autorelease-pytorch-ec2-cpu.yml"
+      - ".github/config/image/pytorch-ec2-cpu.yml"
+      - "docker/pytorch/**"
+      - "!docs/**"
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: "1"
+  CONFIG_FILE: ".github/config/image/pytorch-ec2-cpu.yml"
+
+jobs:
+  load-config:
+    runs-on: ubuntu-latest
+    outputs:
+      config: ${{ steps.load.outputs.config }}
+      framework: ${{ steps.parse.outputs.framework }}
+      framework-version: ${{ steps.parse.outputs.framework-version }}
+      python-version: ${{ steps.parse.outputs.python-version }}
+      cuda-version: ${{ steps.parse.outputs.cuda-version }}
+      os-version: ${{ steps.parse.outputs.os-version }}
+      container-type: ${{ steps.parse.outputs.container-type }}
+      device-type: ${{ steps.parse.outputs.device-type }}
+      arch-type: ${{ steps.parse.outputs.arch-type }}
+      contributor: ${{ steps.parse.outputs.contributor }}
+      customer-type: ${{ steps.parse.outputs.customer-type }}
+      prod-image: ${{ steps.parse.outputs.prod-image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Load configuration
+        id: load
+        uses: ./.github/actions/load-config
+        with:
+          config-file: ${{ env.CONFIG_FILE }}
+
+      - name: Parse configuration
+        id: parse
+        run: |
+          echo '${{ steps.load.outputs.config }}' > config.json
+          echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
+          echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
+          echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
+          echo "cuda-version=$(jq -r '.common.cuda_version' config.json)" >> $GITHUB_OUTPUT
+          echo "os-version=$(jq -r '.common.os_version' config.json)" >> $GITHUB_OUTPUT
+          echo "container-type=$(jq -r '.common.job_type' config.json)" >> $GITHUB_OUTPUT
+          echo "device-type=$(jq -r '.common.device_type // "cpu"' config.json)" >> $GITHUB_OUTPUT
+          echo "arch-type=$(jq -r '.common.arch_type // "x86"' config.json)" >> $GITHUB_OUTPUT
+          echo "contributor=$(jq -r '.common.contributor // "None"' config.json)" >> $GITHUB_OUTPUT
+          echo "customer-type=$(jq -r '.common.customer_type // ""' config.json)" >> $GITHUB_OUTPUT
+          echo "prod-image=$(jq -r '.common.prod_image' config.json)" >> $GITHUB_OUTPUT
+
+  build-image:
+    needs: [load-config]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    outputs:
+      ci-image: ${{ steps.build-runtime.outputs.image-uri }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup buildkitd
+        run: .github/scripts/buildkitd.sh
+
+      - name: ECR login
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Build runtime image
+        id: build-runtime
+        run: |
+          source docker/pytorch/versions-cpu.env
+          CI_IMAGE_URI="${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:pytorch-cpu-runtime-${{ needs.load-config.outputs.framework-version }}-${{ needs.load-config.outputs.python-version }}-${{ needs.load-config.outputs.os-version }}-ec2-${{ github.run_id }}"
+
+          docker buildx build --progress plain \
+            --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
+            --build-arg TORCH_VERSION=${TORCH_VERSION} \
+            --build-arg DLC_MAJOR_VERSION=${DLC_MAJOR_VERSION} \
+            --build-arg DLC_MINOR_VERSION=${DLC_MINOR_VERSION} \
+            --build-arg OPEN_MPI_VERSION=${OPEN_MPI_VERSION} \
+            --cache-to=type=inline \
+            --cache-from=type=registry,ref=${CI_IMAGE_URI} \
+            --tag ${CI_IMAGE_URI} \
+            --push \
+            --target runtime \
+            -f docker/pytorch/Dockerfile.cpu .
+
+          echo "image-uri=${CI_IMAGE_URI}" >> $GITHUB_OUTPUT
+
+  sanity-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-sanity-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      python-version: ${{ needs.load-config.outputs.python-version }}
+      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
+      os-version: ${{ needs.load-config.outputs.os-version }}
+      customer-type: ${{ needs.load-config.outputs.customer-type }}
+      arch-type: ${{ needs.load-config.outputs.arch-type }}
+      device-type: ${{ needs.load-config.outputs.device-type }}
+      contributor: ${{ needs.load-config.outputs.contributor }}
+      container-type: ${{ needs.load-config.outputs.container-type }}
+
+  security-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-security-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+
+  telemetry-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-telemetry-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      container-type: ${{ needs.load-config.outputs.container-type }}
+
+  unit-test:
+    needs: [build-image]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: ECR login
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Run unit tests
+        run: |
+          IMAGE="${{ needs.build-image.outputs.ci-image }}"
+          docker pull ${IMAGE}
+          CONTAINER_ID=$(docker run -d --rm --entrypoint /bin/bash \
+            -e DLC_WORKDIR=/workdir \
+            -v $(pwd):/workdir --workdir /workdir \
+            ${IMAGE} -c 'sleep infinity')
+          docker exec ${CONTAINER_ID} pip install pytest -q
+          docker exec ${CONTAINER_ID} pytest /workdir/test/pytorch/unit/ -v
+          docker kill ${CONTAINER_ID}
+
+  generate-release-spec:
+    needs: [load-config, build-image, sanity-test, security-test, unit-test]
+    runs-on: ubuntu-latest
+    outputs:
+      release-spec: ${{ steps.generate.outputs.release-spec }}
+      should-release: ${{ steps.check-release.outputs.should-release }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Check if release is enabled
+        id: check-release
+        run: |
+          echo '${{ needs.load-config.outputs.config }}' > config.json
+          RELEASE_ENABLED=$(jq -r '.release.release // false' config.json)
+          echo "should-release=${RELEASE_ENABLED}" >> $GITHUB_OUTPUT
+
+      - name: Generate release spec
+        id: generate
+        if: steps.check-release.outputs.should-release == 'true'
+        uses: ./.github/actions/generate-release-spec
+        with:
+          config-json: ${{ needs.load-config.outputs.config }}
+
+  release-image:
+    needs: [load-config, build-image, generate-release-spec]
+    if: needs.generate-release-spec.outputs.should-release == 'true'
+    uses: ./.github/workflows/reusable-release-image.yml
+    with:
+      source-image-uri: ${{ needs.build-image.outputs.ci-image }}
+      release-spec: ${{ needs.generate-release-spec.outputs.release-spec }}
+      environment: ${{ github.event_name == 'pull_request' && 'gamma' || fromJson(needs.load-config.outputs.config).release.environment }}
+      aws-region: ${{ vars.AWS_REGION }}
+      runner-fleet: default-runner
+    secrets: inherit

--- a/.github/workflows/autorelease-pytorch-ec2-cpu.yml
+++ b/.github/workflows/autorelease-pytorch-ec2-cpu.yml
@@ -4,14 +4,6 @@ on:
   schedule:
     - cron: '00 17 * * 1,3'
 
-  # PR trigger for gamma release testing — disable after first successful gamma run
-  pull_request:
-    paths:
-      - ".github/workflows/autorelease-pytorch-ec2-cpu.yml"
-      - ".github/config/image/pytorch-ec2-cpu.yml"
-      - "docker/pytorch/**"
-      - "!docs/**"
-
   workflow_dispatch:
 
 concurrency:
@@ -209,7 +201,7 @@ jobs:
     with:
       source-image-uri: ${{ needs.build-image.outputs.ci-image }}
       release-spec: ${{ needs.generate-release-spec.outputs.release-spec }}
-      environment: ${{ github.event_name == 'pull_request' && 'gamma' || fromJson(needs.load-config.outputs.config).release.environment }}
+      environment: ${{ fromJson(needs.load-config.outputs.config).release.environment }}
       aws-region: ${{ vars.AWS_REGION }}
       runner-fleet: default-runner
     secrets: inherit

--- a/.github/workflows/autorelease-pytorch-ec2-cpu.yml
+++ b/.github/workflows/autorelease-pytorch-ec2-cpu.yml
@@ -178,6 +178,7 @@ jobs:
 
   generate-release-spec:
     needs: [load-config, build-image, sanity-test, security-test, unit-test]
+    if: success()
     runs-on: ubuntu-latest
     outputs:
       release-spec: ${{ steps.generate.outputs.release-spec }}

--- a/.github/workflows/autorelease-pytorch-ec2-cuda.yml
+++ b/.github/workflows/autorelease-pytorch-ec2-cuda.yml
@@ -117,6 +117,7 @@ jobs:
           CI_IMAGE_URI="${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:pytorch-runtime-${{ needs.load-config.outputs.framework-version }}-gpu-${{ needs.load-config.outputs.python-version }}-${{ needs.load-config.outputs.cuda-version }}-${{ needs.load-config.outputs.os-version }}-ec2-${{ github.run_id }}"
 
           docker buildx build --progress plain \
+            --build-arg FRAMEWORK=${{ needs.load-config.outputs.framework }} \
             --build-arg CUDA_VERSION=${CUDA_VERSION} \
             --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
             --build-arg TORCH_VERSION=${TORCH_VERSION} \

--- a/.github/workflows/autorelease-pytorch-ec2-cuda.yml
+++ b/.github/workflows/autorelease-pytorch-ec2-cuda.yml
@@ -5,14 +5,6 @@ on:
     # Runs at 9AM/10AM PST/PDT on Mondays and Wednesdays
     - cron: '00 17 * * 1,3'
 
-  # PR trigger for gamma release testing — disable after first successful gamma run
-  pull_request:
-    paths:
-      - ".github/workflows/autorelease-pytorch-ec2-cuda.yml"
-      - ".github/config/image/pytorch-ec2-cuda.yml"
-      - "docker/pytorch/**"
-      - "!docs/**"
-
   workflow_dispatch:
 
 concurrency:
@@ -287,7 +279,7 @@ jobs:
     with:
       source-image-uri: ${{ needs.build-image.outputs.ci-image }}
       release-spec: ${{ needs.generate-release-spec.outputs.release-spec }}
-      environment: ${{ github.event_name == 'pull_request' && 'gamma' || fromJson(needs.load-config.outputs.config).release.environment }}
+      environment: ${{ fromJson(needs.load-config.outputs.config).release.environment }}
       aws-region: ${{ vars.AWS_REGION }}
       runner-fleet: default-runner
     secrets: inherit

--- a/.github/workflows/autorelease-pytorch-ec2-cuda.yml
+++ b/.github/workflows/autorelease-pytorch-ec2-cuda.yml
@@ -255,6 +255,7 @@ jobs:
 
   generate-release-spec:
     needs: [load-config, build-image, sanity-test, security-test, unit-test, single-gpu-test, efa-test]
+    if: success()
     runs-on: ubuntu-latest
     outputs:
       release-spec: ${{ steps.generate.outputs.release-spec }}

--- a/.github/workflows/autorelease-pytorch-ec2-cuda.yml
+++ b/.github/workflows/autorelease-pytorch-ec2-cuda.yml
@@ -1,0 +1,291 @@
+name: Auto Release - PyTorch EC2 CUDA
+
+on:
+  schedule:
+    # Runs at 9AM/10AM PST/PDT on Mondays and Wednesdays
+    - cron: '00 17 * * 1,3'
+
+  # PR trigger for gamma release testing — disable after first successful gamma run
+  pull_request:
+    paths:
+      - ".github/workflows/autorelease-pytorch-ec2-cuda.yml"
+      - ".github/config/image/pytorch-ec2-cuda.yml"
+      - "docker/pytorch/**"
+      - "!docs/**"
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: "1"
+  CONFIG_FILE: ".github/config/image/pytorch-ec2-cuda.yml"
+
+jobs:
+  load-config:
+    runs-on: ubuntu-latest
+    outputs:
+      config: ${{ steps.load.outputs.config }}
+      framework: ${{ steps.parse.outputs.framework }}
+      framework-version: ${{ steps.parse.outputs.framework-version }}
+      python-version: ${{ steps.parse.outputs.python-version }}
+      cuda-version: ${{ steps.parse.outputs.cuda-version }}
+      os-version: ${{ steps.parse.outputs.os-version }}
+      container-type: ${{ steps.parse.outputs.container-type }}
+      device-type: ${{ steps.parse.outputs.device-type }}
+      arch-type: ${{ steps.parse.outputs.arch-type }}
+      contributor: ${{ steps.parse.outputs.contributor }}
+      customer-type: ${{ steps.parse.outputs.customer-type }}
+      prod-image: ${{ steps.parse.outputs.prod-image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Load configuration
+        id: load
+        uses: ./.github/actions/load-config
+        with:
+          config-file: ${{ env.CONFIG_FILE }}
+
+      - name: Parse configuration
+        id: parse
+        run: |
+          echo '${{ steps.load.outputs.config }}' > config.json
+          echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
+          echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
+          echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
+          echo "cuda-version=$(jq -r '.common.cuda_version' config.json)" >> $GITHUB_OUTPUT
+          echo "os-version=$(jq -r '.common.os_version' config.json)" >> $GITHUB_OUTPUT
+          echo "container-type=$(jq -r '.common.job_type' config.json)" >> $GITHUB_OUTPUT
+          echo "device-type=$(jq -r '.common.device_type // "gpu"' config.json)" >> $GITHUB_OUTPUT
+          echo "arch-type=$(jq -r '.common.arch_type // "x86"' config.json)" >> $GITHUB_OUTPUT
+          echo "contributor=$(jq -r '.common.contributor // "None"' config.json)" >> $GITHUB_OUTPUT
+          echo "customer-type=$(jq -r '.common.customer_type // ""' config.json)" >> $GITHUB_OUTPUT
+          echo "prod-image=$(jq -r '.common.prod_image' config.json)" >> $GITHUB_OUTPUT
+
+  build-image:
+    needs: [load-config]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:x86-build-runner
+        buildspec-override:true
+    timeout-minutes: 720
+    outputs:
+      ci-image: ${{ steps.build-runtime.outputs.image-uri }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup buildkitd
+        run: .github/scripts/buildkitd.sh
+
+      - name: ECR login
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Source versions
+        id: versions
+        run: |
+          source docker/pytorch/versions-cuda.env
+          echo "torch-version=${TORCH_VERSION}" >> $GITHUB_OUTPUT
+          echo "cuda-version=${CUDA_VERSION}" >> $GITHUB_OUTPUT
+          echo "python-version=${PYTHON_VERSION}" >> $GITHUB_OUTPUT
+
+      - name: Fetch cached wheels
+        run: |
+          source docker/pytorch/versions-cuda.env
+          mkdir -p docker/pytorch/wheels
+          bash scripts/pytorch/fetch_cached_wheels.sh \
+            docker/pytorch/wheels \
+            "${{ vars.WHEEL_CACHE_BUCKET }}" \
+            "${CUDA_VERSION}" "${TORCH_VERSION}" "${PYTHON_VERSION}" \
+            "flash-attn:${FLASH_ATTN_VERSION}" \
+            "transformer-engine-torch:${TRANSFORMER_ENGINE_VERSION}" \
+        continue-on-error: true
+
+      - name: Build runtime image
+        id: build-runtime
+        run: |
+          source docker/pytorch/versions-cuda.env
+          CI_IMAGE_URI="${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:pytorch-runtime-${{ needs.load-config.outputs.framework-version }}-gpu-${{ needs.load-config.outputs.python-version }}-${{ needs.load-config.outputs.cuda-version }}-${{ needs.load-config.outputs.os-version }}-ec2-${{ github.run_id }}"
+
+          docker buildx build --progress plain \
+            --build-arg CUDA_VERSION=${CUDA_VERSION} \
+            --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
+            --build-arg TORCH_VERSION=${TORCH_VERSION} \
+            --build-arg DLC_MAJOR_VERSION=${DLC_MAJOR_VERSION} \
+            --build-arg DLC_MINOR_VERSION=${DLC_MINOR_VERSION} \
+            --build-arg FLASH_ATTN_VERSION=${FLASH_ATTN_VERSION} \
+            --build-arg TRANSFORMER_ENGINE_VERSION=${TRANSFORMER_ENGINE_VERSION} \
+            --build-arg GDRCOPY_VERSION=${GDRCOPY_VERSION} \
+            --build-arg EFA_VERSION=${EFA_VERSION} \
+            --build-arg MAX_JOBS=${MAX_JOBS} \
+            --cache-to=type=inline \
+            --cache-from=type=registry,ref=${CI_IMAGE_URI} \
+            --tag ${CI_IMAGE_URI} \
+            --push \
+            --target runtime \
+            -f docker/pytorch/Dockerfile.cuda .
+
+          echo "image-uri=${CI_IMAGE_URI}" >> $GITHUB_OUTPUT
+
+      - name: Upload built wheels to cache
+        run: |
+          source docker/pytorch/versions-cuda.env
+          bash scripts/pytorch/upload_cached_wheels.sh \
+            "${{ vars.WHEEL_CACHE_BUCKET }}" \
+            "${CUDA_VERSION}" "${TORCH_VERSION}" "${PYTHON_VERSION}" \
+            "${{ steps.build-runtime.outputs.image-uri }}" \
+            "flash-attn:${FLASH_ATTN_VERSION}" \
+            "transformer-engine-torch:${TRANSFORMER_ENGINE_VERSION}" \
+        continue-on-error: true
+
+  sanity-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-sanity-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      python-version: ${{ needs.load-config.outputs.python-version }}
+      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
+      os-version: ${{ needs.load-config.outputs.os-version }}
+      customer-type: ${{ needs.load-config.outputs.customer-type }}
+      arch-type: ${{ needs.load-config.outputs.arch-type }}
+      device-type: ${{ needs.load-config.outputs.device-type }}
+      contributor: ${{ needs.load-config.outputs.contributor }}
+      container-type: ${{ needs.load-config.outputs.container-type }}
+
+  security-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-security-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+
+  telemetry-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-telemetry-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      container-type: ${{ needs.load-config.outputs.container-type }}
+
+  unit-test:
+    needs: [build-image]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: ECR login
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Run unit tests
+        run: |
+          IMAGE="${{ needs.build-image.outputs.ci-image }}"
+          docker pull ${IMAGE}
+          CONTAINER_ID=$(docker run -d --rm --entrypoint /bin/bash \
+            -e DLC_WORKDIR=/workdir \
+            -v $(pwd):/workdir --workdir /workdir \
+            ${IMAGE} -c 'sleep infinity')
+          docker exec ${CONTAINER_ID} pip install pytest -q
+          docker exec ${CONTAINER_ID} pytest /workdir/test/pytorch/unit/ -v
+          docker kill ${CONTAINER_ID}
+
+  single-gpu-test:
+    needs: [build-image, sanity-test, security-test, unit-test]
+    if: success()
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:x86-g6xl-runner
+        buildspec-override:true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: ECR login
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Run single-GPU tests
+        run: |
+          IMAGE="${{ needs.build-image.outputs.ci-image }}"
+          docker pull ${IMAGE}
+          CONTAINER_ID=$(docker run -d --rm --gpus all --shm-size=2g \
+            --entrypoint /bin/bash \
+            -e DLC_WORKDIR=/workdir \
+            -v $(pwd):/workdir --workdir /workdir \
+            ${IMAGE} -c 'sleep infinity')
+          docker exec ${CONTAINER_ID} pip install pytest -q
+          docker exec ${CONTAINER_ID} pytest /workdir/test/pytorch/single_gpu/ -v
+          docker kill ${CONTAINER_ID}
+
+  efa-test:
+    needs: [build-image, sanity-test, security-test, unit-test]
+    if: success()
+    uses: ./.github/workflows/reusable-efa-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+
+  generate-release-spec:
+    needs: [load-config, build-image, sanity-test, security-test, unit-test, single-gpu-test, efa-test]
+    runs-on: ubuntu-latest
+    outputs:
+      release-spec: ${{ steps.generate.outputs.release-spec }}
+      should-release: ${{ steps.check-release.outputs.should-release }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Check if release is enabled
+        id: check-release
+        run: |
+          echo '${{ needs.load-config.outputs.config }}' > config.json
+          RELEASE_ENABLED=$(jq -r '.release.release // false' config.json)
+          echo "Release enabled: ${RELEASE_ENABLED}"
+          echo "should-release=${RELEASE_ENABLED}" >> $GITHUB_OUTPUT
+
+      - name: Generate release spec
+        id: generate
+        if: steps.check-release.outputs.should-release == 'true'
+        uses: ./.github/actions/generate-release-spec
+        with:
+          config-json: ${{ needs.load-config.outputs.config }}
+
+  release-image:
+    needs: [load-config, build-image, generate-release-spec]
+    if: needs.generate-release-spec.outputs.should-release == 'true'
+    uses: ./.github/workflows/reusable-release-image.yml
+    with:
+      source-image-uri: ${{ needs.build-image.outputs.ci-image }}
+      release-spec: ${{ needs.generate-release-spec.outputs.release-spec }}
+      environment: ${{ github.event_name == 'pull_request' && 'gamma' || fromJson(needs.load-config.outputs.config).release.environment }}
+      aws-region: ${{ vars.AWS_REGION }}
+      runner-fleet: default-runner
+    secrets: inherit

--- a/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
@@ -212,6 +212,7 @@ jobs:
 
   generate-release-spec:
     needs: [load-config, build-image, sanity-test, security-test, unit-test, sagemaker-test]
+    if: success()
     runs-on: ubuntu-latest
     outputs:
       release-spec: ${{ steps.generate.outputs.release-spec }}

--- a/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
@@ -94,19 +94,24 @@ jobs:
           source docker/pytorch/versions-cpu.env
           CI_IMAGE_URI="${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:pytorch-training-${TORCH_VERSION}-cpu-${{ needs.load-config.outputs.python-version }}-${{ needs.load-config.outputs.os-version }}-sagemaker-${{ github.run_id }}"
 
+          # Derive label values to match check_labels.py expectations
+          FRAMEWORK_LABEL=$(echo "${{ needs.load-config.outputs.framework }}" | tr '_' '-')
+          FWK_VER_LABEL=$(echo "${{ needs.load-config.outputs.framework-version }}" | tr '.' '-')
+          OS_LABEL=$(echo "${{ needs.load-config.outputs.os-version }}" | tr '.' '-')
+
           docker buildx build --progress plain \
             --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
             --build-arg TORCH_VERSION=${TORCH_VERSION} \
             --build-arg DLC_MAJOR_VERSION=${DLC_MAJOR_VERSION} \
             --build-arg DLC_MINOR_VERSION=${DLC_MINOR_VERSION} \
             --build-arg OPEN_MPI_VERSION=${OPEN_MPI_VERSION} \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.framework.pytorch.${TORCH_VERSION//./-}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.framework.${FRAMEWORK_LABEL}.${FWK_VER_LABEL}=true" \
             --label "com.amazonaws.ml.engines.sagemaker.dlc.device.cpu=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.job.training=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.arch.x86=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.os.amzn2023=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.python.py312=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.contributor.None=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.job.${{ needs.load-config.outputs.container-type }}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.arch.${{ needs.load-config.outputs.arch-type }}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.os.${OS_LABEL}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.python.${{ needs.load-config.outputs.python-version }}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.contributor.${{ needs.load-config.outputs.contributor }}=true" \
             --cache-to=type=inline \
             --cache-from=type=registry,ref=${CI_IMAGE_URI} \
             --tag ${CI_IMAGE_URI} \

--- a/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
@@ -100,6 +100,13 @@ jobs:
             --build-arg DLC_MAJOR_VERSION=${DLC_MAJOR_VERSION} \
             --build-arg DLC_MINOR_VERSION=${DLC_MINOR_VERSION} \
             --build-arg OPEN_MPI_VERSION=${OPEN_MPI_VERSION} \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.framework.pytorch.${TORCH_VERSION//./-}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.device.cpu=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.job.training=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.arch.x86=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.os.amzn2023=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.python.py312=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.contributor.None=true" \
             --cache-to=type=inline \
             --cache-from=type=registry,ref=${CI_IMAGE_URI} \
             --tag ${CI_IMAGE_URI} \

--- a/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
@@ -4,14 +4,6 @@ on:
   schedule:
     - cron: '00 17 * * 1,3'
 
-  # PR trigger for gamma release testing — disable after first successful gamma run
-  pull_request:
-    paths:
-      - ".github/workflows/autorelease-pytorch-sagemaker-cpu.yml"
-      - ".github/config/image/pytorch-sagemaker-cpu.yml"
-      - "docker/pytorch/**"
-      - "!docs/**"
-
   workflow_dispatch:
 
 concurrency:
@@ -248,7 +240,7 @@ jobs:
     with:
       source-image-uri: ${{ needs.build-image.outputs.ci-image }}
       release-spec: ${{ needs.generate-release-spec.outputs.release-spec }}
-      environment: ${{ github.event_name == 'pull_request' && 'gamma' || fromJson(needs.load-config.outputs.config).release.environment }}
+      environment: ${{ fromJson(needs.load-config.outputs.config).release.environment }}
       aws-region: ${{ vars.AWS_REGION }}
       runner-fleet: default-runner
     secrets: inherit

--- a/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
@@ -100,6 +100,7 @@ jobs:
           OS_LABEL=$(echo "${{ needs.load-config.outputs.os-version }}" | tr '.' '-')
 
           docker buildx build --progress plain \
+            --build-arg FRAMEWORK=${{ needs.load-config.outputs.framework }} \
             --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
             --build-arg TORCH_VERSION=${TORCH_VERSION} \
             --build-arg DLC_MAJOR_VERSION=${DLC_MAJOR_VERSION} \

--- a/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
@@ -1,0 +1,240 @@
+name: Auto Release - PyTorch SageMaker CPU
+
+on:
+  schedule:
+    - cron: '00 17 * * 1,3'
+
+  # PR trigger for gamma release testing — disable after first successful gamma run
+  pull_request:
+    paths:
+      - ".github/workflows/autorelease-pytorch-sagemaker-cpu.yml"
+      - ".github/config/image/pytorch-sagemaker-cpu.yml"
+      - "docker/pytorch/**"
+      - "!docs/**"
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: "1"
+  CONFIG_FILE: ".github/config/image/pytorch-sagemaker-cpu.yml"
+
+jobs:
+  load-config:
+    runs-on: ubuntu-latest
+    outputs:
+      config: ${{ steps.load.outputs.config }}
+      framework: ${{ steps.parse.outputs.framework }}
+      framework-version: ${{ steps.parse.outputs.framework-version }}
+      python-version: ${{ steps.parse.outputs.python-version }}
+      cuda-version: ${{ steps.parse.outputs.cuda-version }}
+      os-version: ${{ steps.parse.outputs.os-version }}
+      container-type: ${{ steps.parse.outputs.container-type }}
+      device-type: ${{ steps.parse.outputs.device-type }}
+      arch-type: ${{ steps.parse.outputs.arch-type }}
+      contributor: ${{ steps.parse.outputs.contributor }}
+      customer-type: ${{ steps.parse.outputs.customer-type }}
+      prod-image: ${{ steps.parse.outputs.prod-image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Load configuration
+        id: load
+        uses: ./.github/actions/load-config
+        with:
+          config-file: ${{ env.CONFIG_FILE }}
+
+      - name: Parse configuration
+        id: parse
+        run: |
+          echo '${{ steps.load.outputs.config }}' > config.json
+          echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
+          echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
+          echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
+          echo "cuda-version=$(jq -r '.common.cuda_version' config.json)" >> $GITHUB_OUTPUT
+          echo "os-version=$(jq -r '.common.os_version' config.json)" >> $GITHUB_OUTPUT
+          echo "container-type=$(jq -r '.common.job_type' config.json)" >> $GITHUB_OUTPUT
+          echo "device-type=$(jq -r '.common.device_type // "cpu"' config.json)" >> $GITHUB_OUTPUT
+          echo "arch-type=$(jq -r '.common.arch_type // "x86"' config.json)" >> $GITHUB_OUTPUT
+          echo "contributor=$(jq -r '.common.contributor // "None"' config.json)" >> $GITHUB_OUTPUT
+          echo "customer-type=$(jq -r '.common.customer_type // ""' config.json)" >> $GITHUB_OUTPUT
+          echo "prod-image=$(jq -r '.common.prod_image' config.json)" >> $GITHUB_OUTPUT
+
+  build-image:
+    needs: [load-config]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    outputs:
+      ci-image: ${{ steps.build-sagemaker.outputs.image-uri }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup buildkitd
+        run: .github/scripts/buildkitd.sh
+
+      - name: ECR login
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Build sagemaker image
+        id: build-sagemaker
+        run: |
+          source docker/pytorch/versions-cpu.env
+          CI_IMAGE_URI="${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:pytorch-training-${TORCH_VERSION}-cpu-${{ needs.load-config.outputs.python-version }}-${{ needs.load-config.outputs.os-version }}-sagemaker-${{ github.run_id }}"
+
+          docker buildx build --progress plain \
+            --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
+            --build-arg TORCH_VERSION=${TORCH_VERSION} \
+            --build-arg DLC_MAJOR_VERSION=${DLC_MAJOR_VERSION} \
+            --build-arg DLC_MINOR_VERSION=${DLC_MINOR_VERSION} \
+            --build-arg OPEN_MPI_VERSION=${OPEN_MPI_VERSION} \
+            --cache-to=type=inline \
+            --cache-from=type=registry,ref=${CI_IMAGE_URI} \
+            --tag ${CI_IMAGE_URI} \
+            --push \
+            --target sagemaker \
+            -f docker/pytorch/Dockerfile.cpu .
+
+          echo "image-uri=${CI_IMAGE_URI}" >> $GITHUB_OUTPUT
+
+  sanity-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-sanity-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      python-version: ${{ needs.load-config.outputs.python-version }}
+      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
+      os-version: ${{ needs.load-config.outputs.os-version }}
+      customer-type: ${{ needs.load-config.outputs.customer-type }}
+      arch-type: ${{ needs.load-config.outputs.arch-type }}
+      device-type: ${{ needs.load-config.outputs.device-type }}
+      contributor: ${{ needs.load-config.outputs.contributor }}
+      container-type: ${{ needs.load-config.outputs.container-type }}
+
+  security-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-security-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+
+  telemetry-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-telemetry-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      container-type: ${{ needs.load-config.outputs.container-type }}
+
+  unit-test:
+    needs: [build-image]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: ECR login
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Run unit tests
+        run: |
+          IMAGE="${{ needs.build-image.outputs.ci-image }}"
+          docker pull ${IMAGE}
+          CONTAINER_ID=$(docker run -d --rm --entrypoint /bin/bash \
+            -e DLC_WORKDIR=/workdir \
+            -v $(pwd):/workdir --workdir /workdir \
+            ${IMAGE} -c 'sleep infinity')
+          docker exec ${CONTAINER_ID} pip install pytest -q
+          docker exec ${CONTAINER_ID} pytest /workdir/test/pytorch/unit/ -v
+          docker kill ${CONTAINER_ID}
+
+  sagemaker-test:
+    needs: [build-image, sanity-test, security-test, unit-test]
+    if: success()
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: ECR login
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Install test dependencies
+        run: pip install -r test/pytorch/integration/sagemaker/requirements.txt
+
+      - name: Run SageMaker CPU training tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}/test
+          TEST_IMAGE_URI: ${{ needs.build-image.outputs.ci-image }}
+          SM_ROLE_ARN: arn:aws:iam::${{ vars.CI_AWS_ACCOUNT_ID }}:role/SageMakerRole
+        run: pytest test/pytorch/integration/sagemaker/test_sm_training_cpu.py -v
+
+  generate-release-spec:
+    needs: [load-config, build-image, sanity-test, security-test, unit-test, sagemaker-test]
+    runs-on: ubuntu-latest
+    outputs:
+      release-spec: ${{ steps.generate.outputs.release-spec }}
+      should-release: ${{ steps.check-release.outputs.should-release }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Check if release is enabled
+        id: check-release
+        run: |
+          echo '${{ needs.load-config.outputs.config }}' > config.json
+          RELEASE_ENABLED=$(jq -r '.release.release // false' config.json)
+          echo "should-release=${RELEASE_ENABLED}" >> $GITHUB_OUTPUT
+
+      - name: Generate release spec
+        id: generate
+        if: steps.check-release.outputs.should-release == 'true'
+        uses: ./.github/actions/generate-release-spec
+        with:
+          config-json: ${{ needs.load-config.outputs.config }}
+
+  release-image:
+    needs: [load-config, build-image, generate-release-spec]
+    if: needs.generate-release-spec.outputs.should-release == 'true'
+    uses: ./.github/workflows/reusable-release-image.yml
+    with:
+      source-image-uri: ${{ needs.build-image.outputs.ci-image }}
+      release-spec: ${{ needs.generate-release-spec.outputs.release-spec }}
+      environment: ${{ github.event_name == 'pull_request' && 'gamma' || fromJson(needs.load-config.outputs.config).release.environment }}
+      aws-region: ${{ vars.AWS_REGION }}
+      runner-fleet: default-runner
+    secrets: inherit

--- a/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
@@ -118,6 +118,13 @@ jobs:
             --build-arg GDRCOPY_VERSION=${GDRCOPY_VERSION} \
             --build-arg EFA_VERSION=${EFA_VERSION} \
             --build-arg MAX_JOBS=${MAX_JOBS} \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.framework.pytorch.${TORCH_VERSION//./-}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.device.gpu.cu130=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.job.training=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.arch.x86=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.os.amzn2023=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.python.py312=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.contributor.None=true" \
             --cache-to=type=inline \
             --cache-from=type=registry,ref=${CI_IMAGE_URI} \
             --tag ${CI_IMAGE_URI} \

--- a/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
@@ -107,6 +107,12 @@ jobs:
           source docker/pytorch/versions-cuda.env
           CI_IMAGE_URI="${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:pytorch-training-${TORCH_VERSION}-gpu-${{ needs.load-config.outputs.python-version }}-${{ needs.load-config.outputs.cuda-version }}-${{ needs.load-config.outputs.os-version }}-sagemaker-${{ github.run_id }}"
 
+          # Derive label values to match check_labels.py expectations
+          FRAMEWORK_LABEL=$(echo "${{ needs.load-config.outputs.framework }}" | tr '_' '-')
+          FWK_VER_LABEL=$(echo "${{ needs.load-config.outputs.framework-version }}" | tr '.' '-')
+          CUDA_LABEL="${{ needs.load-config.outputs.cuda-version }}"
+          OS_LABEL=$(echo "${{ needs.load-config.outputs.os-version }}" | tr '.' '-')
+
           docker buildx build --progress plain \
             --build-arg CUDA_VERSION=${CUDA_VERSION} \
             --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
@@ -118,13 +124,13 @@ jobs:
             --build-arg GDRCOPY_VERSION=${GDRCOPY_VERSION} \
             --build-arg EFA_VERSION=${EFA_VERSION} \
             --build-arg MAX_JOBS=${MAX_JOBS} \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.framework.pytorch.${TORCH_VERSION//./-}=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.device.gpu.cu130=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.job.training=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.arch.x86=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.os.amzn2023=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.python.py312=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.contributor.None=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.framework.${FRAMEWORK_LABEL}.${FWK_VER_LABEL}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.device.gpu.${CUDA_LABEL}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.job.${{ needs.load-config.outputs.container-type }}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.arch.${{ needs.load-config.outputs.arch-type }}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.os.${OS_LABEL}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.python.${{ needs.load-config.outputs.python-version }}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.contributor.${{ needs.load-config.outputs.contributor }}=true" \
             --cache-to=type=inline \
             --cache-from=type=registry,ref=${CI_IMAGE_URI} \
             --tag ${CI_IMAGE_URI} \

--- a/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
@@ -4,14 +4,6 @@ on:
   schedule:
     - cron: '00 17 * * 1,3'
 
-  # PR trigger for gamma release testing — disable after first successful gamma run
-  pull_request:
-    paths:
-      - ".github/workflows/autorelease-pytorch-sagemaker-cuda.yml"
-      - ".github/config/image/pytorch-sagemaker-cuda.yml"
-      - "docker/pytorch/**"
-      - "!docs/**"
-
   workflow_dispatch:
 
 concurrency:
@@ -278,7 +270,7 @@ jobs:
     with:
       source-image-uri: ${{ needs.build-image.outputs.ci-image }}
       release-spec: ${{ needs.generate-release-spec.outputs.release-spec }}
-      environment: ${{ github.event_name == 'pull_request' && 'gamma' || fromJson(needs.load-config.outputs.config).release.environment }}
+      environment: ${{ fromJson(needs.load-config.outputs.config).release.environment }}
       aws-region: ${{ vars.AWS_REGION }}
       runner-fleet: default-runner
     secrets: inherit

--- a/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
@@ -241,6 +241,7 @@ jobs:
 
   generate-release-spec:
     needs: [load-config, build-image, sanity-test, security-test, unit-test, sagemaker-test]
+    if: success()
     runs-on: ubuntu-latest
     outputs:
       release-spec: ${{ steps.generate.outputs.release-spec }}

--- a/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
@@ -114,6 +114,7 @@ jobs:
           OS_LABEL=$(echo "${{ needs.load-config.outputs.os-version }}" | tr '.' '-')
 
           docker buildx build --progress plain \
+            --build-arg FRAMEWORK=${{ needs.load-config.outputs.framework }} \
             --build-arg CUDA_VERSION=${CUDA_VERSION} \
             --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
             --build-arg TORCH_VERSION=${TORCH_VERSION} \

--- a/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
@@ -1,0 +1,269 @@
+name: Auto Release - PyTorch SageMaker CUDA
+
+on:
+  schedule:
+    - cron: '00 17 * * 1,3'
+
+  # PR trigger for gamma release testing — disable after first successful gamma run
+  pull_request:
+    paths:
+      - ".github/workflows/autorelease-pytorch-sagemaker-cuda.yml"
+      - ".github/config/image/pytorch-sagemaker-cuda.yml"
+      - "docker/pytorch/**"
+      - "!docs/**"
+
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: "1"
+  CONFIG_FILE: ".github/config/image/pytorch-sagemaker-cuda.yml"
+
+jobs:
+  load-config:
+    runs-on: ubuntu-latest
+    outputs:
+      config: ${{ steps.load.outputs.config }}
+      framework: ${{ steps.parse.outputs.framework }}
+      framework-version: ${{ steps.parse.outputs.framework-version }}
+      python-version: ${{ steps.parse.outputs.python-version }}
+      cuda-version: ${{ steps.parse.outputs.cuda-version }}
+      os-version: ${{ steps.parse.outputs.os-version }}
+      container-type: ${{ steps.parse.outputs.container-type }}
+      device-type: ${{ steps.parse.outputs.device-type }}
+      arch-type: ${{ steps.parse.outputs.arch-type }}
+      contributor: ${{ steps.parse.outputs.contributor }}
+      customer-type: ${{ steps.parse.outputs.customer-type }}
+      prod-image: ${{ steps.parse.outputs.prod-image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Load configuration
+        id: load
+        uses: ./.github/actions/load-config
+        with:
+          config-file: ${{ env.CONFIG_FILE }}
+
+      - name: Parse configuration
+        id: parse
+        run: |
+          echo '${{ steps.load.outputs.config }}' > config.json
+          echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
+          echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
+          echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
+          echo "cuda-version=$(jq -r '.common.cuda_version' config.json)" >> $GITHUB_OUTPUT
+          echo "os-version=$(jq -r '.common.os_version' config.json)" >> $GITHUB_OUTPUT
+          echo "container-type=$(jq -r '.common.job_type' config.json)" >> $GITHUB_OUTPUT
+          echo "device-type=$(jq -r '.common.device_type // "gpu"' config.json)" >> $GITHUB_OUTPUT
+          echo "arch-type=$(jq -r '.common.arch_type // "x86"' config.json)" >> $GITHUB_OUTPUT
+          echo "contributor=$(jq -r '.common.contributor // "None"' config.json)" >> $GITHUB_OUTPUT
+          echo "customer-type=$(jq -r '.common.customer_type // ""' config.json)" >> $GITHUB_OUTPUT
+          echo "prod-image=$(jq -r '.common.prod_image' config.json)" >> $GITHUB_OUTPUT
+
+  build-image:
+    needs: [load-config]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:x86-build-runner
+        buildspec-override:true
+    timeout-minutes: 720
+    outputs:
+      ci-image: ${{ steps.build-sagemaker.outputs.image-uri }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup buildkitd
+        run: .github/scripts/buildkitd.sh
+
+      - name: ECR login
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Fetch cached wheels
+        run: |
+          source docker/pytorch/versions-cuda.env
+          mkdir -p docker/pytorch/wheels
+          bash scripts/pytorch/fetch_cached_wheels.sh \
+            docker/pytorch/wheels \
+            "${{ vars.WHEEL_CACHE_BUCKET }}" \
+            "${CUDA_VERSION}" "${TORCH_VERSION}" "${PYTHON_VERSION}" \
+            "flash-attn:${FLASH_ATTN_VERSION}" \
+            "transformer-engine-torch:${TRANSFORMER_ENGINE_VERSION}" \
+        continue-on-error: true
+
+      - name: Build sagemaker image
+        id: build-sagemaker
+        run: |
+          source docker/pytorch/versions-cuda.env
+          CI_IMAGE_URI="${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:pytorch-training-${TORCH_VERSION}-gpu-${{ needs.load-config.outputs.python-version }}-${{ needs.load-config.outputs.cuda-version }}-${{ needs.load-config.outputs.os-version }}-sagemaker-${{ github.run_id }}"
+
+          docker buildx build --progress plain \
+            --build-arg CUDA_VERSION=${CUDA_VERSION} \
+            --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
+            --build-arg TORCH_VERSION=${TORCH_VERSION} \
+            --build-arg DLC_MAJOR_VERSION=${DLC_MAJOR_VERSION} \
+            --build-arg DLC_MINOR_VERSION=${DLC_MINOR_VERSION} \
+            --build-arg FLASH_ATTN_VERSION=${FLASH_ATTN_VERSION} \
+            --build-arg TRANSFORMER_ENGINE_VERSION=${TRANSFORMER_ENGINE_VERSION} \
+            --build-arg GDRCOPY_VERSION=${GDRCOPY_VERSION} \
+            --build-arg EFA_VERSION=${EFA_VERSION} \
+            --build-arg MAX_JOBS=${MAX_JOBS} \
+            --cache-to=type=inline \
+            --cache-from=type=registry,ref=${CI_IMAGE_URI} \
+            --tag ${CI_IMAGE_URI} \
+            --push \
+            --target sagemaker \
+            -f docker/pytorch/Dockerfile.cuda .
+
+          echo "image-uri=${CI_IMAGE_URI}" >> $GITHUB_OUTPUT
+
+      - name: Upload built wheels to cache
+        run: |
+          source docker/pytorch/versions-cuda.env
+          bash scripts/pytorch/upload_cached_wheels.sh \
+            "${{ vars.WHEEL_CACHE_BUCKET }}" \
+            "${CUDA_VERSION}" "${TORCH_VERSION}" "${PYTHON_VERSION}" \
+            "${{ steps.build-sagemaker.outputs.image-uri }}" \
+            "flash-attn:${FLASH_ATTN_VERSION}" \
+            "transformer-engine-torch:${TRANSFORMER_ENGINE_VERSION}" \
+        continue-on-error: true
+
+  sanity-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-sanity-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      python-version: ${{ needs.load-config.outputs.python-version }}
+      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
+      os-version: ${{ needs.load-config.outputs.os-version }}
+      customer-type: ${{ needs.load-config.outputs.customer-type }}
+      arch-type: ${{ needs.load-config.outputs.arch-type }}
+      device-type: ${{ needs.load-config.outputs.device-type }}
+      contributor: ${{ needs.load-config.outputs.contributor }}
+      container-type: ${{ needs.load-config.outputs.container-type }}
+
+  security-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-security-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+
+  telemetry-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-telemetry-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      container-type: ${{ needs.load-config.outputs.container-type }}
+
+  unit-test:
+    needs: [build-image]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: ECR login
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Run unit tests
+        run: |
+          IMAGE="${{ needs.build-image.outputs.ci-image }}"
+          docker pull ${IMAGE}
+          CONTAINER_ID=$(docker run -d --rm --entrypoint /bin/bash \
+            -e DLC_WORKDIR=/workdir \
+            -v $(pwd):/workdir --workdir /workdir \
+            ${IMAGE} -c 'sleep infinity')
+          docker exec ${CONTAINER_ID} pip install pytest -q
+          docker exec ${CONTAINER_ID} pytest /workdir/test/pytorch/unit/ -v
+          docker kill ${CONTAINER_ID}
+
+  sagemaker-test:
+    needs: [build-image, sanity-test, security-test, unit-test]
+    if: success()
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: ECR login
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Install test dependencies
+        run: pip install -r test/pytorch/integration/sagemaker/requirements.txt
+
+      - name: Run SageMaker training tests
+        env:
+          PYTHONPATH: ${{ github.workspace }}/test
+          TEST_IMAGE_URI: ${{ needs.build-image.outputs.ci-image }}
+          SM_ROLE_ARN: arn:aws:iam::${{ vars.CI_AWS_ACCOUNT_ID }}:role/SageMakerRole
+        run: pytest test/pytorch/integration/sagemaker/test_sm_training_cuda.py -v
+
+  generate-release-spec:
+    needs: [load-config, build-image, sanity-test, security-test, unit-test, sagemaker-test]
+    runs-on: ubuntu-latest
+    outputs:
+      release-spec: ${{ steps.generate.outputs.release-spec }}
+      should-release: ${{ steps.check-release.outputs.should-release }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Check if release is enabled
+        id: check-release
+        run: |
+          echo '${{ needs.load-config.outputs.config }}' > config.json
+          RELEASE_ENABLED=$(jq -r '.release.release // false' config.json)
+          echo "should-release=${RELEASE_ENABLED}" >> $GITHUB_OUTPUT
+
+      - name: Generate release spec
+        id: generate
+        if: steps.check-release.outputs.should-release == 'true'
+        uses: ./.github/actions/generate-release-spec
+        with:
+          config-json: ${{ needs.load-config.outputs.config }}
+
+  release-image:
+    needs: [load-config, build-image, generate-release-spec]
+    if: needs.generate-release-spec.outputs.should-release == 'true'
+    uses: ./.github/workflows/reusable-release-image.yml
+    with:
+      source-image-uri: ${{ needs.build-image.outputs.ci-image }}
+      release-spec: ${{ needs.generate-release-spec.outputs.release-spec }}
+      environment: ${{ github.event_name == 'pull_request' && 'gamma' || fromJson(needs.load-config.outputs.config).release.environment }}
+      aws-region: ${{ vars.AWS_REGION }}
+      runner-fleet: default-runner
+    secrets: inherit

--- a/.github/workflows/pr-pytorch-ec2-cpu.yml
+++ b/.github/workflows/pr-pytorch-ec2-cpu.yml
@@ -137,7 +137,7 @@ jobs:
   # Build CPU runtime image
   # ============================================================
   build-image:
-    needs: [check-changes]
+    needs: [check-changes, load-config]
     if: needs.check-changes.outputs.build-change == 'true'
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
@@ -168,6 +168,7 @@ jobs:
           CI_IMAGE_URI="${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:pytorch-cpu-runtime-pr-${{ github.event.pull_request.number }}"
 
           docker buildx build --progress plain \
+            --build-arg FRAMEWORK=${{ needs.load-config.outputs.framework }} \
             --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
             --build-arg TORCH_VERSION=${TORCH_VERSION} \
             --build-arg DLC_MAJOR_VERSION=${DLC_MAJOR_VERSION} \

--- a/.github/workflows/pr-pytorch-ec2-cuda.yml
+++ b/.github/workflows/pr-pytorch-ec2-cuda.yml
@@ -139,7 +139,7 @@ jobs:
   # Build runtime image
   # ============================================================
   build-images:
-    needs: [check-changes]
+    needs: [check-changes, load-config]
     if: needs.check-changes.outputs.build-change == 'true'
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
@@ -190,6 +190,7 @@ jobs:
           CI_IMAGE_URI="${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:pytorch-runtime-pr-${{ github.event.pull_request.number }}"
 
           docker buildx build --progress plain \
+            --build-arg FRAMEWORK=${{ needs.load-config.outputs.framework }} \
             --build-arg CUDA_VERSION=${CUDA_VERSION} \
             --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
             --build-arg TORCH_VERSION=${TORCH_VERSION} \

--- a/.github/workflows/pr-pytorch-sagemaker-cpu.yml
+++ b/.github/workflows/pr-pytorch-sagemaker-cpu.yml
@@ -139,7 +139,7 @@ jobs:
   # Build CPU SageMaker image
   # ============================================================
   build-image:
-    needs: [check-changes]
+    needs: [check-changes, load-config]
     if: needs.check-changes.outputs.build-change == 'true'
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
@@ -169,19 +169,24 @@ jobs:
           source docker/pytorch/versions-cpu.env
           CI_IMAGE_URI="${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:pytorch-training-${TORCH_VERSION}-cpu-py312-sagemaker-pr-${{ github.event.pull_request.number }}"
 
+          # Derive label values to match check_labels.py expectations
+          FRAMEWORK_LABEL=$(echo "${{ needs.load-config.outputs.framework }}" | tr '_' '-')
+          FWK_VER_LABEL=$(echo "${{ needs.load-config.outputs.framework-version }}" | tr '.' '-')
+          OS_LABEL=$(echo "${{ needs.load-config.outputs.os-version }}" | tr '.' '-')
+
           docker buildx build --progress plain \
             --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
             --build-arg TORCH_VERSION=${TORCH_VERSION} \
             --build-arg DLC_MAJOR_VERSION=${DLC_MAJOR_VERSION} \
             --build-arg DLC_MINOR_VERSION=${DLC_MINOR_VERSION} \
             --build-arg OPEN_MPI_VERSION=${OPEN_MPI_VERSION} \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.framework.pytorch.${TORCH_VERSION//./-}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.framework.${FRAMEWORK_LABEL}.${FWK_VER_LABEL}=true" \
             --label "com.amazonaws.ml.engines.sagemaker.dlc.device.cpu=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.job.training=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.arch.x86=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.os.amzn2023=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.python.py312=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.contributor.None=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.job.${{ needs.load-config.outputs.container-type }}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.arch.${{ needs.load-config.outputs.arch-type }}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.os.${OS_LABEL}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.python.${{ needs.load-config.outputs.python-version }}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.contributor.${{ needs.load-config.outputs.contributor }}=true" \
             --cache-to=type=inline \
             --cache-from=type=registry,ref=${CI_IMAGE_URI} \
             --tag ${CI_IMAGE_URI} \

--- a/.github/workflows/pr-pytorch-sagemaker-cpu.yml
+++ b/.github/workflows/pr-pytorch-sagemaker-cpu.yml
@@ -175,6 +175,7 @@ jobs:
           OS_LABEL=$(echo "${{ needs.load-config.outputs.os-version }}" | tr '.' '-')
 
           docker buildx build --progress plain \
+            --build-arg FRAMEWORK=${{ needs.load-config.outputs.framework }} \
             --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
             --build-arg TORCH_VERSION=${TORCH_VERSION} \
             --build-arg DLC_MAJOR_VERSION=${DLC_MAJOR_VERSION} \

--- a/.github/workflows/pr-pytorch-sagemaker-cuda.yml
+++ b/.github/workflows/pr-pytorch-sagemaker-cuda.yml
@@ -187,6 +187,7 @@ jobs:
           OS_LABEL=$(echo "${{ needs.load-config.outputs.os-version }}" | tr '.' '-')
 
           docker buildx build --progress plain \
+            --build-arg FRAMEWORK=${{ needs.load-config.outputs.framework }} \
             --build-arg CUDA_VERSION=${CUDA_VERSION} \
             --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
             --build-arg TORCH_VERSION=${TORCH_VERSION} \

--- a/.github/workflows/pr-pytorch-sagemaker-cuda.yml
+++ b/.github/workflows/pr-pytorch-sagemaker-cuda.yml
@@ -138,7 +138,7 @@ jobs:
   # Build SageMaker image
   # ============================================================
   build-image:
-    needs: [check-changes]
+    needs: [check-changes, load-config]
     if: needs.check-changes.outputs.build-change == 'true'
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
@@ -180,6 +180,12 @@ jobs:
           source docker/pytorch/versions-cuda.env
           CI_IMAGE_URI="${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:pytorch-training-2.11.0-gpu-py312-cu130-sagemaker-pr-${{ github.event.pull_request.number }}"
 
+          # Derive label values to match check_labels.py expectations
+          FRAMEWORK_LABEL=$(echo "${{ needs.load-config.outputs.framework }}" | tr '_' '-')
+          FWK_VER_LABEL=$(echo "${{ needs.load-config.outputs.framework-version }}" | tr '.' '-')
+          CUDA_LABEL="${{ needs.load-config.outputs.cuda-version }}"
+          OS_LABEL=$(echo "${{ needs.load-config.outputs.os-version }}" | tr '.' '-')
+
           docker buildx build --progress plain \
             --build-arg CUDA_VERSION=${CUDA_VERSION} \
             --build-arg PYTHON_VERSION=${PYTHON_VERSION} \
@@ -191,13 +197,13 @@ jobs:
             --build-arg GDRCOPY_VERSION=${GDRCOPY_VERSION} \
             --build-arg EFA_VERSION=${EFA_VERSION} \
             --build-arg MAX_JOBS=${MAX_JOBS} \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.framework.pytorch.${TORCH_VERSION//./-}=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.device.gpu.cu130=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.job.training=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.arch.x86=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.os.amzn2023=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.python.py312=true" \
-            --label "com.amazonaws.ml.engines.sagemaker.dlc.contributor.None=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.framework.${FRAMEWORK_LABEL}.${FWK_VER_LABEL}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.device.gpu.${CUDA_LABEL}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.job.${{ needs.load-config.outputs.container-type }}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.arch.${{ needs.load-config.outputs.arch-type }}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.os.${OS_LABEL}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.python.${{ needs.load-config.outputs.python-version }}=true" \
+            --label "com.amazonaws.ml.engines.sagemaker.dlc.contributor.${{ needs.load-config.outputs.contributor }}=true" \
             --cache-to=type=inline \
             --cache-from=type=registry,ref=${CI_IMAGE_URI} \
             --tag ${CI_IMAGE_URI} \

--- a/scripts/telemetry/deep_learning_container.py
+++ b/scripts/telemetry/deep_learning_container.py
@@ -232,6 +232,7 @@ def parse_args():
             "tensorflow",
             "mxnet",
             "pytorch",
+            "pytorch_runtime",
             "base",
             "vllm",
             "vllm_server",


### PR DESCRIPTION
## Add PyTorch 2.11.0 autorelease workflows with framework-versioned tags

### What

Add autorelease workflows for PyTorch 2.11.0 x86 training images (4 variants: EC2/SageMaker × GPU/CPU). Uses the new framework-versioned tag format instead of legacy DLC tags. This completes the V1 → V2 migration for PyTorch — all build, test, and release logic now runs on GitHub Actions.

### Tag format

Framework-versioned images embed the framework version, compute type, and OS directly in the tag. No DLC version numbers (`v1.0.0`) — the framework version IS the version.

| Tag | Example | Mutability |
|---|---|---|
| `{version}-{cuda/cpu}-{os}{platform}` | `2.11.0-cu130-amzn2023` | Mutable until next patch (2.11.1) |
| `{short_version}-{cuda/cpu}-{os}{platform}` | `2.11-cu130-amzn2023` | Mutable until next minor (2.12.0) |
| `{version}-{cuda/cpu}-{os}{platform}-{date}` | `2.11.0-cu130-amzn2023-20260430` | Immutable snapshot |

SageMaker images append `-sagemaker`: `2.11.0-cu130-amzn2023-sagemaker`.
CPU images use `cpu` instead of `cu130`: `2.11.0-cpu-amzn2023`.

ECR repo: `pytorch` (not `pytorch-training`).

### Workflows

| Workflow | Config | Tests |
|---|---|---|
| `autorelease-pytorch-ec2-cuda.yml` | `pytorch-ec2-cuda.yml` | sanity, security, telemetry, unit, single-gpu, efa |
| `autorelease-pytorch-ec2-cpu.yml` | `pytorch-ec2-cpu.yml` | sanity, security, telemetry, unit |
| `autorelease-pytorch-sagemaker-cuda.yml` | `pytorch-sagemaker-cuda.yml` | sanity, security, telemetry, unit, sagemaker |
| `autorelease-pytorch-sagemaker-cpu.yml` | `pytorch-sagemaker-cpu.yml` | sanity, security, telemetry, unit, sagemaker |

Pipeline: `load-config` → `build-image` → tests → `generate-release-spec` (gated by `if: success()`) → `release-image` via `reusable-release-image.yml`.

### Release pipeline

- **Trigger**: scheduled (Mon/Wed 9AM PST) + `workflow_dispatch`
- **Environment**: production (reads from config)
- **Registry**: private ECR (all regions) + public ECR gallery
- **SOCI**: enabled — lazy-loading indexes generated and pushed alongside each image
- **Release gate**: `generate-release-spec` only runs when all upstream tests pass (`if: success()`) AND `release: true` in config

### Config changes

All 4 image configs (`pytorch-ec2-cuda.yml`, `pytorch-ec2-cpu.yml`, `pytorch-sagemaker-cuda.yml`, `pytorch-sagemaker-cpu.yml`):
- `framework: pytorch_runtime` — uses framework-versioned tag format
- `release: true` — enables the release gate
- `private_registry: true` — pushes to private ECR in all regions
- `public_registry: true` — pushes to ECR public gallery
- `enable_soci: true` — generates SOCI lazy-loading indexes
- `environment: production` — targets production release accounts
- `platform: sagemaker` — added to SageMaker variants (appends `-sagemaker` suffix)
- `prod_image: pytorch:2.11-cu130-amzn2023` — uses short version tag as the prod pointer

### Build changes (all 8 PyTorch workflows: 4 PR + 4 autorelease)

- **`--build-arg FRAMEWORK`**: passed from config to override the Dockerfile default (`pytorch`). Ensures the telemetry script inside the container reports the correct framework name matching what the telemetry test expects.
- **Dynamic SageMaker labels**: SageMaker build steps derive `--label` values from config outputs using the same transformations as `check_labels.py` (`_` → `-` for framework, `.` → `-` for version/os). Replaces previously hardcoded label values.
- **`load-config` dependency**: EC2 PR build jobs now depend on `load-config` (previously only depended on `check-changes`), required for `needs.load-config.outputs.framework` reference.

### Release logic changes (DLContainersReleaseLogicPython)

- `frameworks.yml`: added `pytorch_runtime` entry with `release_tag`, `short_release_tag`, and `with_date` variant
- `tags.py`: added `with_date` variant producing `{tag}-YYYYMMDD`; fixed midnight race by pre-computing date from single `datetime.now()` call
- `test_tags.py`: added `TestPyTorchRuntimeTags` class; fixed `TestPrimaryKey` and `TestValidation` to account for `pytorch_runtime` using `with_date` instead of `with_version` and strict 3-part version pattern

### Gamma verification

All 4 images successfully pushed to gamma account with correct framework-versioned tags:
- `2.11.0-cu130-amzn2023`, `2.11-cu130-amzn2023`, `2.11.0-cu130-amzn2023-20260430`
- `2.11.0-cpu-amzn2023`, `2.11-cpu-amzn2023`, `2.11.0-cpu-amzn2023-20260430`
- `2.11.0-cu130-amzn2023-sagemaker`, `2.11-cu130-amzn2023-sagemaker`, `2.11.0-cu130-amzn2023-sagemaker-20260430`
- `2.11.0-cpu-amzn2023-sagemaker`, `2.11-cpu-amzn2023-sagemaker`, `2.11.0-cpu-amzn2023-sagemaker-20260430`
