### PR TITLE
Fix PT 2.10 package regression and PT 2.9 ECR scan failures

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_sglang", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-sm.yml"
+dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_sglang", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = ""
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-sm.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/pytorch/training/docker/2.10/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/2.10/py3/Dockerfile.cpu
@@ -308,7 +308,10 @@ RUN pip install --no-cache-dir -U \
     seaborn \
     shap \
     cloudpickle \
-    "s3fs>=2026.2.0"
+    "s3fs>=2026.2.0" \
+    "cachetools>=7.0.5" \
+    "greenlet>=3.4.0" \
+    "starlette>=1.0.0"
 
 # Copy workaround script for incorrect hostname
 COPY changehostname.c /

--- a/pytorch/training/docker/2.10/py3/cu130/Dockerfile.gpu
+++ b/pytorch/training/docker/2.10/py3/cu130/Dockerfile.gpu
@@ -271,7 +271,10 @@ RUN pip install --no-cache-dir -U \
     scikit-learn \
     seaborn \
     cloudpickle \
-    "s3fs>=2026.2.0"
+    "s3fs>=2026.2.0" \
+    "cachetools>=7.0.5" \
+    "greenlet>=3.4.0" \
+    "starlette>=1.0.0"
 
 COPY setup_oss_compliance.sh setup_oss_compliance.sh
 RUN bash setup_oss_compliance.sh ${PYTHON} && rm setup_oss_compliance.sh

--- a/pytorch/training/docker/2.9/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
@@ -29,5 +29,36 @@
       "title": "CVE-2026-32274 - black",
       "reason_to_ignore": "N/A"
     }
+  ],
+  "torch": [
+    {
+      "description": "A vulnerability was identified in PyTorch 2.10.0. The affected element is an unknown function of the component pt2 Loading Handler. The manipulation leads to deserialization. The attack can only be performed from a local environment. The exploit is publicly available and might be used. The project was informed of the problem early through a pull request but has not reacted yet.",
+      "vulnerability_id": "CVE-2026-4538",
+      "name": "CVE-2026-4538",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.9.0+cpu.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.9.0+cpu",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.8,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.8,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-4538",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-4538 - torch",
+      "reason_to_ignore": "Local-only attack vector; no upstream fix available for torch 2.9.x"
+    }
   ]
 }

--- a/pytorch/training/docker/2.9/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
@@ -29,5 +29,36 @@
       "title": "CVE-2026-32274 - black",
       "reason_to_ignore": "N/A"
     }
+  ],
+  "torch": [
+    {
+      "description": "A vulnerability was identified in PyTorch 2.10.0. The affected element is an unknown function of the component pt2 Loading Handler. The manipulation leads to deserialization. The attack can only be performed from a local environment. The exploit is publicly available and might be used. The project was informed of the problem early through a pull request but has not reacted yet.",
+      "vulnerability_id": "CVE-2026-4538",
+      "name": "CVE-2026-4538",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.9.0+cpu.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.9.0+cpu",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.8,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.8,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-4538",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-4538 - torch",
+      "reason_to_ignore": "Local-only attack vector; no upstream fix available for torch 2.9.x"
+    }
   ]
 }

--- a/pytorch/training/docker/2.9/py3/cu130/Dockerfile.ec2.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/cu130/Dockerfile.ec2.gpu.os_scan_allowlist.json
@@ -29,5 +29,67 @@
       "title": "CVE-2026-32274 - black",
       "reason_to_ignore": "N/A"
     }
+  ],
+  "flash_attn": [
+    {
+      "description": "The flash-attention training framework thru commit e724e2588cbe754beb97cf7c011b5e7e34119e62 (2025-13-04) contains an insecure deserialization vulnerability (CWE-502) in its checkpoint loading mechanism. The load_checkpoint() function in checkpoint.py and the checkpoint loading code in eval.py use torch.load() without enabling the security-restrictive weights_only=True parameter. This allows the deserialization of arbitrary Python objects via the pickle module. An attacker can exploit this by providing a maliciously crafted checkpoint file. When a victim loads this checkpoint during model warmstarting or evaluation, arbitrary code is executed on the victim's system.",
+      "vulnerability_id": "CVE-2026-31253",
+      "name": "CVE-2026-31253",
+      "package_name": "flash_attn",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/flash_attn-2.8.3.dist-info/METADATA",
+        "name": "flash_attn",
+        "package_manager": "PYTHON",
+        "version": "2.8.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.3,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.3,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31253",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-31253 - flash_attn",
+      "reason_to_ignore": "Vulnerability is in flash-attention's training/eval checkpoint scripts, not in the flash_attn kernel used by DLC"
+    }
+  ],
+  "torch": [
+    {
+      "description": "A vulnerability was identified in PyTorch 2.10.0. The affected element is an unknown function of the component pt2 Loading Handler. The manipulation leads to deserialization. The attack can only be performed from a local environment. The exploit is publicly available and might be used. The project was informed of the problem early through a pull request but has not reacted yet.",
+      "vulnerability_id": "CVE-2026-4538",
+      "name": "CVE-2026-4538",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.9.0+cu130.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.9.0+cu130",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.8,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.8,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-4538",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-4538 - torch",
+      "reason_to_ignore": "Local-only attack vector; no upstream fix available for torch 2.9.x"
+    }
   ]
 }

--- a/pytorch/training/docker/2.9/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
@@ -29,5 +29,67 @@
       "title": "CVE-2026-32274 - black",
       "reason_to_ignore": "N/A"
     }
+  ],
+  "flash_attn": [
+    {
+      "description": "The flash-attention training framework thru commit e724e2588cbe754beb97cf7c011b5e7e34119e62 (2025-13-04) contains an insecure deserialization vulnerability (CWE-502) in its checkpoint loading mechanism. The load_checkpoint() function in checkpoint.py and the checkpoint loading code in eval.py use torch.load() without enabling the security-restrictive weights_only=True parameter. This allows the deserialization of arbitrary Python objects via the pickle module. An attacker can exploit this by providing a maliciously crafted checkpoint file. When a victim loads this checkpoint during model warmstarting or evaluation, arbitrary code is executed on the victim's system.",
+      "vulnerability_id": "CVE-2026-31253",
+      "name": "CVE-2026-31253",
+      "package_name": "flash_attn",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/flash_attn-2.8.3.dist-info/METADATA",
+        "name": "flash_attn",
+        "package_manager": "PYTHON",
+        "version": "2.8.3",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.3,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.3,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31253",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-31253 - flash_attn",
+      "reason_to_ignore": "Vulnerability is in flash-attention's training/eval checkpoint scripts, not in the flash_attn kernel used by DLC"
+    }
+  ],
+  "torch": [
+    {
+      "description": "A vulnerability was identified in PyTorch 2.10.0. The affected element is an unknown function of the component pt2 Loading Handler. The manipulation leads to deserialization. The attack can only be performed from a local environment. The exploit is publicly available and might be used. The project was informed of the problem early through a pull request but has not reacted yet.",
+      "vulnerability_id": "CVE-2026-4538",
+      "name": "CVE-2026-4538",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.9.0+cu130.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.9.0+cu130",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.8,
+      "cvss_v30_score": 0,
+      "cvss_v31_score": 7.8,
+      "cvss_v2_score": 0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-4538",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-4538 - torch",
+      "reason_to_ignore": "Local-only attack vector; no upstream fix available for torch 2.9.x"
+    }
   ]
 }


### PR DESCRIPTION
PT 2.10: Pin cachetools>=7.0.5, greenlet>=3.4.0, starlette>=1.0.0 in SageMaker extra packages to prevent transitive dependency downgrades detected by test_package_version_regression_in_image.

PT 2.9: Add torch CVE-2026-4538 and flash_attn CVE-2026-31253 to ECR enhanced scan allowlists. Both are local-only attack vectors with no upstream fix available for these framework versions.

## Purpose

## Test Plan

## Test Result

______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
