### PR TITLE
docs(vllm-omni): document v1.2 and v1.3 image releases

### DIFF
--- a/docs/vllm-omni/changelog/index.md
+++ b/docs/vllm-omni/changelog/index.md
@@ -4,6 +4,51 @@ Changelog for the Amazon Linux 2023-based vLLM-Omni images (`omni-cuda`, `omni-s
 
 * * *
 
+## v1.3.0 — 2026-05-21
+
+**Tags:** `omni-cuda-v1.3` · `omni-sagemaker-cuda-v1.3`
+
+**vLLM-Omni source:** [v0.21.0rc1](https://github.com/vllm-project/vllm-omni/releases/tag/v0.21.0rc1) (pre-release, tracking upstream vLLM v0.21.0)
+
+### Highlights
+
+- Upgraded to vLLM-Omni 0.21.0rc1, aligned with upstream vLLM v0.21.0
+- Cherry-picked upstream Dockerfile fixes for cublas headers (JIT), flashinfer cubin layering, and the `nixl-cu13` install ordering for matching
+  `nixl_ep_cpp.so`
+
+### Fixes
+
+- **Voice-clone TTS (Qwen3-TTS-Base) throughput restored** — the upstream Code2Wav decode-chunk un-batching regression flagged in v1.1 is resolved in
+  vllm-omni 0.21.0rc1.
+
+### Known Issues
+
+- **Transformers pinned to `<5.9.0`.** Transformers 5.9.0 removed the deprecated `input_embeds` alias and the `cache_position` kwarg from
+  `create_causal_mask` / `create_sliding_window_causal_mask`, which breaks Qwen3-TTS decode in vllm-omni 0.21.0rc1. Pin will be dropped once a
+  vllm-omni release containing the upstream fix ships.
+
+* * *
+
+## v1.2.0 — 2026-05-18
+
+**Tags:** `omni-cuda-v1.2` · `omni-sagemaker-cuda-v1.2`
+
+**vLLM-Omni source:** [v0.20.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.20.0) (unchanged from v1.1)
+
+### Changes
+
+- **SageMaker `/v1/videos` and `/v1/videos/sync` now require `multipart/form-data` directly.** The routing middleware no longer auto-converts JSON
+  request bodies to multipart. Clients must build the multipart body locally and pass `ContentType="multipart/form-data; boundary=..."` to
+  `InvokeEndpoint`; SageMaker forwards the body and `ContentType` through to the model server unchanged.
+- See `examples/vllm-omni/sagemaker/deploy_video_sync.py` for the updated invocation pattern.
+
+### Migration
+
+- Clients that previously sent JSON to `/v1/videos*` via SageMaker `CustomAttributes` routing must switch to a pre-built multipart body. JSON requests
+  to these routes will now reach the model server unconverted and fail.
+
+* * *
+
 ## v1.1.0 — 2026-05-12
 
 **Tags:** `omni-cuda-v1.1` · `omni-sagemaker-cuda-v1.1`

--- a/docs/vllm-omni/changelog/index.md
+++ b/docs/vllm-omni/changelog/index.md
@@ -24,8 +24,9 @@ Changelog for the Amazon Linux 2023-based vLLM-Omni images (`omni-cuda`, `omni-s
 ### Known Issues
 
 - **Transformers pinned to `<5.9.0`.** Transformers 5.9.0 removed the deprecated `input_embeds` alias and the `cache_position` kwarg from
-  `create_causal_mask` / `create_sliding_window_causal_mask`, which breaks Qwen3-TTS decode in vllm-omni 0.21.0rc1. Pin will be dropped once a
-  vllm-omni release containing the upstream fix ships.
+  `create_causal_mask` / `create_sliding_window_causal_mask`, which breaks Qwen3-TTS decode in vllm-omni 0.21.0rc1. Upstream fix:
+  [vllm-project/vllm-omni#3786](https://github.com/vllm-project/vllm-omni/pull/3786). Pin will be dropped once a vllm-omni release containing it
+  ships.
 
 * * *
 

--- a/docs/vllm-omni/changelog/index.md
+++ b/docs/vllm-omni/changelog/index.md
@@ -10,6 +10,8 @@ Changelog for the Amazon Linux 2023-based vLLM-Omni images (`omni-cuda`, `omni-s
 
 **vLLM-Omni source:** [v0.21.0rc1](https://github.com/vllm-project/vllm-omni/releases/tag/v0.21.0rc1) (pre-release, tracking upstream vLLM v0.21.0)
 
+**DLC PR:** [#6110](https://github.com/aws/deep-learning-containers/pull/6110)
+
 ### Highlights
 
 - Upgraded to vLLM-Omni 0.21.0rc1, aligned with upstream vLLM v0.21.0
@@ -35,6 +37,8 @@ Changelog for the Amazon Linux 2023-based vLLM-Omni images (`omni-cuda`, `omni-s
 **Tags:** `omni-cuda-v1.2` · `omni-sagemaker-cuda-v1.2`
 
 **vLLM-Omni source:** [v0.20.0](https://github.com/vllm-project/vllm-omni/releases/tag/v0.20.0) (unchanged from v1.1)
+
+**DLC PR:** [#6101](https://github.com/aws/deep-learning-containers/pull/6101)
 
 ### Changes
 

--- a/docs/vllm-omni/configuration.md
+++ b/docs/vllm-omni/configuration.md
@@ -44,8 +44,6 @@ flag (`SM_VLLM_ENFORCE_EAGER=true` → `--enforce-eager`), and `false` omits the
 
 ## Known Limitations
 
-- **Voice-clone TTS (Qwen3-TTS-Base) is slower in v1.1 than v1.0** due to an upstream Code2Wav decode-chunk un-batching regression. Preset-voice TTS
-  is unaffected. Fix is merged upstream and will land in the next release.
 - **CosyVoice3 requires `--trust-remote-code` and ~32 GB host RAM during model load.** Use `g6e.xlarge` or larger.
 - **Stable-Audio-Open output is capped at ~47 seconds per request** by the model itself. For longer clips, run multiple requests and concatenate
   client-side.

--- a/docs/vllm-omni/deployment/sagemaker.md
+++ b/docs/vllm-omni/deployment/sagemaker.md
@@ -57,22 +57,53 @@ predictor.delete_endpoint(delete_endpoint_config=True)
 
 ## Other Modalities
 
-The same pattern works for image and sync-video endpoints — change `SM_VLLM_MODEL`, `instance_type`, and the `route=` attribute. JSON request bodies
-are auto-converted to `multipart/form-data` for the video routes by the routing middleware.
+The same pattern works for image and sync-video endpoints — change `SM_VLLM_MODEL`, `instance_type`, and the `route=` attribute.
 
 ```python
-# Image generation — FLUX.2-klein-4B on g6.xlarge
+# Image generation — FLUX.2-klein-4B on g6.xlarge (JSON)
 response = predictor.predict(
     data={"prompt": "a red apple on a white table", "size": "512x512", "n": 1},
     custom_attributes="route=/v1/images/generations",
 )
+```
+
+The `/v1/videos` and `/v1/videos/sync` routes require `multipart/form-data`. As of `omni-sagemaker-cuda-v1.2`, the routing middleware no longer
+converts JSON to multipart — clients must build the multipart body locally and pass it through `InvokeEndpoint`'s `ContentType`. SageMaker forwards
+the body and `ContentType` to the model server unchanged.
+
+```python
+import uuid
+import boto3
+
+def build_multipart_body(fields: dict, boundary: str) -> bytes:
+    parts = [
+        f'--{boundary}\r\nContent-Disposition: form-data; name="{k}"\r\n\r\n{v}\r\n'
+        for k, v in fields.items()
+    ]
+    parts.append(f"--{boundary}--\r\n")
+    return "".join(parts).encode()
 
 # Sync video — Wan2.1-T2V-1.3B on g6e.xlarge
-response = predictor.predict(
-    data={"prompt": "a dog running on a beach", "num_frames": 17, "num_inference_steps": 30, "size": "480x320"},
-    custom_attributes="route=/v1/videos/sync",
+boundary = uuid.uuid4().hex
+content_type = f"multipart/form-data; boundary={boundary}"
+body = build_multipart_body(
+    {"prompt": "a dog running on a beach", "num_frames": "17",
+     "num_inference_steps": "30", "size": "480x320"},
+    boundary,
 )
+
+runtime = boto3.client("sagemaker-runtime")
+response = runtime.invoke_endpoint(
+    EndpointName=predictor.endpoint_name,
+    Body=body,
+    ContentType=content_type,
+    CustomAttributes="route=/v1/videos/sync",
+)
+mp4_bytes = response["Body"].read()
 ```
+
+For the async `/v1/videos` route on SageMaker async inference, see
+[examples/vllm-omni/sagemaker/deploy_video_sync.py](https://github.com/aws/deep-learning-containers/blob/main/examples/vllm-omni/sagemaker/deploy_video_sync.py).
 
 For Qwen2.5-Omni multimodal chat (text + speech output), set `route=/v1/chat/completions` and use the request shape from the
 [EC2 multimodal-chat example](ec2.md#speech-output-requirements).


### PR DESCRIPTION
## Summary

Documents the two recent vLLM-Omni AL2023 image releases that landed in `main`:

- **v1.2.0** (#6101) — SageMaker `/v1/videos` and `/v1/videos/sync` now require clients to send `multipart/form-data` directly. The routing middleware no longer converts JSON to multipart; SageMaker `InvokeEndpoint` forwards the body and `ContentType` through to the model server unchanged.
- **v1.3.0** (#6110) — vLLM-Omni 0.21.0rc1 prep (tracking upstream vLLM v0.21.0). Restores voice-clone TTS (Qwen3-TTS-Base) throughput by clearing the upstream Code2Wav un-batching regression. Includes a temporary `transformers<5.9.0` pin until vllm-omni ships the upstream `create_causal_mask` signature fix.

### Files changed

- `docs/vllm-omni/changelog/index.md` — new v1.2.0 and v1.3.0 entries (reverse-chronological).
- `docs/vllm-omni/deployment/sagemaker.md` — replaced the stale "JSON auto-converted to multipart" sync-video sample with a `boto3 invoke_endpoint` example that builds the multipart body client-side.
- `docs/vllm-omni/configuration.md` — removed the carry-over v1.1 voice-clone TTS slowdown note now that v1.3 resolves it.

Per-version release-notes pages and `docs/src/data/vllm-omni/` yml metadata for 0.21.0rc1 are intentionally out of scope — they'll land with the stable 0.21.0 release.

## Test plan

- [x] `mkdocs serve --livereload` renders the changelog, configuration, and SageMaker deployment pages without errors.
- [x] flowmark / markdown formatter pre-commit hook passes.
- [ ] Reviewer confirms the v1.3 fix line for Qwen3-TTS-Base matches the smoke-test results.