### PR TITLE
test: ray ec2 cpu cve baseline (DO NOT MERGE)

### DIFF
--- a/.github/config/image/ray-ec2-cpu.yml
+++ b/.github/config/image/ray-ec2-cpu.yml
@@ -1,5 +1,6 @@
 # Ray EC2 CPU Image Configuration
 # This file contains all configuration for building, testing, and releasing the Ray EC2 CPU image
+# (no-op edit to trigger CI for CVE baseline verification — revert before merge)
 
 # Image identification
 image:


### PR DESCRIPTION
## Purpose

Trigger Ray EC2 CPU CI on current `main` (no patches, no allowlist additions) to verify that the security-test catches the 3 unallowlisted CVEs (transformers, torch, joblib) that PR #6136 is patching.

If security tests **fail** here → confirms the allowlist additions in #6136 are necessary.

If security tests **pass** here → the allowlist isn't strictly required (CI gate skips no-fix CVEs anyway), and #6136's value is purely SLA dashboard hygiene.

## Summary

- One-line no-op comment added to `.github/config/image/ray-ec2-cpu.yml` to fire the `PR - Ray EC2 CPU` workflow.

## Test plan

- [ ] Wait for CI to complete.
- [ ] Inspect `security-test` outcome.

## DO NOT MERGE — diagnostic only.