### PR TITLE
Updating deep-learning-containers repository with neuron 2.30.0 images

### DIFF
--- a/docs/src/data/pytorch-inference-neuronx/2.9-neuronx-sdk2.30.0.yml
+++ b/docs/src/data/pytorch-inference-neuronx/2.9-neuronx-sdk2.30.0.yml
@@ -1,0 +1,11 @@
+framework: PyTorch
+version: "2.9"
+accelerator: neuronx
+python: py312
+sdk: "2.30.0"
+os: ubuntu24.04
+platform: sagemaker
+
+# Image tags (first tag is used in available_images.md)
+tags:
+  - "2.9.0-neuronx-py312-sdk2.30.0-ubuntu24.04"

--- a/docs/src/data/pytorch-training-neuronx/2.9-neuronx-sdk2.30.0.yml
+++ b/docs/src/data/pytorch-training-neuronx/2.9-neuronx-sdk2.30.0.yml
@@ -1,0 +1,11 @@
+framework: PyTorch
+version: "2.9"
+accelerator: neuronx
+python: py312
+sdk: "2.30.0"
+os: ubuntu24.04
+platform: sagemaker
+
+# Image tags (first tag is used in available_images.md)
+tags:
+  - "2.9.0-neuronx-py312-sdk2.30.0-ubuntu24.04"


### PR DESCRIPTION
## Purpose

Add image data files for PyTorch 2.9 inference and training containers with Neuron SDK 2.30.0 on Ubuntu 24.04 with Python 3.12.

New images:
- pytorch-inference-neuronx: 2.9.0-neuronx-py312-sdk2.30.0-ubuntu24.04
- pytorch-training-neuronx: 2.9.0-neuronx-py312-sdk2.30.0-ubuntu24.04

## Test Plan

Documentation-only change adding image metadata YAML files.

## Test Result

N/A

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [x] I ran pre-commit run --all-files locally before creating this PR.

</details>