### PR TITLE
fix: agent waits for tracked workflows before querying failures

### DIFF
--- a/.github/workflows/agent-currency-fix.yml
+++ b/.github/workflows/agent-currency-fix.yml
@@ -51,13 +51,37 @@ jobs:
           fi
           gh --version
 
+      - name: Wait for tracked workflows to complete
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TRACKED="PR - vLLM EC2|PR - vLLM SageMaker|PR - SGLang EC2|PR - SGLang SageMaker"
+          SHA=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}" --jq '.head_sha')
+          echo "HEAD_SHA=$SHA" >> $GITHUB_ENV
+          TIMEOUT=1800
+          ELAPSED=0
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            IN_PROGRESS=$(gh api "/repos/${{ github.repository }}/actions/runs?head_sha=${SHA}&per_page=50" \
+              --jq "[.workflow_runs[] | select(.status != \"completed\" and (.name | test(\"${TRACKED}\")))] | length")
+            if [ "$IN_PROGRESS" = "0" ]; then
+              echo "All tracked workflows completed."
+              break
+            fi
+            echo "⏳ $IN_PROGRESS tracked workflow(s) still running. Waiting 60s... (${ELAPSED}s elapsed)"
+            sleep 60
+            ELAPSED=$((ELAPSED + 60))
+          done
+          if [ $ELAPSED -ge $TIMEOUT ]; then
+            echo "::warning::Timed out waiting for tracked workflows. Proceeding with available results."
+          fi
+
       - name: Find failed tracked workflows
         id: failures
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           TRACKED="PR - vLLM EC2|PR - vLLM SageMaker|PR - SGLang EC2|PR - SGLang SageMaker"
-          SHA=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}" --jq '.head_sha')
+          SHA="${HEAD_SHA}"
 
           FAILED_RUN_IDS=$(gh api "/repos/${{ github.repository }}/actions/runs?head_sha=${SHA}&status=completed&per_page=50" \
             --jq "[.workflow_runs[] | select(.conclusion == \"failure\" and (.name | test(\"${TRACKED}\")))] | .[].id" \


### PR DESCRIPTION
## Summary

The Currency Fix Agent was racing against in-progress PR workflows, causing it to find "no tracked workflows failed" and skip without doing anything.

**Root cause:** Merge Conditions uses a fail-fast strategy — it polls check runs (job-level) and fails the moment *any* check fails. But the agent queries for completed *workflow runs* (workflow-level). A workflow run only reaches `completed` after ALL its jobs finish. So when a security-test job fails at minute 5 but example-test is still running until minute 25, Merge Conditions fires immediately, the agent triggers, queries GitHub, and sees the workflow as still `in_progress`.

This was observed on PR #6058: `security-test/ecr-vulnerability-scan` failed at 21:45 UTC, triggering the agent, but `PR - vLLM EC2` didn't complete until 22:06 (waiting on `upstream-tests/example-test`).

## Design options considered

| Option | Approach | Trade-off |
|--------|----------|-----------|
| **A: Trigger off test workflows directly** | `workflow_run` on `PR - vLLM EC2`, `PR - vLLM SageMaker`, etc. | Guarantees logs are available, but triggers N times if N workflows fail — risks multiple agent runs, duplicate commits, and burning the 3-attempt budget. Concurrency group helps only if runs overlap in time. |
| **B: Query check-runs instead of workflow-runs** | Match Merge Conditions' job-level view | Logs may not be fully downloadable until the parent workflow completes (GitHub packages logs per-workflow, not per-job). Partial log availability makes diagnosis unreliable. |
| **C (chosen): Keep trigger, add wait** | Poll until all tracked workflows complete, then query | Burns runner time waiting (up to 30 min), but: single trigger, single agent run, all failures visible, all logs downloadable. Runner cost is negligible vs. the alternative complexity. |

**Why Option C:** Merge Conditions already fires exactly once per CI cycle — no deduplication needed. The agent just needs to wait for the dust to settle before inspecting results. This is the minimal change that fixes the race without restructuring the trigger model.

## Changes

- Added a "Wait for tracked workflows to complete" step that polls every 60s (30 min timeout) before the failure query
- Extracted `HEAD_SHA` into `GITHUB_ENV` so both the wait step and query step use the same SHA without redundant API calls

## Test plan

- [ ] Rerun on PR #6058 (or similar test PR) — agent should wait for `PR - vLLM EC2` to finish before querying
- [ ] Verify agent finds all failed workflow runs after waiting
- [ ] Verify timeout warning is logged if workflows take >30 min (edge case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)