### PR TITLE
[Auto-Update] vllm 99.99.99

### DIFF
--- a/.github/config/image/vllm-ec2.yml
+++ b/.github/config/image/vllm-ec2.yml
@@ -8,7 +8,7 @@ image:
 # Build configuration
 common:
   framework: "vllm"
-  framework_version: "99.99.99"
+  framework_version: "0.20.1"
   job_type: "general"
   python_version: "py312"
   cuda_version: "cu130"

--- a/.github/config/image/vllm-ec2.yml
+++ b/.github/config/image/vllm-ec2.yml
@@ -8,7 +8,7 @@ image:
 # Build configuration
 common:
   framework: "vllm"
-  framework_version: "0.20.1"
+  framework_version: "99.99.99"
   job_type: "general"
   python_version: "py312"
   cuda_version: "cu130"

--- a/docker/vllm/Dockerfile
+++ b/docker/vllm/Dockerfile
@@ -38,6 +38,7 @@ RUN uv pip install --system \
   "PyJWT>=2.12.0" \
   "model-hosting-container-standards>=0.1.14,<1.0.0" \
   "pyasn1>=0.6.3" \
+  "aiohttp==3.9.0" \
   && uv cache clean
 
 COPY ./scripts/telemetry/deep_learning_container.py /usr/local/bin/deep_learning_container.py

--- a/docker/vllm/Dockerfile
+++ b/docker/vllm/Dockerfile
@@ -38,7 +38,7 @@ RUN uv pip install --system \
   "PyJWT>=2.12.0" \
   "model-hosting-container-standards>=0.1.14,<1.0.0" \
   "pyasn1>=0.6.3" \
-  "aiohttp==3.9.0" \
+  "aiohttp>=3.12.14" \
   && uv cache clean
 
 COPY ./scripts/telemetry/deep_learning_container.py /usr/local/bin/deep_learning_container.py

--- a/test/security/data/ecr_scan_allowlist/vllm/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/vllm/framework_allowlist.json
@@ -91,5 +91,13 @@
     {
         "vulnerability_id": "CVE-2026-1839",
         "reason": "transformers Trainer._load_rng_state() RCE — only triggered when resuming training from checkpoint. DLC vLLM is inference-only, Trainer is never invoked. Fix requires transformers>=5.0.0rc3 (pre-release)."
+    },
+    {
+        "vulnerability_id": "CVE-2026-39820",
+        "reason": "go/stdlib 1.25.9 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
+    },
+    {
+        "vulnerability_id": "CVE-2026-33811",
+        "reason": "go/stdlib 1.25.9 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
     }
 ]


### PR DESCRIPTION
Test PR to validate the currency fix agent workflow.

Intentionally introduces aiohttp==3.9.0 (known CVE) to trigger security scan failure.

**Expected behavior:**
1. PR CI runs (PR - vLLM EC2) → security scan fails on aiohttp CVE
2. Merge Conditions fails
3. Currency Fix Agent triggers
4. Agent diagnoses CVE failure, removes/upgrades aiohttp, pushes [agent-fix] commit
5. CI re-runs

**Cleanup:** Close this PR and delete branch after testing.