### PR TITLE
chore: trigger ray pr ci on framework_allowlist.json changes

### DIFF
--- a/.github/workflows/pr-ray-ec2-cpu.yml
+++ b/.github/workflows/pr-ray-ec2-cpu.yml
@@ -15,6 +15,7 @@ on:
       - "scripts/telemetry/**"
       - "test/ray/**"
       - "test/sanity/**"
+      - "test/security/data/ecr_scan_allowlist/ray/**"
       - "test/telemetry/**"
       - "!docs/**"
 
@@ -130,6 +131,7 @@ jobs:
               - "scripts/common/setup_oss_compliance.sh"
               - "scripts/telemetry/bash_telemetry.sh.template"
               - "scripts/ray/*"
+              - "test/security/data/ecr_scan_allowlist/ray/**"
             ec2-test-change:
               - "test/ray/ec2/**"
             sanity-test-change:

--- a/.github/workflows/pr-ray-ec2-gpu.yml
+++ b/.github/workflows/pr-ray-ec2-gpu.yml
@@ -15,6 +15,7 @@ on:
       - "scripts/telemetry/**"
       - "test/ray/**"
       - "test/sanity/**"
+      - "test/security/data/ecr_scan_allowlist/ray/**"
       - "test/telemetry/**"
       - "!docs/**"
 
@@ -133,6 +134,7 @@ jobs:
               - "scripts/common/setup_oss_compliance.sh"
               - "scripts/telemetry/bash_telemetry.sh.template"
               - "scripts/ray/*"
+              - "test/security/data/ecr_scan_allowlist/ray/**"
             ec2-test-change:
               - "test/ray/ec2/**"
             sanity-test-change:

--- a/.github/workflows/pr-ray-sagemaker-cpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-cpu.yml
@@ -15,6 +15,7 @@ on:
       - "scripts/telemetry/**"
       - "test/ray/**"
       - "test/sanity/**"
+      - "test/security/data/ecr_scan_allowlist/ray/**"
       - "test/telemetry/**"
       - "!docs/**"
 
@@ -129,6 +130,7 @@ jobs:
               - "scripts/common/setup_oss_compliance.sh"
               - "scripts/telemetry/bash_telemetry.sh.template"
               - "scripts/ray/*"
+              - "test/security/data/ecr_scan_allowlist/ray/**"
             sagemaker-test-change:
               - "test/ray/sagemaker/**"
             sanity-test-change:

--- a/.github/workflows/pr-ray-sagemaker-gpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-gpu.yml
@@ -15,6 +15,7 @@ on:
       - "scripts/telemetry/**"
       - "test/ray/**"
       - "test/sanity/**"
+      - "test/security/data/ecr_scan_allowlist/ray/**"
       - "test/telemetry/**"
       - "!docs/**"
 
@@ -131,6 +132,7 @@ jobs:
               - "scripts/common/setup_oss_compliance.sh"
               - "scripts/telemetry/bash_telemetry.sh.template"
               - "scripts/ray/*"
+              - "test/security/data/ecr_scan_allowlist/ray/**"
             sagemaker-test-change:
               - "test/ray/sagemaker/**"
             sanity-test-change:


### PR DESCRIPTION
## Purpose

Currently the 4 Ray PR workflows (`pr-ray-ec2-cpu`, `pr-ray-ec2-gpu`, `pr-ray-sagemaker-cpu`, `pr-ray-sagemaker-gpu`) don't fire when a PR only touches `test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json`. That means an allowlist-only PR can land without any security-test verification — bad experience and risk of merging stale allowlist entries.

`pr-base-v1.yml` and `pr-base-v2.yml` already follow the convention of including their framework's allowlist in the path filter. This brings Ray in line.

## Summary

- Add ``test/security/data/ecr_scan_allowlist/ray/**`` to both the outer ``paths:`` trigger and the inner ``build-change:`` filter for all 4 Ray PR workflows.