### PR TITLE
chore: trigger vllm-omni pr ci on framework_allowlist.json changes

### DIFF
--- a/.github/workflows/pr-vllm-omni-ec2-amzn2023.yml
+++ b/.github/workflows/pr-vllm-omni-ec2-amzn2023.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/telemetry/**"
       - "scripts/vllm/omni_*"
       - "test/sanity/**"
+      - "test/security/data/ecr_scan_allowlist/vllm_omni/**"
       - "test/telemetry/**"
       - "test/vllm-omni/**"
 
@@ -123,6 +124,7 @@ jobs:
               - "scripts/common/setup_oss_compliance.sh"
               - "scripts/telemetry/bash_telemetry.sh.template"
               - "scripts/vllm/omni_*"
+              - "test/security/data/ecr_scan_allowlist/vllm_omni/**"
               - "test/vllm-omni/**"
             sanity-test-change:
               - "test/sanity/**"

--- a/.github/workflows/pr-vllm-omni-sagemaker-amzn2023.yml
+++ b/.github/workflows/pr-vllm-omni-sagemaker-amzn2023.yml
@@ -14,6 +14,7 @@ on:
       - "scripts/telemetry/**"
       - "scripts/vllm/omni_*"
       - "test/sanity/**"
+      - "test/security/data/ecr_scan_allowlist/vllm_omni/**"
       - "test/telemetry/**"
       - "test/vllm-omni/**"
 
@@ -123,6 +124,7 @@ jobs:
               - "scripts/common/setup_oss_compliance.sh"
               - "scripts/telemetry/bash_telemetry.sh.template"
               - "scripts/vllm/omni_*"
+              - "test/security/data/ecr_scan_allowlist/vllm_omni/**"
               - "test/vllm-omni/**"
             sanity-test-change:
               - "test/sanity/**"


### PR DESCRIPTION
## Summary

Add `test/security/data/ecr_scan_allowlist/vllm_omni/**` to the trigger paths for both omni PR workflows