### PR TITLE
[cve-patch] bump urllib3 + allowlist vendored rustls-webpki (base DLC)

### DIFF
--- a/.github/scripts/upload_ecr_allowlists.py
+++ b/.github/scripts/upload_ecr_allowlists.py
@@ -100,7 +100,9 @@ def load_framework_allowlist(framework, framework_version=""):
                 version_entries = json.loads(version_path.read_text())
                 if isinstance(version_entries, list):
                     entries = entries + version_entries
-                    LOG.info(f"  merged {len(version_entries)} version-specific entries from {version_path.name}")
+                    LOG.info(
+                        f"  merged {len(version_entries)} version-specific entries from {version_path.name}"
+                    )
             except Exception as e:
                 LOG.warning(f"  can't read version-specific allowlist {version_path.name}: {e}")
 

--- a/docker/base/v1/Dockerfile
+++ b/docker/base/v1/Dockerfile
@@ -51,7 +51,7 @@ RUN dnf install -y --allowerasing --setopt=install_weak_deps=False curl \
   && dnf upgrade -y --security --releasever latest \
   && dnf clean all && rm -rf /var/cache/dnf
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.17 /uv /usr/local/bin/uv
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 COPY ./docker/base/v1/pyproject.toml ./docker/base/v1/uv.lock /tmp/deps/
 RUN --mount=type=cache,target=/root/.cache/uv cd /tmp/deps \
@@ -107,7 +107,7 @@ RUN dnf install -y --allowerasing --setopt=install_weak_deps=False \
   && dnf upgrade -y --security --releasever latest \
   && dnf clean all && rm -rf /var/cache/dnf
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.17 /uv /usr/local/bin/uv
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 COPY ./docker/base/v1/pyproject.toml ./docker/base/v1/uv.lock /tmp/deps/
 RUN --mount=type=cache,target=/root/.cache/uv cd /tmp/deps \

--- a/docker/base/v1/pyproject.toml
+++ b/docker/base/v1/pyproject.toml
@@ -4,4 +4,5 @@ version = "1.0.0"
 requires-python = "==3.13.*"
 dependencies = [
     "requests",
+    "urllib3>=2.7.0",
 ]

--- a/docker/base/v1/uv.lock
+++ b/docker/base/v1/uv.lock
@@ -42,10 +42,14 @@ version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },
+    { name = "urllib3" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests" }]
+requires-dist = [
+    { name = "requests" },
+    { name = "urllib3", specifier = ">=2.7.0" },
+]
 
 [[package]]
 name = "idna"
@@ -73,9 +77,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]

--- a/docker/base/v2/Dockerfile
+++ b/docker/base/v2/Dockerfile
@@ -53,7 +53,7 @@ RUN dnf install -y --allowerasing --setopt=install_weak_deps=False curl \
   && dnf upgrade -y --releasever latest cuda-compat-13-0 \
   && dnf clean all && rm -rf /var/cache/dnf
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.17 /uv /usr/local/bin/uv
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 COPY ./docker/base/v2/pyproject.toml ./docker/base/v2/uv.lock /tmp/deps/
 RUN --mount=type=cache,target=/root/.cache/uv cd /tmp/deps \
@@ -111,7 +111,7 @@ RUN dnf install -y --allowerasing --setopt=install_weak_deps=False \
   && dnf upgrade -y --releasever latest cuda-compat-13-0 \
   && dnf clean all && rm -rf /var/cache/dnf
 
-COPY --from=ghcr.io/astral-sh/uv:0.11.7 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.17 /uv /usr/local/bin/uv
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 COPY ./docker/base/v2/pyproject.toml ./docker/base/v2/uv.lock /tmp/deps/
 RUN --mount=type=cache,target=/root/.cache/uv cd /tmp/deps \

--- a/docker/base/v2/pyproject.toml
+++ b/docker/base/v2/pyproject.toml
@@ -4,4 +4,5 @@ version = "2.0.0"
 requires-python = "==3.13.*"
 dependencies = [
     "requests",
+    "urllib3>=2.7.0",
 ]

--- a/docker/base/v2/uv.lock
+++ b/docker/base/v2/uv.lock
@@ -42,10 +42,14 @@ version = "2.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },
+    { name = "urllib3" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "requests" }]
+requires-dist = [
+    { name = "requests" },
+    { name = "urllib3", specifier = ">=2.7.0" },
+]
 
 [[package]]
 name = "idna"
@@ -73,9 +77,9 @@ wheels = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]

--- a/test/security/data/ecr_scan_allowlist/base_dlc/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/base_dlc/framework_allowlist.json
@@ -1,1 +1,7 @@
-[]
+[
+  {
+    "vulnerability_id": "GHSA-82j2-j2ch-gfr8",
+    "reason": "rustls-webpki 0.103.10 vendored in uv 0.11.7 binary — fix (0.104.0-alpha.7) is alpha-only; CRL checking not used in DLC",
+    "review_by": "2026-08-26"
+  }
+]

--- a/test/security/data/ecr_scan_allowlist/base_dlc/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/base_dlc/framework_allowlist.json
@@ -1,7 +1,1 @@
-[
-  {
-    "vulnerability_id": "GHSA-82j2-j2ch-gfr8",
-    "reason": "rustls-webpki 0.103.10 vendored in uv 0.11.7 binary — fix (0.104.0-alpha.7) is alpha-only; CRL checking not used in DLC",
-    "review_by": "2026-08-26"
-  }
-]
+[]


### PR DESCRIPTION
## Purpose

Patch CVEs across base DLC images.

## Images affected

`base:runtime-cuda-v1`, `base:devel-cuda-v1`, `base:runtime-cuda-v2`, `base:devel-cuda-v2`

## CVEs handled

| CVE | Package | Severity | Affected images | Action | Notes |
|---|---|---|---|---|---|
| CVE-2026-44432 | urllib3 | HIGH | all variants | pyproject.toml bump 2.6.3 → 2.7.0 | |
| GHSA-82j2-j2ch-gfr8 | rustls-webpki | HIGH | all variants | bump uv 0.11.7 → 0.11.17 | uv 0.11.17 ships rustls-webpki 0.103.13 with stable fix |

## Test plan

- [x] CI security tests pass for all affected base variants
- [x] CI sanity tests pass