### PR TITLE
ray dlc test: tighten privacy-filter test to validate label & text pairs

### DIFF
--- a/test/ray/sagemaker/common.py
+++ b/test/ray/sagemaker/common.py
@@ -286,13 +286,13 @@ def run_test_audio_ffmpeg(endpoint):
 
 
 def run_test_privacy_filter(endpoint):
-    """OpenAI Privacy Filter — 5 samples, validate PII entity detection."""
-    for text, expected_entities in PRIVACY_FILTER_SAMPLES:
+    """OpenAI Privacy Filter — 6 samples, validate PII entity detection and redaction."""
+    for text, expected_label_to_texts in PRIVACY_FILTER_SAMPLES:
         response = _invoke(endpoint, {"text": text})
         result = _parse_response(response)
         LOGGER.info(f"privacy-filter response for '{text[:40]}...': {pformat(result)}")
 
-        err = validate_privacy_filter_response(result, expected_entities)
+        err = validate_privacy_filter_response(result, expected_label_to_texts)
         assert not err, f"privacy-filter '{text[:40]}...': {err}"
 
         entities = (

--- a/test/ray/utils.py
+++ b/test/ray/utils.py
@@ -52,31 +52,48 @@ SENTIMENT_SAMPLES = [
     ("Absolutely perfect, highly recommend!", "POSITIVE"),
 ]
 
-# Privacy filter samples: (text, expected_entity_groups)
+# Privacy filter samples: (text, expected_label_to_texts)
+# Each expected entity is mapped to substrings that should appear in detected span text.
 PRIVACY_FILTER_SAMPLES = [
     (
         "My name is Alice Smith and my email is alice@example.com",
-        {"private_person", "private_email"},
+        {
+            "private_person": ["Alice Smith"],
+            "private_email": ["alice@example.com"],
+        },
     ),
     (
         "Call John at 555-123-4567 or visit 123 Main Street, Springfield IL",
-        {"private_person", "private_phone", "private_address"},
+        {
+            "private_person": ["John"],
+            "private_phone": ["555-123-4567"],
+            "private_address": ["123 Main Street, Springfield IL"],
+        },
     ),
     (
         "My name is Harry Potter and my email is harry.potter@hogwarts.edu.",
-        {"private_person", "private_email"},
+        {
+            "private_person": ["Harry Potter"],
+            "private_email": ["harry.potter@hogwarts.edu"],
+        },
     ),
     (
         "Her birthday is March 15, 1990 and her profile is at https://example.com/users/jdoe",
-        {"private_date", "private_url"},
+        {
+            "private_date": ["March 15, 1990"],
+            "private_url": ["https://example.com/users/jdoe"],
+        },
     ),
     (
         "Account number 1111-2222-3333-4444 belongs to Jane Doe",
-        {"account_number", "private_person"},
+        {
+            "account_number": ["1111-2222-3333-4444"],
+            "private_person": ["Jane Doe"],
+        },
     ),
     (
         "The weather is sunny today and I went hiking",
-        set(),
+        {},
     ),
 ]
 
@@ -344,8 +361,12 @@ def validate_audio_response(result, check_ffmpeg_backend=False):
     return ""
 
 
-def validate_privacy_filter_response(result, expected_entities):
-    """Validate privacy filter response — RedactionResult dict from inference handler."""
+def validate_privacy_filter_response(result, expected_label_to_texts):
+    """Validate privacy filter response — RedactionResult dict from inference handler.
+
+    Asserts each expected (label, text) pair appears in detected_spans, and that
+    expected PII strings are absent from redacted_text.
+    """
     if "predictions" not in result:
         return "Missing 'predictions' field"
     predictions = result["predictions"]
@@ -357,12 +378,21 @@ def validate_privacy_filter_response(result, expected_entities):
     spans = redaction["detected_spans"]
     if not isinstance(spans, list):
         return "detected_spans is not a list"
-    if not expected_entities:
+    if not expected_label_to_texts:
         if spans:
             return f"False positive PII on clean text: {spans}"
         return ""
-    found_labels = {s["label"] for s in spans if "label" in s}
-    if not expected_entities.issubset(found_labels):
-        missing = expected_entities - found_labels
-        return f"Missing expected entities: {missing}, found: {found_labels}"
+    detected = [(s["label"], s["text"]) for s in spans if "label" in s and "text" in s]
+    for label, expected_texts in expected_label_to_texts.items():
+        for expected_text in expected_texts:
+            if not any(
+                d_label == label and expected_text.strip() in d_text.strip()
+                for d_label, d_text in detected
+            ):
+                return f"Missing detection — expected {label}={expected_text!r}, got {detected}"
+    redacted_text = redaction.get("redacted_text", "")
+    for expected_texts in expected_label_to_texts.values():
+        for pii in expected_texts:
+            if pii in redacted_text:
+                return f"PII leak in redacted_text: {pii!r} still present"
     return ""


### PR DESCRIPTION
## Purpose

Improve privacy-filter test for Ray:
- validate `(label, text)` pairs in `PRIVACY_FILTER_SAMPLES` instead of just label sets, catches mis-aligned spans that the old subset check missed
- assert PII strings are absent from `redacted_text`

## Test Plan
- privacy-filter test and all existing tests pass on the current Ray image

## Test Result
- All tests passed: [807b35a](https://github.com/aws/deep-learning-containers/pull/6078/commits/807b35aee8e5668f606c7ffc23e26fac6935ee59)

______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
