### PR TITLE
[cve-patch] ray: bump pip 26.0.1->26.1.1, allowlist rustls-webpki

### DIFF
--- a/docker/ray/pyproject.toml
+++ b/docker/ray/pyproject.toml
@@ -4,7 +4,7 @@ version = "1.1.0"
 requires-python = "==3.13.*"
 dependencies = [
     "awscli==1.44.49",
-    "pip==26.0.1",
+    "pip==26.1.1",
     "boto3==1.42.59",
     "fastapi==0.133.1",
     "httpx==0.28.1",

--- a/docker/ray/uv.lock
+++ b/docker/ray/uv.lock
@@ -352,7 +352,7 @@ requires-dist = [
     { name = "opencv-python", specifier = "==4.13.0.92" },
     { name = "pandas", specifier = "==3.0.1" },
     { name = "pillow", specifier = "==12.2.0" },
-    { name = "pip", specifier = "==26.0.1" },
+    { name = "pip", specifier = "==26.1.1" },
     { name = "pyyaml", specifier = "==6.0.3" },
     { name = "ray", extras = ["serve"], specifier = "==2.55.1" },
     { name = "scikit-learn", specifier = "==1.8.0" },
@@ -1158,11 +1158,11 @@ wheels = [
 
 [[package]]
 name = "pip"
-version = "26.0.1"
+version = "26.1.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/48/83/0d7d4e9efe3344b8e2fe25d93be44f64b65364d3c8d7bc6dc90198d5422e/pip-26.0.1.tar.gz", hash = "sha256:c4037d8a277c89b320abe636d59f91e6d0922d08a05b60e85e53b296613346d8", size = 1812747, upload-time = "2026-02-05T02:20:18.702Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/48/cb9b7a682f6fe01a4221e1728941dd4ac3cd9090a17db3779d6ff490b602/pip-26.1.1.tar.gz", hash = "sha256:d36762751d156a4ee895de8af39aa0abeeeb577f93a2eca6ab62467bbf0f8a78", size = 1840400, upload-time = "2026-05-04T19:02:21.248Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/f0/c81e05b613866b76d2d1066490adf1a3dbc4ee9d9c839961c3fc8a6997af/pip-26.0.1-py3-none-any.whl", hash = "sha256:bdb1b08f4274833d62c1aa29e20907365a2ceb950410df15fc9521bad440122b", size = 1787723, upload-time = "2026-02-05T02:20:16.416Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/eb/fea4d1d51c49832120f7f285d07306db3960f423a2612c6057caf3e8196f/pip-26.1.1-py3-none-any.whl", hash = "sha256:99cb1c2899893b075ff56e4ed0af55669a955b49ad7fb8d8603ecdaf4ed653fb", size = 1812777, upload-time = "2026-05-04T19:02:18.9Z" },
 ]
 
 [[package]]

--- a/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
@@ -16,5 +16,10 @@
   {
     "vulnerability_id": "CVE-2026-34480",
     "reason": "ray bundles log4j-core 2.25.3 in ray_dist.jar, cannot patch without upstream ray rebuild"
+  },
+  {
+    "vulnerability_id": "GHSA-82j2-j2ch-gfr8",
+    "reason": "rustls-webpki vendored in uv binary (/usr/local/bin/uv); fix 0.104.0-alpha.7 not yet in any released uv version (latest 0.11.16 still ships rustls-webpki 0.103.13)",
+    "review_by": "2026-08-24"
   }
 ]


### PR DESCRIPTION
## Purpose

Patch CVEs across Ray DLC images.

## Images affected

`ray:serve-ml-cpu-v1.0.0`, `ray:serve-ml-cuda-v1.0.0`, `ray:serve-ml-sagemaker-cpu-v1.0.0`, `ray:serve-ml-sagemaker-cuda-v1.0.0`

## CVEs handled

| CVE | Package | Severity | Affected images | Action |
|---|---|---|---|---|
| CVE-2026-6357 | pip | HIGH | cpu, cuda, sm-cpu, sm-cuda | bump 26.0.1 → 26.1.1 (pyproject.toml + uv.lock) |
| GHSA-82j2-j2ch-gfr8 | rustls-webpki | HIGH | cpu, cuda, sm-cpu, sm-cuda | allowlist (vendored in `/usr/local/bin/uv`; fix `0.104.0-alpha.7` not yet in any released uv version — latest 0.11.16 still ships rustls-webpki 0.103.13) |

## Test plan

- [ ] CI security tests pass for cpu and gpu
- [ ] CI sanity tests pass for cpu and gpu
- [ ] CI Ray-specific tests pass

Verified `pip==26.1.1` in a `cve-patch-test:ray-cpu` rebuild on a CPU devbox before pushing.