### PR TITLE
docs(xgboost): fix 3.2-0 image data to use region-specific account pattern

### DIFF
--- a/docs/src/data/sagemaker-xgboost/3.2-0-cpu-sagemaker.yml
+++ b/docs/src/data/sagemaker-xgboost/3.2-0-cpu-sagemaker.yml
@@ -1,11 +1,8 @@
 framework: XGBoost
 version: "3.2-0"
 accelerator: cpu
-python: py312
-cuda: cu129
-os: amzn2023
 platform: sagemaker
-public_registry: false
+example_ecr_account: "<account-id>"
 
 tags:
   - "3.2-0"


### PR DESCRIPTION
## Summary
- Removed `python`, `cuda`, `os`, and `public_registry` fields from XGBoost 3.2-0 image data
- Added `example_ecr_account: "<account-id>"` to match the 3.0-5 pattern
- The XGBoost 3.2-0 image is not deployed in the standard DLC public registry (`763104351884`), so it should use region-specific account IDs like 3.0-5

## Test plan
- [ ] Verify the available images docs page renders correctly with the region-specific account placeholder