### PR TITLE
[POC] CVE Patcher agent

### DIFF
--- a/.github/workflows/cve-patcher-fix.yml
+++ b/.github/workflows/cve-patcher-fix.yml
@@ -1,0 +1,229 @@
+# CVE Patcher Fix Agent — diagnoses and fixes CI failures on cve-patch/* PRs.
+# Triggers when CI completes on a cve-patch/* branch. Pushes [cve-patch-fix] commits.
+# Max 3 attempts per PR branch, then escalates to human via PR comment.
+#
+# Mirrors agent-currency-fix.yml. Same retry semantics, different branch prefix and
+# different Python entry point.
+
+name: CVE Patcher Fix Agent
+
+on:
+  workflow_run:
+    workflows: ["Merge Conditions"]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: cve-patcher-fix-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+# Workflow-level env: applies to all jobs. Today there's only one job (fix-agent),
+# so this is equivalent to a job-level env. If a second job is ever added, it will
+# inherit MAX_ATTEMPTS automatically — move to job-level if that's not desired.
+env:
+  MAX_ATTEMPTS: 3
+
+jobs:
+  fix-agent:
+    if: >-
+      github.event.workflow_run.conclusion == 'failure' &&
+      startsWith(github.event.workflow_run.head_branch, 'cve-patch/')
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    timeout-minutes: 240  # 30 min poll loop + up to a few hours of CI on the PR branch + headroom
+    env:
+      HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+      RUN_ID: ${{ github.event.workflow_run.id }}
+      RUN_URL: ${{ github.event.workflow_run.html_url }}
+      AWS_REGION: us-west-2
+      # Tracked PR-CI workflows whose failure should trigger the fix agent.
+      # Single source of truth — referenced in the wait + failure-finding steps below.
+      TRACKED: "PR - vLLM EC2|PR - vLLM SageMaker|PR - SGLang EC2|PR - SGLang SageMaker|PR - Ray EC2|PR - Ray SageMaker|PR - PyTorch|reusable-security-tests|reusable-sanity-tests"
+    steps:
+      - name: Install dependencies
+        run: |
+          if ! command -v gh &> /dev/null; then
+            GH_VERSION="2.74.0"
+            curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" | tar xz
+            sudo mv "gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
+            rm -rf "gh_${GH_VERSION}_linux_amd64"
+          fi
+          gh --version
+          python3 -m pip install boto3 -q
+
+      - name: Decode GitHub App Private Key
+        id: decode
+        run: |
+          private_key=$(echo "${{ secrets.ASIMOVBOT_APP_PRIVATE_KEY }}" | base64 -d | awk 'BEGIN {ORS="\\n"} {print}' | head -c -2) &> /dev/null
+          echo "::add-mask::$private_key"
+          echo "private-key=$private_key" >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.ASIMOVBOT_APP_ID }}
+          private-key: ${{ steps.decode.outputs.private-key }}
+
+      - name: Checkout main, switch to PR branch
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Prepare workspace
+        run: |
+          # Use scripts from main (trusted), operate on PR branch contents
+          cp scripts/cve-patcher/agent-fix.py /tmp/agent-fix.py
+          git fetch origin "$HEAD_BRANCH"
+          git checkout "origin/$HEAD_BRANCH" -B pr-branch
+
+      - name: Wait for tracked workflows to complete
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # TRACKED is set at the job level; covers PR-CI workflows for all DLC frameworks.
+          SHA=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}" --jq '.head_sha')
+          echo "HEAD_SHA=$SHA" >> $GITHUB_ENV
+          TIMEOUT=1800
+          ELAPSED=0
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            IN_PROGRESS=$(gh api "/repos/${{ github.repository }}/actions/runs?head_sha=${SHA}&per_page=50" \
+              --jq "[.workflow_runs[] | select(.status != \"completed\" and (.name | test(\"${TRACKED}\")))] | length")
+            if [ "$IN_PROGRESS" = "0" ]; then
+              echo "All tracked workflows completed."
+              break
+            fi
+            echo "⏳ $IN_PROGRESS tracked workflow(s) still running. Waiting 60s... (${ELAPSED}s elapsed)"
+            sleep 60
+            ELAPSED=$((ELAPSED + 60))
+          done
+
+      - name: Find failed tracked workflows
+        id: failures
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # TRACKED is set at the job level.
+          SHA="${HEAD_SHA}"
+          FAILED_RUN_IDS=$(gh api "/repos/${{ github.repository }}/actions/runs?head_sha=${SHA}&status=completed&per_page=50" \
+            --jq "[.workflow_runs[] | select(.conclusion == \"failure\" and (.name | test(\"${TRACKED}\")))] | .[].id" \
+            | tr '\n' ' ')
+          if [ -z "$FAILED_RUN_IDS" ]; then
+            echo "::notice::No tracked workflows failed. Skipping."
+            echo "has_failures=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          echo "Failed run IDs: $FAILED_RUN_IDS"
+          echo "has_failures=true" >> $GITHUB_OUTPUT
+          echo "failed_runs=$FAILED_RUN_IDS" >> $GITHUB_OUTPUT
+
+      - name: Count previous attempts
+        if: steps.failures.outputs.has_failures == 'true'
+        id: retry
+        run: |
+          ATTEMPTS=$(git log --oneline origin/main..HEAD --grep='\[cve-patch-fix\]' | wc -l)
+          echo "attempts=$ATTEMPTS" >> $GITHUB_OUTPUT
+          if [ "$ATTEMPTS" -ge "$MAX_ATTEMPTS" ]; then
+            echo "max_reached=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Escalate if exhausted
+        if: steps.failures.outputs.has_failures == 'true' && steps.retry.outputs.max_reached == 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR_NUMBER=$(gh pr list --head "$HEAD_BRANCH" --json number --jq '.[0].number')
+          if [ -n "$PR_NUMBER" ]; then
+            ALREADY=$(gh pr view "$PR_NUMBER" --comments --json comments --jq '[.comments[].body | select(contains("CVE Patcher Fix Agent exhausted"))] | length')
+            if [ "$ALREADY" -gt "0" ]; then
+              echo "::notice::Escalation already posted. Skipping."
+              exit 0
+            fi
+            gh pr comment "$PR_NUMBER" --body "🔴 **CVE Patcher Fix Agent exhausted** (${MAX_ATTEMPTS} attempts). Needs human review.
+
+          Failed workflow: ${RUN_URL}"
+          fi
+
+      - name: Comment on PR — agent starting
+        if: steps.failures.outputs.has_failures == 'true' && steps.retry.outputs.max_reached != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          PR_NUMBER=$(gh pr list --head "$HEAD_BRANCH" --json number --jq '.[0].number')
+          if [ -n "$PR_NUMBER" ]; then
+            ATTEMPT=$(git log --oneline origin/main..HEAD --grep='\[cve-patch-fix\]' | wc -l)
+            gh pr comment "$PR_NUMBER" --body "🤖 **CVE Patcher Fix Agent** running (attempt $((ATTEMPT+1))/${MAX_ATTEMPTS}).
+
+          Agent run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          fi
+
+      - name: Run fix agent
+        if: steps.failures.outputs.has_failures == 'true' && steps.retry.outputs.max_reached != 'true'
+        id: fix
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # Use our forked agent-fix.py — same shape as autocurrency's but with CVE-flavored system prompt
+          # (talks about allowlists, review_by, contract boundaries) and CVE_RELATED vs NOT_CVE_RELATED classifications.
+          # Framework name extraction. Try in order:
+          # 1. docker/<framework>/...    — the common case (Dockerfile / pyproject changes)
+          # 2. test/security/data/ecr_scan_allowlist/<framework>/...  — allowlist-only PRs
+          # 3. fall back to "unknown" if nothing matched
+          CHANGED=$(git diff --name-only origin/main..HEAD)
+          FRAMEWORK=$(echo "$CHANGED" | grep -m1 -E '^docker/[^/]+/' | cut -d/ -f2)
+          if [ -z "$FRAMEWORK" ]; then
+            FRAMEWORK=$(echo "$CHANGED" | grep -m1 -E '^test/security/data/ecr_scan_allowlist/[^/]+/' | cut -d/ -f5)
+          fi
+          FRAMEWORK="${FRAMEWORK:-unknown}"
+          echo "Detected framework: $FRAMEWORK"
+          python3 /tmp/agent-fix.py \
+            --framework "$FRAMEWORK" \
+            --branch "$HEAD_BRANCH" \
+            --run-ids "${{ steps.failures.outputs.failed_runs }}" \
+            --token "$GH_TOKEN" \
+            --repo "${{ github.repository }}"
+
+      - name: Escalate non-CVE failures
+        if: steps.failures.outputs.has_failures == 'true' && steps.retry.outputs.max_reached != 'true' && steps.fix.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          # If the LLM classified the failure as NOT_CVE_RELATED, agent-fix.py wrote a marker file.
+          # Post a PR comment and stop — don't try to commit non-existent fixes.
+          if [ -f /tmp/agent-fix-not-cve-related.txt ]; then
+            REASON=$(cat /tmp/agent-fix-not-cve-related.txt)
+            PR_NUMBER=$(gh pr list --head "$HEAD_BRANCH" --json number --jq '.[0].number')
+            if [ -n "$PR_NUMBER" ]; then
+              gh pr comment "$PR_NUMBER" --body "🟡 **CVE Patcher Fix Agent: failure is not CVE-related** — $REASON
+
+          Needs human review. Failed workflow: ${RUN_URL}"
+            fi
+            echo "::notice::Failure classified as not CVE-related. PR comment posted. Skipping commit."
+            exit 0
+          fi
+
+      - name: Commit and push
+        if: steps.failures.outputs.has_failures == 'true' && steps.retry.outputs.max_reached != 'true' && steps.fix.outcome == 'success'
+        run: |
+          # Skip the commit if the previous step posted a NOT_CVE_RELATED escalation.
+          if [ -f /tmp/agent-fix-not-cve-related.txt ]; then
+            echo "::notice::Skipping commit (not CVE-related)."
+            exit 0
+          fi
+          if git diff --quiet && git diff --cached --quiet; then
+            echo "::notice::No changes generated. Nothing to push."
+            exit 0
+          fi
+          git config user.name "asimov-bot[bot]"
+          git config user.email "asimov-bot[bot]@users.noreply.github.com"
+          git add -A
+          DESCRIPTION=$(cat /tmp/agent-fix-description.txt 2>/dev/null || echo "automated fix")
+          git commit -m "[cve-patch-fix] ${DESCRIPTION}"
+          git push origin "HEAD:$HEAD_BRANCH"

--- a/.github/workflows/cve-patcher.yml
+++ b/.github/workflows/cve-patcher.yml
@@ -1,0 +1,278 @@
+# CVE Patcher Agent — POC version.
+#
+# POC scope: manual dispatch only. User passes a target tag + list of CVE IDs.
+# Agent classifies each CVE and opens one PR per Dockerfile with the fix.
+# Companion workflow cve-patcher-fix.yml handles CI-failure retries on the PRs this opens.
+#
+# Production target (commented out below): daily cron poll of CloudWatch SLA metrics,
+# S3 fetch of the scan dump, agent picks targets autonomously. Deferred until POC validates.
+#
+# === TODO BEFORE FINAL MERGE ===
+# Three POC-only items to remove before merging this for production use:
+#   1. Drop the `pull_request:` trigger block below (it exists so the workflow can
+#      self-test against PR #6116's CI image during development).
+#   2. Drop the `else` branch in the "Resolve inputs" step that hardcodes the test
+#      image tag + CVE ID for pull_request runs.
+#   3. Switch ECR_BASE in "Construct target image URI" from vars.CI_AWS_ACCOUNT_ID
+#      to vars.PROD_AWS_ACCOUNT_ID so we operate against released images, not CI builds.
+
+name: CVE Patcher Agent
+
+on:
+  # Production trigger (commented out for POC — re-enable once cross-account access is wired):
+  # schedule:
+  #   - cron: '0 6 * * *'  # daily at 06:00 UTC
+  #
+  # PR trigger for testing the workflow during POC development.
+  # Limits to changes within our own files so unrelated PRs don't fire it.
+  # Remove before final POC validation if we want stricter trigger control.
+  pull_request:
+    paths:
+      - ".github/workflows/cve-patcher.yml"
+      - ".github/workflows/cve-patcher-fix.yml"
+      - "scripts/cve-patcher/**"
+  workflow_dispatch:
+    inputs:
+      target_tag:
+        description: "Image tag to patch (e.g. serve-ml-cuda-v1.1). Workflow constructs the full URI server-side."
+        required: true
+        type: string
+      target_repo:
+        description: "ECR repo name (default: ray)."
+        required: false
+        type: string
+        default: ray
+      cve_id_list:
+        description: "Comma- or newline-separated CVE IDs to patch (e.g. CVE-2024-37891)."
+        required: true
+        type: string
+      dry_run:
+        description: "Classify + preview only, do not open PRs."
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: cve-patcher
+  cancel-in-progress: false
+
+jobs:
+  patch:
+    # Runs on workflow_dispatch (real use) or pull_request (POC self-test against PR #6116's CI image).
+    # TODO BEFORE MERGE: drop the pull_request branch — testing-only.
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    timeout-minutes: 30  # ~5 min LLM + ~5 min git ops + slack for cold start
+    env:
+      AWS_REGION: us-west-2
+    steps:
+      - name: Install dependencies
+        run: |
+          if ! command -v gh &> /dev/null; then
+            GH_VERSION="2.74.0"
+            curl -sL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" | tar xz
+            sudo mv "gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin/gh
+            rm -rf "gh_${GH_VERSION}_linux_amd64"
+          fi
+          gh --version
+          python3 -m pip install boto3 -q
+
+      - name: Decode GitHub App Private Key
+        id: decode
+        run: |
+          private_key=$(echo "${{ secrets.ASIMOVBOT_APP_PRIVATE_KEY }}" | base64 -d | awk 'BEGIN {ORS="\\n"} {print}' | head -c -2) &> /dev/null
+          echo "::add-mask::$private_key"
+          echo "private-key=$private_key" >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.ASIMOVBOT_APP_ID }}
+          private-key: ${{ steps.decode.outputs.private-key }}
+
+      - name: Checkout main
+        uses: actions/checkout@v5
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Resolve inputs (dispatch vs PR-trigger test defaults)
+        id: resolve
+        run: |
+          # On workflow_dispatch, use the user-provided inputs.
+          # On pull_request (POC self-test), hardcode the CI-built image from PR #6116
+          # (deliberately old urllib3, used to validate the agent end-to-end).
+          # TODO BEFORE MERGE: remove the pull_request branch.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "target_repo=${{ inputs.target_repo }}" >> $GITHUB_OUTPUT
+            echo "target_tag=${{ inputs.target_tag }}" >> $GITHUB_OUTPUT
+            echo "cve_id_list=${{ inputs.cve_id_list }}" >> $GITHUB_OUTPUT
+            echo "dry_run=${{ inputs.dry_run }}" >> $GITHUB_OUTPUT
+          else
+            echo "target_repo=ci" >> $GITHUB_OUTPUT
+            echo "target_tag=ray-2.55.1-cpu-py313-amzn2023-ec2-pr-6116" >> $GITHUB_OUTPUT
+            echo "cve_id_list=CVE-2024-37891" >> $GITHUB_OUTPUT
+            echo "dry_run=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Construct target image URI
+        id: target
+        env:
+          # POC: pointed at CI-built images. TODO BEFORE MERGE: switch to vars.PROD_AWS_ACCOUNT_ID.
+          ECR_BASE: "${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com"
+        run: |
+          IMAGE_URI="${ECR_BASE}/${{ steps.resolve.outputs.target_repo }}:${{ steps.resolve.outputs.target_tag }}"
+          echo "image_uri=$IMAGE_URI" >> $GITHUB_OUTPUT
+          echo "Target image: $IMAGE_URI"
+
+      # === PRODUCTION POLL STEP — COMMENTED OUT FOR POC ===
+      # Re-enable once cross-account access is wired up.
+      #
+      # - name: Poll CloudWatch for OUT_OF_SLA / NEAR_SLA images
+      #   id: poll
+      #   env:
+      #     AWS_REGION: us-east-1
+      #   run: |
+      #     python3 scripts/cve-patcher/poll.py --dimension ASIMOV_IMAGE_METRICS --include-near-sla --output /tmp/cve-targets.json
+      #     COUNT=$(python3 -c 'import json; print(len(json.load(open("/tmp/cve-targets.json"))))')
+      #     echo "count=$COUNT" >> $GITHUB_OUTPUT
+      #
+      # - name: Fetch S3 scan dump
+      #   if: steps.poll.outputs.count != '0'
+      #   run: |
+      #     for image in $(jq -r '.[].image' /tmp/cve-targets.json); do
+      #       python3 scripts/cve-patcher/fetch-findings.py --image "$image"
+      #     done
+
+      - name: Build target list from inputs
+        id: build_targets
+        run: |
+          # POC: build a single-image target list from the dispatch inputs
+          IMAGE="${{ steps.target.outputs.image_uri }}"
+          # Normalize CVE list (commas or newlines → JSON array)
+          CVES=$(echo "${{ steps.resolve.outputs.cve_id_list }}" | tr ',\n' '\n' | grep -v '^$' | python3 -c "import json,sys; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))")
+          python3 -c "
+          import json
+          print(json.dumps([{
+              'image': '$IMAGE',
+              'cve_ids': $CVES,
+          }]))
+          " > /tmp/cve-targets.json
+          cat /tmp/cve-targets.json
+
+      - name: Run CVE patcher agent
+        if: steps.resolve.outputs.dry_run != 'true'
+        id: agent
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          python3 scripts/cve-patcher/agent.py \
+            --input /tmp/cve-targets.json \
+            --summary-output /tmp/cve-patcher-summary.json
+          echo "summary<<EOF" >> $GITHUB_OUTPUT
+          cat /tmp/cve-patcher-summary.json >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Dry-run preview
+        if: steps.resolve.outputs.dry_run == 'true'
+        run: |
+          python3 scripts/cve-patcher/agent.py \
+            --input /tmp/cve-targets.json \
+            --dry-run
+
+      - name: Open one PR per modified Dockerfile
+        if: steps.resolve.outputs.dry_run != 'true'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -e
+          git config user.name "asimov-bot[bot]"
+          git config user.email "asimov-bot[bot]@users.noreply.github.com"
+
+          if ! [ -s /tmp/cve-patcher-summary.json ]; then
+            echo "::warning::No summary file. Agent produced no edits."
+            exit 0
+          fi
+
+          # Note: 'set -e' is intentionally NOT used here (the surrounding bash has it,
+          # but Python failures inside one Dockerfile shouldn't abort the whole run).
+          set +e
+          python3 << 'PYEOF'
+          import json, subprocess, hashlib, traceback
+          from pathlib import Path
+
+          summary = json.load(open('/tmp/cve-patcher-summary.json'))
+
+          for dockerfile, entry in summary.items():
+              msg = entry['summary']
+              blocks = entry.get('blocks', [])
+              slug = dockerfile.replace('/', '-').replace('.', '-')
+              branch = f'cve-patch/{slug}-' + hashlib.sha1(msg.encode()).hexdigest()[:8]
+              print(f'\n=== Processing {dockerfile} -> {branch} ===')
+              try:
+                  subprocess.run(['git','checkout','-b',branch],check=True)
+
+                  # Apply blocks for THIS dockerfile only, on the dockerfile's branch.
+                  # If ANY block fails to apply cleanly, abort this image (don't ship a
+                  # half-patched PR). Other dockerfiles in the run continue independently.
+                  failed_blocks = []
+                  for b in blocks:
+                      path_str = b['path']
+                      p = Path(path_str)
+                      if not p.exists():
+                          failed_blocks.append(f'file does not exist: {path_str}')
+                          continue
+                      content = p.read_text()
+                      if b['search'] not in content:
+                          failed_blocks.append(f'SEARCH not found in {path_str}')
+                          continue
+                      if content.count(b['search']) > 1:
+                          failed_blocks.append(f'SEARCH ambiguous in {path_str}')
+                          continue
+                      p.write_text(content.replace(b['search'], b['replace']))
+
+                  if failed_blocks:
+                      print(f'::warning::Aborting {dockerfile}: {len(failed_blocks)} block(s) failed:')
+                      for f in failed_blocks:
+                          print(f'  - {f}')
+                      subprocess.run(['git','checkout','main'],check=False)
+                      subprocess.run(['git','branch','-D',branch],check=False)
+                      continue
+
+                  subprocess.run(['git','add','-A'],check=True)
+                  if subprocess.run(['git','diff','--cached','--quiet']).returncode == 0:
+                      print('  No changes for this branch, skipping')
+                      subprocess.run(['git','checkout','main'],check=False)
+                      subprocess.run(['git','branch','-D',branch],check=False)
+                      continue
+                  subprocess.run(['git','commit','-m',f'[cve-patch] {msg}'],check=True)
+                  subprocess.run(['git','push','origin',branch],check=True)
+
+                  pr_body = (
+                      '## Purpose\n\n'
+                      f'Automated CVE patch for `{dockerfile}`.\n\n'
+                      '## Summary\n\n'
+                      f'{msg}\n\n'
+                      '## Test Plan\n\n'
+                      '- [ ] CI security tests pass (rescan confirms CVEs gone)\n'
+                      '- [ ] CI sanity tests pass\n'
+                      '- [ ] CI framework-specific tests pass\n\n'
+                      '## Test Result\n\nPending CI.\n'
+                  )
+                  subprocess.run(['gh','pr','create','--base','main','--head',branch,
+                                  '--title',f'[cve-patch] {msg}',
+                                  '--body',pr_body], check=True)
+              except Exception:
+                  print(f'::error::Failed to ship {dockerfile}:')
+                  traceback.print_exc()
+              finally:
+                  subprocess.run(['git','checkout','main'],check=False)
+          PYEOF

--- a/.github/workflows/cve-patcher.yml
+++ b/.github/workflows/cve-patcher.yml
@@ -8,13 +8,15 @@
 # S3 fetch of the scan dump, agent picks targets autonomously. Deferred until POC validates.
 #
 # === TODO BEFORE FINAL MERGE ===
-# Three POC-only items to remove before merging this for production use:
+# Four POC-only items to remove before merging this for production use:
 #   1. Drop the `pull_request:` trigger block below (it exists so the workflow can
 #      self-test against PR #6116's CI image during development).
 #   2. Drop the `else` branch in the "Resolve inputs" step that hardcodes the test
 #      image tag + CVE ID for pull_request runs.
 #   3. Switch ECR_BASE in "Construct target image URI" from vars.CI_AWS_ACCOUNT_ID
 #      to vars.PROD_AWS_ACCOUNT_ID so we operate against released images, not CI builds.
+#   4. Drop the "Stage PR agent scripts to /tmp" step + AGENT_SCRIPT env on the
+#      run/dry-run steps. Production always runs scripts/cve-patcher/agent.py from main.
 
 name: CVE Patcher Agent
 
@@ -104,6 +106,21 @@ jobs:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
+      - name: Stage PR agent scripts to /tmp (POC self-test only)
+        # The per-Dockerfile branching loop later branches off whatever is checked out.
+        # We want those branches to fork off main (clean diffs), so we keep main checked
+        # out and copy the PR-head version of the scripts into /tmp/ before running them.
+        # TODO BEFORE MERGE: drop this whole step (no PR self-test in production).
+        if: github.event_name == 'pull_request'
+        env:
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
+        run: |
+          git fetch origin "$PR_HEAD"
+          mkdir -p /tmp/cve-patcher-scripts
+          git show "origin/${PR_HEAD}:scripts/cve-patcher/agent.py" > /tmp/cve-patcher-scripts/agent.py
+          chmod +x /tmp/cve-patcher-scripts/agent.py
+          echo "Staged agent.py from origin/${PR_HEAD}"
+
       - name: Resolve inputs (dispatch vs PR-trigger test defaults)
         id: resolve
         run: |
@@ -173,8 +190,11 @@ jobs:
         id: agent
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          # On pull_request, run the PR-head agent staged in /tmp; otherwise run from main.
+          # TODO BEFORE MERGE: drop this var, hardcode scripts/cve-patcher/agent.py.
+          AGENT_SCRIPT: ${{ github.event_name == 'pull_request' && '/tmp/cve-patcher-scripts/agent.py' || 'scripts/cve-patcher/agent.py' }}
         run: |
-          python3 scripts/cve-patcher/agent.py \
+          python3 "$AGENT_SCRIPT" \
             --input /tmp/cve-targets.json \
             --summary-output /tmp/cve-patcher-summary.json
           echo "summary<<EOF" >> $GITHUB_OUTPUT
@@ -183,8 +203,10 @@ jobs:
 
       - name: Dry-run preview
         if: steps.resolve.outputs.dry_run == 'true'
+        env:
+          AGENT_SCRIPT: ${{ github.event_name == 'pull_request' && '/tmp/cve-patcher-scripts/agent.py' || 'scripts/cve-patcher/agent.py' }}
         run: |
-          python3 scripts/cve-patcher/agent.py \
+          python3 "$AGENT_SCRIPT" \
             --input /tmp/cve-targets.json \
             --dry-run
 

--- a/.github/workflows/cve-patcher.yml
+++ b/.github/workflows/cve-patcher.yml
@@ -44,8 +44,8 @@ on:
         required: false
         type: string
         default: ray
-      cve_id_list:
-        description: "Comma- or newline-separated CVE IDs to patch (e.g. CVE-2024-37891)."
+      findings_json:
+        description: "JSON array of finding objects (matches ECR enhanced-scan shape)."
         required: true
         type: string
       dry_run:
@@ -123,22 +123,44 @@ jobs:
 
       - name: Resolve inputs (dispatch vs PR-trigger test defaults)
         id: resolve
+        env:
+          # On workflow_dispatch: real inputs. On pull_request (POC self-test): hardcoded test
+          # finding for PR #6116's deliberately-old urllib3 image.
+          # TODO BEFORE MERGE: remove the pull_request branch + hardcoded test finding.
+          DISPATCH_FINDINGS: ${{ inputs.findings_json }}
+          TEST_FINDINGS: |
+            [
+              {
+                "vulnerabilityId": "CVE-2024-37891",
+                "description": "urllib3's Proxy-Authorization request header isn't stripped during cross-origin redirects when used with the ProxyManager. Fixed in 2.2.2.",
+                "packageVulnerabilityDetails": {
+                  "vendorSeverity": "HIGH",
+                  "vulnerabilityId": "CVE-2024-37891",
+                  "vulnerablePackages": [
+                    {
+                      "name": "urllib3",
+                      "version": "2.2.1",
+                      "fixedInVersion": "2.2.2",
+                      "packageManager": "PYTHON",
+                      "filePath": "/usr/local/lib/python3.13/site-packages/urllib3-2.2.1.dist-info/METADATA"
+                    }
+                  ]
+                }
+              }
+            ]
         run: |
-          # On workflow_dispatch, use the user-provided inputs.
-          # On pull_request (POC self-test), hardcode the CI-built image from PR #6116
-          # (deliberately old urllib3, used to validate the agent end-to-end).
-          # TODO BEFORE MERGE: remove the pull_request branch.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             echo "target_repo=${{ inputs.target_repo }}" >> $GITHUB_OUTPUT
             echo "target_tag=${{ inputs.target_tag }}" >> $GITHUB_OUTPUT
-            echo "cve_id_list=${{ inputs.cve_id_list }}" >> $GITHUB_OUTPUT
             echo "dry_run=${{ inputs.dry_run }}" >> $GITHUB_OUTPUT
+            printf '%s' "$DISPATCH_FINDINGS" > /tmp/findings.json
           else
             echo "target_repo=ci" >> $GITHUB_OUTPUT
             echo "target_tag=ray-2.55.1-cpu-py313-amzn2023-ec2-pr-6116" >> $GITHUB_OUTPUT
-            echo "cve_id_list=CVE-2024-37891" >> $GITHUB_OUTPUT
             echo "dry_run=false" >> $GITHUB_OUTPUT
+            printf '%s' "$TEST_FINDINGS" > /tmp/findings.json
           fi
+          python3 -c "import json; json.load(open('/tmp/findings.json'))" && echo "findings.json valid"
 
       - name: Construct target image URI
         id: target
@@ -171,17 +193,14 @@ jobs:
 
       - name: Build target list from inputs
         id: build_targets
+        env:
+          IMAGE: ${{ steps.target.outputs.image_uri }}
         run: |
-          # POC: build a single-image target list from the dispatch inputs
-          IMAGE="${{ steps.target.outputs.image_uri }}"
-          # Normalize CVE list (commas or newlines → JSON array)
-          CVES=$(echo "${{ steps.resolve.outputs.cve_id_list }}" | tr ',\n' '\n' | grep -v '^$' | python3 -c "import json,sys; print(json.dumps([l.strip() for l in sys.stdin if l.strip()]))")
+          # POC: build a single-image target list combining the resolved image URI + findings.
           python3 -c "
-          import json
-          print(json.dumps([{
-              'image': '$IMAGE',
-              'cve_ids': $CVES,
-          }]))
+          import json, os
+          findings = json.load(open('/tmp/findings.json'))
+          print(json.dumps([{'image': os.environ['IMAGE'], 'findings': findings}], indent=2))
           " > /tmp/cve-targets.json
           cat /tmp/cve-targets.json
 

--- a/scripts/cve-patcher/agent-fix.py
+++ b/scripts/cve-patcher/agent-fix.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import boto3
 
-MODEL_ID = "us.anthropic.claude-opus-4-7-v1"
+MODEL_ID = "us.anthropic.claude-opus-4-6-v1"
 MAX_TOKENS = 16384
 REGION = os.environ.get("AWS_REGION", "us-west-2")
 MAX_LOG_LINES = 500

--- a/scripts/cve-patcher/agent-fix.py
+++ b/scripts/cve-patcher/agent-fix.py
@@ -1,0 +1,510 @@
+#!/usr/bin/env python3
+"""agent-fix.py — Diagnose CI failures on cve-patch/* PRs using Bedrock Claude.
+
+Uses search/replace blocks (Aider/Cline format) with retry-on-failure loop.
+Called by cve-patcher-fix.yml workflow. Forked from scripts/autocurrency/agent-fix.py
+with a CVE-flavored system prompt and NOT_CVE_RELATED response shape.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import boto3
+
+MODEL_ID = "us.anthropic.claude-opus-4-7-v1"
+MAX_TOKENS = 16384
+REGION = os.environ.get("AWS_REGION", "us-west-2")
+MAX_LOG_LINES = 500
+MAX_LLM_RETRIES = 3
+CONTEXT_MAP_PATH = ".github/config/agent-context-files.yml"
+
+SEARCH_REPLACE_PATTERN = re.compile(
+    r"^([^\n]*?/[^\n]*)\n<<<<<<< SEARCH\n(.*?)\n=======\n(.*?)\n>>>>>>> REPLACE$",
+    re.MULTILINE | re.DOTALL,
+)
+
+SYSTEM_PROMPT = """You are an automated CVE-patch CI fix agent for the AWS Deep Learning Containers repo.
+A CVE-patch PR (branch prefix `cve-patch/`) has failed CI. The PR was opened by a sibling agent that
+already applied an initial fix (a dependency bump, an OS-package upgrade, or an allowlist entry).
+Your job: read the CI failure, decide if it's CVE-related, and emit minimal additional edits.
+
+## Rules
+- ONLY fix the specific failure shown in the logs.
+- Do NOT delete or skip tests.
+- Do NOT modify files unrelated to the failure.
+- ONLY edit files that are provided in the context below. If a file is not shown, do not edit it.
+- ALWAYS populate `review_by` for new allowlist entries with an ISO date (YYYY-MM-DD), 90 days from today.
+  Example entry: `{"vulnerability_id": "CVE-2026-XXXXX", "reason": "...", "review_by": "2026-08-18"}`
+- NEVER bump CUDA / Python / framework versions (e.g. CUDA 12.9 → 13.0, py312 → py313, vllm 0.19 → 0.20).
+  Those are image-contract boundaries; allowlist instead with a reason citing the contract.
+
+## CVE-related failures (you SHOULD fix these)
+
+- Security test still flags the CVE → the bump didn't actually resolve it. Try a higher version, or fall back to allowlist.
+- A new CVE was introduced by your bump → either bump again, revert, or allowlist if vendored / no upstream fix.
+- Allowlist JSON is malformed (parse error) → fix the JSON shape.
+- Allowlist entry missing required fields (vulnerability_id, reason, review_by) → fix the entry.
+
+## NOT CVE-related failures (you should NOT fix these — comment instead)
+
+- Functional test regression: the new version changed behavior. Out of scope for the patcher; needs a human to assess.
+- Image build broke: typically a transitive resolver conflict, sometimes a base-image change.
+- Test infrastructure flake: capacity, timeout, runner crash. Don't fix; respond with TRANSIENT.
+
+## Response Format
+
+If the failure is TRANSIENT (capacity, timeout, runner crash, network blip), respond with exactly:
+TRANSIENT: <brief reason>
+
+If the failure is NOT CVE-related (functional regression, build break, etc.), respond with exactly:
+NOT_CVE_RELATED: <brief one-line classification>
+
+Otherwise, respond with search/replace blocks. Use this EXACT format:
+
+path/to/file.ext
+<<<<<<< SEARCH
+exact text to find in the file
+=======
+replacement text
+>>>>>>> REPLACE
+
+IMPORTANT: Write the file path as plain text (e.g., docker/vllm/Dockerfile). Do NOT wrap it in angle brackets, backticks, or any other formatting.
+
+Include 1-2 surrounding lines in SEARCH for unique anchoring.
+For JSON allowlist arrays, SEARCH the last few lines (including the closing `]`) and REPLACE with those lines plus the new entry. Preserve existing indentation and trailing-comma rules.
+
+End with: DESCRIPTION: one-line commit message"""
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--framework", required=True)
+    p.add_argument("--branch", required=True)
+    p.add_argument("--run-ids", default="", help="Space-separated failed run IDs")
+    p.add_argument("--token", default=os.environ.get("GH_TOKEN", ""), help="GitHub token")
+    p.add_argument("--repo", default="aws/deep-learning-containers")
+    return p.parse_args()
+
+
+def extract_failure_info(run_ids: str, token: str, repo: str) -> tuple:
+    """Use GitHub API to get structured failure info. Returns (error_text, failed_job_names)."""
+    print("Using GitHub API for structured failure extraction")
+    import urllib.request
+
+    results = []
+    failed_job_names = []
+    for run_id in run_ids.strip().split():
+        if not run_id:
+            continue
+        # Get jobs for this run
+        url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100"
+        req = urllib.request.Request(
+            url,
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github+json",
+            },
+        )
+        try:
+            resp = urllib.request.urlopen(req)
+            data = json.loads(resp.read())
+        except Exception as e:
+            results.append(f"Failed to fetch jobs for run {run_id}: {e}")
+            continue
+
+        # Find failed jobs and steps
+        tracked_jobs = [
+            "build-image",
+            "sanity-test",
+            "security-test",
+            "telemetry-test",
+            "upstream-tests",
+            "sagemaker-test",
+        ]
+        for job in data.get("jobs", []):
+            if job.get("conclusion") != "failure":
+                continue
+
+            # Only process jobs that match our tracked job names
+            job_lower = job["name"].lower()
+            matched_key = None
+            for key in tracked_jobs:
+                if key.replace("-", "") in job_lower.replace("-", "").replace(" ", ""):
+                    matched_key = key
+                    break
+            if not matched_key:
+                continue
+
+            failed_steps = [
+                s["name"] for s in job.get("steps", []) if s.get("conclusion") == "failure"
+            ]
+            results.append(f"FAILED JOB: {job['name']}")
+            failed_job_names.append(matched_key)
+            results.append(f"  Failed steps: {', '.join(failed_steps)}")
+
+            # Download log from run zip
+            import io
+            import zipfile
+
+            zip_url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/logs"
+            zip_req = urllib.request.Request(
+                zip_url,
+                headers={
+                    "Authorization": f"token {token}",
+                    "Accept": "application/vnd.github+json",
+                },
+            )
+            try:
+                resp = urllib.request.urlopen(zip_req)
+                z = zipfile.ZipFile(io.BytesIO(resp.read()))
+                target = job["name"].replace(" / ", " _ ")
+                for name in z.namelist():
+                    if target in name:
+                        log_lines = z.read(name).decode(errors="replace").splitlines()
+                        results.append(f"  Log ({name}, {len(log_lines)} lines):")
+                        results.extend(f"    {line}" for line in log_lines)
+                        break
+                else:
+                    results.append(f"  No matching log file for '{target}' in zip")
+            except Exception as e:
+                results.append(f"  Failed to download logs: {e}")
+
+            results.append("")
+
+    return "\n".join(results) or "No failure info extracted.", failed_job_names
+
+
+def _extract_via_grep(logs_dir: str) -> str:
+    """Fallback: grep log files for error keywords."""
+    logs_path = Path(logs_dir)
+    if not logs_path.exists():
+        return "No logs available."
+
+    error_lines = []
+    keywords = ["error", "failed", "failure", "cve-", "not found", "exception", "denied"]
+
+    for log_file in sorted(logs_path.rglob("*.txt")):
+        try:
+            lines = log_file.read_text(errors="replace").splitlines()
+        except Exception:
+            continue
+        for i, line in enumerate(lines):
+            if any(kw in line.lower() for kw in keywords):
+                start, end = max(0, i - 2), min(len(lines), i + 3)
+                error_lines.append(f"--- {log_file.name}:{i + 1} ---")
+                error_lines.extend(lines[start:end])
+                error_lines.append("")
+        if len(error_lines) > MAX_LOG_LINES:
+            break
+
+    return "\n".join(error_lines[:MAX_LOG_LINES]) or "No error patterns found in logs."
+
+
+def read_file(path: str) -> str:
+    try:
+        return Path(path).read_text()
+    except (FileNotFoundError, PermissionError):
+        return ""
+
+
+def detect_failed_jobs(logs_dir: str) -> list:
+    """Detect which CI jobs failed based on log filenames."""
+    logs_path = Path(logs_dir)
+    if not logs_path.exists():
+        return []
+    # Log files are named like "8_security-test _ ecr-vulnerability-scan.txt"
+    job_names = set()
+    for f in logs_path.rglob("*.txt"):
+        name = f.stem.lower()
+        for job in [
+            "build-image",
+            "sanity-test",
+            "security-test",
+            "telemetry-test",
+            "upstream-tests",
+            "sagemaker-test",
+        ]:
+            if job in name:
+                job_names.add(job)
+    return list(job_names)
+
+
+def load_context_files(framework: str, failed_jobs: list) -> dict:
+    """Load relevant source files based on which jobs failed.
+
+    Returns dict of {filepath: content}.
+    """
+    mapping_path = Path(CONTEXT_MAP_PATH)
+    if not mapping_path.exists():
+        return {
+            p: read_file(p)
+            for p in [
+                f"docker/{framework}/Dockerfile",
+                f".github/config/image/{framework}-ec2.yml",
+                f"test/security/data/ecr_scan_allowlist/{framework}/framework_allowlist.json",
+            ]
+            if read_file(p)
+        }
+
+    # Parse YAML via subprocess (yq available on runners) or fallback to simple parsing
+    try:
+        import yaml
+
+        config = yaml.safe_load(mapping_path.read_text())
+    except ImportError:
+        # Fallback: parse the simple YAML structure manually
+        config = _parse_simple_yaml(mapping_path.read_text())
+
+    paths = set()
+    for p in config.get("common", []):
+        paths.add(p.replace("{framework}", framework))
+
+    jobs_map = config.get("jobs", {})
+    for job in failed_jobs:
+        for p in jobs_map.get(job, []):
+            paths.add(p.replace("{framework}", framework))
+
+    if not failed_jobs:
+        for files in jobs_map.values():
+            for p in files:
+                paths.add(p.replace("{framework}", framework))
+
+    return {p: content for p in sorted(paths) if (content := read_file(p))}
+
+
+def _parse_simple_yaml(text: str) -> dict:
+    """Minimal YAML parser for our flat list-of-strings structure."""
+    result = {"common": [], "jobs": {}}
+    current_section = None
+    current_job = None
+
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if line == "common:":
+            current_section = "common"
+            current_job = None
+        elif line == "jobs:":
+            current_section = "jobs"
+        elif (
+            current_section == "jobs"
+            and line.startswith("  ")
+            and not line.startswith("    ")
+            and stripped.endswith(":")
+        ):
+            current_job = stripped.rstrip(":")
+            result["jobs"][current_job] = []
+        elif stripped.startswith("- "):
+            value = stripped[2:].strip().strip('"')
+            if current_section == "common":
+                result["common"].append(value)
+            elif current_job:
+                result["jobs"][current_job].append(value)
+    return result
+
+
+def get_previous_fixes() -> str:
+    try:
+        r = subprocess.run(
+            ["git", "log", "--oneline", "origin/main..HEAD", "--grep=[cve-patch-fix]"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return r.stdout.strip() or "None"
+    except subprocess.CalledProcessError:
+        return "None"
+
+
+def parse_blocks(response: str) -> list:
+    blocks = []
+    for m in SEARCH_REPLACE_PATTERN.finditer(response):
+        filepath = m.group(1).strip().strip("`").strip()
+        # Strip all common LLM artifacts: <filepath>path, <path>, **path**, `path`
+        filepath = re.sub(r"^<[^>]*>", "", filepath).strip()  # strips <filepath>, <file>, etc.
+        filepath = re.sub(r"^<|>$", "", filepath).strip()  # strips bare < >
+        filepath = filepath.strip("*").strip("`").strip()
+        blocks.append({"path": filepath, "search": m.group(2), "replace": m.group(3)})
+    return blocks
+
+
+def find_match(content: str, search: str) -> tuple:
+    """Exact match, then whitespace-normalized. Returns (start, end) or (None, None)."""
+    idx = content.find(search)
+    if idx != -1:
+        return idx, idx + len(search)
+
+    # Whitespace-normalized: strip trailing spaces per line
+    def norm(s):
+        return "\n".join(line.rstrip() for line in s.splitlines())
+
+    norm_content, norm_search = norm(content), norm(search)
+    idx = norm_content.find(norm_search)
+    if idx != -1:
+        line_num = norm_content[:idx].count("\n")
+        lines = content.splitlines(keepends=True)
+        end_line = line_num + norm_search.count("\n")
+        return sum(len(lines[i]) for i in range(line_num)), sum(
+            len(lines[i]) for i in range(end_line + 1)
+        )
+
+    return None, None
+
+
+def apply_blocks(blocks: list) -> tuple:
+    """Returns (modified_files, errors)."""
+    modified, errors = [], []
+
+    for b in blocks:
+        path, search, replace = b["path"], b["search"], b["replace"]
+
+        if not Path(path).exists():
+            if not search.strip():  # Create new file
+                Path(path).parent.mkdir(parents=True, exist_ok=True)
+                Path(path).write_text(replace)
+                modified.append(path)
+            else:
+                errors.append(f"File not found: {path}")
+            continue
+
+        content = Path(path).read_text()
+        start, end = find_match(content, search)
+
+        if start is None:
+            errors.append(
+                f"SEARCH not found in {path}.\n"
+                f"  Searched for: {search[:100]}...\n"
+                f"  Actual content (first 500 chars): {content[:500]}"
+            )
+            continue
+
+        Path(path).write_text(content[:start] + replace + content[end:])
+        modified.append(path)
+
+    return modified, errors
+
+
+def call_bedrock(system: str, user: str) -> str:
+    client = boto3.client("bedrock-runtime", region_name=REGION)
+    resp = client.invoke_model(
+        modelId=MODEL_ID,
+        body=json.dumps(
+            {
+                "anthropic_version": "bedrock-2023-05-31",
+                "max_tokens": MAX_TOKENS,
+                "system": system,
+                "messages": [{"role": "user", "content": user}],
+            }
+        ),
+    )
+    return json.loads(resp["body"].read())["content"][0]["text"]
+
+
+def build_prompt(framework, branch, error_lines, context_files, previous_fixes, retry_context=""):
+    files_section = ""
+    for path, content in context_files.items():
+        ext = Path(path).suffix.lstrip(".")
+        lang = {"py": "python", "sh": "bash", "yml": "yaml", "json": "json"}.get(ext, "")
+        files_section += f"\n### {path}:\n```{lang}\n{content}\n```\n"
+
+    prompt = f"""## Context
+Framework: {framework}
+Branch: {branch}
+
+### CI Error Lines:
+```
+{error_lines}
+```
+{files_section}
+### Previous fix attempts on this branch:
+{previous_fixes}"""
+
+    if retry_context:
+        prompt += f"\n\n### RETRY — Previous attempt failed:\n{retry_context}\n\nFix ONLY the failed SEARCH blocks. Do NOT resend already-applied blocks."
+    return prompt
+
+
+def main():
+    args = parse_args()
+    print(f"=== CVE Patcher Fix Agent: {args.framework} @ {args.branch} ===\n")
+
+    error_lines, api_failed_jobs = extract_failure_info(args.run_ids, args.token, args.repo)
+    # Use API-detected jobs if available, otherwise fall back to log filename detection
+    failed_jobs = api_failed_jobs
+    context_files = load_context_files(args.framework, failed_jobs)
+    previous_fixes = get_previous_fixes()
+
+    print(f"Error lines extracted: {len(error_lines.splitlines())} lines")
+    print(f"Error lines preview: {error_lines[:500]}")
+    print(f"Failed jobs detected: {failed_jobs or 'none (including all files)'}")
+    print(f"Context files loaded: {list(context_files.keys())}")
+    print()
+
+    retry_context = ""
+    for attempt in range(1, MAX_LLM_RETRIES + 1):
+        print(f"--- Attempt {attempt}/{MAX_LLM_RETRIES} ---")
+
+        prompt = build_prompt(
+            args.framework, args.branch, error_lines, context_files, previous_fixes, retry_context
+        )
+        print(f"Prompt size: {len(prompt)} chars")
+        response = call_bedrock(SYSTEM_PROMPT, prompt)
+        print(f"LLM response ({len(response)} chars):")
+        print(response[:2000])
+        if len(response) > 2000:
+            print(f"  ... ({len(response) - 2000} more chars)")
+        print()
+
+        if response.strip().startswith("TRANSIENT:"):
+            print(f"Transient: {response.strip().split(':', 1)[1].strip()}")
+            sys.exit(0)
+
+        if response.strip().startswith("NOT_CVE_RELATED:"):
+            reason = response.strip().split(":", 1)[1].strip()
+            print(f"Not CVE-related: {reason}")
+            # Workflow reads this file and posts a PR comment + escalates to human.
+            Path("/tmp/agent-fix-not-cve-related.txt").write_text(reason)
+            sys.exit(0)
+
+        blocks = parse_blocks(response)
+        if blocks:
+            paths = [b["path"] for b in blocks]
+            print(f"Parsed {len(blocks)} block(s): {paths}")
+        if not blocks:
+            retry_context = (
+                f"Could not parse search/replace blocks from response.\n"
+                f"Response started with: {response[:300]}...\n"
+                f"Use exact format: <filepath>\\n<<<<<<< SEARCH\\n...\\n=======\\n...\\n>>>>>>> REPLACE"
+            )
+            print("No blocks parsed, retrying...")
+            print(f"  Response preview: {response[:200]}")
+            continue
+
+        modified, errors = apply_blocks(blocks)
+        if errors:
+            retry_context = f"{len(modified)} applied, {len(errors)} failed:\n" + "\n".join(errors)
+            print(f"{'Partial' if modified else 'All failed'}: {len(errors)} error(s), retrying...")
+            for e in errors:
+                print(f"  ERROR: {e[:300]}")
+            continue
+
+        # Success
+        desc_match = re.search(r"^DESCRIPTION:\s*(.+)$", response, re.MULTILINE)
+        description = desc_match.group(1).strip() if desc_match else "automated fix"
+        Path("/tmp/agent-fix-description.txt").write_text(description)
+        print(f"✅ {len(modified)} edit(s) applied: {modified}")
+        print(f"Description: {description}")
+        return
+
+    print(f"ERROR: Failed after {MAX_LLM_RETRIES} attempts.")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cve-patcher/agent.py
+++ b/scripts/cve-patcher/agent.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python3
+"""agent.py — CVE patching agent.
+
+POC flow (current):
+  1. Take a list of CVE IDs from the workflow dispatch input (passed via /tmp/cve-targets.json).
+  2. Map image → Dockerfile path in this repo.
+  3. Classify each CVE via Bedrock Claude (vendored / ESM / no-upstream-fix / direct-pin /
+     dep-conflict / contract-boundary / OS_PACKAGE).
+  4. Return search/replace blocks per Dockerfile. The workflow applies them on a per-Dockerfile
+     branch and opens one PR per Dockerfile.
+
+Production flow (future, gated on cross-account access being wired):
+  Same as above, but step 1 pulls the full CVE list from the daily ECR enhanced scan dump
+  (poll.py + fetch_ecr_scan below) instead of taking it as input.
+
+Calls Bedrock Claude (same pattern as scripts/autocurrency/agent-fix.py) for the
+classification + fix-generation step.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import boto3
+
+MODEL_ID = "us.anthropic.claude-opus-4-7-v1"
+MAX_TOKENS = 16384
+REGION = os.environ.get("AWS_REGION", "us-west-2")
+
+ALLOWLIST_DIR = Path("test/security/data/ecr_scan_allowlist")
+DOCKER_DIR = Path("docker")
+
+SEARCH_REPLACE_PATTERN = re.compile(
+    r"^([^\n]*?/[^\n]*)\n<<<<<<< SEARCH\n(.*?)\n=======\n(.*?)\n>>>>>>> REPLACE$",
+    re.MULTILINE | re.DOTALL,
+)
+
+SYSTEM_PROMPT = """You are an automated CVE patching agent for the AWS Deep Learning Containers repo.
+You are given a list of CVEs for one Dockerfile. Generate minimal file edits to fix or allowlist them.
+
+## Rules
+- For each CVE, classify it as one of:
+  - VENDORED (filePath in scan result contains thirdparty_files/ or similar) → allowlist
+  - ESM_ONLY (package_manager indicates Ubuntu ESM or fix only in ESM) → allowlist
+  - NO_UPSTREAM_FIX (fixedInVersion is empty / N/A / NotAvailable / NotPlanned / WontFix) → allowlist
+  - CONTRACT_BOUNDARY (fix would change a version the image promises in its tag, e.g. CUDA 12.9 → 13.0, py312 → py313, vllm 0.19 → 0.20) → allowlist with reason citing the contract
+  - DIRECT_PIN (fix is a clean SemVer bump on a directly-pinned package) → bump in pyproject.toml or Dockerfile
+  - DEP_CONFLICT (transitive dep, no direct pin) → attempt parent bump in pyproject.toml
+  - OS_PACKAGE (package_manager is RPM/DNF/OS/APT/DPKG/GENERIC, NOT PYTHON/PIP/NPM) → handle per sub-type:
+    * NVIDIA repo packages (cuda-*, nvidia-*, libnvidia-*) → add explicit `dnf upgrade -y --releasever latest <pkg>` line in Dockerfile, applied to BOTH EC2 and SageMaker stages. AL2023's --security flag may miss NVIDIA-tagged packages.
+    * Conda-bundled (file path includes miniconda3/, conda/) → bump the conda pin in the Dockerfile
+    * ESM-only (Ubuntu Pro) → allowlist
+    * Otherwise (standard AL2023/Ubuntu repos) → no edit needed; auto-resolves on next rebuild via existing `dnf upgrade --security` line. Note this in summary instead of editing.
+- ALWAYS populate `review_by` for new allowlist entries with an ISO date string (YYYY-MM-DD), 90 days from today.
+  Example entry: `{"vulnerability_id": "CVE-2026-XXXXX", "reason": "...", "review_by": "2026-08-18"}`
+- NEVER bump CUDA/Python/framework versions that would change the image's tag promise — those are CONTRACT_BOUNDARY.
+- NEVER delete or skip tests.
+- If unsure, prefer ALLOWLIST over BUMP. CI is the validator either way.
+
+## Response Format
+
+For each file you edit, emit:
+
+path/to/file.ext
+<<<<<<< SEARCH
+<exact existing text>
+=======
+<replacement text>
+>>>>>>> REPLACE
+
+End with a one-line summary on the LAST line, prefixed `SUMMARY: ` (used for the commit message).
+"""
+
+
+def fetch_ecr_scan(image_uri):
+    """Pull full ECR scan findings for an image.
+
+    Production path. Currently UNREACHABLE in POC — process_image() takes cve_ids as
+    explicit input. Saved here for when cross-account access to the scan account is wired.
+
+    Note: this returns legacy `findings` + `enhancedFindings`. The actual ECR enhanced
+    scan dump in S3 uses a `vulnerabilities` key — when re-enabling for production, prefer
+    reading the S3 dump (per the daily DJS scan) over calling DescribeImageScanFindings.
+    """
+    # image_uri = 763104351884.dkr.ecr.us-west-2.amazonaws.com/pytorch:2.10-gpu-py312
+    m = re.match(r"^(\d+)\.dkr\.ecr\.([\w-]+)\.amazonaws\.com/([\w-]+):(.+)$", image_uri)
+    if not m:
+        raise ValueError(f"Cannot parse image URI: {image_uri}")
+    account, region, repo, tag = m.groups()
+    ecr = boto3.client("ecr", region_name=region)
+    r = ecr.describe_image_scan_findings(
+        repositoryName=repo,
+        imageId={"imageTag": tag},
+        maxResults=1000,
+    )
+    return r.get("imageScanFindings", {}).get("findings", []) + r.get(
+        "imageScanFindings", {}
+    ).get("enhancedFindings", [])
+
+
+# Single source of truth for image → Dockerfile + allowlist mapping.
+# Scope: aws/deep-learning-containers main branch only. V1/master images return None.
+#
+# Each entry maps a (repo, predicate-fn) → (dockerfile_parts, allowlist_dir).
+# Predicate takes the tag string and returns True if this entry matches.
+#
+# Tag patterns reference: DLContainersReleaseLogicPython config/frameworks.yml
+# (the canonical source for release-tag construction). Examples:
+#   pytorch (runtime):  "2.11.0-cu130-amzn2023"  / "2.11.0-cpu-amzn2023"
+#   ray:                "serve-ml-cuda" / "serve-ml-cpu" (+ -v1 / -v1.0 / -v1.0.3 variants)
+#   vllm_server:        "server-cuda" (+ -v1) — repo is "vllm", disambiguate by tag prefix
+#   vllm_omni:          "omni-cuda" (+ -v1) — repo is "vllm", disambiguate by tag prefix
+#   vllm (legacy):      "0.18-gpu-py312-amzn2023-sagemaker"
+#   base_dlc:           "runtime-cuda" / "devel-cuda" (+ -v1 → v1 dir, -v2 → v2 dir)
+# CI tags (e.g. "cuda129-devel-amzn2023") are NOT release tags — don't pattern-match those here.
+#
+# When adding a new image, add its row here — both functions below derive from this table.
+def _is_cpu(tag): return "-cpu" in tag or tag.startswith("cpu")
+def _is_cuda(tag): return "-cuda" in tag or "-cu1" in tag or "-gpu" in tag
+def _is_amzn2023(tag): return "amzn2023" in tag
+def _always(_): return True
+
+# Base v1 vs v2: distinguished by the version suffix on the release tag (-v1.x.x vs -v2.x.x).
+def _is_base_v1(tag): return re.search(r"-v1(\.|$)", tag) is not None
+def _is_base_v2(tag): return re.search(r"-v2(\.|$)", tag) is not None
+
+# (repo_name, predicate, dockerfile_path_parts, allowlist_dir)
+# Order matters: first match wins.
+IMAGE_TABLE = [
+    ("pytorch",     _is_cpu,      ("pytorch", "Dockerfile.cpu"),    "pytorch"),
+    ("pytorch",     _is_cuda,     ("pytorch", "Dockerfile.cuda"),   "pytorch"),
+    ("ray",         _is_cpu,      ("ray", "Dockerfile.cpu"),        "ray"),
+    ("ray",         _is_cuda,     ("ray", "Dockerfile.gpu"),        "ray"),
+    # vllm repo hosts 3 frameworks — disambiguate by tag prefix.
+    ("vllm",        lambda t: t.startswith("server-"), ("vllm", "Dockerfile.amzn2023"),     "vllm_server"),
+    ("vllm",        lambda t: t.startswith("omni-"),   ("vllm_omni", "Dockerfile.amzn2023"), "vllm_omni"),
+    ("vllm",        _is_amzn2023,                      ("vllm", "Dockerfile.amzn2023"),     "vllm"),
+    ("vllm",        _always,                           ("vllm", "Dockerfile"),              "vllm"),  # Ubuntu fallback
+    # sglang: forward-compat for sglang_server (not in use today).
+    ("sglang",      lambda t: t.startswith("server-"), ("sglang", "Dockerfile.amzn2023"),   "sglang_server"),
+    ("sglang",      _is_amzn2023,                      ("sglang", "Dockerfile.amzn2023"),   "sglang"),
+    ("sglang",      _always,                           ("sglang", "Dockerfile"),            "sglang"),
+    # base_dlc release tags are e.g. "runtime-cuda-v1.0.3" or "devel-cuda-v2.1.0".
+    # The Dockerfile to edit lives at docker/base/v1/ or v2/.
+    ("base",        _is_base_v1,  ("base", "v1", "Dockerfile"),     "base_dlc"),
+    ("base",        _is_base_v2,  ("base", "v2", "Dockerfile"),     "base_dlc"),
+]
+
+
+def _parse_image_uri(image_uri):
+    """Return (repo, tag) or None."""
+    m = re.match(r"^.*?/([\w-]+):(.+)$", image_uri)
+    if not m:
+        return None
+    return m.group(1), m.group(2)
+
+
+def _lookup(image_uri):
+    """Find the IMAGE_TABLE entry for an image URI. Returns the row or None."""
+    parsed = _parse_image_uri(image_uri)
+    if not parsed:
+        return None
+    repo, tag = parsed
+    for row in IMAGE_TABLE:
+        if row[0] == repo and row[1](tag):
+            return row
+    return None
+
+
+def map_image_to_dockerfile(image_uri):
+    """Map ECR image URI → Dockerfile path for main-branch DLC images."""
+    row = _lookup(image_uri)
+    if not row:
+        return None
+    candidate = DOCKER_DIR.joinpath(*row[2])
+    return candidate if candidate.exists() else None
+
+
+def map_image_to_allowlist(image_uri):
+    """Map ECR image URI → framework_allowlist.json path. Pure lookup, no side effects.
+
+    Returns the path even if the file doesn't exist on disk yet. Caller is
+    responsible for ensuring the file exists before pointing the LLM at it
+    (see ensure_allowlist_exists).
+    """
+    row = _lookup(image_uri)
+    if not row:
+        return None
+    return ALLOWLIST_DIR / row[3] / "framework_allowlist.json"
+
+
+def ensure_allowlist_exists(allowlist_path):
+    """Create the allowlist file with an empty `[]` array if missing.
+
+    Side-effecting: makes parent dirs and writes file. Idempotent.
+    """
+    if allowlist_path is None or allowlist_path.exists():
+        return
+    allowlist_path.parent.mkdir(parents=True, exist_ok=True)
+    allowlist_path.write_text("[]\n")
+    print(f"  Created empty allowlist file: {allowlist_path}", file=sys.stderr)
+
+
+def call_llm(messages):
+    """Call Bedrock Claude. No retry — caller can rerun the whole agent if needed."""
+    client = boto3.client("bedrock-runtime", region_name=REGION)
+    response = client.converse(
+        modelId=MODEL_ID,
+        messages=messages,
+        inferenceConfig={"maxTokens": MAX_TOKENS, "temperature": 0.0},
+        system=[{"text": SYSTEM_PROMPT}],
+    )
+    return response["output"]["message"]["content"][0]["text"]
+
+
+def parse_search_replace(text):
+    """Extract search/replace blocks. Returns list of (path, search, replace)."""
+    return [(m.group(1), m.group(2), m.group(3)) for m in SEARCH_REPLACE_PATTERN.finditer(text)]
+
+
+def process_image(image_uri, cve_ids=None, dry_run=False):
+    """Run the agent for a single image. Returns dict of {dockerfile: summary}.
+
+    POC: cve_ids is a list of CVE IDs passed by the workflow dispatch input.
+    Production (TODO): when cve_ids is None, fall back to fetch_ecr_scan(image_uri)
+    to discover CVEs autonomously from the scan dump.
+    """
+    print(f"== Processing {image_uri} ==", file=sys.stderr)
+
+    if cve_ids is None or not cve_ids:
+        # Production path: fetch from ECR / S3 dump.
+        # Commented out for POC since cross-account access isn't wired yet.
+        # findings = fetch_ecr_scan(image_uri)
+        # if not findings:
+        #     print(f"  No findings for {image_uri}", file=sys.stderr)
+        #     return {}
+        print(f"::warning::[{image_uri}] No cve_ids provided. POC requires explicit input.", file=sys.stderr)
+        return {}
+
+    dockerfile = map_image_to_dockerfile(image_uri)
+    if not dockerfile:
+        print(f"::warning::[{image_uri}] Could not map to a Dockerfile. Skipping.", file=sys.stderr)
+        return {}
+
+    allowlist = map_image_to_allowlist(image_uri)
+    ensure_allowlist_exists(allowlist)
+    print(f"  Dockerfile: {dockerfile}", file=sys.stderr)
+    print(f"  Allowlist:  {allowlist}", file=sys.stderr)
+    print(f"  CVEs:       {len(cve_ids)} (from input: {cve_ids})", file=sys.stderr)
+
+    # If allowlist is freshly empty, give the LLM unambiguous shape instructions.
+    allowlist_hint = ""
+    is_empty_allowlist = False
+    if allowlist:
+        try:
+            is_empty_allowlist = json.loads(allowlist.read_text()) == []
+        except json.JSONDecodeError:
+            pass
+    if is_empty_allowlist:
+        allowlist_hint = (
+            f"\n\nNOTE: The allowlist file ({allowlist}) currently contains exactly `[]`. "
+            "If you need to add allowlist entries, emit ONE SEARCH/REPLACE block where SEARCH is `[]` "
+            "and REPLACE is a JSON array containing your entries. Example:\n"
+            "```\n"
+            "[\n"
+            '  {"vulnerability_id": "CVE-2026-XXXXX", "reason": "vendored in <pkg>", "review_by": "2026-08-18"}\n'
+            "]\n"
+            "```"
+        )
+
+    user_prompt = f"""Image: {image_uri}
+Dockerfile: {dockerfile}
+Allowlist file: {allowlist}{allowlist_hint}
+
+CVE IDs to patch:
+{json.dumps(cve_ids, indent=2)}
+
+For each CVE, classify it (VENDORED / ESM_ONLY / NO_UPSTREAM_FIX / CONTRACT_BOUNDARY / DIRECT_PIN / DEP_CONFLICT)
+and generate the appropriate fix as search/replace blocks.
+
+If you need to look up details for a CVE (package, fixedInVersion, severity), use the Dockerfile and the
+existing allowlist file as reference for what's currently pinned. Search the codebase if needed.
+
+Generate search/replace blocks to fix or allowlist these CVEs."""
+
+    if dry_run:
+        print(user_prompt)
+        return {str(dockerfile): "DRY RUN"}
+
+    text = call_llm([{"role": "user", "content": [{"text": user_prompt}]}])
+
+    # Return blocks as data — workflow applies them on the per-Dockerfile branch.
+    # Don't apply to working tree here, otherwise edits leak across branches.
+    blocks = parse_search_replace(text)
+    print(f"  Got {len(blocks)} edit blocks from LLM", file=sys.stderr)
+
+    # Validate review_by on allowlist edits. Any block touching framework_allowlist.json
+    # must include `"review_by": "YYYY-MM-DD"` (ISO date) in the replacement.
+    # ecr_scan.py uses datetime.date.fromisoformat() and crashes on bad strings, so a missing
+    # or non-ISO review_by would break security CI on every allowlist file.
+    # If any block fails, abort the whole image (won't ship a partial patch).
+    review_by_pattern = re.compile(r'"review_by"\s*:\s*"\d{4}-\d{2}-\d{2}"')
+    bad = [b for b in blocks if "framework_allowlist.json" in b[0] and not review_by_pattern.search(b[2])]
+    if bad:
+        print(
+            f"::error::[{image_uri}] {len(bad)} allowlist edit(s) missing or malformed review_by "
+            "(must be ISO date YYYY-MM-DD). Aborting image (will not ship partial patch).",
+            file=sys.stderr,
+        )
+        return {}
+
+    # Simulate applying each allowlist block and json.loads() the result.
+    # Catches malformed JSON (LLM dropped a comma, mismatched braces, etc.).
+    for path_str, search, replace in blocks:
+        if "framework_allowlist.json" not in path_str:
+            continue
+        p = Path(path_str)
+        try:
+            sim = p.read_text().replace(search, replace, 1) if p.exists() else replace
+            json.loads(sim)
+        except (json.JSONDecodeError, OSError) as e:
+            print(
+                f"::error::[{image_uri}] Allowlist edit produces invalid JSON in {path_str}: {e}. Aborting image.",
+                file=sys.stderr,
+            )
+            return {}
+    summary_match = re.search(r"^SUMMARY:\s*(.+)$", text, re.MULTILINE)
+    summary = summary_match.group(1).strip() if summary_match else f"patch CVEs in {dockerfile.name}"
+    print(f"  Summary: {summary}", file=sys.stderr)
+    return {
+        str(dockerfile): {
+            "summary": summary,
+            "blocks": [{"path": p, "search": s, "replace": r} for p, s, r in blocks],
+        }
+    }
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--input", required=True, help="JSON file from poll.py")
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--summary-output", default="/tmp/cve-patcher-summary.json")
+    args = parser.parse_args()
+
+    rows = json.loads(Path(args.input).read_text())
+    summaries = {}
+    for row in rows:
+        try:
+            s = process_image(row["image"], cve_ids=row.get("cve_ids"), dry_run=args.dry_run)
+            summaries.update(s)
+        except Exception as e:
+            print(f"::error::Failed on {row['image']}: {e}", file=sys.stderr)
+
+    Path(args.summary_output).write_text(json.dumps(summaries, indent=2))
+    print(f"Wrote summary to {args.summary_output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cve-patcher/agent.py
+++ b/scripts/cve-patcher/agent.py
@@ -27,7 +27,7 @@ from pathlib import Path
 
 import boto3
 
-MODEL_ID = "us.anthropic.claude-opus-4-7-v1"
+MODEL_ID = "us.anthropic.claude-opus-4-6-v1"
 MAX_TOKENS = 16384
 REGION = os.environ.get("AWS_REGION", "us-west-2")
 

--- a/scripts/cve-patcher/agent.py
+++ b/scripts/cve-patcher/agent.py
@@ -282,45 +282,47 @@ def process_image(image_uri, cve_ids=None, dry_run=False):
         return {}
 
     allowlist = map_image_to_allowlist(image_uri)
+    if not allowlist:
+        print(f"::warning::[{image_uri}] Could not map to an allowlist. Skipping.", file=sys.stderr)
+        return {}
     ensure_allowlist_exists(allowlist)
     print(f"  Dockerfile: {dockerfile}", file=sys.stderr)
     print(f"  Allowlist:  {allowlist}", file=sys.stderr)
     print(f"  CVEs:       {len(cve_ids)} (from input: {cve_ids})", file=sys.stderr)
 
-    # If allowlist is freshly empty, give the LLM unambiguous shape instructions.
+    dockerfile_text = dockerfile.read_text()
+    allowlist_text = allowlist.read_text()
+
+    # If allowlist is freshly empty, spell out the SEARCH/REPLACE shape — the
+    # `[]` text alone is too minimal for the LLM to reliably anchor against.
     allowlist_hint = ""
-    is_empty_allowlist = False
-    if allowlist:
-        try:
-            is_empty_allowlist = json.loads(allowlist.read_text()) == []
-        except json.JSONDecodeError:
-            pass
-    if is_empty_allowlist:
-        allowlist_hint = (
-            f"\n\nNOTE: The allowlist file ({allowlist}) currently contains exactly `[]`. "
-            "If you need to add allowlist entries, emit ONE SEARCH/REPLACE block where SEARCH is `[]` "
-            "and REPLACE is a JSON array containing your entries. Example:\n"
-            "```\n"
-            "[\n"
-            '  {"vulnerability_id": "CVE-2026-XXXXX", "reason": "vendored in <pkg>", "review_by": "2026-08-18"}\n'
-            "]\n"
-            "```"
-        )
+    try:
+        if json.loads(allowlist_text) == []:
+            allowlist_hint = (
+                "\n\nNOTE: The allowlist currently contains exactly `[]`. To add entries, emit ONE SEARCH/REPLACE "
+                "block where SEARCH is `[]` and REPLACE is the new JSON array."
+            )
+    except json.JSONDecodeError:
+        pass
 
     user_prompt = f"""Image: {image_uri}
-Dockerfile: {dockerfile}
-Allowlist file: {allowlist}{allowlist_hint}
+
+### {dockerfile} (current contents):
+```
+{dockerfile_text}
+```
+
+### {allowlist} (current contents):
+```json
+{allowlist_text}
+```{allowlist_hint}
 
 CVE IDs to patch:
 {json.dumps(cve_ids, indent=2)}
 
 For each CVE, classify it (VENDORED / ESM_ONLY / NO_UPSTREAM_FIX / CONTRACT_BOUNDARY / DIRECT_PIN / DEP_CONFLICT)
-and generate the appropriate fix as search/replace blocks.
-
-If you need to look up details for a CVE (package, fixedInVersion, severity), use the Dockerfile and the
-existing allowlist file as reference for what's currently pinned. Search the codebase if needed.
-
-Generate search/replace blocks to fix or allowlist these CVEs."""
+and generate the appropriate fix as search/replace blocks. SEARCH text MUST exactly match a substring of
+one of the file contents above."""
 
     if dry_run:
         print(user_prompt)

--- a/scripts/cve-patcher/agent.py
+++ b/scripts/cve-patcher/agent.py
@@ -29,6 +29,7 @@ import boto3
 
 MODEL_ID = "us.anthropic.claude-opus-4-6-v1"
 MAX_TOKENS = 16384
+MAX_LLM_RETRIES = 3
 REGION = os.environ.get("AWS_REGION", "us-west-2")
 
 ALLOWLIST_DIR = Path("test/security/data/ecr_scan_allowlist")
@@ -225,7 +226,35 @@ def call_llm(messages):
 
 def parse_search_replace(text):
     """Extract search/replace blocks. Returns list of (path, search, replace)."""
-    return [(m.group(1), m.group(2), m.group(3)) for m in SEARCH_REPLACE_PATTERN.finditer(text)]
+    blocks = []
+    for m in SEARCH_REPLACE_PATTERN.finditer(text):
+        path = m.group(1).strip()
+        # Strip common LLM artifacts: `path:`, <filepath>...</filepath>, `path`, **path**, bare < >.
+        path = re.sub(r"^[Pp]ath\s*:\s*", "", path)
+        path = re.sub(r"^<[^>]*>", "", path).strip()
+        path = re.sub(r"</[^>]*>$", "", path).strip()
+        path = re.sub(r"^<|>$", "", path).strip()
+        path = path.strip("*").strip("`").strip()
+        blocks.append((path, m.group(2), m.group(3)))
+    return blocks
+
+
+def _validate_blocks_apply(blocks):
+    """Dry-run blocks against disk. Returns list of (block_index, error_str) for failures."""
+    failures = []
+    for i, (path, search, _) in enumerate(blocks):
+        p = Path(path)
+        if not p.exists():
+            failures.append((i, f"file does not exist: {path}"))
+            continue
+        content = p.read_text()
+        if search not in content:
+            preview = search.splitlines()[0][:120] if search else "(empty)"
+            failures.append((i, f"SEARCH not found in {path} (first line: {preview!r})"))
+            continue
+        if content.count(search) > 1:
+            failures.append((i, f"SEARCH ambiguous in {path} (matches {content.count(search)} times)"))
+    return failures
 
 
 def process_image(image_uri, cve_ids=None, dry_run=False):
@@ -297,12 +326,38 @@ Generate search/replace blocks to fix or allowlist these CVEs."""
         print(user_prompt)
         return {str(dockerfile): "DRY RUN"}
 
-    text = call_llm([{"role": "user", "content": [{"text": user_prompt}]}])
+    # If any block doesn't apply cleanly, feed failures back to the LLM and retry.
+    # Zero blocks is a legit outcome (e.g. OS_PACKAGE auto-resolves on rebuild) — accept it.
+    messages = [{"role": "user", "content": [{"text": user_prompt}]}]
+    blocks = []
+    text = ""
+    failures = []
+    for attempt in range(1, MAX_LLM_RETRIES + 1):
+        text = call_llm(messages)
+        blocks = parse_search_replace(text)
+        failures = _validate_blocks_apply(blocks)
+        print(f"  Attempt {attempt}: {len(blocks)} block(s), {len(failures)} failed to apply", file=sys.stderr)
+        if not failures:
+            break
+        for i, err in failures:
+            print(f"    [{i}] {err}", file=sys.stderr)
+        if attempt == MAX_LLM_RETRIES:
+            break
+        retry_msg = (
+            f"{len(failures)} of your {len(blocks)} SEARCH/REPLACE block(s) failed to apply:\n"
+            + "\n".join(f"  - block #{i+1}: {err}" for i, err in failures)
+            + "\nFix ONLY those blocks. Re-emit ALL blocks (working ones plus corrected versions)."
+            " Make sure SEARCH text matches the file exactly."
+        )
+        messages.append({"role": "assistant", "content": [{"text": text}]})
+        messages.append({"role": "user", "content": [{"text": retry_msg}]})
 
-    # Return blocks as data — workflow applies them on the per-Dockerfile branch.
-    # Don't apply to working tree here, otherwise edits leak across branches.
-    blocks = parse_search_replace(text)
-    print(f"  Got {len(blocks)} edit blocks from LLM", file=sys.stderr)
+    if failures:
+        print(
+            f"::error::[{image_uri}] {len(failures)} block(s) still don't apply after {MAX_LLM_RETRIES} attempts. Aborting image.",
+            file=sys.stderr,
+        )
+        return {}
 
     # Validate review_by on allowlist edits. Any block touching framework_allowlist.json
     # must include `"review_by": "YYYY-MM-DD"` (ISO date) in the replacement.

--- a/scripts/cve-patcher/agent.py
+++ b/scripts/cve-patcher/agent.py
@@ -41,26 +41,27 @@ SEARCH_REPLACE_PATTERN = re.compile(
 )
 
 SYSTEM_PROMPT = """You are an automated CVE patching agent for the AWS Deep Learning Containers repo.
-You are given a list of CVEs for one Dockerfile. Generate minimal file edits to fix or allowlist them.
+You are given a list of CVE findings (with package, version, fixedInVersion, filePath, severity)
+for one Dockerfile. Generate minimal file edits to fix or allowlist them.
 
 ## Rules
-- For each CVE, classify it as one of:
-  - VENDORED (filePath in scan result contains thirdparty_files/ or similar) → allowlist
-  - ESM_ONLY (package_manager indicates Ubuntu ESM or fix only in ESM) → allowlist
-  - NO_UPSTREAM_FIX (fixedInVersion is empty / N/A / NotAvailable / NotPlanned / WontFix) → allowlist
+- For each CVE, classify it using the finding fields provided:
+  - VENDORED (filePath contains `thirdparty_files/`, `vendored/`, `bundled/`, or similar) → allowlist
+  - ESM_ONLY (packageManager indicates Ubuntu ESM, or fix only in ESM/Pro) → allowlist
+  - NO_UPSTREAM_FIX (fixedInVersion is empty / null / N/A / NotAvailable / NotPlanned / WontFix) → allowlist
   - CONTRACT_BOUNDARY (fix would change a version the image promises in its tag, e.g. CUDA 12.9 → 13.0, py312 → py313, vllm 0.19 → 0.20) → allowlist with reason citing the contract
-  - DIRECT_PIN (fix is a clean SemVer bump on a directly-pinned package) → bump in pyproject.toml or Dockerfile
-  - DEP_CONFLICT (transitive dep, no direct pin) → attempt parent bump in pyproject.toml
-  - OS_PACKAGE (package_manager is RPM/DNF/OS/APT/DPKG/GENERIC, NOT PYTHON/PIP/NPM) → handle per sub-type:
+  - DIRECT_PIN (package appears directly in the Dockerfile/pyproject and fixedInVersion is a clean SemVer bump) → bump the pin
+  - DEP_CONFLICT (transitive dep, no direct pin in the file) → attempt parent bump, fall back to allowlist
+  - OS_PACKAGE (packageManager is RPM/DNF/OS/APT/DPKG/GENERIC, NOT PYTHON/PIP/NPM) → handle per sub-type:
     * NVIDIA repo packages (cuda-*, nvidia-*, libnvidia-*) → add explicit `dnf upgrade -y --releasever latest <pkg>` line in Dockerfile, applied to BOTH EC2 and SageMaker stages. AL2023's --security flag may miss NVIDIA-tagged packages.
-    * Conda-bundled (file path includes miniconda3/, conda/) → bump the conda pin in the Dockerfile
+    * Conda-bundled (filePath includes miniconda3/, conda/) → bump the conda pin in the Dockerfile
     * ESM-only (Ubuntu Pro) → allowlist
     * Otherwise (standard AL2023/Ubuntu repos) → no edit needed; auto-resolves on next rebuild via existing `dnf upgrade --security` line. Note this in summary instead of editing.
+- Default to FIXING when fixedInVersion is set and the package is editable. Allowlist only when classification rules say so above.
 - ALWAYS populate `review_by` for new allowlist entries with an ISO date string (YYYY-MM-DD), 90 days from today.
   Example entry: `{"vulnerability_id": "CVE-2026-XXXXX", "reason": "...", "review_by": "2026-08-18"}`
 - NEVER bump CUDA/Python/framework versions that would change the image's tag promise — those are CONTRACT_BOUNDARY.
 - NEVER delete or skip tests.
-- If unsure, prefer ALLOWLIST over BUMP. CI is the validator either way.
 
 ## Response Format
 
@@ -239,6 +240,26 @@ def parse_search_replace(text):
     return blocks
 
 
+def _normalize_finding(f):
+    """Flatten a finding (raw enhanced-scan or pre-flattened) into the fields the LLM needs."""
+    # Raw enhanced-scan shape: vulnerabilityId + packageVulnerabilityDetails.vulnerablePackages[]
+    if "packageVulnerabilityDetails" in f:
+        details = f["packageVulnerabilityDetails"]
+        pkg = (details.get("vulnerablePackages") or [{}])[0]
+        return {
+            "vulnerability_id": details.get("vulnerabilityId") or f.get("vulnerabilityId"),
+            "severity": details.get("vendorSeverity") or f.get("severity"),
+            "package": pkg.get("name"),
+            "version": pkg.get("version"),
+            "fixed_in_version": pkg.get("fixedInVersion"),
+            "package_manager": pkg.get("packageManager"),
+            "file_path": pkg.get("filePath"),
+            "description": (f.get("description") or "")[:500],
+        }
+    # Already flat — just return as-is (caller knows the shape).
+    return f
+
+
 def _validate_blocks_apply(blocks):
     """Dry-run blocks against disk. Returns list of (block_index, error_str) for failures."""
     failures = []
@@ -257,23 +278,16 @@ def _validate_blocks_apply(blocks):
     return failures
 
 
-def process_image(image_uri, cve_ids=None, dry_run=False):
+def process_image(image_uri, findings=None, dry_run=False):
     """Run the agent for a single image. Returns dict of {dockerfile: summary}.
 
-    POC: cve_ids is a list of CVE IDs passed by the workflow dispatch input.
-    Production (TODO): when cve_ids is None, fall back to fetch_ecr_scan(image_uri)
-    to discover CVEs autonomously from the scan dump.
+    POC: findings is a list of finding dicts (matches the ECR enhanced-scan S3 dump shape).
+    Production (TODO): when findings is None, fall back to fetch_ecr_scan(image_uri).
     """
     print(f"== Processing {image_uri} ==", file=sys.stderr)
 
-    if cve_ids is None or not cve_ids:
-        # Production path: fetch from ECR / S3 dump.
-        # Commented out for POC since cross-account access isn't wired yet.
-        # findings = fetch_ecr_scan(image_uri)
-        # if not findings:
-        #     print(f"  No findings for {image_uri}", file=sys.stderr)
-        #     return {}
-        print(f"::warning::[{image_uri}] No cve_ids provided. POC requires explicit input.", file=sys.stderr)
+    if not findings:
+        print(f"::warning::[{image_uri}] No findings provided. POC requires explicit input.", file=sys.stderr)
         return {}
 
     dockerfile = map_image_to_dockerfile(image_uri)
@@ -288,7 +302,7 @@ def process_image(image_uri, cve_ids=None, dry_run=False):
     ensure_allowlist_exists(allowlist)
     print(f"  Dockerfile: {dockerfile}", file=sys.stderr)
     print(f"  Allowlist:  {allowlist}", file=sys.stderr)
-    print(f"  CVEs:       {len(cve_ids)} (from input: {cve_ids})", file=sys.stderr)
+    print(f"  Findings:   {len(findings)}", file=sys.stderr)
 
     dockerfile_text = dockerfile.read_text()
     allowlist_text = allowlist.read_text()
@@ -305,6 +319,8 @@ def process_image(image_uri, cve_ids=None, dry_run=False):
     except json.JSONDecodeError:
         pass
 
+    findings_text = json.dumps([_normalize_finding(f) for f in findings], indent=2)
+
     user_prompt = f"""Image: {image_uri}
 
 ### {dockerfile} (current contents):
@@ -317,12 +333,14 @@ def process_image(image_uri, cve_ids=None, dry_run=False):
 {allowlist_text}
 ```{allowlist_hint}
 
-CVE IDs to patch:
-{json.dumps(cve_ids, indent=2)}
+### CVE findings to patch:
+```json
+{findings_text}
+```
 
-For each CVE, classify it (VENDORED / ESM_ONLY / NO_UPSTREAM_FIX / CONTRACT_BOUNDARY / DIRECT_PIN / DEP_CONFLICT)
-and generate the appropriate fix as search/replace blocks. SEARCH text MUST exactly match a substring of
-one of the file contents above."""
+For each finding, classify it using the rules in the system prompt and generate the appropriate
+fix as search/replace blocks. SEARCH text MUST exactly match a substring of one of the file
+contents above."""
 
     if dry_run:
         print(user_prompt)
@@ -413,7 +431,7 @@ def main():
     summaries = {}
     for row in rows:
         try:
-            s = process_image(row["image"], cve_ids=row.get("cve_ids"), dry_run=args.dry_run)
+            s = process_image(row["image"], findings=row.get("findings"), dry_run=args.dry_run)
             summaries.update(s)
         except Exception as e:
             print(f"::error::Failed on {row['image']}: {e}", file=sys.stderr)

--- a/scripts/cve-patcher/agent.py
+++ b/scripts/cve-patcher/agent.py
@@ -156,7 +156,13 @@ def _parse_image_uri(image_uri):
     m = re.match(r"^.*?/([\w-]+):(.+)$", image_uri)
     if not m:
         return None
-    return m.group(1), m.group(2)
+    repo, tag = m.group(1), m.group(2)
+    # CI repo holds framework-prefixed tags; normalize for IMAGE_TABLE lookup.
+    if repo == "ci":
+        ci_match = re.match(r"^([a-z]+)-(.+)$", tag)
+        if ci_match:
+            return ci_match.group(1), ci_match.group(2)
+    return repo, tag
 
 
 def _lookup(image_uri):
@@ -355,7 +361,7 @@ def main():
         except Exception as e:
             print(f"::error::Failed on {row['image']}: {e}", file=sys.stderr)
 
-    Path(args.summary_output).write_text(json.dumps(summaries, indent=2))
+    Path(args.summary_output).write_text(json.dumps(summaries, indent=2) + "\n")
     print(f"Wrote summary to {args.summary_output}", file=sys.stderr)
 
 

--- a/scripts/cve-patcher/poll.py
+++ b/scripts/cve-patcher/poll.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""poll.py — Query CloudWatch for DLC images out of SLA.
+
+Emits JSON: list of {image, total_out_of_sla, critical, high} (one row per image).
+"""
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+
+import boto3
+
+NAMESPACE = "AsimovImageSecurityScanV2"
+# CW metrics live in us-east-1 even though the rest of the tooling is us-west-2.
+REGION = os.environ.get("AWS_REGION", "us-east-1")
+
+# Default severities to report. MEDIUM has 180d SLA and LOW has effectively none, so
+# they're rarely actionable — if we ever want them, add a CLI flag rather than expanding here.
+SEVERITIES = ["CRITICAL", "HIGH"]
+
+
+def list_image_metrics(cw, dimension_name, metric_name):
+    """List all images that have the given metric."""
+    paginator = cw.get_paginator("list_metrics")
+    images = []
+    for page in paginator.paginate(
+        Namespace=NAMESPACE,
+        MetricName=metric_name,
+        Dimensions=[{"Name": dimension_name}],
+    ):
+        for m in page["Metrics"]:
+            images.append(m["Dimensions"][0]["Value"])
+    return images
+
+
+def get_max_value(cw, dimension_name, image, metric_name, lookback_hours):
+    """Get max of a metric over the last `lookback_hours`.
+
+    Returns one value over the full window via Period=3600 (so up to 48 points for the default
+    48h lookback). CloudWatch caps GetMetricStatistics at 1440 points per call — fine here.
+    If --lookback-hours ever grows past ~1440, switch to Period=86400 or paginate.
+    """
+    end = datetime.now(timezone.utc)
+    start = end - timedelta(hours=lookback_hours)
+    r = cw.get_metric_statistics(
+        Namespace=NAMESPACE,
+        MetricName=metric_name,
+        Dimensions=[{"Name": dimension_name, "Value": image}],
+        StartTime=start,
+        EndTime=end,
+        Period=3600,
+        Statistics=["Maximum"],
+    )
+    points = r.get("Datapoints", [])
+    if not points:
+        return 0
+    return int(max(p["Maximum"] for p in points))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dimension",
+        default="ASIMOV_IMAGE_METRICS",
+        help="Dimension name (e.g. ASIMOV_IMAGE_METRICS, AUTOGLUON_IMAGE_METRICS)",
+    )
+    parser.add_argument(
+        "--lookback-hours",
+        type=int,
+        default=48,
+        help="How far back to look for metric datapoints",
+    )
+    # POC: out-of-SLA only. Near-SLA support deferred.
+    parser.add_argument(
+        "--output",
+        default="-",
+        help="Output file (- for stdout)",
+    )
+    args = parser.parse_args()
+
+    cw = boto3.client("cloudwatch", region_name=REGION)
+
+    # Get all images that have a TOTAL_OUT_OF_SLA metric. Filter to count > 0 below.
+    images = set(list_image_metrics(cw, args.dimension, "TOTAL_OUT_OF_SLA"))
+
+    rows = []
+    for image in sorted(images):
+        total_oos = get_max_value(
+            cw, args.dimension, image, "TOTAL_OUT_OF_SLA", args.lookback_hours
+        )
+        if total_oos == 0:
+            continue
+        per_severity = {
+            sev: get_max_value(
+                cw, args.dimension, image, f"{sev}_OUT_OF_SLA", args.lookback_hours
+            )
+            for sev in SEVERITIES
+        }
+        rows.append(
+            {
+                "image": image,
+                "total_out_of_sla": total_oos,
+                **{sev.lower(): per_severity[sev] for sev in SEVERITIES},
+            }
+        )
+
+    rows.sort(key=lambda r: (-r["critical"], -r["high"], -r["total_out_of_sla"]))
+
+    out = json.dumps(rows, indent=2)
+    if args.output == "-":
+        print(out)
+    else:
+        with open(args.output, "w") as f:
+            f.write(out)
+        print(f"Wrote {len(rows)} rows to {args.output}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cve-patcher/poll.py
+++ b/scripts/cve-patcher/poll.py
@@ -64,7 +64,7 @@ def main():
     parser.add_argument(
         "--dimension",
         default="ASIMOV_IMAGE_METRICS",
-        help="Dimension name (e.g. ASIMOV_IMAGE_METRICS, AUTOGLUON_IMAGE_METRICS)",
+        help="CloudWatch dimension name for per-image metrics",
     )
     parser.add_argument(
         "--lookback-hours",


### PR DESCRIPTION
## Purpose

POC for autonomous CVE patching. `workflow_dispatch` takes a target tag + CVE ID list, the agent classifies each CVE, and opens one PR per modified Dockerfile with search/replace edits. Companion `cve-patcher-fix` workflow retries CI failures up to 3 attempts.

## Summary

- `cve-patcher.yml` — orchestrates the patch flow. Manual dispatch for POC; cron + CloudWatch poll wired but commented out until cross-account access lands.
- `cve-patcher-fix.yml` — listens for Merge Conditions failures on `cve-patch/*` PRs, runs the fix agent.
- `scripts/cve-patcher/agent.py` — classifies + emits search/replace blocks per Dockerfile (does not apply).
- `scripts/cve-patcher/agent-fix.py` — diagnoses CI failures, returns `TRANSIENT` / `NOT_CVE_RELATED` / search-replace edits.
- `scripts/cve-patcher/poll.py` — CloudWatch query for OUT_OF_SLA images.

## Test Plan

- [ ] On PR open, `cve-patcher.yml` fires (paths filter matches workflow + scripts/cve-patcher/).
- [ ] Workflow uses hardcoded test inputs: `ci:ray-2.55.1-cpu-py313-amzn2023-ec2-pr-6116` + `CVE-2024-37891`.
- [ ] Agent classifies → emits edit blocks → opens one `cve-patch/*` PR per modified Dockerfile.

## Test Result

Pending CI.

## Before merge

- Drop the `pull_request:` trigger.
- Drop the `else` branch in "Resolve inputs" (hardcoded test defaults).
- Switch `ECR_BASE` from `vars.CI_AWS_ACCOUNT_ID` to `vars.PROD_AWS_ACCOUNT_ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)