### PR TITLE
fix: use python3 -m pip to match interpreter

### DIFF
--- a/.github/workflows/agent-currency-fix.yml
+++ b/.github/workflows/agent-currency-fix.yml
@@ -136,7 +136,7 @@ jobs:
             ATTEMPT=$(git log --oneline origin/main..HEAD --grep='\[agent-fix\]' | wc -l)
             gh pr comment "$PR_NUMBER" --body "🤖 **Currency Fix Agent** running (attempt $((ATTEMPT+1))/${MAX_ATTEMPTS}).
 
-          Diagnosing failure: ${RUN_URL}"
+          Agent run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           fi
 
       - name: Download failed run logs
@@ -163,7 +163,7 @@ jobs:
         env:
           AWS_REGION: us-west-2
         run: |
-          pip install boto3 -q
+          python3 -m pip install boto3 -q
           python3 /tmp/agent-fix.py \
             --logs-dir /tmp/ci-logs/ \
             --framework "$FRAMEWORK" \


### PR DESCRIPTION
Two fixes for the currency fix agent workflow:

1. **`python3 -m pip`** — `pip` and `python3` resolve to different Python versions on the CodeBuild runner. Use `python3 -m pip` to ensure boto3 installs for the same interpreter that runs the script.

2. **PR comment link** — Was linking to the Merge Conditions run (the trigger). Now links to the agent's own workflow run so humans can see what the agent is doing.