### PR TITLE
Fix XGBoost config environment value

### DIFF
--- a/.github/config/image/sagemaker-xgboost.yml
+++ b/.github/config/image/sagemaker-xgboost.yml
@@ -27,4 +27,4 @@ release:
   public_registry: false
   private_registry: true
   enable_soci: false
-  environment: prod
+  environment: production


### PR DESCRIPTION
## Summary
- Change `environment: prod` to `environment: production` in sagemaker-xgboost config
- `prod` is not a valid value — the release workflow expects `gamma`, `preprod`, or `production`

## Test plan
- [ ] PR checks pass