### PR TITLE
chore(inference): Update Triton inference DLC version to 26.04

### DIFF
--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -17,7 +17,7 @@ release_images:
       # has already been published. Re-released image will have minor version incremented by 1.
   2:
     framework: "triton"
-    version: "26.03"
+    version: "26.04"
     arch_type: "x86"
     inference:
       device_types: [ "cpu", "gpu" ]


### PR DESCRIPTION
- Update Triton framework version from 26.03 to 26.04 in release configuration
- Reflects latest Triton inference server release with performance and stability improvements