### PR TITLE
fix: install dependencies for agent workflow + fix docs-pr gh install

### DIFF
--- a/.github/workflows/agent-currency-fix.yml
+++ b/.github/workflows/agent-currency-fix.yml
@@ -41,7 +41,7 @@ jobs:
             exit 1
           fi
 
-      - name: Install GitHub CLI
+      - name: Install dependencies
         run: |
           if ! command -v gh &> /dev/null; then
             GH_VERSION="2.74.0"
@@ -49,6 +49,7 @@ jobs:
             sudo mv "gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
             rm -rf "gh_${GH_VERSION}_linux_amd64"
           fi
+          pip install boto3 -q
           gh --version
 
       - name: Find failed tracked workflows

--- a/.github/workflows/reusable-release-image.yml
+++ b/.github/workflows/reusable-release-image.yml
@@ -340,14 +340,10 @@ jobs:
       - name: Install GitHub CLI
         run: |
           if ! command -v gh &> /dev/null; then
-            echo "Installing GitHub CLI..."
-            (type -p wget >/dev/null || (sudo apt update && sudo apt-get install wget -y))
-            sudo mkdir -p -m 755 /etc/apt/keyrings
-            out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
-              && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
-              && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg
-            echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-            sudo apt-get update && sudo apt-get install -y gh
+            GH_VERSION="2.74.0"
+            curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" | tar xz
+            sudo mv "gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
+            rm -rf "gh_${GH_VERSION}_linux_amd64"
           fi
           gh --version
 


### PR DESCRIPTION
CodeBuild runners use AL2023 (no apt/dpkg).

**Changes:**
- `agent-currency-fix.yml`: Add 'Install dependencies' step (gh CLI tarball + boto3)
- `reusable-release-image.yml`: Replace apt-based gh CLI install with tarball (same method)
- Fix corrupted heredoc (`<<'EOF'-q` → `<<'EOF'`) in release-image workflow