### PR TITLE
Patch `diffusers` in Hugging Face PyTorch DLCs

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -1,6 +1,6 @@
 [dev]
 # Set to "huggingface", for example, if you are a huggingface developer. Default is ""
-partner_developer = ""
+partner_developer = "huggingface"
 # Please only set it to true if you are preparing an EI related PR
 # Do remember to revert it back to false before merging any PR (including EI dedicated PR)
 ei_mode = false
@@ -37,7 +37,7 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_sglang", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["huggingface_pytorch"]
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -1,6 +1,6 @@
 [dev]
 # Set to "huggingface", for example, if you are a huggingface developer. Default is ""
-partner_developer = "huggingface"
+partner_developer = ""
 # Please only set it to true if you are preparing an EI related PR
 # Do remember to revert it back to false before merging any PR (including EI dedicated PR)
 ei_mode = false
@@ -37,7 +37,7 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_sglang", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["huggingface_pytorch"]
+build_frameworks = []
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.

--- a/huggingface/pytorch/inference/docker/2.6/py3/Dockerfile.cpu
+++ b/huggingface/pytorch/inference/docker/2.6/py3/Dockerfile.cpu
@@ -21,7 +21,7 @@ ARG TORCHDATA_URL=https://framework-binaries.s3.us-west-2.amazonaws.com/pytorch/
 # HF ARGS
 ARG TRANSFORMERS_VERSION=5.5.3
 ARG HUGGINGFACE_HUB_VERSION=1.10.0
-ARG DIFFUSERS_VERSION=0.37.1
+ARG DIFFUSERS_VERSION=0.38.0
 ARG PEFT_VERSION=0.18.1
 ARG ACCELERATE_VERSION=1.12.0
 # Install the latest version of the sagemaker-huggingface-inference-toolkit from the git repository
@@ -50,8 +50,8 @@ ENV MKL_THREADING_LAYER=GNU
 ENV DLC_CONTAINER_TYPE=inference
 
 RUN apt-get update \
- && apt-get -y upgrade \
- && apt-get install -y --no-install-recommends \
+    && apt-get -y upgrade \
+    && apt-get install -y --no-install-recommends \
     automake \
     build-essential \
     ca-certificates \
@@ -85,19 +85,19 @@ RUN apt-get update \
     libpng-dev \
     libffi-dev \
     ffmpeg \
- && apt-get autoremove -y \
- && rm -rf /var/lib/apt/lists/* \
- && apt-get clean
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
 
 # Install OpenMPI
 RUN wget https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OPEN_MPI_VERSION}.tar.gz \
- && gunzip -c openmpi-$OPEN_MPI_VERSION.tar.gz | tar xf - \
- && cd openmpi-$OPEN_MPI_VERSION \
- && ./configure --prefix=/home/.openmpi \
- && make all install \
- && cd .. \
- && rm openmpi-$OPEN_MPI_VERSION.tar.gz \
- && rm -rf openmpi-$OPEN_MPI_VERSION
+    && gunzip -c openmpi-$OPEN_MPI_VERSION.tar.gz | tar xf - \
+    && cd openmpi-$OPEN_MPI_VERSION \
+    && ./configure --prefix=/home/.openmpi \
+    && make all install \
+    && cd .. \
+    && rm openmpi-$OPEN_MPI_VERSION.tar.gz \
+    && rm -rf openmpi-$OPEN_MPI_VERSION
 
 # The ENV variables declared below are changed in the previous section
 # Grouping these ENV variables in the first section causes
@@ -108,10 +108,10 @@ RUN ompi_info --parsable --all | grep mpi_built_with_cuda_support:value
 
 # Install CondaForge miniconda
 RUN curl -L -o ~/miniforge3.sh https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE3_VERSION}/Miniforge3-${MINIFORGE3_VERSION}-Linux-x86_64.sh \
- && chmod +x ~/miniforge3.sh \
- && ~/miniforge3.sh -b -p /opt/conda \
- && rm ~/miniforge3.sh \
- && /opt/conda/bin/conda install -c conda-forge \
+    && chmod +x ~/miniforge3.sh \
+    && ~/miniforge3.sh -b -p /opt/conda \
+    && rm ~/miniforge3.sh \
+    && /opt/conda/bin/conda install -c conda-forge \
     python=${PYTHON_VERSION} \
     cython \
     "mkl<2024.1.0" \
@@ -133,12 +133,12 @@ RUN curl -L -o ~/miniforge3.sh https://github.com/conda-forge/miniforge/releases
     "idna>=3.7" \
     "tqdm>=4.66.3" \
     "zstandard>=0.22.0" \
- && /opt/conda/bin/conda clean -afy \
- && rm -rf /etc/apt/sources.list.d/*
+    && /opt/conda/bin/conda clean -afy \
+    && rm -rf /etc/apt/sources.list.d/*
 
 # symlink pip for OS use
 RUN pip install --upgrade pip --trusted-host pypi.org --trusted-host files.pythonhosted.org \
- && ln -s /opt/conda/bin/pip /usr/local/bin/pip3
+    && ln -s /opt/conda/bin/pip /usr/local/bin/pip3
 
 # Install Common python packages
 RUN pip install --no-cache-dir --extra-index-url https://download.pytorch.org/whl/cpu -U \
@@ -185,8 +185,8 @@ RUN mkdir -p /etc/pki/tls/certs && cp /etc/ssl/certs/ca-certificates.crt /etc/pk
 
 # create user and folders
 RUN useradd -m model-server \
- && mkdir -p /home/model-server/tmp /opt/ml/model \
- && chown -R model-server /home/model-server /opt/ml/model
+    && mkdir -p /home/model-server/tmp /opt/ml/model \
+    && chown -R model-server /home/model-server /opt/ml/model
 
 # add MMS entrypoint
 COPY mms-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
@@ -244,13 +244,13 @@ ENV HF_HUB_USER_AGENT_ORIGIN="aws:sagemaker:cpu:inference:regular"
 #     "pyyaml>=5.4"
 
 RUN HOME_DIR=/root \
- && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
- && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
- && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
- && chmod +x /usr/local/bin/testOSSCompliance \
- && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
- && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
- && rm -rf ${HOME_DIR}/oss_compliance*
+    && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
+    && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
+    && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
+    && chmod +x /usr/local/bin/testOSSCompliance \
+    && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
+    && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
+    && rm -rf ${HOME_DIR}/oss_compliance*
 
 RUN curl -o /license.txt  https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.6/license.txt
 
@@ -274,42 +274,42 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libvpx-dev \
     libx264-dev \
     libx265-dev \
- && git clone https://git.ffmpeg.org/ffmpeg.git /tmp/ffmpeg \
- && cd /tmp/ffmpeg \
- && git checkout "${FFMPEG_TAG}" \
- && ./configure \
-      --prefix=/usr/local \
-      --disable-debug \
-      --disable-doc \
-      --enable-gpl \
-      --enable-libmp3lame \
-      --enable-libopus \
-      --enable-libvorbis \
-      --enable-libvpx \
-      --enable-libx264 \
-      --enable-libx265 \
- && make -j"$(nproc)" \
- && make install \
- && which ffmpeg \
- && ffmpeg -version \
- && ffprobe -version \
- && rm -rf /tmp/ffmpeg \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+    && git clone https://git.ffmpeg.org/ffmpeg.git /tmp/ffmpeg \
+    && cd /tmp/ffmpeg \
+    && git checkout "${FFMPEG_TAG}" \
+    && ./configure \
+    --prefix=/usr/local \
+    --disable-debug \
+    --disable-doc \
+    --enable-gpl \
+    --enable-libmp3lame \
+    --enable-libopus \
+    --enable-libvorbis \
+    --enable-libvpx \
+    --enable-libx264 \
+    --enable-libx265 \
+    && make -j"$(nproc)" \
+    && make install \
+    && which ffmpeg \
+    && ffmpeg -version \
+    && ffprobe -version \
+    && rm -rf /tmp/ffmpeg \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Fix CVE-2024-53920 and CVE-2025-1244: emacs is not essential for core functionality and has known
 # vulnerabilities, so we remove it
 RUN apt-get remove -y --purge emacs emacs-common \
- && apt-get autoremove -y \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ## Cleanup ##
 RUN pip cache purge \
- && rm -rf /tmp/tmp* \
- && rm -iRf /root/.cache \
- && rm -rf /opt/llvm-project \
- && rm -rf opt/intel-extension-for-pytorch
+    && rm -rf /tmp/tmp* \
+    && rm -iRf /root/.cache \
+    && rm -rf /opt/llvm-project \
+    && rm -rf opt/intel-extension-for-pytorch
 
 EXPOSE 8080 8081
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]

--- a/huggingface/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.gpu
+++ b/huggingface/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.gpu
@@ -26,7 +26,7 @@ ARG TORCHDATA_URL=https://framework-binaries.s3.us-west-2.amazonaws.com/pytorch/
 # HF ARGS
 ARG TRANSFORMERS_VERSION=5.5.3
 ARG HUGGINGFACE_HUB_VERSION=1.10.0
-ARG DIFFUSERS_VERSION=0.37.1
+ARG DIFFUSERS_VERSION=0.38.0
 ARG PEFT_VERSION=0.18.1
 ARG ACCELERATE_VERSION=1.12.0
 # Install the latest version of the sagemaker-huggingface-inference-toolkit from the git repository
@@ -70,8 +70,8 @@ ENV DLC_CONTAINER_TYPE=inference
 WORKDIR /
 
 RUN apt-get update \
- && apt-get -y upgrade \
- && apt-get install -y --allow-change-held-packages --no-install-recommends \
+    && apt-get -y upgrade \
+    && apt-get install -y --allow-change-held-packages --no-install-recommends \
     automake \
     build-essential \
     ca-certificates \
@@ -124,28 +124,28 @@ RUN apt-get update \
     ffmpeg \
     libxml2 \
     linux-libc-dev \
- && apt-get autoremove -y \
- && rm -rf /var/lib/apt/lists/* \
- && apt-get clean
+    && apt-get autoremove -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
 
 # Install NCCL
 RUN cd /tmp \
- && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION}-1 \
- && cd nccl \
- && make -j64 src.build BUILDDIR=/usr/local \
- && rm -rf /tmp/nccl
+    && git clone https://github.com/NVIDIA/nccl.git -b v${NCCL_VERSION}-1 \
+    && cd nccl \
+    && make -j64 src.build BUILDDIR=/usr/local \
+    && rm -rf /tmp/nccl
 # preload system nccl for PyTorch to use if it is dynamically linking NCCL
 ENV LD_PRELOAD="/usr/local/lib/libnccl.so"
 
 # Install OpenMPI
 RUN wget --quiet https://download.open-mpi.org/release/open-mpi/v4.1/openmpi-${OPEN_MPI_VERSION}.tar.gz \
- && gunzip -c openmpi-${OPEN_MPI_VERSION}.tar.gz | tar xf - \
- && cd openmpi-${OPEN_MPI_VERSION} \
- && ./configure --prefix=/home/.openmpi --with-cuda \
- && make all install \
- && cd .. \
- && rm openmpi-${OPEN_MPI_VERSION}.tar.gz \
- && rm -rf openmpi-${OPEN_MPI_VERSION}
+    && gunzip -c openmpi-${OPEN_MPI_VERSION}.tar.gz | tar xf - \
+    && cd openmpi-${OPEN_MPI_VERSION} \
+    && ./configure --prefix=/home/.openmpi --with-cuda \
+    && make all install \
+    && cd .. \
+    && rm openmpi-${OPEN_MPI_VERSION}.tar.gz \
+    && rm -rf openmpi-${OPEN_MPI_VERSION}
 
 # The ENV variables declared below are changed in the previous section
 # Grouping these ENV variables in the first section causes
@@ -156,9 +156,9 @@ RUN ompi_info --parsable --all | grep mpi_built_with_cuda_support:value
 
 # Install CondaForge miniconda
 RUN curl -L -o ~/miniforge3.sh https://github.com/conda-forge/miniforge/releases/download/${MINIFORGE3_VERSION}/Miniforge3-${MINIFORGE3_VERSION}-Linux-x86_64.sh \
- && chmod +x ~/miniforge3.sh \
- && ~/miniforge3.sh -b -p /opt/conda \
- && rm ~/miniforge3.sh
+    && chmod +x ~/miniforge3.sh \
+    && ~/miniforge3.sh -b -p /opt/conda \
+    && rm ~/miniforge3.sh
 
 # Install common conda packages
 RUN /opt/conda/bin/conda install -y -c conda-forge \
@@ -184,15 +184,15 @@ RUN /opt/conda/bin/conda install -y -c conda-forge \
     "idna>=3.7"\
     "tqdm>=4.66.3" \
     "zstandard>=0.22.0" \
- && /opt/conda/bin/conda clean -afy \
- && rm -rf /etc/apt/sources.list.d/* \
- && rm -rf /opt/conda/lib/python3.12/site-packages/setuptools/_vendor/jaraco.context-*.dist-info \
- # Fix CVE-2026-24049
- && rm -rf /opt/conda/lib/python3.12/site-packages/setuptools/_vendor/wheel-0.43.0.dist-info/METADATA
+    && /opt/conda/bin/conda clean -afy \
+    && rm -rf /etc/apt/sources.list.d/* \
+    && rm -rf /opt/conda/lib/python3.12/site-packages/setuptools/_vendor/jaraco.context-*.dist-info \
+    # Fix CVE-2026-24049
+    && rm -rf /opt/conda/lib/python3.12/site-packages/setuptools/_vendor/wheel-0.43.0.dist-info/METADATA
 
 # symlink pip for OS use
 RUN pip install --upgrade pip --no-cache-dir --trusted-host pypi.org --trusted-host files.pythonhosted.org \
- && ln -s /opt/conda/bin/pip /usr/local/bin/pip3
+    && ln -s /opt/conda/bin/pip /usr/local/bin/pip3
 
 # Install Common python packages
 RUN pip install --no-cache-dir -U \
@@ -213,7 +213,7 @@ RUN pip install --no-cache-dir -U \
     "prompt-toolkit<3.0.39" \
     # Fix jaraco.context vulnerability 
     "setuptools>=81.0.0" \
-&& rm -rf /opt/conda/lib/python3.12/site-packages/setuptools/_vendor/jaraco.context-*.dist-info
+    && rm -rf /opt/conda/lib/python3.12/site-packages/setuptools/_vendor/jaraco.context-*.dist-info
 
 # Ensure PyTorch did not get installed from Conda or pip, prior to now
 # Any Nvidia installs for the DLC will be below, removing nvidia and cuda packages from pip here
@@ -244,8 +244,8 @@ RUN pip install --no-cache-dir \
 
 # create user and folders
 RUN useradd -m model-server \
- && mkdir -p /home/model-server/tmp /opt/ml/model \
- && chown -R model-server /home/model-server /opt/ml/model
+    && mkdir -p /home/model-server/tmp /opt/ml/model \
+    && chown -R model-server /home/model-server /opt/ml/model
 
 # add MMS entrypoint
 COPY mms-entrypoint.py /usr/local/bin/dockerd-entrypoint.py
@@ -270,7 +270,7 @@ RUN pip install --no-cache-dir --no-build-isolation kenlm
 # install Hugging Face libraries and its dependencies
 RUN pip install --no-cache-dir \
     huggingface_hub==${HUGGINGFACE_HUB_VERSION} \
-	transformers[sentencepiece,audio,vision]==${TRANSFORMERS_VERSION} \
+    transformers[sentencepiece,audio,vision]==${TRANSFORMERS_VERSION} \
     diffusers==${DIFFUSERS_VERSION} \
     peft==${PEFT_VERSION} \
     accelerate==${ACCELERATE_VERSION} \
@@ -286,13 +286,13 @@ RUN pip install --no-cache-dir -U "wheel>=0.46.2" "protobuf>=5.29.6"
 ENV HF_HUB_USER_AGENT_ORIGIN="aws:sagemaker:gpu-cuda:inference:regular"
 
 RUN HOME_DIR=/root \
- && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
- && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
- && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
- && chmod +x /usr/local/bin/testOSSCompliance \
- && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
- && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
- && rm -rf ${HOME_DIR}/oss_compliance*
+    && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
+    && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
+    && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
+    && chmod +x /usr/local/bin/testOSSCompliance \
+    && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
+    && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
+    && rm -rf ${HOME_DIR}/oss_compliance*
 
 RUN curl -o /license.txt  https://aws-dlc-licenses.s3.amazonaws.com/pytorch-2.6/license.txt
 
@@ -316,40 +316,40 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libvpx-dev \
     libx264-dev \
     libx265-dev \
- && git clone https://git.ffmpeg.org/ffmpeg.git /tmp/ffmpeg \
- && cd /tmp/ffmpeg \
- && git checkout "${FFMPEG_TAG}" \
- && ./configure \
-      --prefix=/usr/local \
-      --disable-debug \
-      --disable-doc \
-      --enable-gpl \
-      --enable-libmp3lame \
-      --enable-libopus \
-      --enable-libvorbis \
-      --enable-libvpx \
-      --enable-libx264 \
-      --enable-libx265 \
- && make -j"$(nproc)" \
- && make install \
- && which ffmpeg \
- && ffmpeg -version \
- && ffprobe -version \
- && rm -rf /tmp/ffmpeg \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+    && git clone https://git.ffmpeg.org/ffmpeg.git /tmp/ffmpeg \
+    && cd /tmp/ffmpeg \
+    && git checkout "${FFMPEG_TAG}" \
+    && ./configure \
+    --prefix=/usr/local \
+    --disable-debug \
+    --disable-doc \
+    --enable-gpl \
+    --enable-libmp3lame \
+    --enable-libopus \
+    --enable-libvorbis \
+    --enable-libvpx \
+    --enable-libx264 \
+    --enable-libx265 \
+    && make -j"$(nproc)" \
+    && make install \
+    && which ffmpeg \
+    && ffmpeg -version \
+    && ffprobe -version \
+    && rm -rf /tmp/ffmpeg \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Fix CVE-2024-53920 and CVE-2025-1244: emacs is not essential for core functionality and has known
 # vulnerabilities, so we remove it
 RUN apt-get remove -y --purge emacs emacs-common \
- && apt-get autoremove -y \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 ## Cleanup ##
 RUN pip cache purge \
- && rm -rf /tmp/tmp* \
- && rm -iRf /root/.cache
+    && rm -rf /tmp/tmp* \
+    && rm -iRf /root/.cache
 
 EXPOSE 8080 8081
 ENTRYPOINT ["python", "/usr/local/bin/dockerd-entrypoint.py"]

--- a/huggingface/pytorch/training/docker/2.9/py3/cu130/Dockerfile.gpu
+++ b/huggingface/pytorch/training/docker/2.9/py3/cu130/Dockerfile.gpu
@@ -11,7 +11,7 @@ LABEL dlc_major_version="1"
 ARG TRANSFORMERS_VERSION=5.3.0
 ARG DATASETS_VERSION=4.5.0
 ARG HUGGINGFACE_HUB_VERSION=1.10.0
-ARG DIFFUSERS_VERSION=0.37.0
+ARG DIFFUSERS_VERSION=0.38.0
 ARG EVALUATE_VERSION=0.4.6
 ARG ACCELERATE_VERSION=1.12.0
 ARG TRL_VERSION=0.28.0
@@ -45,10 +45,10 @@ RUN pip install --no-cache-dir \
 
 # Override conflicting versions to satisfy datasets requirements
 RUN pip install --no-cache-dir dill==0.3.8 multiprocess==0.70.16 \
- && pip install --no-cache-dir pathos==0.3.3 --no-deps \
- && PATHOS_META=$(find /usr/local/lib -type f -path "*pathos-0.3.3.dist-info/METADATA") \
- && sed -i 's/dill.*/dill/' $PATHOS_META \
- && sed -i 's/multiprocess.*/multiprocess/' $PATHOS_META
+    && pip install --no-cache-dir pathos==0.3.3 --no-deps \
+    && PATHOS_META=$(find /usr/local/lib -type f -path "*pathos-0.3.3.dist-info/METADATA") \
+    && sed -i 's/dill.*/dill/' $PATHOS_META \
+    && sed -i 's/multiprocess.*/multiprocess/' $PATHOS_META
 
 # Fix CVE-77744: Upgrade urllib3 to version 2.5.0 or higher
 # Remove sigopt to avoid dependency conflict (it's not essential for core functionality)
@@ -56,9 +56,9 @@ RUN pip install --no-cache-dir dill==0.3.8 multiprocess==0.70.16 \
 # Fix CVE-2026-25990 - Pillow>12.1.1 has the fix for this vulnerability
 # CVE patch
 RUN pip install --upgrade pip \
- && pip uninstall -y sigopt || true \
- && pip uninstall -y ray pyctcdecode \
- && pip install --no-cache-dir -U \
+    && pip uninstall -y sigopt || true \
+    && pip uninstall -y ray pyctcdecode \
+    && pip install --no-cache-dir -U \
     pyarrow \
     cryptography \
     pyopenssl \
@@ -87,7 +87,7 @@ RUN pip install --no-cache-dir \
 ENV HF_HUB_USER_AGENT_ORIGIN="aws:sagemaker:gpu-cuda:training"
 
 RUN apt-get update \
- && apt-get install -y --allow-change-held-packages --no-install-recommends \
+    && apt-get install -y --allow-change-held-packages --no-install-recommends \
     libgl1-mesa-glx \
     build-essential \
     ca-certificates \
@@ -103,29 +103,29 @@ RUN apt-get update \
     vim \
     wget \
     libcrypt1 \
-&& rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/*
 
 COPY cuda-compatibility-lib.sh /usr/local/bin/cuda-compatibility-lib.sh
 RUN chmod +x /usr/local/bin/cuda-compatibility-lib.sh
 
 RUN apt-get update \
- && apt-get upgrade -y \
- && apt-get autoremove -y \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+    && apt-get upgrade -y \
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 # Fix CVE-2024-53920 and CVE-2025-1244: emacs is not essential for core functionality and has known
 # vulnerabilities, so we remove it
 RUN apt-get remove -y --purge emacs emacs-common \
- && apt-get autoremove -y \
- && apt-get clean \
- && rm -rf /var/lib/apt/lists/*
+    && apt-get autoremove -y \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
 
 RUN HOME_DIR=/root \
- && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
- && unzip -o ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
- && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
- && chmod +x /usr/local/bin/testOSSCompliance \
- && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
- && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
- && rm -rf ${HOME_DIR}/oss_compliance*
+    && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
+    && unzip -o ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
+    && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
+    && chmod +x /usr/local/bin/testOSSCompliance \
+    && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
+    && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} ${PYTHON} \
+    && rm -rf ${HOME_DIR}/oss_compliance*


### PR DESCRIPTION
## Purpose

This PR patches the `diffusers` version that's installed in the latest Hugging Face PyTorch DLCs as there was a vulnerability on a way to bypass the `trust_remote_code` flag which was allowing malicious actors to inject custom code without previous authorization from the user, as per https://github.com/huggingface/diffusers/security/advisories/GHSA-j7w6-vpvq-j3gm.
The vulnerability was promptly fixed and a patched version was released at https://github.com/huggingface/diffusers/releases/tag/v0.38.0.

## Test Plan

## Test Result

______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
