### PR TITLE
refactor: reusable workflows accept config-file input (PoC)

### DIFF
--- a/.github/workflows/autorelease-base.yml
+++ b/.github/workflows/autorelease-base.yml
@@ -126,10 +126,10 @@ jobs:
       fail-fast: false
       matrix:
         target:
-          - { tag: cuda129-runtime-amzn2023, framework-version: "12.9.1", cuda-version: cu129 }
-          - { tag: cuda129-devel-amzn2023,   framework-version: "12.9.1", cuda-version: cu129 }
-          - { tag: cuda130-runtime-amzn2023, framework-version: "13.0.2", cuda-version: cu130 }
-          - { tag: cuda130-devel-amzn2023,   framework-version: "13.0.2", cuda-version: cu130 }
+          - { tag: cuda129-runtime-amzn2023, config-file: ".github/config/image/base-v1-runtime.yml" }
+          - { tag: cuda129-devel-amzn2023,   config-file: ".github/config/image/base-v1-devel.yml" }
+          - { tag: cuda130-runtime-amzn2023, config-file: ".github/config/image/base-v2-runtime.yml" }
+          - { tag: cuda130-devel-amzn2023,   config-file: ".github/config/image/base-v2-devel.yml" }
     concurrency:
       group: ${{ github.workflow }}-sanity-${{ matrix.target.tag }}-${{ github.run_id }}
       cancel-in-progress: true
@@ -138,16 +138,7 @@ jobs:
       image-uri: ${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:base-${{ matrix.target.tag }}-${{ github.run_id }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: base_dlc
-      framework-version: ${{ matrix.target.framework-version }}
-      python-version: py313
-      cuda-version: ${{ matrix.target.cuda-version }}
-      os-version: amzn2023
-      customer-type: ec2
-      arch-type: x86
-      device-type: gpu
-      contributor: None
-      container-type: general
+      config-file: ${{ matrix.target.config-file }}
 
   # ============================================================
   # Base-specific sanity tests (CPU only — Python, compiler flags)

--- a/.github/workflows/autorelease-pytorch-ec2-cpu.yml
+++ b/.github/workflows/autorelease-pytorch-ec2-cpu.yml
@@ -21,6 +21,7 @@ jobs:
   load-config:
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
@@ -47,6 +48,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/pytorch-ec2-cpu.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -109,16 +111,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -127,8 +120,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [build-image, load-config]
@@ -137,9 +129,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   unit-test:
     needs: [build-image]

--- a/.github/workflows/autorelease-pytorch-ec2-cuda.yml
+++ b/.github/workflows/autorelease-pytorch-ec2-cuda.yml
@@ -22,6 +22,7 @@ jobs:
   load-config:
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
@@ -48,6 +49,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/pytorch-ec2-cuda.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -147,16 +149,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -165,8 +158,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [build-image, load-config]
@@ -175,9 +167,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   unit-test:
     needs: [build-image]
@@ -208,7 +198,7 @@ jobs:
           docker kill ${CONTAINER_ID}
 
   single-gpu-test:
-    needs: [build-image, sanity-test, security-test, unit-test]
+    needs: [build-image, load-config, sanity-test, security-test, unit-test]
     if: success()
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
@@ -238,13 +228,14 @@ jobs:
           docker kill ${CONTAINER_ID}
 
   efa-test:
-    needs: [build-image, sanity-test, security-test, unit-test]
+    needs: [build-image, load-config, sanity-test, security-test, unit-test]
     if: success()
     uses: ./.github/workflows/reusable-efa-tests.yml
     with:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   generate-release-spec:
     needs: [load-config, build-image, sanity-test, security-test, unit-test, single-gpu-test, efa-test]

--- a/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cpu.yml
@@ -21,6 +21,7 @@ jobs:
   load-config:
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
@@ -47,6 +48,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/pytorch-sagemaker-cpu.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -121,16 +123,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -139,8 +132,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [build-image, load-config]
@@ -149,9 +141,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   unit-test:
     needs: [build-image]

--- a/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
+++ b/.github/workflows/autorelease-pytorch-sagemaker-cuda.yml
@@ -21,6 +21,7 @@ jobs:
   load-config:
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
@@ -47,6 +48,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/pytorch-sagemaker-cuda.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -151,16 +153,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -169,8 +162,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [build-image, load-config]
@@ -179,9 +171,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   unit-test:
     needs: [build-image]

--- a/.github/workflows/autorelease-ray.yml
+++ b/.github/workflows/autorelease-ray.yml
@@ -344,21 +344,13 @@ jobs:
       matrix:
         include:
           - ci-image: ${{ needs.build-ec2-gpu.outputs.ci-image }}
-            device-type: gpu
-            cuda-version: cu129
-            customer-type: ec2
+            config-file: .github/config/image/ray-ec2-gpu.yml
           - ci-image: ${{ needs.build-ec2-cpu.outputs.ci-image }}
-            device-type: cpu
-            cuda-version: ""
-            customer-type: ec2
+            config-file: .github/config/image/ray-ec2-cpu.yml
           - ci-image: ${{ needs.build-sagemaker-gpu.outputs.ci-image }}
-            device-type: gpu
-            cuda-version: cu129
-            customer-type: sagemaker
+            config-file: .github/config/image/ray-sagemaker-gpu.yml
           - ci-image: ${{ needs.build-sagemaker-cpu.outputs.ci-image }}
-            device-type: cpu
-            cuda-version: ""
-            customer-type: sagemaker
+            config-file: .github/config/image/ray-sagemaker-cpu.yml
     concurrency:
       group: ${{ github.workflow }}-sanity-${{ matrix.ci-image }}-${{ github.run_id }}
       cancel-in-progress: true
@@ -367,16 +359,7 @@ jobs:
       image-uri: ${{ matrix.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ray
-      framework-version: "2.55.1"
-      python-version: py313
-      cuda-version: ${{ matrix.cuda-version }}
-      os-version: amzn2023
-      customer-type: ${{ matrix.customer-type }}
-      arch-type: x86
-      device-type: ${{ matrix.device-type }}
-      contributor: None
-      container-type: inference
+      config-file: ${{ matrix.config-file }}
 
   # ============================================================
   # EC2 GPU — FFmpeg + serve tests
@@ -615,9 +598,13 @@ jobs:
       matrix:
         include:
           - ci-image: ${{ needs.build-ec2-gpu.outputs.ci-image }}
+            config-file: .github/config/image/ray-ec2-gpu.yml
           - ci-image: ${{ needs.build-ec2-cpu.outputs.ci-image }}
+            config-file: .github/config/image/ray-ec2-cpu.yml
           - ci-image: ${{ needs.build-sagemaker-gpu.outputs.ci-image }}
+            config-file: .github/config/image/ray-sagemaker-gpu.yml
           - ci-image: ${{ needs.build-sagemaker-cpu.outputs.ci-image }}
+            config-file: .github/config/image/ray-sagemaker-cpu.yml
     concurrency:
       group: ${{ github.workflow }}-telemetry-${{ matrix.ci-image }}-${{ github.run_id }}
       cancel-in-progress: false
@@ -626,9 +613,7 @@ jobs:
       image-uri: ${{ matrix.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ray
-      framework-version: "2.55.1"
-      container-type: inference
+      config-file: ${{ matrix.config-file }}
 
   # ============================================================
   # Generate release specs

--- a/.github/workflows/autorelease-sglang-ec2.yml
+++ b/.github/workflows/autorelease-sglang-ec2.yml
@@ -43,6 +43,7 @@ jobs:
     needs: [autocurrency-pr-gate]
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
@@ -69,6 +70,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/sglang-ec2.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -121,16 +123,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [build-image, load-config]
@@ -139,9 +132,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/autorelease-sglang-sagemaker.yml
+++ b/.github/workflows/autorelease-sglang-sagemaker.yml
@@ -42,6 +42,7 @@ jobs:
     needs: [autocurrency-pr-gate]
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
@@ -68,6 +69,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/sglang-sagemaker.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -120,16 +122,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [build-image, load-config]
@@ -138,9 +131,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/autorelease-vllm-ec2-amzn2023.yml
+++ b/.github/workflows/autorelease-vllm-ec2-amzn2023.yml
@@ -30,6 +30,7 @@ jobs:
   load-config:
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
@@ -58,6 +59,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/vllm-ec2-amzn2023.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "vllm-ref=$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)" >> $GITHUB_OUTPUT
@@ -166,16 +168,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [build-image, load-config]
@@ -184,9 +177,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/autorelease-vllm-ec2.yml
+++ b/.github/workflows/autorelease-vllm-ec2.yml
@@ -43,6 +43,7 @@ jobs:
     needs: [autocurrency-pr-gate]
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
@@ -69,6 +70,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/vllm-ec2.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -121,16 +123,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [build-image, load-config]
@@ -139,9 +132,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/autorelease-vllm-hyperpod-amzn2023.yml
+++ b/.github/workflows/autorelease-vllm-hyperpod-amzn2023.yml
@@ -30,6 +30,7 @@ jobs:
   load-config:
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
@@ -58,6 +59,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/vllm-hyperpod-amzn2023.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "vllm-ref=$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)" >> $GITHUB_OUTPUT
@@ -166,16 +168,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [build-image, load-config]
@@ -184,9 +177,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/autorelease-vllm-omni.yml
+++ b/.github/workflows/autorelease-vllm-omni.yml
@@ -301,52 +301,43 @@ jobs:
   # Sanity tests
   # ============================================================
   sanity-test:
-    needs: [build-ec2, build-sagemaker, load-config-ec2, load-config-sagemaker]
+    needs: [build-ec2, build-sagemaker]
     if: success()
     strategy:
       fail-fast: false
       matrix:
         include:
           - ci-image: ${{ needs.build-ec2.outputs.ci-image }}
-            customer-type: ec2
+            config-file: .github/config/image/vllm-omni-ec2-amzn2023.yml
           - ci-image: ${{ needs.build-sagemaker.outputs.ci-image }}
-            customer-type: sagemaker
+            config-file: .github/config/image/vllm-omni-sagemaker-amzn2023.yml
     uses: ./.github/workflows/reusable-sanity-tests.yml
     with:
       image-uri: ${{ matrix.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config-ec2.outputs.framework }}
-      framework-version: ${{ needs.load-config-ec2.outputs.framework-version }}
-      python-version: ${{ needs.load-config-ec2.outputs.python-version }}
-      cuda-version: ${{ needs.load-config-ec2.outputs.cuda-version }}
-      os-version: ${{ needs.load-config-ec2.outputs.os-version }}
-      customer-type: ${{ matrix.customer-type }}
-      arch-type: ${{ needs.load-config-ec2.outputs.arch-type }}
-      device-type: ${{ needs.load-config-ec2.outputs.device-type }}
-      contributor: ${{ needs.load-config-ec2.outputs.contributor }}
-      container-type: ${{ needs.load-config-ec2.outputs.container-type }}
+      config-file: ${{ matrix.config-file }}
 
   # ============================================================
   # Telemetry tests
   # ============================================================
   telemetry-test:
-    needs: [build-ec2, build-sagemaker, load-config-ec2]
+    needs: [build-ec2, build-sagemaker]
     if: success()
     strategy:
       fail-fast: false
       matrix:
         include:
           - ci-image: ${{ needs.build-ec2.outputs.ci-image }}
+            config-file: .github/config/image/vllm-omni-ec2-amzn2023.yml
           - ci-image: ${{ needs.build-sagemaker.outputs.ci-image }}
+            config-file: .github/config/image/vllm-omni-sagemaker-amzn2023.yml
     uses: ./.github/workflows/reusable-telemetry-tests.yml
     with:
       image-uri: ${{ matrix.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config-ec2.outputs.framework }}
-      framework-version: ${{ needs.load-config-ec2.outputs.framework-version }}
-      container-type: ${{ needs.load-config-ec2.outputs.container-type }}
+      config-file: ${{ matrix.config-file }}
 
   # ============================================================
   # Model smoke tests (EC2 + SageMaker)

--- a/.github/workflows/autorelease-vllm-sagemaker-amzn2023.yml
+++ b/.github/workflows/autorelease-vllm-sagemaker-amzn2023.yml
@@ -30,6 +30,7 @@ jobs:
   load-config:
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
@@ -58,6 +59,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/vllm-sagemaker-amzn2023.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "vllm-ref=$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)" >> $GITHUB_OUTPUT
@@ -166,16 +168,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [build-image, load-config]
@@ -184,9 +177,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/autorelease-vllm-sagemaker.yml
+++ b/.github/workflows/autorelease-vllm-sagemaker.yml
@@ -43,6 +43,7 @@ jobs:
     needs: [autocurrency-pr-gate]
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
@@ -69,6 +70,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/vllm-sagemaker.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -121,16 +123,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [build-image, load-config]
@@ -139,9 +132,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/dispatch-release-sagemaker-xgboost.yml
+++ b/.github/workflows/dispatch-release-sagemaker-xgboost.yml
@@ -20,6 +20,7 @@ jobs:
       group: ${{ github.workflow }}-load-config-${{ github.run_id }}
       cancel-in-progress: true
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
@@ -46,6 +47,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/sagemaker-xgboost.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -176,8 +178,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   xgboost-tests:
     needs: [security-test, build-image, load-config]

--- a/.github/workflows/pr-base-v1.yml
+++ b/.github/workflows/pr-base-v1.yml
@@ -44,6 +44,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       python-version: ${{ steps.parse.outputs.python-version }}
@@ -69,6 +70,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/base-v1-runtime.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -192,16 +194,7 @@ jobs:
       image-uri: ${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:base-${{ matrix.target.tag }}-pr-${{ github.event.pull_request.number }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Base-specific sanity tests (CPU only — Python, compiler flags)
@@ -265,8 +258,7 @@ jobs:
       image-uri: ${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:base-${{ matrix.target.tag }}-pr-${{ github.event.pull_request.number }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # CUDA tests — GPU sanity checks for both targets

--- a/.github/workflows/pr-base-v2.yml
+++ b/.github/workflows/pr-base-v2.yml
@@ -44,6 +44,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       python-version: ${{ steps.parse.outputs.python-version }}
@@ -69,6 +70,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/base-v2-runtime.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -192,16 +194,7 @@ jobs:
       image-uri: ${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:base-${{ matrix.target.tag }}-pr-${{ github.event.pull_request.number }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Base-specific sanity tests (CPU only — Python, compiler flags)
@@ -265,8 +258,7 @@ jobs:
       image-uri: ${{ vars.CI_AWS_ACCOUNT_ID }}.dkr.ecr.${{ vars.AWS_REGION }}.amazonaws.com/ci:base-${{ matrix.target.tag }}-pr-${{ github.event.pull_request.number }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # CUDA tests — GPU sanity checks for both targets

--- a/.github/workflows/pr-pytorch-ec2-cpu.yml
+++ b/.github/workflows/pr-pytorch-ec2-cpu.yml
@@ -51,6 +51,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       python-version: ${{ steps.parse.outputs.python-version }}
@@ -76,6 +77,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/pytorch-ec2-cpu.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -196,16 +198,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.runtime-image-uri || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Security tests
@@ -218,8 +211,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.runtime-image-uri || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Telemetry tests
@@ -237,9 +229,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.runtime-image-uri || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Unit tests

--- a/.github/workflows/pr-pytorch-ec2-cuda.yml
+++ b/.github/workflows/pr-pytorch-ec2-cuda.yml
@@ -47,23 +47,15 @@ jobs:
         uses: ./.github/actions/pr-permission-gate
 
   # ============================================================
-  # Load configuration from YAML
+  # Load configuration from YAML (only prod-image needed locally for fallback URI)
   # ============================================================
   load-config:
     needs: [gatekeeper]
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
-      framework-version: ${{ steps.parse.outputs.framework-version }}
-      python-version: ${{ steps.parse.outputs.python-version }}
-      cuda-version: ${{ steps.parse.outputs.cuda-version }}
-      os-version: ${{ steps.parse.outputs.os-version }}
-      container-type: ${{ steps.parse.outputs.container-type }}
-      device-type: ${{ steps.parse.outputs.device-type }}
-      arch-type: ${{ steps.parse.outputs.arch-type }}
-      contributor: ${{ steps.parse.outputs.contributor }}
-      customer-type: ${{ steps.parse.outputs.customer-type }}
       prod-image: ${{ steps.parse.outputs.prod-image }}
     steps:
       - name: Checkout code
@@ -79,16 +71,8 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=${{ env.CONFIG_FILE }}" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
-          echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
-          echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
-          echo "cuda-version=$(jq -r '.common.cuda_version' config.json)" >> $GITHUB_OUTPUT
-          echo "os-version=$(jq -r '.common.os_version' config.json)" >> $GITHUB_OUTPUT
-          echo "container-type=$(jq -r '.common.job_type' config.json)" >> $GITHUB_OUTPUT
-          echo "device-type=$(jq -r '.common.device_type // "gpu"' config.json)" >> $GITHUB_OUTPUT
-          echo "arch-type=$(jq -r '.common.arch_type // "x86"' config.json)" >> $GITHUB_OUTPUT
-          echo "contributor=$(jq -r '.common.contributor // "None"' config.json)" >> $GITHUB_OUTPUT
-          echo "customer-type=$(jq -r '.common.customer_type // ""' config.json)" >> $GITHUB_OUTPUT
           echo "prod-image=$(jq -r '.common.prod_image' config.json)" >> $GITHUB_OUTPUT
 
   # ============================================================
@@ -235,16 +219,7 @@ jobs:
       image-uri: ${{ needs.build-images.result == 'success' && needs.build-images.outputs.runtime-image-uri || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-images.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Security tests (ECR scan, CVE allowlist)
@@ -257,8 +232,7 @@ jobs:
       image-uri: ${{ needs.build-images.result == 'success' && needs.build-images.outputs.runtime-image-uri || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-images.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Telemetry tests (opt-out, environment variables)
@@ -276,9 +250,7 @@ jobs:
       image-uri: ${{ needs.build-images.result == 'success' && needs.build-images.outputs.runtime-image-uri || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-images.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Unit tests (CPU-only, no GPU needed)
@@ -355,13 +327,14 @@ jobs:
   # EFA integration test (2x p4d.24xlarge, NCCL over EFA)
   # ============================================================
   efa-test:
-    needs: [build-images, sanity-test, security-test, unit-test]
+    needs: [build-images, load-config, sanity-test, security-test, unit-test]
     if: success()
     uses: ./.github/workflows/reusable-efa-tests.yml
     with:
       image-uri: ${{ needs.build-images.outputs.runtime-image-uri }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Multi-GPU tests (need >=2 GPUs)

--- a/.github/workflows/pr-pytorch-sagemaker-cpu.yml
+++ b/.github/workflows/pr-pytorch-sagemaker-cpu.yml
@@ -51,6 +51,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       python-version: ${{ steps.parse.outputs.python-version }}
@@ -76,6 +77,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/pytorch-sagemaker-cpu.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -210,16 +212,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.sagemaker-image-uri || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Security tests
@@ -232,8 +225,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.sagemaker-image-uri || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Unit tests

--- a/.github/workflows/pr-pytorch-sagemaker-cuda.yml
+++ b/.github/workflows/pr-pytorch-sagemaker-cuda.yml
@@ -53,6 +53,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       python-version: ${{ steps.parse.outputs.python-version }}
@@ -78,6 +79,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/pytorch-sagemaker-cuda.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -228,16 +230,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.sagemaker-image-uri || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Security tests (ECR scan, CVE allowlist)
@@ -250,8 +243,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.sagemaker-image-uri || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Telemetry tests (opt-out, environment variables)
@@ -269,9 +261,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.sagemaker-image-uri || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   # ============================================================
   # Unit tests

--- a/.github/workflows/pr-ray-ec2-cpu.yml
+++ b/.github/workflows/pr-ray-ec2-cpu.yml
@@ -74,11 +74,13 @@ jobs:
       contributor: ${{ steps.parse.outputs.contributor }}
       customer-type: ${{ steps.parse.outputs.customer-type }}
       prod-image: ${{ steps.parse.outputs.prod-image }}
+      config-file: ${{ steps.parse.outputs.config-file }}
     steps:
       - name: Parse configuration
         id: parse
         run: |
           echo '${{ needs.load-config.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/ray-ec2-cpu.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -256,15 +258,7 @@ jobs:
       image-uri: ${{ needs.build-ray-ec2-cpu-image.result == 'success' && needs.build-ray-ec2-cpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-ray-ec2-cpu-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.parse-config.outputs.framework }}
-      framework-version: ${{ needs.parse-config.outputs.framework-version }}
-      python-version: ${{ needs.parse-config.outputs.python-version }}
-      os-version: ${{ needs.parse-config.outputs.os-version }}
-      customer-type: ${{ needs.parse-config.outputs.customer-type }}
-      arch-type: ${{ needs.parse-config.outputs.arch-type }}
-      device-type: ${{ needs.parse-config.outputs.device-type }}
-      contributor: ${{ needs.parse-config.outputs.contributor }}
-      container-type: ${{ needs.parse-config.outputs.container-type }}
+      config-file: ${{ needs.parse-config.outputs.config-file }}
 
   security-test:
     needs: [build-ray-ec2-cpu-image, parse-config]
@@ -277,8 +271,7 @@ jobs:
       image-uri: ${{ needs.build-ray-ec2-cpu-image.result == 'success' && needs.build-ray-ec2-cpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-ray-ec2-cpu-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.parse-config.outputs.framework }}
-      framework-version: ${{ needs.parse-config.outputs.framework-version }}
+      config-file: ${{ needs.parse-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-ray-ec2-cpu-image, parse-config]
@@ -293,6 +286,4 @@ jobs:
       image-uri: ${{ needs.build-ray-ec2-cpu-image.result == 'success' && needs.build-ray-ec2-cpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-ray-ec2-cpu-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.parse-config.outputs.framework }}
-      framework-version: ${{ needs.parse-config.outputs.framework-version }}
-      container-type: ${{ needs.parse-config.outputs.container-type }}
+      config-file: ${{ needs.parse-config.outputs.config-file }}

--- a/.github/workflows/pr-ray-ec2-gpu.yml
+++ b/.github/workflows/pr-ray-ec2-gpu.yml
@@ -75,11 +75,13 @@ jobs:
       contributor: ${{ steps.parse.outputs.contributor }}
       customer-type: ${{ steps.parse.outputs.customer-type }}
       prod-image: ${{ steps.parse.outputs.prod-image }}
+      config-file: ${{ steps.parse.outputs.config-file }}
     steps:
       - name: Parse configuration
         id: parse
         run: |
           echo '${{ needs.load-config.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/ray-ec2-gpu.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -263,16 +265,7 @@ jobs:
       image-uri: ${{ needs.build-ray-ec2-gpu-image.result == 'success' && needs.build-ray-ec2-gpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-ray-ec2-gpu-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.parse-config.outputs.framework }}
-      framework-version: ${{ needs.parse-config.outputs.framework-version }}
-      python-version: ${{ needs.parse-config.outputs.python-version }}
-      cuda-version: ${{ needs.parse-config.outputs.cuda-version }}
-      os-version: ${{ needs.parse-config.outputs.os-version }}
-      customer-type: ${{ needs.parse-config.outputs.customer-type }}
-      arch-type: ${{ needs.parse-config.outputs.arch-type }}
-      device-type: ${{ needs.parse-config.outputs.device-type }}
-      contributor: ${{ needs.parse-config.outputs.contributor }}
-      container-type: ${{ needs.parse-config.outputs.container-type }}
+      config-file: ${{ needs.parse-config.outputs.config-file }}
 
   security-test:
     needs: [build-ray-ec2-gpu-image, parse-config]
@@ -285,8 +278,7 @@ jobs:
       image-uri: ${{ needs.build-ray-ec2-gpu-image.result == 'success' && needs.build-ray-ec2-gpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-ray-ec2-gpu-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.parse-config.outputs.framework }}
-      framework-version: ${{ needs.parse-config.outputs.framework-version }}
+      config-file: ${{ needs.parse-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-ray-ec2-gpu-image, parse-config]
@@ -301,6 +293,4 @@ jobs:
       image-uri: ${{ needs.build-ray-ec2-gpu-image.result == 'success' && needs.build-ray-ec2-gpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-ray-ec2-gpu-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.parse-config.outputs.framework }}
-      framework-version: ${{ needs.parse-config.outputs.framework-version }}
-      container-type: ${{ needs.parse-config.outputs.container-type }}
+      config-file: ${{ needs.parse-config.outputs.config-file }}

--- a/.github/workflows/pr-ray-sagemaker-cpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-cpu.yml
@@ -73,11 +73,13 @@ jobs:
       contributor: ${{ steps.parse.outputs.contributor }}
       customer-type: ${{ steps.parse.outputs.customer-type }}
       prod-image: ${{ steps.parse.outputs.prod-image }}
+      config-file: ${{ steps.parse.outputs.config-file }}
     steps:
       - name: Parse configuration
         id: parse
         run: |
           echo '${{ needs.load-config.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/ray-sagemaker-cpu.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -248,15 +250,7 @@ jobs:
       image-uri: ${{ needs.build-ray-sagemaker-cpu-image.result == 'success' && needs.build-ray-sagemaker-cpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-ray-sagemaker-cpu-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.parse-config.outputs.framework }}
-      framework-version: ${{ needs.parse-config.outputs.framework-version }}
-      python-version: ${{ needs.parse-config.outputs.python-version }}
-      os-version: ${{ needs.parse-config.outputs.os-version }}
-      customer-type: ${{ needs.parse-config.outputs.customer-type }}
-      arch-type: ${{ needs.parse-config.outputs.arch-type }}
-      device-type: ${{ needs.parse-config.outputs.device-type }}
-      contributor: ${{ needs.parse-config.outputs.contributor }}
-      container-type: ${{ needs.parse-config.outputs.container-type }}
+      config-file: ${{ needs.parse-config.outputs.config-file }}
 
   security-test:
     needs: [build-ray-sagemaker-cpu-image, parse-config]
@@ -269,8 +263,7 @@ jobs:
       image-uri: ${{ needs.build-ray-sagemaker-cpu-image.result == 'success' && needs.build-ray-sagemaker-cpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-ray-sagemaker-cpu-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.parse-config.outputs.framework }}
-      framework-version: ${{ needs.parse-config.outputs.framework-version }}
+      config-file: ${{ needs.parse-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-ray-sagemaker-cpu-image, parse-config]
@@ -285,6 +278,4 @@ jobs:
       image-uri: ${{ needs.build-ray-sagemaker-cpu-image.result == 'success' && needs.build-ray-sagemaker-cpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-ray-sagemaker-cpu-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.parse-config.outputs.framework }}
-      framework-version: ${{ needs.parse-config.outputs.framework-version }}
-      container-type: ${{ needs.parse-config.outputs.container-type }}
+      config-file: ${{ needs.parse-config.outputs.config-file }}

--- a/.github/workflows/pr-ray-sagemaker-gpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-gpu.yml
@@ -74,11 +74,13 @@ jobs:
       contributor: ${{ steps.parse.outputs.contributor }}
       customer-type: ${{ steps.parse.outputs.customer-type }}
       prod-image: ${{ steps.parse.outputs.prod-image }}
+      config-file: ${{ steps.parse.outputs.config-file }}
     steps:
       - name: Parse configuration
         id: parse
         run: |
           echo '${{ needs.load-config.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/ray-sagemaker-gpu.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -254,16 +256,7 @@ jobs:
       image-uri: ${{ needs.build-ray-sagemaker-gpu-image.result == 'success' && needs.build-ray-sagemaker-gpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-ray-sagemaker-gpu-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.parse-config.outputs.framework }}
-      framework-version: ${{ needs.parse-config.outputs.framework-version }}
-      python-version: ${{ needs.parse-config.outputs.python-version }}
-      cuda-version: ${{ needs.parse-config.outputs.cuda-version }}
-      os-version: ${{ needs.parse-config.outputs.os-version }}
-      customer-type: ${{ needs.parse-config.outputs.customer-type }}
-      arch-type: ${{ needs.parse-config.outputs.arch-type }}
-      device-type: ${{ needs.parse-config.outputs.device-type }}
-      contributor: ${{ needs.parse-config.outputs.contributor }}
-      container-type: ${{ needs.parse-config.outputs.container-type }}
+      config-file: ${{ needs.parse-config.outputs.config-file }}
 
   security-test:
     needs: [build-ray-sagemaker-gpu-image, parse-config]
@@ -276,8 +269,7 @@ jobs:
       image-uri: ${{ needs.build-ray-sagemaker-gpu-image.result == 'success' && needs.build-ray-sagemaker-gpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-ray-sagemaker-gpu-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.parse-config.outputs.framework }}
-      framework-version: ${{ needs.parse-config.outputs.framework-version }}
+      config-file: ${{ needs.parse-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-ray-sagemaker-gpu-image, parse-config]
@@ -292,6 +284,4 @@ jobs:
       image-uri: ${{ needs.build-ray-sagemaker-gpu-image.result == 'success' && needs.build-ray-sagemaker-gpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-ray-sagemaker-gpu-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.parse-config.outputs.framework }}
-      framework-version: ${{ needs.parse-config.outputs.framework-version }}
-      container-type: ${{ needs.parse-config.outputs.container-type }}
+      config-file: ${{ needs.parse-config.outputs.config-file }}

--- a/.github/workflows/pr-sagemaker-xgboost.yml
+++ b/.github/workflows/pr-sagemaker-xgboost.yml
@@ -41,6 +41,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       python-version: ${{ steps.parse.outputs.python-version }}
@@ -67,6 +68,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/sagemaker-xgboost.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -244,8 +246,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   integration-test:
     needs: [build-image, load-config]

--- a/.github/workflows/pr-sglang-ec2-amzn2023.yml
+++ b/.github/workflows/pr-sglang-ec2-amzn2023.yml
@@ -48,6 +48,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       python-version: ${{ steps.parse.outputs.python-version }}
@@ -73,6 +74,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/sglang-ec2-amzn2023.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -180,16 +182,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -202,8 +195,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-image, load-config]
@@ -218,9 +210,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   model-test:
     needs: [build-image, load-config]

--- a/.github/workflows/pr-sglang-ec2.yml
+++ b/.github/workflows/pr-sglang-ec2.yml
@@ -52,6 +52,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       python-version: ${{ steps.parse.outputs.python-version }}
@@ -77,6 +78,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/sglang-ec2.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -182,16 +184,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -204,8 +197,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-image, load-config]
@@ -220,9 +212,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/pr-sglang-sagemaker-amzn2023.yml
+++ b/.github/workflows/pr-sglang-sagemaker-amzn2023.yml
@@ -49,6 +49,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       python-version: ${{ steps.parse.outputs.python-version }}
@@ -74,6 +75,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/sglang-sagemaker-amzn2023.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -184,16 +186,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -206,8 +199,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-image, load-config]
@@ -222,9 +214,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   endpoint-test:
     needs: [check-changes, build-image, load-config]

--- a/.github/workflows/pr-sglang-sagemaker.yml
+++ b/.github/workflows/pr-sglang-sagemaker.yml
@@ -52,6 +52,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       python-version: ${{ steps.parse.outputs.python-version }}
@@ -77,6 +78,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/sglang-sagemaker.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -185,16 +187,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-image, load-config]
@@ -209,9 +202,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -224,8 +215,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/pr-vllm-ec2-amzn2023.yml
+++ b/.github/workflows/pr-vllm-ec2-amzn2023.yml
@@ -49,6 +49,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       vllm-ref: ${{ steps.parse.outputs.vllm-ref }}
@@ -76,6 +77,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/vllm-ec2-amzn2023.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "vllm-ref=$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)" >> $GITHUB_OUTPUT
@@ -254,16 +256,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -276,8 +269,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-image, load-config]
@@ -292,9 +284,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/pr-vllm-ec2.yml
+++ b/.github/workflows/pr-vllm-ec2.yml
@@ -54,6 +54,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       python-version: ${{ steps.parse.outputs.python-version }}
@@ -79,6 +80,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/vllm-ec2.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -184,16 +186,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -206,8 +199,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-image, load-config]
@@ -222,9 +214,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/pr-vllm-hyperpod-amzn2023.yml
+++ b/.github/workflows/pr-vllm-hyperpod-amzn2023.yml
@@ -49,6 +49,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       vllm-ref: ${{ steps.parse.outputs.vllm-ref }}
@@ -76,6 +77,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/vllm-hyperpod-amzn2023.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "vllm-ref=$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)" >> $GITHUB_OUTPUT
@@ -254,16 +256,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -276,8 +269,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-image, load-config]
@@ -292,9 +284,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/pr-vllm-omni-ec2-amzn2023.yml
+++ b/.github/workflows/pr-vllm-omni-ec2-amzn2023.yml
@@ -46,6 +46,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       vllm-ref: ${{ steps.parse.outputs.vllm-ref }}
@@ -72,6 +73,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/vllm-omni-ec2-amzn2023.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "vllm-ref=$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)" >> $GITHUB_OUTPUT
@@ -237,16 +239,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -259,8 +252,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-image, load-config]
@@ -275,9 +267,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   omni-model-smoke-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/pr-vllm-omni-sagemaker-amzn2023.yml
+++ b/.github/workflows/pr-vllm-omni-sagemaker-amzn2023.yml
@@ -46,6 +46,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       vllm-ref: ${{ steps.parse.outputs.vllm-ref }}
@@ -72,6 +73,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/vllm-omni-sagemaker-amzn2023.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "vllm-ref=$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)" >> $GITHUB_OUTPUT
@@ -229,16 +231,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -251,8 +244,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-image, load-config]
@@ -267,9 +259,7 @@ jobs:
       image-uri: ${{ needs.build-image.outputs.ci-image }}
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   omni-model-smoke-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/pr-vllm-sagemaker-amzn2023.yml
+++ b/.github/workflows/pr-vllm-sagemaker-amzn2023.yml
@@ -50,6 +50,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       vllm-ref: ${{ steps.parse.outputs.vllm-ref }}
@@ -77,6 +78,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/vllm-sagemaker-amzn2023.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "vllm-ref=$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)" >> $GITHUB_OUTPUT
@@ -246,16 +248,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -268,8 +261,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-image, load-config]
@@ -284,9 +276,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/pr-vllm-sagemaker.yml
+++ b/.github/workflows/pr-vllm-sagemaker.yml
@@ -55,6 +55,7 @@ jobs:
     if: success()
     runs-on: ubuntu-latest
     outputs:
+      config-file: ${{ steps.parse.outputs.config-file }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
       python-version: ${{ steps.parse.outputs.python-version }}
@@ -80,6 +81,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "config-file=.github/config/image/vllm-sagemaker.yml" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
@@ -188,16 +190,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   security-test:
     needs: [build-image, load-config]
@@ -210,8 +203,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   telemetry-test:
     needs: [check-changes, build-image, load-config]
@@ -226,9 +218,7 @@ jobs:
       image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
       aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
+      config-file: ${{ needs.load-config.outputs.config-file }}
 
   upstream-tests:
     needs: [build-image, load-config]

--- a/.github/workflows/reusable-efa-tests.yml
+++ b/.github/workflows/reusable-efa-tests.yml
@@ -18,6 +18,11 @@ on:
         description: 'AWS region'
         required: true
         type: string
+      config-file:
+        description: 'Path to image config YAML file (reserved for future use, e.g., reading efa-instance-type from config).'
+        required: false
+        type: string
+        default: ''
       efa-instance-type:
         description: 'EFA-enabled instance type (default: p4d.24xlarge)'
         required: false

--- a/.github/workflows/reusable-efa-tests.yml
+++ b/.github/workflows/reusable-efa-tests.yml
@@ -19,10 +19,9 @@ on:
         required: true
         type: string
       config-file:
-        description: 'Path to image config YAML file (reserved for future use, e.g., reading efa-instance-type from config).'
-        required: false
+        description: 'Path to image config YAML file (e.g., .github/config/image/pytorch-ec2-cuda.yml)'
+        required: true
         type: string
-        default: ''
       efa-instance-type:
         description: 'EFA-enabled instance type (default: p4d.24xlarge)'
         required: false

--- a/.github/workflows/reusable-sanity-tests.yml
+++ b/.github/workflows/reusable-sanity-tests.yml
@@ -18,22 +18,31 @@ on:
         description: 'AWS region for ECR authentication'
         required: true
         type: string
+      config-file:
+        description: 'Path to image config YAML file. When provided, all fields below are read from the config and individual inputs are ignored.'
+        required: false
+        type: string
+        default: ''
       framework:
         description: 'Framework name (e.g., vllm, sglang, pytorch, tensorflow, base)'
-        required: true
+        required: false
         type: string
+        default: ''
       framework-version:
         description: 'Framework version (e.g., 0.15.1, 0.5.8)'
-        required: true
+        required: false
         type: string
+        default: ''
       python-version:
         description: 'Python version in pyXYZ format (e.g., py312)'
-        required: true
+        required: false
         type: string
+        default: ''
       os-version:
         description: 'OS version (e.g., ubuntu22.04, ubuntu24.04)'
-        required: true
+        required: false
         type: string
+        default: ''
       cuda-version:
         description: 'CUDA version in cuXYZ format (e.g., cu129). Empty for CPU images.'
         required: false
@@ -71,7 +80,61 @@ on:
         default: ''
 
 jobs:
+  load-config:
+    runs-on: ubuntu-latest
+    outputs:
+      framework: ${{ steps.resolve.outputs.framework }}
+      framework-version: ${{ steps.resolve.outputs.framework-version }}
+      python-version: ${{ steps.resolve.outputs.python-version }}
+      os-version: ${{ steps.resolve.outputs.os-version }}
+      cuda-version: ${{ steps.resolve.outputs.cuda-version }}
+      customer-type: ${{ steps.resolve.outputs.customer-type }}
+      arch-type: ${{ steps.resolve.outputs.arch-type }}
+      device-type: ${{ steps.resolve.outputs.device-type }}
+      contributor: ${{ steps.resolve.outputs.contributor }}
+      container-type: ${{ steps.resolve.outputs.container-type }}
+      transformers-version: ${{ steps.resolve.outputs.transformers-version }}
+    steps:
+      - name: Checkout code
+        if: inputs.config-file != ''
+        uses: actions/checkout@v5
+
+      - name: Resolve config
+        id: resolve
+        run: |
+          if [ -n "${{ inputs.config-file }}" ]; then
+            echo "Reading config from: ${{ inputs.config-file }}"
+            sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+            sudo chmod +x /usr/local/bin/yq
+            CONFIG="${{ inputs.config-file }}"
+            echo "framework=$(yq '.common.framework' $CONFIG)" >> $GITHUB_OUTPUT
+            echo "framework-version=$(yq '.common.framework_version' $CONFIG)" >> $GITHUB_OUTPUT
+            echo "python-version=$(yq '.common.python_version' $CONFIG)" >> $GITHUB_OUTPUT
+            echo "os-version=$(yq '.common.os_version' $CONFIG)" >> $GITHUB_OUTPUT
+            echo "cuda-version=$(yq '.common.cuda_version // ""' $CONFIG)" >> $GITHUB_OUTPUT
+            echo "customer-type=$(yq '.common.customer_type // ""' $CONFIG)" >> $GITHUB_OUTPUT
+            echo "arch-type=$(yq '.common.arch_type // "x86"' $CONFIG)" >> $GITHUB_OUTPUT
+            echo "device-type=$(yq '.common.device_type // "gpu"' $CONFIG)" >> $GITHUB_OUTPUT
+            echo "contributor=$(yq '.common.contributor // "None"' $CONFIG)" >> $GITHUB_OUTPUT
+            echo "container-type=$(yq '.common.job_type // ""' $CONFIG)" >> $GITHUB_OUTPUT
+            echo "transformers-version=$(yq '.common.transformers_version // ""' $CONFIG)" >> $GITHUB_OUTPUT
+          else
+            echo "Using individual inputs"
+            echo "framework=${{ inputs.framework }}" >> $GITHUB_OUTPUT
+            echo "framework-version=${{ inputs.framework-version }}" >> $GITHUB_OUTPUT
+            echo "python-version=${{ inputs.python-version }}" >> $GITHUB_OUTPUT
+            echo "os-version=${{ inputs.os-version }}" >> $GITHUB_OUTPUT
+            echo "cuda-version=${{ inputs.cuda-version }}" >> $GITHUB_OUTPUT
+            echo "customer-type=${{ inputs.customer-type }}" >> $GITHUB_OUTPUT
+            echo "arch-type=${{ inputs.arch-type }}" >> $GITHUB_OUTPUT
+            echo "device-type=${{ inputs.device-type }}" >> $GITHUB_OUTPUT
+            echo "contributor=${{ inputs.contributor }}" >> $GITHUB_OUTPUT
+            echo "container-type=${{ inputs.container-type }}" >> $GITHUB_OUTPUT
+            echo "transformers-version=${{ inputs.transformers-version }}" >> $GITHUB_OUTPUT
+          fi
+
   preflight:
+    needs: [load-config]
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
         fleet:default-runner
@@ -88,7 +151,7 @@ jobs:
           image-uri: ${{ inputs.image-uri }}
 
   general-tests:
-    needs: preflight
+    needs: [preflight, load-config]
     if: needs.preflight.outputs.image-exists == 'true'
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
@@ -162,9 +225,9 @@ jobs:
       # ==========================================
 
       - name: Run inference engine sanity tests
-        if: inputs.framework == 'vllm' || inputs.framework == 'sglang'
+        if: needs.load-config.outputs.framework == 'vllm' || needs.load-config.outputs.framework == 'sglang'
         run: |
-          IMAGE_TAG="${{ inputs.framework }}:${{ inputs.framework-version }}-${{ inputs.device-type }}-${{ inputs.python-version }}-${{ inputs.cuda-version }}-${{ inputs.os-version }}-${{ inputs.customer-type }}"
+          IMAGE_TAG="${{ needs.load-config.outputs.framework }}:${{ needs.load-config.outputs.framework-version }}-${{ needs.load-config.outputs.device-type }}-${{ needs.load-config.outputs.python-version }}-${{ needs.load-config.outputs.cuda-version }}-${{ needs.load-config.outputs.os-version }}-${{ needs.load-config.outputs.customer-type }}"
           docker exec -e IMAGE_TAG="${IMAGE_TAG}" ${CONTAINER_ID} \
             python3 /workdir/test/sanity/scripts/test_sanity_vllm_sglang.py
 
@@ -186,8 +249,8 @@ jobs:
           PYTHONPATH=$(pwd)/test:$PYTHONPATH python3 test/sanity/scripts/upload_oss_source.py THIRD_PARTY_SOURCE_CODE_URLS
 
   sagemaker-only:
-    needs: preflight
-    if: needs.preflight.outputs.image-exists == 'true' && inputs.customer-type == 'sagemaker'
+    needs: [preflight, load-config]
+    if: needs.preflight.outputs.image-exists == 'true' && needs.load-config.outputs.customer-type == 'sagemaker'
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
         fleet:default-runner
@@ -214,13 +277,13 @@ jobs:
           source .venv/bin/activate
           PYTHONPATH=$(pwd)/test:$PYTHONPATH python3 test/sanity/scripts/check_labels.py \
             ${{ inputs.image-uri }} \
-            --framework "${{ inputs.framework }}" \
-            --framework-version "${{ inputs.framework-version }}" \
-            --device-type "${{ inputs.device-type }}" \
-            --cuda-version "${{ inputs.cuda-version }}" \
-            --arch-type "${{ inputs.arch-type }}" \
-            --python-version "${{ inputs.python-version }}" \
-            --os-version "${{ inputs.os-version }}" \
-            --container-type "${{ inputs.container-type }}" \
-            --contributor "${{ inputs.contributor }}" \
-            --transformers-version "${{ inputs.transformers-version }}"
+            --framework "${{ needs.load-config.outputs.framework }}" \
+            --framework-version "${{ needs.load-config.outputs.framework-version }}" \
+            --device-type "${{ needs.load-config.outputs.device-type }}" \
+            --cuda-version "${{ needs.load-config.outputs.cuda-version }}" \
+            --arch-type "${{ needs.load-config.outputs.arch-type }}" \
+            --python-version "${{ needs.load-config.outputs.python-version }}" \
+            --os-version "${{ needs.load-config.outputs.os-version }}" \
+            --container-type "${{ needs.load-config.outputs.container-type }}" \
+            --contributor "${{ needs.load-config.outputs.contributor }}" \
+            --transformers-version "${{ needs.load-config.outputs.transformers-version }}"

--- a/.github/workflows/reusable-sanity-tests.yml
+++ b/.github/workflows/reusable-sanity-tests.yml
@@ -19,119 +19,47 @@ on:
         required: true
         type: string
       config-file:
-        description: 'Path to image config YAML file. When provided, all fields below are read from the config and individual inputs are ignored.'
-        required: false
+        description: 'Path to image config YAML file (e.g., .github/config/image/pytorch-ec2-cuda.yml)'
+        required: true
         type: string
-        default: ''
-      framework:
-        description: 'Framework name (e.g., vllm, sglang, pytorch, tensorflow, base)'
-        required: false
-        type: string
-        default: ''
-      framework-version:
-        description: 'Framework version (e.g., 0.15.1, 0.5.8)'
-        required: false
-        type: string
-        default: ''
-      python-version:
-        description: 'Python version in pyXYZ format (e.g., py312)'
-        required: false
-        type: string
-        default: ''
-      os-version:
-        description: 'OS version (e.g., ubuntu22.04, ubuntu24.04)'
-        required: false
-        type: string
-        default: ''
-      cuda-version:
-        description: 'CUDA version in cuXYZ format (e.g., cu129). Empty for CPU images.'
-        required: false
-        type: string
-        default: ''
-      customer-type:
-        description: 'Customer type (e.g., sagemaker, ec2)'
-        required: false
-        type: string
-        default: ''
-      arch-type:
-        description: 'Architecture type (e.g., x86, arm64, graviton)'
-        required: false
-        type: string
-        default: 'x86'
-      device-type:
-        description: 'Device type (e.g., gpu, cpu)'
-        required: false
-        type: string
-        default: 'gpu'
-      contributor:
-        description: 'Contributor name'
-        required: false
-        type: string
-        default: ''
-      container-type:
-        description: 'Container/job type (e.g., general, training, inference)'
-        required: false
-        type: string
-        default: ''
-      transformers-version:
-        description: 'Transformers library version'
-        required: false
-        type: string
-        default: ''
 
 jobs:
   load-config:
     runs-on: ubuntu-latest
     outputs:
-      framework: ${{ steps.resolve.outputs.framework }}
-      framework-version: ${{ steps.resolve.outputs.framework-version }}
-      python-version: ${{ steps.resolve.outputs.python-version }}
-      os-version: ${{ steps.resolve.outputs.os-version }}
-      cuda-version: ${{ steps.resolve.outputs.cuda-version }}
-      customer-type: ${{ steps.resolve.outputs.customer-type }}
-      arch-type: ${{ steps.resolve.outputs.arch-type }}
-      device-type: ${{ steps.resolve.outputs.device-type }}
-      contributor: ${{ steps.resolve.outputs.contributor }}
-      container-type: ${{ steps.resolve.outputs.container-type }}
-      transformers-version: ${{ steps.resolve.outputs.transformers-version }}
+      framework: ${{ steps.parse.outputs.framework }}
+      framework-version: ${{ steps.parse.outputs.framework-version }}
+      python-version: ${{ steps.parse.outputs.python-version }}
+      os-version: ${{ steps.parse.outputs.os-version }}
+      cuda-version: ${{ steps.parse.outputs.cuda-version }}
+      customer-type: ${{ steps.parse.outputs.customer-type }}
+      arch-type: ${{ steps.parse.outputs.arch-type }}
+      device-type: ${{ steps.parse.outputs.device-type }}
+      contributor: ${{ steps.parse.outputs.contributor }}
+      container-type: ${{ steps.parse.outputs.container-type }}
+      transformers-version: ${{ steps.parse.outputs.transformers-version }}
     steps:
       - name: Checkout code
-        if: inputs.config-file != ''
         uses: actions/checkout@v5
 
-      - name: Resolve config
-        id: resolve
+      - name: Parse config file
+        id: parse
         run: |
-          if [ -n "${{ inputs.config-file }}" ]; then
-            echo "Reading config from: ${{ inputs.config-file }}"
-            sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-            sudo chmod +x /usr/local/bin/yq
-            CONFIG="${{ inputs.config-file }}"
-            echo "framework=$(yq '.common.framework' $CONFIG)" >> $GITHUB_OUTPUT
-            echo "framework-version=$(yq '.common.framework_version' $CONFIG)" >> $GITHUB_OUTPUT
-            echo "python-version=$(yq '.common.python_version' $CONFIG)" >> $GITHUB_OUTPUT
-            echo "os-version=$(yq '.common.os_version' $CONFIG)" >> $GITHUB_OUTPUT
-            echo "cuda-version=$(yq '.common.cuda_version // ""' $CONFIG)" >> $GITHUB_OUTPUT
-            echo "customer-type=$(yq '.common.customer_type // ""' $CONFIG)" >> $GITHUB_OUTPUT
-            echo "arch-type=$(yq '.common.arch_type // "x86"' $CONFIG)" >> $GITHUB_OUTPUT
-            echo "device-type=$(yq '.common.device_type // "gpu"' $CONFIG)" >> $GITHUB_OUTPUT
-            echo "contributor=$(yq '.common.contributor // "None"' $CONFIG)" >> $GITHUB_OUTPUT
-            echo "container-type=$(yq '.common.job_type // ""' $CONFIG)" >> $GITHUB_OUTPUT
-            echo "transformers-version=$(yq '.common.transformers_version // ""' $CONFIG)" >> $GITHUB_OUTPUT
-          else
-            echo "Using individual inputs"
-            echo "framework=${{ inputs.framework }}" >> $GITHUB_OUTPUT
-            echo "framework-version=${{ inputs.framework-version }}" >> $GITHUB_OUTPUT
-            echo "python-version=${{ inputs.python-version }}" >> $GITHUB_OUTPUT
-            echo "os-version=${{ inputs.os-version }}" >> $GITHUB_OUTPUT
-            echo "cuda-version=${{ inputs.cuda-version }}" >> $GITHUB_OUTPUT
-            echo "customer-type=${{ inputs.customer-type }}" >> $GITHUB_OUTPUT
-            echo "arch-type=${{ inputs.arch-type }}" >> $GITHUB_OUTPUT
-            echo "device-type=${{ inputs.device-type }}" >> $GITHUB_OUTPUT
-            echo "contributor=${{ inputs.contributor }}" >> $GITHUB_OUTPUT
-            echo "container-type=${{ inputs.container-type }}" >> $GITHUB_OUTPUT
-            echo "transformers-version=${{ inputs.transformers-version }}" >> $GITHUB_OUTPUT
-          fi
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          CONFIG="${{ inputs.config-file }}"
+          echo "Loading config from: ${CONFIG}"
+          echo "framework=$(yq '.common.framework' $CONFIG)" >> $GITHUB_OUTPUT
+          echo "framework-version=$(yq '.common.framework_version' $CONFIG)" >> $GITHUB_OUTPUT
+          echo "python-version=$(yq '.common.python_version' $CONFIG)" >> $GITHUB_OUTPUT
+          echo "os-version=$(yq '.common.os_version' $CONFIG)" >> $GITHUB_OUTPUT
+          echo "cuda-version=$(yq '.common.cuda_version // ""' $CONFIG)" >> $GITHUB_OUTPUT
+          echo "customer-type=$(yq '.common.customer_type // ""' $CONFIG)" >> $GITHUB_OUTPUT
+          echo "arch-type=$(yq '.common.arch_type // "x86"' $CONFIG)" >> $GITHUB_OUTPUT
+          echo "device-type=$(yq '.common.device_type // "gpu"' $CONFIG)" >> $GITHUB_OUTPUT
+          echo "contributor=$(yq '.common.contributor // "None"' $CONFIG)" >> $GITHUB_OUTPUT
+          echo "container-type=$(yq '.common.job_type // ""' $CONFIG)" >> $GITHUB_OUTPUT
+          echo "transformers-version=$(yq '.common.transformers_version // ""' $CONFIG)" >> $GITHUB_OUTPUT
 
   preflight:
     needs: [load-config]

--- a/.github/workflows/reusable-security-tests.yml
+++ b/.github/workflows/reusable-security-tests.yml
@@ -19,47 +19,29 @@ on:
         required: true
         type: string
       config-file:
-        description: 'Path to image config YAML file. When provided, framework/version are read from config and individual inputs are ignored.'
-        required: false
+        description: 'Path to image config YAML file (e.g., .github/config/image/pytorch-ec2-cuda.yml)'
+        required: true
         type: string
-        default: ''
-      framework:
-        description: 'Framework name (e.g., vllm, sglang, pytorch, tensorflow, base)'
-        required: false
-        type: string
-        default: ''
-      framework-version:
-        description: 'Framework version (e.g., 0.15.1, 0.5.8)'
-        required: false
-        type: string
-        default: ''
 
 jobs:
   load-config:
     runs-on: ubuntu-latest
     outputs:
-      framework: ${{ steps.resolve.outputs.framework }}
-      framework-version: ${{ steps.resolve.outputs.framework-version }}
+      framework: ${{ steps.parse.outputs.framework }}
+      framework-version: ${{ steps.parse.outputs.framework-version }}
     steps:
       - name: Checkout code
-        if: inputs.config-file != ''
         uses: actions/checkout@v5
 
-      - name: Resolve config
-        id: resolve
+      - name: Parse config file
+        id: parse
         run: |
-          if [ -n "${{ inputs.config-file }}" ]; then
-            echo "Reading config from: ${{ inputs.config-file }}"
-            sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-            sudo chmod +x /usr/local/bin/yq
-            CONFIG="${{ inputs.config-file }}"
-            echo "framework=$(yq '.common.framework' $CONFIG)" >> $GITHUB_OUTPUT
-            echo "framework-version=$(yq '.common.framework_version' $CONFIG)" >> $GITHUB_OUTPUT
-          else
-            echo "Using individual inputs"
-            echo "framework=${{ inputs.framework }}" >> $GITHUB_OUTPUT
-            echo "framework-version=${{ inputs.framework-version }}" >> $GITHUB_OUTPUT
-          fi
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          CONFIG="${{ inputs.config-file }}"
+          echo "Loading config from: ${CONFIG}"
+          echo "framework=$(yq '.common.framework' $CONFIG)" >> $GITHUB_OUTPUT
+          echo "framework-version=$(yq '.common.framework_version' $CONFIG)" >> $GITHUB_OUTPUT
 
   ecr-vulnerability-scan:
     needs: [load-config]

--- a/.github/workflows/reusable-security-tests.yml
+++ b/.github/workflows/reusable-security-tests.yml
@@ -18,17 +18,51 @@ on:
         description: 'AWS region for ECR authentication'
         required: true
         type: string
+      config-file:
+        description: 'Path to image config YAML file. When provided, framework/version are read from config and individual inputs are ignored.'
+        required: false
+        type: string
+        default: ''
       framework:
         description: 'Framework name (e.g., vllm, sglang, pytorch, tensorflow, base)'
-        required: true
+        required: false
         type: string
+        default: ''
       framework-version:
         description: 'Framework version (e.g., 0.15.1, 0.5.8)'
-        required: true
+        required: false
         type: string
+        default: ''
 
 jobs:
+  load-config:
+    runs-on: ubuntu-latest
+    outputs:
+      framework: ${{ steps.resolve.outputs.framework }}
+      framework-version: ${{ steps.resolve.outputs.framework-version }}
+    steps:
+      - name: Checkout code
+        if: inputs.config-file != ''
+        uses: actions/checkout@v5
+
+      - name: Resolve config
+        id: resolve
+        run: |
+          if [ -n "${{ inputs.config-file }}" ]; then
+            echo "Reading config from: ${{ inputs.config-file }}"
+            sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+            sudo chmod +x /usr/local/bin/yq
+            CONFIG="${{ inputs.config-file }}"
+            echo "framework=$(yq '.common.framework' $CONFIG)" >> $GITHUB_OUTPUT
+            echo "framework-version=$(yq '.common.framework_version' $CONFIG)" >> $GITHUB_OUTPUT
+          else
+            echo "Using individual inputs"
+            echo "framework=${{ inputs.framework }}" >> $GITHUB_OUTPUT
+            echo "framework-version=${{ inputs.framework-version }}" >> $GITHUB_OUTPUT
+          fi
+
   ecr-vulnerability-scan:
+    needs: [load-config]
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
         fleet:default-runner
@@ -54,5 +88,5 @@ jobs:
           source .venv/bin/activate
           PYTHONPATH=$(pwd):$(pwd)/test:$PYTHONPATH python3 test/security/scripts/ecr_scan.py \
             --image-uri "${{ inputs.image-uri }}" \
-            --framework "${{ inputs.framework }}" \
-            --framework-version "${{ inputs.framework-version }}"
+            --framework "${{ needs.load-config.outputs.framework }}" \
+            --framework-version "${{ needs.load-config.outputs.framework-version }}"

--- a/.github/workflows/reusable-telemetry-tests.yml
+++ b/.github/workflows/reusable-telemetry-tests.yml
@@ -19,55 +19,31 @@ on:
         required: true
         type: string
       config-file:
-        description: 'Path to image config YAML file. When provided, framework/version/container-type are read from config and individual inputs are ignored.'
-        required: false
+        description: 'Path to image config YAML file (e.g., .github/config/image/pytorch-ec2-cuda.yml)'
+        required: true
         type: string
-        default: ''
-      framework:
-        description: 'Framework name (e.g., vllm, sglang, pytorch)'
-        required: false
-        type: string
-        default: ''
-      framework-version:
-        description: 'Framework version (e.g., 0.15.1, 0.5.8)'
-        required: false
-        type: string
-        default: ''
-      container-type:
-        description: 'Container/job type (e.g., general, training, inference)'
-        required: false
-        type: string
-        default: ''
 
 jobs:
   load-config:
     runs-on: ubuntu-latest
     outputs:
-      framework: ${{ steps.resolve.outputs.framework }}
-      framework-version: ${{ steps.resolve.outputs.framework-version }}
-      container-type: ${{ steps.resolve.outputs.container-type }}
+      framework: ${{ steps.parse.outputs.framework }}
+      framework-version: ${{ steps.parse.outputs.framework-version }}
+      container-type: ${{ steps.parse.outputs.container-type }}
     steps:
       - name: Checkout code
-        if: inputs.config-file != ''
         uses: actions/checkout@v5
 
-      - name: Resolve config
-        id: resolve
+      - name: Parse config file
+        id: parse
         run: |
-          if [ -n "${{ inputs.config-file }}" ]; then
-            echo "Reading config from: ${{ inputs.config-file }}"
-            sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
-            sudo chmod +x /usr/local/bin/yq
-            CONFIG="${{ inputs.config-file }}"
-            echo "framework=$(yq '.common.framework' $CONFIG)" >> $GITHUB_OUTPUT
-            echo "framework-version=$(yq '.common.framework_version' $CONFIG)" >> $GITHUB_OUTPUT
-            echo "container-type=$(yq '.common.job_type // ""' $CONFIG)" >> $GITHUB_OUTPUT
-          else
-            echo "Using individual inputs"
-            echo "framework=${{ inputs.framework }}" >> $GITHUB_OUTPUT
-            echo "framework-version=${{ inputs.framework-version }}" >> $GITHUB_OUTPUT
-            echo "container-type=${{ inputs.container-type }}" >> $GITHUB_OUTPUT
-          fi
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          CONFIG="${{ inputs.config-file }}"
+          echo "Loading config from: ${CONFIG}"
+          echo "framework=$(yq '.common.framework' $CONFIG)" >> $GITHUB_OUTPUT
+          echo "framework-version=$(yq '.common.framework_version' $CONFIG)" >> $GITHUB_OUTPUT
+          echo "container-type=$(yq '.common.job_type // ""' $CONFIG)" >> $GITHUB_OUTPUT
 
   preflight:
     needs: [load-config]

--- a/.github/workflows/reusable-telemetry-tests.yml
+++ b/.github/workflows/reusable-telemetry-tests.yml
@@ -18,20 +18,59 @@ on:
         description: 'AWS region for ECR authentication'
         required: true
         type: string
+      config-file:
+        description: 'Path to image config YAML file. When provided, framework/version/container-type are read from config and individual inputs are ignored.'
+        required: false
+        type: string
+        default: ''
       framework:
         description: 'Framework name (e.g., vllm, sglang, pytorch)'
-        required: true
+        required: false
         type: string
+        default: ''
       framework-version:
         description: 'Framework version (e.g., 0.15.1, 0.5.8)'
-        required: true
+        required: false
         type: string
+        default: ''
       container-type:
         description: 'Container/job type (e.g., general, training, inference)'
-        required: true
+        required: false
         type: string
+        default: ''
+
 jobs:
+  load-config:
+    runs-on: ubuntu-latest
+    outputs:
+      framework: ${{ steps.resolve.outputs.framework }}
+      framework-version: ${{ steps.resolve.outputs.framework-version }}
+      container-type: ${{ steps.resolve.outputs.container-type }}
+    steps:
+      - name: Checkout code
+        if: inputs.config-file != ''
+        uses: actions/checkout@v5
+
+      - name: Resolve config
+        id: resolve
+        run: |
+          if [ -n "${{ inputs.config-file }}" ]; then
+            echo "Reading config from: ${{ inputs.config-file }}"
+            sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+            sudo chmod +x /usr/local/bin/yq
+            CONFIG="${{ inputs.config-file }}"
+            echo "framework=$(yq '.common.framework' $CONFIG)" >> $GITHUB_OUTPUT
+            echo "framework-version=$(yq '.common.framework_version' $CONFIG)" >> $GITHUB_OUTPUT
+            echo "container-type=$(yq '.common.job_type // ""' $CONFIG)" >> $GITHUB_OUTPUT
+          else
+            echo "Using individual inputs"
+            echo "framework=${{ inputs.framework }}" >> $GITHUB_OUTPUT
+            echo "framework-version=${{ inputs.framework-version }}" >> $GITHUB_OUTPUT
+            echo "container-type=${{ inputs.container-type }}" >> $GITHUB_OUTPUT
+          fi
+
   preflight:
+    needs: [load-config]
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
         fleet:default-runner
@@ -48,7 +87,7 @@ jobs:
           image-uri: ${{ inputs.image-uri }}
 
   telemetry-environment:
-    needs: preflight
+    needs: [preflight, load-config]
     if: needs.preflight.outputs.image-exists == 'true'
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
@@ -79,13 +118,13 @@ jobs:
           docker exec ${CONTAINER_ID} bash -c '! grep -q "{{" /usr/local/bin/bash_telemetry.sh'
           docker exec ${CONTAINER_ID} bash -c "grep -q 'bash_telemetry.sh' /etc/bash.bashrc 2>/dev/null || grep -q 'bash_telemetry.sh' /etc/bashrc"
           ACTUAL=$(docker exec ${CONTAINER_ID} printenv DLC_CONTAINER_TYPE)
-          if [ "$ACTUAL" != "${{ inputs.container-type }}" ]; then
-            echo "DLC_CONTAINER_TYPE expected '${{ inputs.container-type }}' but got '$ACTUAL'"
+          if [ "$ACTUAL" != "${{ needs.load-config.outputs.container-type }}" ]; then
+            echo "DLC_CONTAINER_TYPE expected '${{ needs.load-config.outputs.container-type }}' but got '$ACTUAL'"
             exit 1
           fi
 
   telemetry-instance:
-    needs: preflight
+    needs: [preflight, load-config]
     if: needs.preflight.outputs.image-exists == 'true'
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
@@ -109,7 +148,7 @@ jobs:
           cd test/
           PYTHONPATH=$(pwd)/../scripts/telemetry:$PYTHONPATH pytest -vs -rA telemetry \
             --image-uri "${{ inputs.image-uri }}" \
-            --framework "${{ inputs.framework }}" \
-            --framework-version "${{ inputs.framework-version }}" \
-            --container-type "${{ inputs.container-type }}" \
+            --framework "${{ needs.load-config.outputs.framework }}" \
+            --framework-version "${{ needs.load-config.outputs.framework-version }}" \
+            --container-type "${{ needs.load-config.outputs.container-type }}" \
             --region "${{ inputs.aws-region }}"

--- a/docker/pytorch/Dockerfile.cuda
+++ b/docker/pytorch/Dockerfile.cuda
@@ -1,5 +1,6 @@
 # ============================================================================
 # PyTorch DLC — Amazon Linux 2023 (CUDA 13.0)
+# Trigger: PoC for config-file-based reusable workflows (PR #6126)
 # Multi-stage build with parallel builder stages:
 #
 #   builder-base ──┬── builder-flash-attn   (torch + flash-attn)


### PR DESCRIPTION
## Summary

- Add optional `config-file` input to 4 PyTorch-relevant reusable workflows (sanity, security, telemetry, EFA)
- When `config-file` is provided, the reusable workflow reads metadata from the YAML config directly — callers no longer need to parse and forward 10+ individual parameters
- Backward compatible: existing callers (vLLM, SGLang, Ray, Base) pass individual inputs and work unchanged
- Updated `pr-pytorch-ec2-cuda.yml` as PoC — eliminates the verbose `load-config→parse→forward` pattern

## Motivation

GitHub Actions limitation: when a **matrix job** has outputs, only the **last-finishing matrix leg** gets its outputs exposed. If multiple PyTorch versions change in the same PR, downstream reusable workflow calls only receive metadata from one version.

By making reusable workflows self-sufficient (reading their own config), each matrix leg can pass its own `config-file` path without shared outputs clobbering each other.

## Workflow & Caller Inventory

### 13 Reusable Workflows

| # | Reusable Workflow | Key Inputs |
|---|---|---|
| 1 | `reusable-sanity-tests.yml` | image-uri, framework, framework-version, python-version, cuda-version, os-version, customer-type, arch-type, device-type, contributor, container-type |
| 2 | `reusable-security-tests.yml` | image-uri, framework, framework-version |
| 3 | `reusable-telemetry-tests.yml` | image-uri, framework, framework-version, container-type |
| 4 | `reusable-efa-tests.yml` | image-uri, aws-account-id, aws-region |
| 5 | `reusable-vllm-model-tests.yml` | image-uri, aws-account-id, aws-region |
| 6 | `reusable-vllm-upstream-tests.yml` | image-uri, framework-version, vllm-ref, setup-script, example-test-script |
| 7 | `reusable-vllm-sagemaker-tests.yml` | image-uri only |
| 8 | `reusable-vllm-omni-model-tests.yml` | image-uri, customer-type |
| 9 | `reusable-sglang-model-tests.yml` | image-uri, aws-account-id, aws-region |
| 10 | `reusable-sglang-upstream-tests.yml` | image-uri, framework-version, benchmark-start-command |
| 11 | `reusable-sglang-sagemaker-tests.yml` | image-uri only |
| 12 | `reusable-release-image.yml` | source-image-uri, release-spec, environment |
| 13 | `reusable-sagemaker-xgboost-integ-tests.yml` | image-uri, aws-account-id, aws-region |

### PR Workflows (20 callers)

| Caller | Reusable(s) Called | Multi-version Matrix? |
|---|---|---|
| `pr-pytorch-ec2-cuda.yml` (**this PoC**) | sanity, security, telemetry, efa | Future: yes |
| `pr-pytorch-ec2-cpu.yml` | sanity, security, telemetry | Future: yes |
| `pr-pytorch-sagemaker-cpu.yml` | sanity, security, telemetry | Future: yes |
| `pr-pytorch-sagemaker-cuda.yml` | sanity, security, telemetry | Future: yes |
| `pr-base-v1.yml` | sanity, security | No |
| `pr-base-v2.yml` | sanity, security | No (matrix over targets) |
| `pr-vllm-ec2-amzn2023.yml` | sanity, security, telemetry, upstream, model | No |
| `pr-vllm-ec2.yml` | sanity, security, telemetry, upstream, model | No |
| `pr-vllm-sagemaker-amzn2023.yml` | sanity, security, telemetry, sagemaker | No |
| `pr-vllm-sagemaker.yml` | sanity, security, telemetry, sagemaker | No |
| `pr-vllm-hyperpod-amzn2023.yml` | sanity, security, telemetry | No |
| `pr-vllm-omni-ec2-amzn2023.yml` | sanity, security, telemetry, vllm-omni-model | No |
| `pr-vllm-omni-sagemaker-amzn2023.yml` | sanity, security, telemetry, vllm-omni-model | No |
| `pr-sglang-ec2-amzn2023.yml` | sanity, security, telemetry, sglang-upstream, sglang-model | No |
| `pr-sglang-ec2.yml` | sanity, security, telemetry, sglang-upstream, sglang-model | No |
| `pr-sglang-sagemaker-amzn2023.yml` | sanity, security, telemetry, sglang-sagemaker | No |
| `pr-sglang-sagemaker.yml` | sanity, security, telemetry, sglang-sagemaker | No |
| `pr-ray-ec2-cpu.yml` | sanity, security | No |
| `pr-ray-ec2-gpu.yml` | sanity, security | No |
| `pr-ray-sagemaker-cpu/gpu.yml` | sanity, security | No |
| `pr-sagemaker-xgboost.yml` | xgboost-integ | No |

### Autorelease Workflows (14 callers)

| Caller | Reusable(s) Called |
|---|---|
| `autorelease-pytorch-ec2-cuda.yml` | sanity, security, telemetry, efa, release |
| `autorelease-pytorch-ec2-cpu.yml` | sanity, security, telemetry, release |
| `autorelease-pytorch-sagemaker-cpu.yml` | sanity, security, telemetry, release |
| `autorelease-pytorch-sagemaker-cuda.yml` | sanity, security, telemetry, efa, release |
| `autorelease-vllm-ec2-amzn2023.yml` | sanity, security, telemetry, upstream, model, release |
| `autorelease-vllm-ec2.yml` | sanity, security, telemetry, upstream, model, release |
| `autorelease-vllm-sagemaker-amzn2023.yml` | sanity, security, telemetry, sagemaker, release |
| `autorelease-vllm-sagemaker.yml` | sanity, security, telemetry, sagemaker, release |
| `autorelease-vllm-hyperpod-amzn2023.yml` | sanity, security, telemetry, release |
| `autorelease-vllm-omni.yml` | sanity, security, telemetry, vllm-omni-model, release |
| `autorelease-sglang-ec2.yml` | sanity, security, telemetry, sglang-upstream, sglang-model, release |
| `autorelease-sglang-sagemaker.yml` | sanity, security, telemetry, sglang-sagemaker, release |
| `autorelease-ray.yml` | sanity, security, release |
| `autorelease-base.yml` | sanity, security, release |

### Dispatch Workflows (3 callers)

| Caller | Reusable(s) Called |
|---|---|
| `dispatch-partner-release.yml` | release |
| `dispatch-release-sagemaker-xgboost.yml` | xgboost-integ, release |

## Design

```
Before (10+ inputs forwarded per call):
┌─────────────────┐     ┌──────────────────────────────────────┐
│ PR Workflow      │     │ Reusable Workflow                    │
│                  │     │                                      │
│ load-config ────────┐  │  inputs:                            │
│   parse YAML    │   │  │    framework: "pytorch"             │
│   forward each  │   ├──│    framework-version: "2.11.0"      │
│   field as      │   │  │    python-version: "py312"          │
│   input         │   │  │    cuda-version: "cu130"            │
│                  │   │  │    os-version: "amzn2023"           │
│                  │   │  │    ... (10+ more)                   │
└─────────────────┘   │  └──────────────────────────────────────┘
                      └──→  (each field passed individually)

After (single config-file input):
┌─────────────────┐     ┌──────────────────────────────────────┐
│ PR Workflow      │     │ Reusable Workflow                    │
│                  │     │                                      │
│ config-file ─────────── │  inputs:                            │
│   just pass     │     │    config-file: "path/to/config.yml" │
│   the path      │     │                                      │
│                  │     │  load-config job:                    │
│                  │     │    reads YAML → resolves all fields  │
└─────────────────┘     └──────────────────────────────────────┘
```

## Blast Radius

- Only `pr-pytorch-ec2-cuda.yml` is triggered by this PR (it watches its own path)
- Non-pytorch workflows do NOT have `reusable-sanity/security/telemetry/efa` in their path triggers
- Backward compatible: vLLM/SGLang/Ray/Base callers pass individual inputs → `else` branch forwards them unchanged

## Test plan

- [ ] Verify YAML syntax passes (done locally)
- [ ] Confirm only `PR - PyTorch EC2 CUDA` workflow triggers on this PR
- [ ] Validate that existing callers (vLLM, SGLang, etc.) work unchanged on their next PR
- [ ] Future: migrate remaining 3 PyTorch PR workflows + 4 autorelease workflows to config-file interface