### PR TITLE
feat: add diagnostic logging to EFA NCCL test

### DIFF
--- a/test/efa/test_efa.py
+++ b/test/efa/test_efa.py
@@ -11,6 +11,7 @@ Usage:
 
 import os
 
+import pytest
 from efa.ec2_helpers import (
     DEFAULT_TIMEOUT,
     HOSTS_FILE_LOCATION,
@@ -41,6 +42,15 @@ def test_efa_sanity_and_nccl(image_uri=IMAGE_URI):
         worker_conn,
         aws_session,
     ):
+        # Diagnostics: CUDA driver and GPU info for failure analysis
+        diag = run_on_container(
+            MASTER_CONTAINER_NAME,
+            master_conn,
+            "nvidia-smi --query-gpu=driver_version,name --format=csv,noheader && "
+            "ls /usr/local/cuda/compat/libcuda* 2>/dev/null || true",
+        )
+        print(f"=== CUDA diagnostics (master) ===\n{diag.stdout}")
+
         # EFA sanity on master
         run_on_container(
             MASTER_CONTAINER_NAME,
@@ -48,10 +58,26 @@ def test_efa_sanity_and_nccl(image_uri=IMAGE_URI):
             "/test/efa/scripts/efa_sanity.sh",
         )
 
-        # NCCL all_reduce across 2 nodes
-        run_on_container(
+        # NCCL all_reduce across 2 nodes — capture failure details
+        result = run_on_container(
             MASTER_CONTAINER_NAME,
             master_conn,
             f"/test/efa/scripts/nccl_allreduce.sh {HOSTS_FILE_LOCATION} 2",
             timeout=DEFAULT_TIMEOUT,
+            warn=True,
         )
+        if result.failed:
+            print(f"=== NCCL allreduce FAILED (exit code {result.return_code}) ===")
+            print(f"=== stdout ===\n{result.stdout}")
+            print(f"=== stderr ===\n{result.stderr}")
+            log_dump = run_on_container(
+                MASTER_CONTAINER_NAME,
+                master_conn,
+                "cat /test/efa/logs/testEFA.log 2>&1 || echo 'Log file empty or missing'",
+                warn=True,
+            )
+            print(f"=== testEFA.log ===\n{log_dump.stdout}")
+            pytest.fail(
+                f"NCCL allreduce failed with exit code {result.return_code}. "
+                f"See stdout above for details."
+            )


### PR DESCRIPTION
## Summary

Add diagnostic logging to the EFA test so future failures are easier to diagnose without manual SSH debugging.

### Changes (test_efa.py only)

1. **Pre-test diagnostics**: Print host driver version and cuda-compat library version inside the container before running tests
2. **Failure capture**: Use `warn=True` on the NCCL allreduce command to capture stdout/stderr/log on failure instead of losing output through fabric's exception handling

### Context

The EFA test was failing for ~2 weeks due to a DLAMI embargo driver (580.150) incompatible with CUDA 13.0.2 on A100. The failure message (`system not yet initialized`) gave no indication of the driver mismatch. These diagnostics would have identified the root cause immediately by showing:
```
580.150, NVIDIA A100-SXM4-40GB    ← host driver
libcuda.so.580.159.04              ← cuda-compat (mismatch!)
```

Now resolved by DLAMI team publishing the post-embargo AMI.

## Test plan

- [ ] EFA test passes with new DLAMI (post-embargo driver)
- [ ] Diagnostics print driver info in CI logs