### PR TITLE
[Docs Update] vLLM 0.21.0 SageMaker + SGLang 0.5.12 EC2/SageMaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,14 @@ ______________________________________________________________________
 
 ### 🚀 Release Highlights
 
+- **[2026/05/18]** [SGLang v0.5.12](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.12-gpu-py312-ec2` · SageMaker: `0.5.12-gpu-py312` · DeepSeek V4, Intern-S2-Preview, MiniCPM-V 4.6, Laguna-XS.2, Ring-2.6-1T, Gemma 4 MTP.
+- **[2026/05/16]** [vLLM v0.21.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.21.0-gpu-py312-ec2` · SageMaker: `0.21.0-gpu-py312` · MiMo-V2.5, Laguna XS.2, Moondream3, Cohere MoE/Eagle; DeepSeek V4 on AMD + pipeline parallelism.
 - **[2026/05/13]** [vLLM-Omni v0.20.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `omni-cuda-v1.1` · SageMaker: `omni-sagemaker-cuda-v1.1` · Adds `/v1/audio/generate` (stable-audio-open) and `/v1/videos/sync` (unblocks video on SageMaker); supports CosyVoice3, ERNIE-Image-Turbo, Wan2.1-VACE-1.3B; CUDA 13.0 + PyTorch 2.11.0.
 - **[2026/05/11]** [vLLM v0.20.2](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.20.2-gpu-py312-ec2` · SageMaker: `0.20.2-gpu-py312` · Bug fixes for DeepSeek V4.
 - **[2026/05/06]** [SGLang v0.5.11](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.11-gpu-py312-ec2` · SageMaker: `0.5.11-gpu-py312` · Model support for Gemma 4, GLM-5.1, Qwen 3.4, and more
 - **[2026/05/05]** [vLLM v0.20.1](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.20.1-gpu-py312-ec2` · SageMaker: `0.20.1-gpu-py312` · Bug fixes for DeepSeek V4.
 - **[2026/04/30]** [PyTorch v2.11.0](https://gallery.ecr.aws/deep-learning-containers/pytorch) — EC2: `2.11.0-cu130-amzn2023` · SageMaker: `2.11.0-cu130-amzn2023-sagemaker` · Amazon Linux 2023 with EFA, flash-attn, and transformer-engine.
 - **[2026/04/28]** [vLLM v0.20.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.20.0-gpu-py312-ec2` · SageMaker: `0.20.0-gpu-py312` · Introduces support for DeepSeek V4.
-- **[2026/04/24]** [vLLM-Omni v0.18.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `omni-cuda-v1.0` · SageMaker: `omni-sagemaker-cuda-v1.0` · Initial release. Serves omni-modality models (TTS, image, video, multimodal chat) through OpenAI-compatible APIs; SageMaker routing middleware via `CustomAttributes`.
-- **[2026/04/20]** [vLLM v0.19.1](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.19-gpu-py312-ec2` · SageMaker: `0.19-gpu-py312` · This upgrades Transformers to 5.5.4, enabling Gemma 4 support.
 
 ### 📢 Support Updates
 

--- a/docs/src/data/sglang/0.5.12-gpu-ec2.yml
+++ b/docs/src/data/sglang/0.5.12-gpu-ec2.yml
@@ -1,0 +1,32 @@
+framework: SGLang
+version: "0.5.12"
+accelerator: gpu
+python: py312
+cuda: cu130
+os: ubuntu24.04
+platform: ec2
+public_registry: true
+
+tags:
+  - "0.5.12-gpu-py312-cu130-ubuntu24.04-ec2"
+  - "0.5-gpu-py312-cu130-ubuntu24.04-ec2-v1"
+  - "0.5.12-gpu-py312-ec2"
+  - "0.5-gpu-py312-ec2"
+
+announcements:
+  - "Introduced SGLang 0.5.12 containers for EC2, ECS, EKS"
+
+packages:
+  sglang: "0.5.12"
+  sglang-kernel: "0.4.2.post2"
+  pytorch: "2.11.0"
+  torchvision: "0.26.0"
+  torchaudio: "2.11.0"
+  torchao: "0.17.0"
+  transformers: "5.6.0"
+  flashinfer: "0.6.11.post1"
+  cuda: "13.0"
+  cudnn: "9.13.0.50"
+  nccl: "2.28.9"
+  efa: "1.46.0"
+  gdrcopy: "2.5.1"

--- a/docs/src/data/sglang/0.5.12-gpu-sagemaker.yml
+++ b/docs/src/data/sglang/0.5.12-gpu-sagemaker.yml
@@ -1,0 +1,32 @@
+framework: SGLang
+version: "0.5.12"
+accelerator: gpu
+python: py312
+cuda: cu130
+os: ubuntu24.04
+platform: sagemaker
+public_registry: true
+
+tags:
+  - "0.5.12-gpu-py312-cu130-ubuntu24.04-sagemaker"
+  - "0.5-gpu-py312-cu130-ubuntu24.04-sagemaker-v1"
+  - "0.5.12-gpu-py312"
+  - "0.5-gpu-py312"
+
+announcements:
+  - "Introduced SGLang 0.5.12 containers for SageMaker"
+
+packages:
+  sglang: "0.5.12"
+  sglang-kernel: "0.4.2.post2"
+  pytorch: "2.11.0"
+  torchvision: "0.26.0"
+  torchaudio: "2.11.0"
+  torchao: "0.17.0"
+  transformers: "5.6.0"
+  flashinfer: "0.6.11.post1"
+  cuda: "13.0"
+  cudnn: "9.13.0.50"
+  nccl: "2.28.9"
+  efa: "1.46.0"
+  gdrcopy: "2.5.1"

--- a/docs/src/data/vllm/0.21.0-gpu-sagemaker.yml
+++ b/docs/src/data/vllm/0.21.0-gpu-sagemaker.yml
@@ -1,0 +1,27 @@
+framework: vLLM
+version: "0.21.0"
+accelerator: gpu
+python: py312
+cuda: cu130
+os: ubuntu22.04
+platform: sagemaker
+public_registry: true
+
+tags:
+  - "0.21.0-gpu-py312-cu130-ubuntu22.04-sagemaker"
+  - "0.21-gpu-py312-cu130-ubuntu22.04-sagemaker-v1"
+  - "0.21.0-gpu-py312"
+  - "0.21-gpu-py312"
+
+announcements:
+  - "Introduced vLLM 0.21.0 containers for SageMaker"
+
+packages:
+  vllm: "0.21.0"
+  pytorch: "2.11.0"
+  torchvision: "0.26.0"
+  torchaudio: "2.11.0"
+  transformers: "5.8.1"
+  cuda: "13.0"
+  nccl: "2.28.9"
+  efa: "1.47.0"


### PR DESCRIPTION
## Summary

Add docs data files and README release highlights for:

- **vLLM 0.21.0 SageMaker** — MiMo-V2.5, Laguna XS.2, Moondream3, Cohere MoE/Eagle; DeepSeek V4 on AMD + pipeline parallelism
- **SGLang 0.5.12 EC2 + SageMaker** — DeepSeek V4, Intern-S2-Preview, MiniCPM-V 4.6, Laguna-XS.2, Ring-2.6-1T, Gemma 4 MTP

Package versions verified by pulling the released sglang image and extracting via pip/nvcc/dpkg.

## Files added

- `docs/src/data/vllm/0.21.0-gpu-sagemaker.yml`
- `docs/src/data/sglang/0.5.12-gpu-ec2.yml`
- `docs/src/data/sglang/0.5.12-gpu-sagemaker.yml`
- `README.md` — updated release highlights

🤖 Generated with [Claude Code](https://claude.com/claude-code)