### PR TITLE
[cve-patch] backfill review_by on ray log4j allowlist entries

### DIFF
--- a/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
@@ -11,10 +11,12 @@
   },
   {
     "vulnerability_id": "CVE-2026-34478",
-    "reason": "ray bundles log4j-core 2.25.3 in ray_dist.jar, cannot patch without upstream ray rebuild"
+    "reason": "ray bundles log4j-core 2.25.3 in ray_dist.jar, cannot patch without upstream ray rebuild",
+    "review_by": "2026-08-24"
   },
   {
     "vulnerability_id": "CVE-2026-34480",
-    "reason": "ray bundles log4j-core 2.25.3 in ray_dist.jar, cannot patch without upstream ray rebuild"
+    "reason": "ray bundles log4j-core 2.25.3 in ray_dist.jar, cannot patch without upstream ray rebuild",
+    "review_by": "2026-08-24"
   }
 ]


### PR DESCRIPTION
## Purpose

Patch CVEs across Ray DLC images.

## Images affected

`ray:serve-ml-cpu-v1`, `ray:serve-ml-cuda-v1`, `ray:serve-ml-sagemaker-cpu-v1`, `ray:serve-ml-sagemaker-cuda-v1`

## CVEs handled

| CVE | Package | Severity | Affected images | Action |
|---|---|---|---|---|
| CVE-2026-34478 | log4j-core 2.25.3 | HIGH | cpu, cuda, sm-cpu, sm-cuda | backfill `review_by` on existing VENDORED entry (vendored in `ray_dist.jar`) |
| CVE-2026-34480 | log4j-core 2.25.3 | HIGH | cpu, cuda, sm-cpu, sm-cuda | backfill `review_by` on existing VENDORED entry (vendored in `ray_dist.jar`) |

## Test plan

- [x] CI security tests pass for cpu and gpu
- [x] CI sanity tests pass for cpu and gpu
- [x] CI Ray-specific tests pass