### PR TITLE
vllm hyperpod v1.2: remove lmcache pin

### DIFF
--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -401,15 +401,12 @@ ENTRYPOINT ["/usr/local/bin/sagemaker_entrypoint.sh"]
 # ====================== hyperpod =========================================
 FROM base AS vllm-hyperpod-amzn2023
 
-LABEL dlc_minor_version="1"
+LABEL dlc_minor_version="2"
 
 # Override NIXL to include libfabric plugin for disaggregated P/D over EFA,
 # upstream vLLM caps nixl at <=0.10.1.
 RUN --mount=type=cache,target=/root/.cache/uv uv pip uninstall nixl-cu13 || true \
   && uv pip install --force-reinstall --no-deps "nixl>=1.0.1" "nixl-cu12>=1.0.1"
-
-# Pin LMCache to 0.4.3 — 0.4.4 introduced a regression on HyperPod.
-RUN --mount=type=cache,target=/root/.cache/uv uv pip install --force-reinstall --no-deps lmcache==0.4.3
 
 ARG CACHE_REFRESH=0
 RUN dnf upgrade -y --security --releasever latest --setopt=install_weak_deps=False \


### PR DESCRIPTION
## Purpose

Remove the `lmcache==0.4.3` pin from the vllm-hyperpod-amzn2023 image; bump dlc_minor_version 1 → 2. NIXL override stays.

## Test Plan

- [ ] PR CI builds the hyperpod image successfully

## Test Result

Pending CI.