### PR TITLE
fix: logout stale public ECR credential before docs-pr pull

### DIFF
--- a/scripts/autocurrency/docs-pr.sh
+++ b/scripts/autocurrency/docs-pr.sh
@@ -171,6 +171,7 @@ echo "Step 1: Pull image and extract package versions"
 echo "============================================================"
 
 echo "Pulling image: ${IMAGE_URI}"
+docker logout public.ecr.aws 2>/dev/null || true
 docker pull "${IMAGE_URI}"
 
 pip_count=$(yq eval ".frameworks.${FRAMEWORK}.docs_packages.pip | length" "$TRACKER")


### PR DESCRIPTION
## Summary

The `step4-docs-pr` in autorelease workflows consistently fails with:

```
pull access denied for public.ecr.aws/deep-learning-containers/sglang:
Your authorization token has expired. Reauthenticate and try again.
```

**Root cause:** PR #6012 (`3240421f`) moved `step4-docs-pr` from `ubuntu-latest` (fresh VM every time) to CodeBuild fleet runners (persistent, reused across workflow runs). CodeBuild fleet runners retain Docker credentials from previous runs in `~/.docker/config.json`. When a previous release run logged into `public.ecr.aws`, the credential persists on the machine. By the time a later workflow run reaches step4 on the same machine, the token has expired — but Docker uses it instead of falling back to anonymous access.

On `ubuntu-latest` this was never an issue because each run got a clean VM with no cached credentials.

**Fix:** `docker logout public.ecr.aws` before the pull in `docs-pr.sh`. Clears any stale credential so Docker uses anonymous access, which always works for public ECR.

## Test plan

- [ ] Rerun a failed autorelease `step4-docs-pr` after merging — should pull successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)