### PR TITLE
fix: only post agent escalation comment once

### DIFF
--- a/.github/workflows/agent-currency-fix.yml
+++ b/.github/workflows/agent-currency-fix.yml
@@ -145,6 +145,11 @@ jobs:
         run: |
           PR_NUMBER=$(gh pr list --head "$HEAD_BRANCH" --json number --jq '.[0].number')
           if [ -n "$PR_NUMBER" ]; then
+            ALREADY_ESCALATED=$(gh pr view "$PR_NUMBER" --comments --json comments --jq '[.comments[].body | select(contains("Currency Fix Agent exhausted"))] | length')
+            if [ "$ALREADY_ESCALATED" -gt "0" ]; then
+              echo "::notice::Escalation already posted. Skipping."
+              exit 0
+            fi
             gh pr comment "$PR_NUMBER" --body "🔴 **Currency Fix Agent exhausted** (${MAX_ATTEMPTS} attempts). Needs human review.
 
           Failed workflow: ${RUN_URL}"


### PR DESCRIPTION
## Summary

After the currency fix agent reaches max attempts (3), every subsequent CI cycle triggers the workflow, which re-posts "Currency Fix Agent exhausted" on the PR. This spams the PR with duplicate escalation comments.

**Fix:** Before posting, check if an escalation comment already exists on the PR. Skip if it does.

## Test plan

- [ ] Push a commit to a PR with 3+ `[agent-fix]` commits — verify only one escalation comment exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)