### PR TITLE
ray v1.2: fix - forward X-Amzn-SageMaker-* headers through Ray Serve adapter

### DIFF
--- a/.github/workflows/pr-ray-sagemaker-cpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-cpu.yml
@@ -203,6 +203,9 @@ jobs:
             ${{ needs.build-ray-sagemaker-cpu-image.result == 'success' && needs.build-ray-sagemaker-cpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }})
           echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
 
+      - name: Run unit tests
+        run: docker exec ${CONTAINER_ID} bash -c "pip install pytest && python -m pytest -vs /workdir/test/ray/unit/"
+
       - name: Run FFmpeg codecs test
         run: docker exec ${CONTAINER_ID} bash /workdir/test/ray/test_ffmpeg_codecs.sh
 

--- a/.github/workflows/pr-ray-sagemaker-cpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-cpu.yml
@@ -204,7 +204,7 @@ jobs:
           echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
 
       - name: Run unit tests
-        run: docker exec ${CONTAINER_ID} bash -c "pip install pytest && python -m pytest -vs /workdir/test/ray/unit/"
+        run: docker exec ${CONTAINER_ID} bash -c "pip install pytest && python -m pytest -vs --confcutdir=/workdir/test/ray/unit --import-mode=importlib /workdir/test/ray/unit/"
 
       - name: Run FFmpeg codecs test
         run: docker exec ${CONTAINER_ID} bash /workdir/test/ray/test_ffmpeg_codecs.sh

--- a/.github/workflows/pr-ray-sagemaker-cpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-cpu.yml
@@ -204,7 +204,13 @@ jobs:
           echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
 
       - name: Run unit tests
-        run: docker exec ${CONTAINER_ID} bash -c "pip install pytest && python -m pytest -vs --confcutdir=/workdir/test/ray/unit --import-mode=importlib /workdir/test/ray/unit/"
+        run: |
+          docker exec ${CONTAINER_ID} bash -c '
+            pip install pytest && \
+            cp /workdir/test/ray/unit/test_sagemaker_serve.py /tmp/ && \
+            cd /tmp && \
+            PYTHONPATH=/workdir/scripts/ray python -m pytest -vs test_sagemaker_serve.py
+          '
 
       - name: Run FFmpeg codecs test
         run: docker exec ${CONTAINER_ID} bash /workdir/test/ray/test_ffmpeg_codecs.sh

--- a/.github/workflows/pr-ray-sagemaker-cpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-cpu.yml
@@ -206,10 +206,9 @@ jobs:
       - name: Run unit tests
         run: |
           docker exec ${CONTAINER_ID} bash -c '
-            pip install pytest && \
-            cp /workdir/test/ray/unit/test_sagemaker_serve.py /tmp/ && \
-            cd /tmp && \
-            PYTHONPATH=/workdir/scripts/ray python -m pytest -vs test_sagemaker_serve.py
+            pip install -r /workdir/test/requirements.txt && \
+            cd /workdir/test && \
+            python -m pytest -vs ray/unit/
           '
 
       - name: Run FFmpeg codecs test

--- a/.github/workflows/pr-ray-sagemaker-gpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-gpu.yml
@@ -209,10 +209,9 @@ jobs:
       - name: Run unit tests
         run: |
           docker exec ${CONTAINER_ID} bash -c '
-            pip install pytest && \
-            cp /workdir/test/ray/unit/test_sagemaker_serve.py /tmp/ && \
-            cd /tmp && \
-            PYTHONPATH=/workdir/scripts/ray python -m pytest -vs test_sagemaker_serve.py
+            pip install -r /workdir/test/requirements.txt && \
+            cd /workdir/test && \
+            python -m pytest -vs ray/unit/
           '
 
       - name: Run FFmpeg codecs test

--- a/.github/workflows/pr-ray-sagemaker-gpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-gpu.yml
@@ -207,7 +207,7 @@ jobs:
           echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
 
       - name: Run unit tests
-        run: docker exec ${CONTAINER_ID} bash -c "pip install pytest && python -m pytest -vs /workdir/test/ray/unit/"
+        run: docker exec ${CONTAINER_ID} bash -c "pip install pytest && python -m pytest -vs --confcutdir=/workdir/test/ray/unit --import-mode=importlib /workdir/test/ray/unit/"
 
       - name: Run FFmpeg codecs test
         run: docker exec ${CONTAINER_ID} bash /workdir/test/ray/test_ffmpeg_codecs.sh

--- a/.github/workflows/pr-ray-sagemaker-gpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-gpu.yml
@@ -207,7 +207,13 @@ jobs:
           echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
 
       - name: Run unit tests
-        run: docker exec ${CONTAINER_ID} bash -c "pip install pytest && python -m pytest -vs --confcutdir=/workdir/test/ray/unit --import-mode=importlib /workdir/test/ray/unit/"
+        run: |
+          docker exec ${CONTAINER_ID} bash -c '
+            pip install pytest && \
+            cp /workdir/test/ray/unit/test_sagemaker_serve.py /tmp/ && \
+            cd /tmp && \
+            PYTHONPATH=/workdir/scripts/ray python -m pytest -vs test_sagemaker_serve.py
+          '
 
       - name: Run FFmpeg codecs test
         run: docker exec ${CONTAINER_ID} bash /workdir/test/ray/test_ffmpeg_codecs.sh

--- a/.github/workflows/pr-ray-sagemaker-gpu.yml
+++ b/.github/workflows/pr-ray-sagemaker-gpu.yml
@@ -206,6 +206,9 @@ jobs:
             ${{ needs.build-ray-sagemaker-gpu-image.result == 'success' && needs.build-ray-sagemaker-gpu-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.parse-config.outputs.prod-image) }})
           echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
 
+      - name: Run unit tests
+        run: docker exec ${CONTAINER_ID} bash -c "pip install pytest && python -m pytest -vs /workdir/test/ray/unit/"
+
       - name: Run FFmpeg codecs test
         run: docker exec ${CONTAINER_ID} bash /workdir/test/ray/test_ffmpeg_codecs.sh
 

--- a/docker/ray/Dockerfile.cpu
+++ b/docker/ray/Dockerfile.cpu
@@ -57,7 +57,7 @@ RUN dnf upgrade -y --security --releasever latest && dnf clean all && rm -rf /va
 
 LABEL maintainer="Amazon AI"
 LABEL dlc_major_version="1"
-LABEL dlc_minor_version="1"
+LABEL dlc_minor_version="2"
 
 ARG PYTHON="python"
 ARG FRAMEWORK="ray"

--- a/docker/ray/Dockerfile.gpu
+++ b/docker/ray/Dockerfile.gpu
@@ -86,7 +86,7 @@ RUN dnf upgrade -y --security --releasever latest && dnf clean all && rm -rf /va
 
 LABEL maintainer="Amazon AI"
 LABEL dlc_major_version="1"
-LABEL dlc_minor_version="1"
+LABEL dlc_minor_version="2"
 
 ARG PYTHON="python"
 ARG FRAMEWORK="ray"

--- a/scripts/ray/sagemaker_serve.py
+++ b/scripts/ray/sagemaker_serve.py
@@ -132,11 +132,14 @@ async def invocations(request: Request):
 
         logger.info(f"Received /invocations request: Content-Type={content_type}, Accept={accept}")
 
-        # Prepare headers for Ray Serve
+        # Forward all X-Amzn-SageMaker-* headers plus Content-Type and Accept
         headers = {
-            "Content-Type": content_type,
-            "Accept": accept,
+            name: value
+            for name, value in request.headers.items()
+            if name.lower().startswith("x-amzn-sagemaker-")
         }
+        headers["Content-Type"] = content_type
+        headers["Accept"] = accept
 
         # Proxy to Ray Serve (default route is "/")
         response = await request.app.state.client.post(
@@ -147,11 +150,18 @@ async def invocations(request: Request):
 
         logger.info(f"Ray Serve response: status={response.status_code}")
 
-        # Return Ray Serve response with proper headers
+        # Collect X-Amzn-SageMaker-* headers from Ray Serve response
+        response_headers = {
+            name: value
+            for name, value in response.headers.items()
+            if name.lower().startswith("x-amzn-sagemaker-")
+        }
+
         return Response(
             content=response.content,
             status_code=response.status_code,
             media_type=response.headers.get("Content-Type", accept),
+            headers=response_headers,
         )
 
     except httpx.TimeoutException as e:

--- a/test/ray/unit/test_sagemaker_serve.py
+++ b/test/ray/unit/test_sagemaker_serve.py
@@ -1,0 +1,201 @@
+"""Unit tests for Ray Serve SageMaker adapter header forwarding."""
+
+import os
+import sys
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "scripts", "ray"))
+
+from sagemaker_serve import app  # noqa: E402
+
+
+@pytest.fixture
+def mock_backend():
+    """Provide a helper that patches app.state.client with a mock httpx response."""
+
+    class MockBackend:
+        def __init__(self):
+            self.last_request_headers = None
+
+        def configure(self, status_code=200, body=b'{"ok":true}', headers=None):
+            resp_headers = {"content-type": "application/json"}
+            if headers:
+                resp_headers.update(headers)
+
+            response = httpx.Response(
+                status_code=status_code,
+                content=body,
+                headers=resp_headers,
+            )
+
+            async def mock_post(url, content=None, headers=None):
+                self.last_request_headers = headers
+                return response
+
+            return mock_post
+
+    return MockBackend()
+
+
+class TestRequestHeaderForwarding:
+    """X-Amzn-SageMaker-* headers flow from SageMaker to Ray Serve."""
+
+    def test_custom_attributes_forwarded(self, mock_backend):
+        from starlette.testclient import TestClient
+
+        mock_post = mock_backend.configure()
+
+        with TestClient(app) as client:
+            client.app.state.client = AsyncMock()
+            client.app.state.client.post = mock_post
+
+            client.post(
+                "/invocations",
+                content=b"hello",
+                headers={
+                    "Content-Type": "application/octet-stream",
+                    "Accept": "application/json",
+                    "X-Amzn-SageMaker-Custom-Attributes": "trace-id-123",
+                },
+            )
+
+        assert mock_backend.last_request_headers["x-amzn-sagemaker-custom-attributes"] == "trace-id-123"
+
+    def test_multiple_sagemaker_headers_forwarded(self, mock_backend):
+        from starlette.testclient import TestClient
+
+        mock_post = mock_backend.configure()
+
+        with TestClient(app) as client:
+            client.app.state.client = AsyncMock()
+            client.app.state.client.post = mock_post
+
+            client.post(
+                "/invocations",
+                content=b"hello",
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                    "X-Amzn-SageMaker-Custom-Attributes": "my-attr",
+                    "X-Amzn-SageMaker-Inference-Id": "inf-001",
+                    "X-Amzn-SageMaker-Session-Id": "sess-abc",
+                },
+            )
+
+        headers = mock_backend.last_request_headers
+        assert headers["x-amzn-sagemaker-custom-attributes"] == "my-attr"
+        assert headers["x-amzn-sagemaker-inference-id"] == "inf-001"
+        assert headers["x-amzn-sagemaker-session-id"] == "sess-abc"
+
+    def test_non_sagemaker_headers_not_forwarded(self, mock_backend):
+        from starlette.testclient import TestClient
+
+        mock_post = mock_backend.configure()
+
+        with TestClient(app) as client:
+            client.app.state.client = AsyncMock()
+            client.app.state.client.post = mock_post
+
+            client.post(
+                "/invocations",
+                content=b"hello",
+                headers={
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                    "X-Custom-Header": "should-not-forward",
+                },
+            )
+
+        headers = mock_backend.last_request_headers
+        assert "X-Custom-Header" not in headers
+        assert "x-custom-header" not in headers
+
+    def test_content_type_and_accept_always_forwarded(self, mock_backend):
+        from starlette.testclient import TestClient
+
+        mock_post = mock_backend.configure()
+
+        with TestClient(app) as client:
+            client.app.state.client = AsyncMock()
+            client.app.state.client.post = mock_post
+
+            client.post(
+                "/invocations",
+                content=b"data",
+                headers={
+                    "Content-Type": "image/png",
+                    "Accept": "image/jpeg",
+                },
+            )
+
+        headers = mock_backend.last_request_headers
+        assert headers["Content-Type"] == "image/png"
+        assert headers["Accept"] == "image/jpeg"
+
+
+class TestResponseHeaderForwarding:
+    """X-Amzn-SageMaker-* headers flow from Ray Serve back to the caller."""
+
+    def test_response_custom_attributes_forwarded(self, mock_backend):
+        from starlette.testclient import TestClient
+
+        mock_post = mock_backend.configure(
+            headers={"X-Amzn-SageMaker-Custom-Attributes": "resp-attr-456"}
+        )
+
+        with TestClient(app) as client:
+            client.app.state.client = AsyncMock()
+            client.app.state.client.post = mock_post
+
+            response = client.post(
+                "/invocations",
+                content=b"hello",
+                headers={"Content-Type": "application/json"},
+            )
+
+        assert response.headers["x-amzn-sagemaker-custom-attributes"] == "resp-attr-456"
+
+    def test_response_multiple_sagemaker_headers_forwarded(self, mock_backend):
+        from starlette.testclient import TestClient
+
+        mock_post = mock_backend.configure(
+            headers={
+                "X-Amzn-SageMaker-Custom-Attributes": "val1",
+                "X-Amzn-SageMaker-New-Session-Id": "new-sess",
+            }
+        )
+
+        with TestClient(app) as client:
+            client.app.state.client = AsyncMock()
+            client.app.state.client.post = mock_post
+
+            response = client.post(
+                "/invocations",
+                content=b"hello",
+                headers={"Content-Type": "application/json"},
+            )
+
+        assert response.headers["x-amzn-sagemaker-custom-attributes"] == "val1"
+        assert response.headers["x-amzn-sagemaker-new-session-id"] == "new-sess"
+
+    def test_response_non_sagemaker_headers_not_forwarded(self, mock_backend):
+        from starlette.testclient import TestClient
+
+        mock_post = mock_backend.configure(
+            headers={"X-Internal-Debug": "should-not-leak"}
+        )
+
+        with TestClient(app) as client:
+            client.app.state.client = AsyncMock()
+            client.app.state.client.post = mock_post
+
+            response = client.post(
+                "/invocations",
+                content=b"hello",
+                headers={"Content-Type": "application/json"},
+            )
+
+        assert "x-internal-debug" not in response.headers

--- a/test/ray/unit/test_sagemaker_serve.py
+++ b/test/ray/unit/test_sagemaker_serve.py
@@ -62,7 +62,10 @@ class TestRequestHeaderForwarding:
                 },
             )
 
-        assert mock_backend.last_request_headers["x-amzn-sagemaker-custom-attributes"] == "trace-id-123"
+        assert (
+            mock_backend.last_request_headers["x-amzn-sagemaker-custom-attributes"]
+            == "trace-id-123"
+        )
 
     def test_multiple_sagemaker_headers_forwarded(self, mock_backend):
         from starlette.testclient import TestClient
@@ -184,9 +187,7 @@ class TestResponseHeaderForwarding:
     def test_response_non_sagemaker_headers_not_forwarded(self, mock_backend):
         from starlette.testclient import TestClient
 
-        mock_post = mock_backend.configure(
-            headers={"X-Internal-Debug": "should-not-leak"}
-        )
+        mock_post = mock_backend.configure(headers={"X-Internal-Debug": "should-not-leak"})
 
         with TestClient(app) as client:
             client.app.state.client = AsyncMock()


### PR DESCRIPTION
## Summary

- Forward all `X-Amzn-SageMaker-*` request headers from SageMaker to the Ray Serve backend (previously only `Content-Type` and `Accept` were forwarded)
- Forward all `X-Amzn-SageMaker-*` response headers from Ray Serve back to the caller (previously only `Content-Type` was returned)
- Add unit tests covering both directions and verifying non-SageMaker headers are not leaked

Fixes #6163

## Test plan

- [x] Unit tests pass locally (`pytest test/ray/unit/test_sagemaker_serve.py` — 7 tests) and in CI
- [x] Existing integration tests still pass (no behavior change for endpoints not using these headers)

## Test Results
CI passing: https://github.com/aws/deep-learning-containers/pull/6167/commits/077f38610caae87dea91ab9deb1c1a2ced3c80e5

🤖 Generated with [Claude Code](https://claude.com/claude-code)