### PR TITLE
trigger ray pr workflows on pyproject.toml and uv.lock changes

### DIFF
--- a/.github/workflows/pr-ray-ec2-cpu.yml
+++ b/.github/workflows/pr-ray-ec2-cpu.yml
@@ -124,6 +124,8 @@ jobs:
             build-change:
               - ".github/config/image/ray-ec2-cpu.yml"
               - "docker/ray/Dockerfile.cpu"
+              - "docker/ray/pyproject.toml"
+              - "docker/ray/uv.lock"
               - "scripts/common/install_python.sh"
               - "scripts/common/setup_oss_compliance.sh"
               - "scripts/telemetry/bash_telemetry.sh.template"

--- a/.github/workflows/pr-ray-ec2-cpu.yml
+++ b/.github/workflows/pr-ray-ec2-cpu.yml
@@ -8,6 +8,8 @@ on:
       - ".github/config/image/ray-ec2-cpu.yml"
       - ".github/workflows/pr-ray-ec2-cpu.yml"
       - "docker/ray/Dockerfile.cpu"
+      - "docker/ray/pyproject.toml"
+      - "docker/ray/uv.lock"
       - "scripts/common/**"
       - "scripts/ray/**"
       - "scripts/telemetry/**"

--- a/.github/workflows/pr-ray-ec2-gpu.yml
+++ b/.github/workflows/pr-ray-ec2-gpu.yml
@@ -8,6 +8,8 @@ on:
       - ".github/config/image/ray-ec2-gpu.yml"
       - ".github/workflows/pr-ray-ec2-gpu.yml"
       - "docker/ray/Dockerfile.gpu"
+      - "docker/ray/pyproject.toml"
+      - "docker/ray/uv.lock"
       - "scripts/common/**"
       - "scripts/ray/**"
       - "scripts/telemetry/**"

--- a/.github/workflows/pr-ray-ec2-gpu.yml
+++ b/.github/workflows/pr-ray-ec2-gpu.yml
@@ -127,6 +127,8 @@ jobs:
             build-change:
               - ".github/config/image/ray-ec2-gpu.yml"
               - "docker/ray/Dockerfile.gpu"
+              - "docker/ray/pyproject.toml"
+              - "docker/ray/uv.lock"
               - "scripts/common/install_python.sh"
               - "scripts/common/setup_oss_compliance.sh"
               - "scripts/telemetry/bash_telemetry.sh.template"

--- a/.github/workflows/pr-ray-sagemaker-cpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-cpu.yml
@@ -8,6 +8,8 @@ on:
       - ".github/config/image/ray-sagemaker-cpu.yml"
       - ".github/workflows/pr-ray-sagemaker-cpu.yml"
       - "docker/ray/Dockerfile.cpu"
+      - "docker/ray/pyproject.toml"
+      - "docker/ray/uv.lock"
       - "scripts/common/**"
       - "scripts/ray/**"
       - "scripts/telemetry/**"

--- a/.github/workflows/pr-ray-sagemaker-cpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-cpu.yml
@@ -123,6 +123,8 @@ jobs:
             build-change:
               - ".github/config/image/ray-sagemaker-cpu.yml"
               - "docker/ray/Dockerfile.cpu"
+              - "docker/ray/pyproject.toml"
+              - "docker/ray/uv.lock"
               - "scripts/common/install_python.sh"
               - "scripts/common/setup_oss_compliance.sh"
               - "scripts/telemetry/bash_telemetry.sh.template"

--- a/.github/workflows/pr-ray-sagemaker-gpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-gpu.yml
@@ -8,6 +8,8 @@ on:
       - ".github/config/image/ray-sagemaker-gpu.yml"
       - ".github/workflows/pr-ray-sagemaker-gpu.yml"
       - "docker/ray/Dockerfile.gpu"
+      - "docker/ray/pyproject.toml"
+      - "docker/ray/uv.lock"
       - "scripts/common/**"
       - "scripts/ray/**"
       - "scripts/telemetry/**"

--- a/.github/workflows/pr-ray-sagemaker-gpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-gpu.yml
@@ -125,6 +125,8 @@ jobs:
             build-change:
               - ".github/config/image/ray-sagemaker-gpu.yml"
               - "docker/ray/Dockerfile.gpu"
+              - "docker/ray/pyproject.toml"
+              - "docker/ray/uv.lock"
               - "scripts/common/install_python.sh"
               - "scripts/common/setup_oss_compliance.sh"
               - "scripts/telemetry/bash_telemetry.sh.template"


### PR DESCRIPTION
## Purpose

Ray PR workflows currently only trigger on `Dockerfile.cpu`/`Dockerfile.gpu` changes. After Ray DLC v1.1.0 (#6049) moved Python deps into `docker/ray/pyproject.toml` + `docker/ray/uv.lock`, edits to those files don't trigger a build. Add explicit paths so dep bumps run CI.