### PR TITLE
sglang patching

### DIFF
--- a/docker/sglang/Dockerfile
+++ b/docker/sglang/Dockerfile
@@ -34,7 +34,7 @@ WORKDIR /
 RUN pip install \
   botocore
 
-# patch CVEs
+# patch CVEs (rebuild to pick up latest OS patches)
 RUN pip install \
   "black>=26.3.1" \
   "pillow>=12.1.1" \

--- a/docker/sglang/Dockerfile
+++ b/docker/sglang/Dockerfile
@@ -34,9 +34,10 @@ WORKDIR /
 RUN pip install \
   botocore
 
-# patch CVEs (rebuild to pick up latest OS patches)
+# patch CVEs
 RUN pip install \
   "black>=26.3.1" \
+  "lxml>=6.1.0" \
   "pillow>=12.1.1" \
   "pyasn1>=0.6.3" \
   "python_multipart>=0.0.22" \

--- a/test/security/data/ecr_scan_allowlist/sglang/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/sglang/framework_allowlist.json
@@ -22,5 +22,25 @@
     {
         "vulnerability_id": "CVE-2025-68263",
         "reason": "linux-libc-dev 6.8.0 is a kernel header package from the Ubuntu base image, fix not yet available in upstream base image"
+    },
+    {
+        "vulnerability_id": "CVE-2025-68121",
+        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+"
+    },
+    {
+        "vulnerability_id": "CVE-2026-32283",
+        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+"
+    },
+    {
+        "vulnerability_id": "CVE-2026-32281",
+        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+"
+    },
+    {
+        "vulnerability_id": "CVE-2026-32280",
+        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+"
+    },
+    {
+        "vulnerability_id": "CVE-2026-25679",
+        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+"
     }
 ]


### PR DESCRIPTION
## Purpose
Patch HIGH/CRITICAL CVEs in sglang 0.5 GPU image `sglang:0.5-gpu-py312`.

## Changes
  - Dockerfile: Add lxml>=6.1.0 to pip CVE patch section
  - Allowlist: Add 5 go/stdlib CVEs embedded in mooncake's libetcd_wrapper.so - these are compiled into a prebuilt shared library from the upstream sglang base image and cannot be patched

## Test Plan

## Test Result

security test passes: [5e9e3cd](https://github.com/aws/deep-learning-containers/pull/6023/commits/5e9e3cda412f5d6e283e3f8aa53dca7641bd7231)
______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
