### PR TITLE
[cve-patch] allowlist 3 ray cves with no in-image fix

### DIFF
--- a/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
@@ -16,5 +16,20 @@
   {
     "vulnerability_id": "CVE-2026-34480",
     "reason": "ray bundles log4j-core 2.25.3 in ray_dist.jar, cannot patch without upstream ray rebuild"
+  },
+  {
+    "vulnerability_id": "CVE-2025-14930",
+    "reason": "transformers 5.8.0 fix needs new Ray release bump (core contract package)",
+    "review_by": "2026-11-18"
+  },
+  {
+    "vulnerability_id": "CVE-2026-4538",
+    "reason": "torch 2.10.0 fix needs new Ray release bump (core contract package)",
+    "review_by": "2026-11-18"
+  },
+  {
+    "vulnerability_id": "CVE-2024-34997",
+    "reason": "no upstream fix as of 2026-05-22; on pypi latest 1.5.3",
+    "review_by": "2026-07-21"
   }
 ]


### PR DESCRIPTION
## Purpose

Patch CVEs across Ray DLC images.

## CVEs handled

| CVE | Package | Severity | Affected images | Action |
|---|---|---|---|---|
| CVE-2025-14930 | transformers 5.8.0 | HIGH | cpu, cuda, sm-cpu, sm-cuda | allowlist (core contract) |
| CVE-2026-4538 | torch 2.10.0 | HIGH | cpu, cuda, sm-cpu, sm-cuda | allowlist (core contract) |
| CVE-2024-34997 | joblib 1.5.3 | HIGH | cpu, cuda, sm-cpu, sm-cuda | allowlist (no upstream fix; pypi latest = installed) |
| CVE-2026-34478 | log4j-core 2.25.3 | HIGH | cpu, cuda, sm-cpu, sm-cuda | already allowlisted (vendored in ray_dist.jar) |
| CVE-2026-34480 | log4j-core 2.25.3 | HIGH | cpu, cuda, sm-cpu, sm-cuda | already allowlisted (vendored in ray_dist.jar) |
| CVE-2025-23308 | cuda-toolkit-config-common 12.9.79 | HIGH | cuda, sm-cuda | already allowlisted (CUDA 13 only) |
| CVE-2025-23339 | cuda-toolkit-config-common 12.9.79 | HIGH | cuda, sm-cuda | already allowlisted (CUDA 13 only) |

## Core-package CVEs (need new Ray release bump)

CVEs on Ray's core contract packages (ray, torch, torchvision, torchaudio, transformers, scikit-learn, ffmpeg, cuda). The patcher allowlists these because bumping a core package is the framework owner's call (handled via the Ray autorelease).

| CVE | Package | Installed | Severity | Notes |
|---|---|---|---|---|
| CVE-2025-14930 | transformers | 5.8.0 | HIGH | needs new Ray release bump |
| CVE-2026-4538 | torch | 2.10.0 | HIGH | needs new Ray release bump |

## Test plan

- [ ] CI security tests pass for cpu and gpu
- [ ] CI sanity tests pass for cpu and gpu
- [ ] CI Ray-specific tests pass