### PR TITLE
fix: install gh CLI in currency fix agent workflow

### DIFF
--- a/.github/workflows/agent-currency-fix.yml
+++ b/.github/workflows/agent-currency-fix.yml
@@ -41,6 +41,18 @@ jobs:
             exit 1
           fi
 
+      - name: Install GitHub CLI
+        run: |
+          if ! command -v gh &> /dev/null; then
+            (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y))
+            sudo mkdir -p -m 755 /etc/apt/keyrings
+            out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+              && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+              && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
+            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+            sudo apt-get update && sudo apt-get install -y gh
+          fi
+
       - name: Find failed tracked workflows
         id: failures
         env:


### PR DESCRIPTION
CodeBuild runners don't have `gh` pre-installed. Adds install step (same pattern as `reusable-release-image.yml`).