### PR TITLE
test(vllm-omni): verify SageMaker InvokeEndpoint accepts multipart ContentType

### DIFF
--- a/docker/vllm_omni/versions.env
+++ b/docker/vllm_omni/versions.env
@@ -36,7 +36,7 @@ export EFA_VERSION="1.47.0"
 
 # ── DLC image versioning ───────────────────────────────────────
 export DLC_MAJOR_VERSION="1"
-export DLC_MINOR_VERSION="1"
+export DLC_MINOR_VERSION="2"
 
 # ── Build configuration ────────────────────────────────────────
 # Aligned with upstream vllm v0.20.0 Dockerfile.

--- a/examples/vllm-omni/sagemaker/deploy_video_sync.py
+++ b/examples/vllm-omni/sagemaker/deploy_video_sync.py
@@ -10,21 +10,22 @@ deposits the response body verbatim at the configured S3 output path, so the
 
 Available since vLLM-Omni 0.20.0; supersedes the 0.18.0 limitation that
 SageMaker async inference could only retrieve the job-ID JSON, not the MP4.
-The routing middleware (`CustomAttributes="route=/v1/videos/sync"`) auto-
-converts the JSON request body to multipart/form-data for the underlying
-endpoint; values must therefore be JSON strings.
+/v1/videos/sync expects multipart/form-data input; SageMaker InvokeEndpoint
+forwards the request body and ContentType through to the model server
+unchanged, so the client builds the multipart body locally and uploads it
+with ContentType="multipart/form-data; boundary=...".
 
 Validated 2026-05-11 on ml.g5.2xlarge (A10G 24 GB VRAM, 32 GB host RAM):
 45 KB MP4 returned in ~10s after warmup.
 """
 
 import time
+import uuid
 
 import boto3
 from sagemaker.async_inference import AsyncInferenceConfig
 from sagemaker.model import Model
 from sagemaker.predictor import Predictor
-from sagemaker.serializers import JSONSerializer
 
 BUCKET = "<BUCKET>"  # replace with an S3 bucket your role can read/write
 ROLE_ARN = "arn:aws:iam::<ACCOUNT>:role/SageMakerExecutionRole"
@@ -42,7 +43,6 @@ predictor = model.deploy(
     initial_instance_count=1,
     endpoint_name=ENDPOINT_NAME,
     inference_ami_version="al2-ami-sagemaker-inference-gpu-3-1",
-    serializer=JSONSerializer(),
     async_inference_config=AsyncInferenceConfig(
         output_path=f"s3://{BUCKET}/vllm-omni-async-output/",
         max_concurrent_invocations_per_instance=1,
@@ -50,26 +50,43 @@ predictor = model.deploy(
     wait=True,
 )
 
-# Upload the input payload to S3, then call invoke_endpoint_async with
-# CustomAttributes routing to /v1/videos/sync. Values are strings because
-# the middleware converts JSON to multipart/form-data.
+
+def build_multipart_body(fields: dict, boundary: str) -> bytes:
+    parts = [
+        f'--{boundary}\r\nContent-Disposition: form-data; name="{k}"\r\n\r\n{v}\r\n'
+        for k, v in fields.items()
+    ]
+    parts.append(f"--{boundary}--\r\n")
+    return "".join(parts).encode()
+
+
+# Build a multipart/form-data body locally; upload to S3, then invoke async.
+boundary = uuid.uuid4().hex
+content_type = f"multipart/form-data; boundary={boundary}"
+body = build_multipart_body(
+    {
+        "prompt": "a dog running on a beach",
+        "num_frames": "17",
+        "num_inference_steps": "4",
+        "size": "480x320",
+        "seed": "42",
+    },
+    boundary,
+)
+
 s3 = boto3.client("s3")
 s3.put_object(
     Bucket=BUCKET,
-    Key="vllm-omni-async-input/request.json",
-    Body=(
-        '{"prompt": "a dog running on a beach", '
-        '"num_frames": "17", "num_inference_steps": "4", '
-        '"size": "480x320", "seed": "42"}'
-    ),
-    ContentType="application/json",
+    Key="vllm-omni-async-input/request.bin",
+    Body=body,
+    ContentType=content_type,
 )
 
 runtime = boto3.client("sagemaker-runtime")
 result = runtime.invoke_endpoint_async(
     EndpointName=ENDPOINT_NAME,
-    InputLocation=f"s3://{BUCKET}/vllm-omni-async-input/request.json",
-    ContentType="application/json",
+    InputLocation=f"s3://{BUCKET}/vllm-omni-async-input/request.bin",
+    ContentType=content_type,
     CustomAttributes="route=/v1/videos/sync",
 )
 output_location = result["OutputLocation"]  # s3://.../<id>.out

--- a/scripts/vllm/omni_sagemaker_serve.py
+++ b/scripts/vllm/omni_sagemaker_serve.py
@@ -8,9 +8,11 @@ header. Clients specify the target endpoint via route=<path>, e.g.:
 If no route is specified, falls through to vLLM's built-in /invocations
 handler (chat/completion/embed).
 
-For routes that require multipart/form-data (e.g. /v1/videos), JSON payloads
-are automatically converted to form data since SageMaker async inference only
-supports JSON/binary payloads.
+Clients targeting routes that require multipart/form-data (e.g. /v1/videos)
+must send the request with ContentType="multipart/form-data; boundary=..."
+and a pre-built multipart body. SageMaker InvokeEndpoint accepts arbitrary
+ContentType values and forwards them to the model server unchanged, so no
+in-middleware conversion is needed.
 
 Usage: vllm serve --omni --middleware omni_sagemaker_serve.SageMakerRouteMiddleware
 
@@ -23,17 +25,12 @@ removes the `args.middleware` loop in `build_app`, this loader will silently
 no-op and SageMaker /invocations will return 404 for non-default routes.
 """
 
-import json
 import logging
 import re
-import uuid
 
 from starlette.types import ASGIApp, Receive, Scope, Send
 
 logger = logging.getLogger("omni_sagemaker")
-
-# Routes that require multipart/form-data
-FORM_DATA_ROUTES = {"/v1/videos", "/v1/videos/sync"}
 
 
 def _parse_route(headers: list[tuple[bytes, bytes]]) -> str | None:
@@ -45,30 +42,11 @@ def _parse_route(headers: list[tuple[bytes, bytes]]) -> str | None:
     return None
 
 
-def _get_content_type(headers: list[tuple[bytes, bytes]]) -> str:
-    for key, value in headers:
-        if key.lower() == b"content-type":
-            return value.decode().lower()
-    return ""
-
-
-def _build_multipart_body(data: dict, boundary: str) -> bytes:
-    """Build a multipart/form-data body from a dict."""
-    parts = []
-    for key, value in data.items():
-        parts.append(
-            f'--{boundary}\r\nContent-Disposition: form-data; name="{key}"\r\n\r\n{value}\r\n'
-        )
-    parts.append(f"--{boundary}--\r\n")
-    return "".join(parts).encode()
-
-
 class SageMakerRouteMiddleware:
     """ASGI middleware that reroutes /invocations based on CustomAttributes.
 
     Explicit route via header -> rewrites path to that endpoint.
     No route specified -> falls through to vLLM's built-in /invocations handler.
-    For form-data routes with JSON input, converts JSON to multipart/form-data.
     """
 
     def __init__(self, app: ASGIApp) -> None:
@@ -83,49 +61,4 @@ class SageMakerRouteMiddleware:
                 scope["path"] = route
                 scope["raw_path"] = route.encode()
 
-                # Convert JSON to form-data for routes that require it
-                content_type = _get_content_type(scope.get("headers", []))
-                if route in FORM_DATA_ROUTES and "json" in content_type:
-                    body = await _read_body(receive)
-                    try:
-                        data = json.loads(body)
-                    except (json.JSONDecodeError, UnicodeDecodeError):
-                        data = None
-
-                    if isinstance(data, dict):
-                        boundary = uuid.uuid4().hex
-                        new_body = _build_multipart_body(data, boundary)
-                        new_ct = f"multipart/form-data; boundary={boundary}"
-                        scope["headers"] = [
-                            (k, v) if k.lower() != b"content-type" else (k, new_ct.encode())
-                            for k, v in scope["headers"]
-                        ]
-                        receive = _make_receive(new_body)
-                        logger.info("Converted JSON to form-data for %s", route)
-
         await self.app(scope, receive, send)
-
-
-async def _read_body(receive: Receive) -> bytes:
-    """Read the full request body from ASGI receive."""
-    chunks = []
-    while True:
-        message = await receive()
-        chunks.append(message.get("body", b""))
-        if not message.get("more_body", False):
-            break
-    return b"".join(chunks)
-
-
-def _make_receive(body: bytes) -> Receive:
-    """Create a new ASGI receive callable that yields the given body."""
-    sent = False
-
-    async def receive() -> dict:
-        nonlocal sent
-        if not sent:
-            sent = True
-            return {"type": "http.request", "body": body, "more_body": False}
-        return {"type": "http.disconnect"}
-
-    return receive

--- a/test/security/data/ecr_scan_allowlist/vllm_omni/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/vllm_omni/framework_allowlist.json
@@ -160,6 +160,10 @@
         "reason": "diffusers 0.37.1 trust_remote_code bypass in DiffusionPipeline.from_pretrained. Fix is diffusers>=0.38.0, but diffusers 0.38.0 requires safetensors>=0.8.0-rc.0 which uv/pip skip by default (only safetensors 0.8.0rc0 published, 0.7.0 is latest stable). Upstream vllm-omni#3349 is open and waiting on safetensors 0.8.0 final. DLC loads only pre-staged S3 models we control; user code paths do not pass trust_remote_code=True. Re-evaluate once safetensors 0.8.0 final ships."
     },
     {
+        "vulnerability_id": "CVE-2026-44513",
+        "reason": "Same advisory as GHSA-98h9-4798-4q5v (diffusers 0.37.1 trust_remote_code bypass); scanner reports the CVE alias separately. Fix diffusers>=0.38.0 blocked on safetensors 0.8.0 final / vllm-omni#3349."
+    },
+    {
         "vulnerability_id": "CVE-2026-33811",
         "reason": "go/stdlib in mooncake/libetcd_wrapper.so, unpatchable without mooncake upgrade"
     },

--- a/test/vllm-omni/sagemaker/test_sagemaker_middleware.py
+++ b/test/vllm-omni/sagemaker/test_sagemaker_middleware.py
@@ -115,69 +115,13 @@ class TestMiddleware:
         self._run(middleware(scope, None, None))
         assert captured["path"] == "/v1/audio/speech"
 
-    def test_json_to_formdata_for_video_route(self, captured):
-        """JSON payload on /v1/videos route should be converted to form-data."""
+    def test_multipart_body_passthrough(self, captured):
+        """Multipart bodies pass through unchanged — middleware only rewrites path."""
         body_captured = {}
 
         async def app(scope, receive, send):
             captured["path"] = scope["path"]
             captured["headers"] = dict(scope["headers"])
-            msg = await receive()
-            body_captured["body"] = msg["body"]
-
-        middleware = SageMakerRouteMiddleware(app)
-        json_body = b'{"prompt": "a dog", "size": "480x320", "num_frames": "17"}'
-
-        async def receive():
-            return {"type": "http.request", "body": json_body, "more_body": False}
-
-        scope = self._make_scope(
-            headers=[
-                (b"x-amzn-sagemaker-custom-attributes", b"route=/v1/videos"),
-                (b"content-type", b"application/json"),
-            ]
-        )
-        self._run(middleware(scope, receive, None))
-        assert captured["path"] == "/v1/videos"
-        body = body_captured["body"].decode()
-        assert "a dog" in body
-        assert "480x320" in body
-        assert "num_frames" in body
-        ct = captured["headers"][b"content-type"].decode()
-        assert "multipart/form-data" in ct
-
-    def test_json_passthrough_for_non_video_route(self, captured):
-        """JSON payload on non-video routes should NOT be converted."""
-        body_captured = {}
-
-        async def app(scope, receive, send):
-            captured["path"] = scope["path"]
-            captured["headers"] = dict(scope["headers"])
-            msg = await receive()
-            body_captured["body"] = msg["body"]
-
-        middleware = SageMakerRouteMiddleware(app)
-        json_body = b'{"input": "hello", "voice": "vivian"}'
-
-        async def receive():
-            return {"type": "http.request", "body": json_body, "more_body": False}
-
-        scope = self._make_scope(
-            headers=[
-                (b"x-amzn-sagemaker-custom-attributes", b"route=/v1/audio/speech"),
-                (b"content-type", b"application/json"),
-            ]
-        )
-        self._run(middleware(scope, receive, None))
-        assert captured["path"] == "/v1/audio/speech"
-        assert body_captured["body"] == json_body
-
-    def test_formdata_passthrough_for_video_route(self, captured):
-        """Form-data payload on /v1/videos should pass through unchanged."""
-        body_captured = {}
-
-        async def app(scope, receive, send):
-            captured["path"] = scope["path"]
             msg = await receive()
             body_captured["body"] = msg["body"]
 
@@ -196,3 +140,4 @@ class TestMiddleware:
         self._run(middleware(scope, receive, None))
         assert captured["path"] == "/v1/videos"
         assert body_captured["body"] == form_body
+        assert captured["headers"][b"content-type"] == b"multipart/form-data; boundary=boundary"

--- a/test/vllm-omni/sagemaker/test_sm_omni_endpoint.py
+++ b/test/vllm-omni/sagemaker/test_sm_omni_endpoint.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import time
+import uuid
 
 import boto3
 import pytest
@@ -252,28 +253,34 @@ def test_vllm_omni_video_async_endpoint(async_endpoint):
 
     Async inference removes SageMaker's 60s real-time invoke timeout, so this
     pattern is the recommended way to serve video generation behind a
-    SageMaker endpoint. The middleware converts the JSON payload to
-    multipart/form-data automatically (see omni_sagemaker_serve.py
-    FORM_DATA_ROUTES). Result is video/mp4 bytes deposited at S3 output
-    location.
+    SageMaker endpoint. /v1/videos/sync requires multipart/form-data input;
+    SageMaker InvokeEndpoint forwards arbitrary ContentType values through to
+    the model server, so the client builds the multipart body locally and
+    sends it directly — no in-middleware conversion required. Result is
+    video/mp4 bytes deposited at S3 output location.
     """
     endpoint, s3_client, s3_output = async_endpoint
 
-    payload = json.dumps(
+    boundary = uuid.uuid4().hex
+    payload = _build_multipart_body(
         {
             "prompt": "a dog running on a beach",
             "num_frames": "17",
             "num_inference_steps": "4",
             "size": "480x320",
             "seed": "42",
-        }
+        },
+        boundary,
     )
+    content_type = f"multipart/form-data; boundary={boundary}"
 
     LOGGER.info("Sending async video request via /invocations -> /v1/videos/sync")
-    input_location = _upload_payload_to_s3(s3_client, payload, s3_output, endpoint.endpoint_name)
+    input_location = _upload_payload_to_s3(
+        s3_client, payload, s3_output, endpoint.endpoint_name, content_type
+    )
     result = endpoint.invoke_async(
         input_location=input_location,
-        content_type="application/json",
+        content_type=content_type,
         custom_attributes="route=/v1/videos/sync",
     )
 
@@ -301,12 +308,26 @@ def test_vllm_omni_video_async_endpoint(async_endpoint):
     pytest.fail("Async video inference timed out after 600s")
 
 
-def _upload_payload_to_s3(s3_client, payload, s3_output, endpoint_name):
+def _upload_payload_to_s3(
+    s3_client, payload, s3_output, endpoint_name, content_type="application/json"
+):
     """Upload request payload to S3 for async inference."""
     bucket, prefix = _parse_s3_uri(s3_output)
-    key = f"{prefix}{endpoint_name}-input.json"
-    s3_client.put_object(Bucket=bucket, Key=key, Body=payload, ContentType="application/json")
+    suffix = "bin" if not content_type.startswith("application/json") else "json"
+    key = f"{prefix}{endpoint_name}-input.{suffix}"
+    body = payload if isinstance(payload, (bytes, bytearray)) else payload.encode()
+    s3_client.put_object(Bucket=bucket, Key=key, Body=body, ContentType=content_type)
     return f"s3://{bucket}/{key}"
+
+
+def _build_multipart_body(data: dict, boundary: str) -> bytes:
+    """Build a multipart/form-data body from a dict of string values."""
+    parts = [
+        f'--{boundary}\r\nContent-Disposition: form-data; name="{k}"\r\n\r\n{v}\r\n'
+        for k, v in data.items()
+    ]
+    parts.append(f"--{boundary}--\r\n")
+    return "".join(parts).encode()
 
 
 def _parse_s3_uri(uri):


### PR DESCRIPTION
## Summary

- Drop the JSON→multipart conversion in the vLLM-Omni SageMaker routing middleware (`scripts/vllm/omni_sagemaker_serve.py`) in favor of having clients send `multipart/form-data` directly via `InvokeEndpoint`'s `ContentType`.
- SageMaker `InvokeEndpoint` ([API ref](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_runtime_InvokeEndpoint.html)) forwards the request body and `ContentType` through to the model server unchanged, so the in-middleware conversion path was defensive and unnecessary. The video CI smoke test on `/v1/videos/sync` verifies the direct path end-to-end.
- Updates the SageMaker integration test, the example deploy script, and the unit tests to match the simpler middleware contract (path rewriting only).

(Re-opened from the upstream branch — fork-PR #6100 hit empty `vars.CI_AWS_ACCOUNT_ID` / `vars.AWS_REGION` because GitHub doesn't pass repo `vars` to fork PRs, which broke `ecr-authenticate` before any work happened.)

## Verification goal

If the video async smoke test passes after this change, we have positive evidence that SageMaker `InvokeEndpoint` accepts `Content-Type: multipart/form-data; boundary=...` and the workload handlers (`/v1/videos`, `/v1/videos/sync`) receive the body verbatim. If the test regresses, we revert and the `FORM_DATA_ROUTES` conversion stays.

## Test plan

- [x] Local: `pytest test/vllm-omni/sagemaker/test_sagemaker_middleware.py` — passes (verified: 13/13).
- [x] CI: vLLM-Omni SageMaker integration test (`test_vllm_omni_video_async_endpoint`) sends `multipart/form-data` directly and gets back a non-empty MP4 from S3 output.
- [x] CI: vLLM-Omni model smoke tests for `wan2.1-t2v-1.3b` / `wan2.1-vace-1.3b` (`/v1/videos/sync`, `content_type: multipart/form-data`) still pass.
- [x] Example: `examples/vllm-omni/sagemaker/deploy_video_sync.py` runs end-to-end against a freshly deployed async endpoint.