### PR TITLE
docs(xgboost): add 3.2-0 image data and remove unused Dockerfile ARGs

### DIFF
--- a/docker/xgboost/Dockerfile
+++ b/docker/xgboost/Dockerfile
@@ -10,8 +10,6 @@
 
 # ── Global ARGs ─────────────────────────────────────────────────────────────
 ARG PYTHON_VERSION=3.12
-ARG XGBOOST_VERSION=3.2.0
-ARG SAGEMAKER_XGBOOST_VERSION=3.0-5
 
 # ── Stage: builder-base ─────────────────────────────────────────────────────
 FROM amazonlinux:2023 AS builder-base
@@ -42,8 +40,6 @@ COPY docker/xgboost/prebuilt.whl /build/dist/sagemaker_xgboost_container-2.0-py2
 FROM nvidia/cuda:12.9.1-base-amzn2023 AS xgboost-sagemaker
 
 ARG PYTHON_VERSION
-ARG XGBOOST_VERSION
-ARG SAGEMAKER_XGBOOST_VERSION
 ARG FRAMEWORK
 ARG FRAMEWORK_VERSION
 ARG CONTAINER_TYPE

--- a/docs/src/data/sagemaker-xgboost/3.2-0-cpu-sagemaker.yml
+++ b/docs/src/data/sagemaker-xgboost/3.2-0-cpu-sagemaker.yml
@@ -1,0 +1,14 @@
+framework: XGBoost
+version: "3.2-0"
+accelerator: cpu
+python: py312
+cuda: cu129
+os: amzn2023
+platform: sagemaker
+public_registry: false
+
+tags:
+  - "3.2-0-cpu-py312-sagemaker"
+
+ga: "2026-05-13"
+eop: "2027-05-13"


### PR DESCRIPTION
## Summary
- Add `docs/src/data/sagemaker-xgboost/3.2-0-cpu-sagemaker.yml` for the released XGBoost 3.2 SageMaker image (CPU, Python 3.12, AL2023, CUDA 12.9)
- Remove unused `XGBOOST_VERSION` and `SAGEMAKER_XGBOOST_VERSION` ARGs from `docker/xgboost/Dockerfile` — they were declared but never referenced in any RUN/ENV/COPY instruction

## Test plan
- [ ] Verify docs site generates correctly with the new data file
- [ ] Verify Docker build still succeeds without the removed ARGs