### PR TITLE
[pytorch] add tox/pyproject-api allowed exception for arm64 sagemaker images

### DIFF
--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -680,11 +680,18 @@ def test_pip_check(image):
 
     # ipython requires psutil>=7, but TorchServe's common.txt pins psutil==5.9.8.
     # This is a version conflict between TorchServe and ipython's transitive deps.
+    # Note: don't use ^...$ anchors — re.findall without re.MULTILINE won't match non-first lines.
     allowed_exceptions.append(
-        r"^ipython \d+(\.\d+)* has requirement psutil>=\d+, but you have psutil \d+(\.\d+)*\.$"
+        r"ipython \d+(\.\d+)* has requirement psutil>=\d+, but you have psutil \d+(\.\d+)*\."
     )
     allowed_exceptions.append(
-        r"^ipython \d+(\.\d+)* requires psutil>=\d+, but you have psutil \d+(\.\d+)* which is incompatible\.$"
+        r"ipython \d+(\.\d+)* requires psutil>=\d+, but you have psutil \d+(\.\d+)* which is incompatible\."
+    )
+
+    # tox and pyproject-api require packaging>=25, but packaging is pinned to 24.2 in some images
+    # (e.g., arm64 sagemaker). These are transitive deps present in certain image variants.
+    allowed_exceptions.append(
+        r"(tox|pyproject-api) \d+(\.\d+)* requires packaging>=\d+, but you have packaging \d+(\.\d+)* which is incompatible\."
     )
 
     if framework in ["pytorch"]:


### PR DESCRIPTION
### Description

Follow-up to #6046. Two issues found:

1. **Regex anchors bug:** `re.findall` without `re.MULTILINE` flag does not match `^...$` patterns on non-first lines. When `pip check` reports multiple incompatibilities, only the first line would match anchored patterns. Removed `^` and `$` anchors.

2. **Missing tox/pyproject-api exception:** The arm64 sagemaker images have `tox 4.31.0` and `pyproject-api 1.10.0` with `packaging 24.2`, causing additional pip check failures not present in x86 EC2 images.

Verified locally:
```python
>>> output = "ipython 9.13.0 has requirement psutil>=7, but you have psutil 5.9.8.\nninja 1.11.1.1 is not supported on this platform\n"
>>> any([re.findall(exc, output) for exc in allowed_exceptions])
True
```

### Tests Run

```
/buildspec pytorch/inference/buildspec-2-6-ec2.yml
/tests sanity security
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.