### PR TITLE
[pytorch] fix pip_check test failure for tox/pyproject-api packaging incompatibility

### DIFF
--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -678,10 +678,13 @@ def test_pip_check(image):
             rf"tf-models-official 2.9.2 has requirement tensorflow-text~=2.9.0, but you have tensorflow-text 2.10.0."
         )
 
-    # tox and pyproject-api are installed as transitive dependencies in the container
-    # and require packaging>=25, but the container has an older version of packaging.
+    # ipython requires psutil>=7, but TorchServe's common.txt pins psutil==5.9.8.
+    # This is a version conflict between TorchServe and ipython's transitive deps.
     allowed_exceptions.append(
-        r"^(tox|pyproject-api) \d+(\.\d+)* requires packaging>=\d+, but you have packaging \d+(\.\d+)* which is incompatible\.$"
+        r"^ipython \d+(\.\d+)* has requirement psutil>=\d+, but you have psutil \d+(\.\d+)*\.$"
+    )
+    allowed_exceptions.append(
+        r"^ipython \d+(\.\d+)* requires psutil>=\d+, but you have psutil \d+(\.\d+)* which is incompatible\.$"
     )
 
     if framework in ["pytorch"]:

--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -678,10 +678,10 @@ def test_pip_check(image):
             rf"tf-models-official 2.9.2 has requirement tensorflow-text~=2.9.0, but you have tensorflow-text 2.10.0."
         )
 
-    # tox and pyproject-api are installed by the OSS compliance tooling (generate_oss_compliance.sh)
+    # tox and pyproject-api are installed as transitive dependencies in the container
     # and require packaging>=25, but packaging may be constrained to an older version by other deps.
     allowed_exceptions.append(
-        r"^(tox|pyproject-api) \d+(\.\d+)* has requirement packaging>=\d+, but you have packaging \d+(\.\d+)* which is incompatible\.$"
+        r"^(tox|pyproject-api) \d+(\.\d+)* requires packaging>=\d+, but you have packaging \d+(\.\d+)* which is incompatible\.$"
     )
 
     if framework in ["pytorch"]:

--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -678,6 +678,12 @@ def test_pip_check(image):
             rf"tf-models-official 2.9.2 has requirement tensorflow-text~=2.9.0, but you have tensorflow-text 2.10.0."
         )
 
+    # tox and pyproject-api are installed by the OSS compliance tooling (generate_oss_compliance.sh)
+    # and require packaging>=25, but packaging may be constrained to an older version by other deps.
+    allowed_exceptions.append(
+        r"^(tox|pyproject-api) \d+(\.\d+)* has requirement packaging>=\d+, but you have packaging \d+(\.\d+)* which is incompatible\.$"
+    )
+
     if framework in ["pytorch"]:
         exception_strings = []
 

--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -679,7 +679,7 @@ def test_pip_check(image):
         )
 
     # tox and pyproject-api are installed as transitive dependencies in the container
-    # and require packaging>=25, but packaging may be constrained to an older version by other deps.
+    # and require packaging>=25, but the container has an older version of packaging.
     allowed_exceptions.append(
         r"^(tox|pyproject-api) \d+(\.\d+)* requires packaging>=\d+, but you have packaging \d+(\.\d+)* which is incompatible\.$"
     )


### PR DESCRIPTION
*GitHub Issue #, if available:*

N/A

### Description

The `test_pip_check` sanity test fails on PyTorch Inference 2.6 images because `ipython 9.13.0` requires `psutil>=7`, but TorchServe's `common.txt` pins `psutil==5.9.8`. This version conflict causes `pip check` to report an incompatibility.

This adds an allowed exception for the ipython/psutil version conflict in `test_pip_check`, following the same pattern used for other known transitive dependency conflicts (e.g., awscli pyyaml, aiobotocore botocore).

Verified by pulling and inspecting the actual beta image:
```
docker run --entrypoint='' 910539337338.dkr.ecr.us-west-2.amazonaws.com/beta-pytorch-inference:2.6.0-cpu-py312-ubuntu22.04-ec2-2026-05-03-06-01-49 pip check
```
Output: `ipython 9.13.0 has requirement psutil>=7, but you have psutil 5.9.8.`

This fix unblocks all 4 PyTorch Inference 2.6 RC building pipelines which are currently failing at the `SANITY_CHECK` stage due to `test_pip_check` failures.

### Tests Run

```
/buildspec pytorch/inference/buildspec-2-6-ec2.yml
/tests sanity security
```

### Formatting
- [x] I have run `black -l 100` on my code

### PR Checklist

- [x] I've prepended PR tag with frameworks/job this applies to : [pytorch]
- [x] (If applicable) I've documented below the DLC image/dockerfile this relates to
- [x] (If applicable) I've documented below the tests I've run on the DLC image

### Pytest Marker Checklist

N/A - no new tests added

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.