### PR TITLE
test(vllm-ec2): trigger autorelease on PR to validate gamma public gallery

### DIFF
--- a/.github/workflows/autorelease-vllm-ec2.yml
+++ b/.github/workflows/autorelease-vllm-ec2.yml
@@ -10,6 +10,11 @@ on:
   push:
     branches: [main]
 
+  # TEMPORARY: trigger on PRs to validate gamma public-gallery flow.
+  # MUST BE REVERTED before this PR is merged.
+  pull_request:
+    branches: [main]
+
   # Manual trigger
   workflow_dispatch:
 

--- a/.github/workflows/autorelease-vllm-ec2.yml
+++ b/.github/workflows/autorelease-vllm-ec2.yml
@@ -192,7 +192,7 @@ jobs:
     with:
       source-image-uri: ${{ needs.build-image.outputs.ci-image }}
       release-spec: ${{ needs.generate-release-spec.outputs.release-spec }}
-      environment: ${{ fromJson(needs.load-config.outputs.config).release.environment }}
+      environment: ${{ github.event_name == 'pull_request' && 'gamma' || fromJson(needs.load-config.outputs.config).release.environment }}
       aws-region: ${{ vars.AWS_REGION }}
       runner-fleet: default-runner
     secrets: inherit


### PR DESCRIPTION
## Summary

Temporary change to validate the new **gamma public ECR gallery** end-to-end after `DLContainersInfraCDK` CR-274409049 and `DLContainersReleaseLogicPython` CR-274540509 landed:

- Account: `097083928086`
- Role: `dlc-gamma-public-registry-role`
- Default registry alias: `c2i7f2p2` (verified alias `deep-learning-containers-gamma` is pending)

Adds a `pull_request: branches: [main]` trigger to `.github/workflows/autorelease-vllm-ec2.yml` so this PR fires the auto-release workflow once and we can confirm the new gamma role is assumed correctly and images publish to `public.ecr.aws/c2i7f2p2/vllm/...`.

## Test plan

- [ ] PR opened → `Auto Release - vLLM EC2` workflow fires on `pull_request`
- [ ] STS assume of `arn:aws:iam::097083928086:role/dlc-gamma-public-registry-role` succeeds
- [ ] Image push to `public.ecr.aws/c2i7f2p2/vllm` succeeds
- [ ] Verify image appears in ECR Public console under account `097083928086`

## ⚠️ DO NOT MERGE

The trigger change must be reverted before merge — leaving `pull_request` enabled would fire auto-release on every future PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)