### PR TITLE
feat: wire vLLM SageMaker entrypoint to standard-supervisor

### DIFF
--- a/docker/vllm/Dockerfile
+++ b/docker/vllm/Dockerfile
@@ -36,7 +36,7 @@ RUN uv pip install --system \
   "pillow>=12.1.1" \
   "xgrammar>=0.1.32" \
   "PyJWT>=2.12.0" \
-  "model-hosting-container-standards>=0.1.14,<1.0.0" \
+  "model-hosting-container-standards>=0.1.15,<1.0.0" \
   "pyasn1>=0.6.3" \
   && uv cache clean
 

--- a/scripts/vllm/sagemaker_entrypoint.sh
+++ b/scripts/vllm/sagemaker_entrypoint.sh
@@ -38,4 +38,4 @@ while IFS='=' read -r key value; do
     fi
 done < <(env | grep "^${PREFIX}")
 
-exec python3 -m vllm.entrypoints.openai.api_server "${ARGS[@]}"
+exec standard-supervisor python3 -m vllm.entrypoints.openai.api_server "${ARGS[@]}"


### PR DESCRIPTION
### Summary
Adds standard-supervisor (from model-hosting-container-standards) to the vLLM SageMaker launch chain, aligning the DLC with the vLLM open source SageMaker stage which already uses standard-supervisor as its entrypoint wrapper.

### Why this is necessary
1. Parity with vLLM open source

The upstream vLLM project's sagemaker-entrypoint.sh already launches via standard-supervisor.

2. Process supervision and auto-recovery

Without standard-supervisor, if the vLLM process crashes, the container exits immediately. With it, the process is managed by supervisord which:

Automatically restarts the vLLM process on unexpected exits (configurable via PROCESS_AUTO_RECOVERY, default: true)
Retries up to N times before giving up (configurable via PROCESS_MAX_START_RETRIES, default: 3)
Provides structured exit codes so SageMaker can distinguish between transient failures and permanent ones

3. Dynamic dependency installation

standard-supervisor (v0.1.15+) automatically installs dependencies from requirements.txt before starting the server. This enables customers to bundle custom dependencies with their model artifacts without needing a custom container. 

Controlled by:
STANDARD_AUTO_INSTALL_REQ (default: true) — enable/disable
STANDARD_PIP_ARGS — override with explicit pip arguments

### Testing
Local validation 
CI will run: sanity tests, security tests, telemetry tests, upstream vLLM tests (GPU), and a real SageMaker endpoint deployment test
