### PR TITLE
[vllm-cve-patch] prune stale allowlist + add CVE-2026-39821 (vllm_server)

### DIFF
--- a/test/security/data/ecr_scan_allowlist/vllm/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/vllm/framework_allowlist.json
@@ -1,103 +1,5 @@
 [
     {
-        "vulnerability_id": "CVE-2026-25537",
-        "reason": "vllm0.17.0 jsonwebtoken 9.3.1 is a RUST package bundled with uv(https://github.com/astral-sh/uv/blob/1cf6247447f9a9e48d65283d85e6b11aa4a6fdfd/Cargo.lock#L2498) cannot be patched"
-    },
-    {
-        "vulnerability_id": "CVE-2026-27482",
-        "reason": "vllm0.15.1 Base image ray version 2.53.0"
-    },
-    {
-        "vulnerability_id": "CVE-2025-69227",
-        "reason": "vllm0.15.1 Container has aiohttp 3.13.3, reported is under /usr/local/lib/python3.12/dist-packages/ray/_private/runtime_env/agent/thirdparty_files/aiohttp-3.13.2.dist-info/METADATA"
-    },
-    {
-        "vulnerability_id": "CVE-2025-69228",
-        "reason": "vllm 0.15.1 Container has aiohttp 3.13.3, reported is under /usr/local/lib/python3.12/dist-packages/ray/_private/runtime_env/agent/thirdparty_files/aiohttp-3.13.2.dist-info/METADATA"
-    },
-    {
-        "vulnerability_id": "CVE-2025-69223",
-        "reason": "vllm 0.15.1 Container has aiohttp 3.13.3, reported is under /usr/local/lib/python3.12/dist-packages/ray/_private/runtime_env/agent/thirdparty_files/aiohttp-3.13.2.dist-info/METADATA"
-    },
-    {
-        "vulnerability_id": "GHSA-72hv-8253-57qq",
-        "reason": "vllm 0.15.1 Nested in ray, unpatchable /usr/local/lib/python3.12/dist-packages/ray/jars/ray_dist.jar/META-INF/maven/com.fasterxml.jackson.core/jackson-core/pom.properties"
-    },
-    {
-        "vulnerability_id": "CVE-2026-31812",
-        "reason": "Coming in as a dependency from the latest uv 0.10.9"
-    },
-    {
-        "vulnerability_id": "CVE-2026-22815",
-        "reason": "aiohttp 3.12.15 vendored inside ray/_private/runtime_env/agent/thirdparty_files/, unpatchable without Ray upgrade"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34516",
-        "reason": "aiohttp 3.12.15 vendored inside ray/_private/runtime_env/agent/thirdparty_files/, unpatchable without Ray upgrade"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34520",
-        "reason": "aiohttp 3.12.15 vendored inside ray/_private/runtime_env/agent/thirdparty_files/, unpatchable without Ray upgrade"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32281",
-        "reason": "go/stdlib 1.24.13 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
-    },
-    {
-        "vulnerability_id": "CVE-2026-33186",
-        "reason": "google.golang.org/grpc v1.59.0 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
-    },
-    {
-        "vulnerability_id": "CVE-2026-25679",
-        "reason": "go/stdlib 1.24.13 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32283",
-        "reason": "go/stdlib 1.24.13 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32280",
-        "reason": "go/stdlib 1.24.13 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34515",
-        "reason": "aiohttp 3.12.15 vendored inside ray/_private/runtime_env/agent/thirdparty_files/, unpatchable without Ray upgrade"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34513",
-        "reason": "aiohttp 3.12.15 vendored inside ray/_private/runtime_env/agent/thirdparty_files/, unpatchable without Ray upgrade"
-    },
-    {
-        "vulnerability_id": "CVE-2025-68121",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
-    },
-    {
-        "vulnerability_id": "CVE-2025-61726",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
-    },
-    {
-        "vulnerability_id": "CVE-2025-23339",
-        "reason": "cuda-toolkit-config-common (12.9.79 → 0:13.0.48-1) cuda is a key dependency that cannot be upgraded"
-    },
-    {
-        "vulnerability_id": "CVE-2025-23308",
-        "reason": "cuda-toolkit-config-common (12.9.79 → 0:13.0.48-1) cuda is a key dependency that cannot be upgraded"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34480",
-        "reason": "log4j-core 2.17.1 bundled in ray_dist.jar, unpatchable without Ray upgrade. Fix: >=2.25.4",
-        "review_by": "2026-06-04"
-    },
-    {
-        "vulnerability_id": "CVE-2026-1839",
-        "reason": "transformers Trainer._load_rng_state() RCE — only triggered when resuming training from checkpoint. DLC vLLM is inference-only, Trainer is never invoked. Fix requires transformers>=5.0.0rc3 (pre-release)."
-    },
-    {
-        "vulnerability_id": "GHSA-82j2-j2ch-gfr8",
-        "reason": "rustls-webpki 0.103.12 bundled in /usr/local/bin/uv (Rust binary). Fix requires uv rebuild with rustls-webpki>=0.104.0-alpha.7 (pre-release). Not exploitable in our usage — uv only connects to PyPI over TLS.",
-        "review_by": "2026-06-04"
-    },
-    {
         "vulnerability_id": "CVE-2026-33811",
         "reason": "go/stdlib 1.25.9 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
         "review_by": "2026-06-10"
@@ -120,16 +22,6 @@
     {
         "vulnerability_id": "CVE-2026-39820",
         "reason": "go/stdlib 1.25.9 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-06-10"
-    },
-    {
-        "vulnerability_id": "CVE-2026-44432",
-        "reason": "urllib3 2.6.3 reported from /root/.oh-my-zsh/.github/workflows/dependencies/requirements.txt, not a runtime dependency, cannot be patched without oh-my-zsh update",
-        "review_by": "2026-06-10"
-    },
-    {
-        "vulnerability_id": "CVE-2026-44513",
-        "reason": "diffusers fix requires safetensors>=0.8.0rc0 (pre-release) which is not yet available as stable, cannot pin without --prerelease=allow",
         "review_by": "2026-06-10"
     },
     {

--- a/test/security/data/ecr_scan_allowlist/vllm_server/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/vllm_server/framework_allowlist.json
@@ -1,119 +1,82 @@
 [
     {
-        "vulnerability_id": "CVE-2026-25537",
-        "reason": "vllm0.17.0 jsonwebtoken 9.3.1 is a RUST package bundled with uv(https://github.com/astral-sh/uv/blob/1cf6247447f9a9e48d65283d85e6b11aa4a6fdfd/Cargo.lock#L2498) cannot be patched"
-    },
-    {
-        "vulnerability_id": "CVE-2026-27482",
-        "reason": "vllm0.15.1 Base image ray version 2.53.0"
-    },
-    {
-        "vulnerability_id": "CVE-2025-69227",
-        "reason": "vllm0.15.1 Container has aiohttp 3.13.3, reported is under /usr/local/lib/python3.12/dist-packages/ray/_private/runtime_env/agent/thirdparty_files/aiohttp-3.13.2.dist-info/METADATA"
-    },
-    {
-        "vulnerability_id": "CVE-2025-69228",
-        "reason": "vllm 0.15.1 Container has aiohttp 3.13.3, reported is under /usr/local/lib/python3.12/dist-packages/ray/_private/runtime_env/agent/thirdparty_files/aiohttp-3.13.2.dist-info/METADATA"
-    },
-    {
-        "vulnerability_id": "CVE-2025-69223",
-        "reason": "vllm 0.15.1 Container has aiohttp 3.13.3, reported is under /usr/local/lib/python3.12/dist-packages/ray/_private/runtime_env/agent/thirdparty_files/aiohttp-3.13.2.dist-info/METADATA"
-    },
-    {
-        "vulnerability_id": "GHSA-72hv-8253-57qq",
-        "reason": "vllm 0.15.1 Nested in ray, unpatchable /usr/local/lib/python3.12/dist-packages/ray/jars/ray_dist.jar/META-INF/maven/com.fasterxml.jackson.core/jackson-core/pom.properties"
-    },
-    {
-        "vulnerability_id": "CVE-2026-31812",
-        "reason": "Coming in as a dependency from the latest uv 0.10.9"
-    },
-    {
-        "vulnerability_id": "CVE-2026-22815",
-        "reason": "aiohttp 3.12.15 vendored inside ray/_private/runtime_env/agent/thirdparty_files/, unpatchable without Ray upgrade"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34516",
-        "reason": "aiohttp 3.12.15 vendored inside ray/_private/runtime_env/agent/thirdparty_files/, unpatchable without Ray upgrade"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34520",
-        "reason": "aiohttp 3.12.15 vendored inside ray/_private/runtime_env/agent/thirdparty_files/, unpatchable without Ray upgrade"
-    },
-    {
         "vulnerability_id": "CVE-2026-32281",
-        "reason": "go/stdlib 1.24.13 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     },
     {
         "vulnerability_id": "CVE-2026-33186",
-        "reason": "google.golang.org/grpc v1.59.0 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
+        "reason": "google.golang.org/grpc v1.59.0 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     },
     {
         "vulnerability_id": "CVE-2026-25679",
-        "reason": "go/stdlib 1.24.13 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     },
     {
         "vulnerability_id": "CVE-2026-32283",
-        "reason": "go/stdlib 1.24.13 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     },
     {
         "vulnerability_id": "CVE-2026-32280",
-        "reason": "go/stdlib 1.24.13 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34515",
-        "reason": "aiohttp 3.12.15 vendored inside ray/_private/runtime_env/agent/thirdparty_files/, unpatchable without Ray upgrade"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34513",
-        "reason": "aiohttp 3.12.15 vendored inside ray/_private/runtime_env/agent/thirdparty_files/, unpatchable without Ray upgrade"
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     },
     {
         "vulnerability_id": "CVE-2025-68121",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     },
     {
         "vulnerability_id": "CVE-2025-61726",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     },
     {
         "vulnerability_id": "CVE-2025-23339",
-        "reason": "cuda-toolkit-config-common (12.9.79 \u2192 0:13.0.48-1) cuda is a key dependency that cannot be upgraded"
+        "reason": "cuda-toolkit-config-common (12.9.79 \u2192 0:13.0.48-1) cuda is a key dependency that cannot be upgraded",
+        "review_by": "2026-11-28"
     },
     {
         "vulnerability_id": "CVE-2025-23308",
-        "reason": "cuda-toolkit-config-common (12.9.79 \u2192 0:13.0.48-1) cuda is a key dependency that cannot be upgraded"
-    },
-    {
-        "vulnerability_id": "CVE-2026-1839",
-        "reason": "transformers 4.57.6 Trainer RCE; fix requires >=5.0.0rc3 which is incompatible with current stack"
-    },
-    {
-        "vulnerability_id": "GHSA-82j2-j2ch-gfr8",
-        "reason": "rustls-webpki 0.103.12 bundled in uv binary (Rust). Fix requires rustls-webpki>=0.104.0-alpha.7 (pre-release). Not exploitable — uv only connects to PyPI over TLS, no CRL checking enabled.",
-        "review_by": "2026-06-04"
+        "reason": "cuda-toolkit-config-common (12.9.79 \u2192 0:13.0.48-1) cuda is a key dependency that cannot be upgraded",
+        "review_by": "2026-11-28"
     },
     {
         "vulnerability_id": "CVE-2026-33811",
-        "reason": "go/stdlib 1.24.13 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     },
     {
         "vulnerability_id": "CVE-2026-39820",
-        "reason": "go/stdlib 1.24.13 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     },
     {
         "vulnerability_id": "CVE-2026-33814",
-        "reason": "go/stdlib 1.24.13 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     },
     {
         "vulnerability_id": "CVE-2026-39836",
-        "reason": "go/stdlib 1.24.13 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     },
     {
         "vulnerability_id": "CVE-2026-42499",
-        "reason": "go/stdlib 1.24.13 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild"
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     },
     {
         "vulnerability_id": "CVE-2026-44222",
-        "reason": "False positive: image ships vllm 0.20.0.dev361 (361 commits after v0.20.0 which contains the fix). PEP 440 dev version string causes scanner to report as pre-release."
+        "reason": "False positive: image ships vllm 0.20.0.dev361 (361 commits after v0.20.0 which contains the fix). PEP 440 dev version string causes scanner to report as pre-release.",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-39821",
+        "reason": "golang.org/x/net v0.38.0 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     }
 ]


### PR DESCRIPTION
## Purpose

Patch CVEs across vllm DLC images.

## Images affected

- `vllm:0.22-gpu-py312-ec2`
- `vllm:0.22-gpu-py312`
- `vllm:server-cuda-v1`
- `vllm:server-sagemaker-cuda-v1`

## CVEs handled

| CVE | Package | Severity | Affected images | Action | Notes |
|---|---|---|---|---|---|
| CVE-2026-39821 | golang.org/x/net (vendored in mooncake `libetcd_wrapper.so`) | CRITICAL | vllm:server-cuda-v1, vllm:server-sagemaker-cuda-v1 | Allowlist (vllm_server) | Statically linked Go binary; cannot patch independently of mooncake-transfer-engine rebuild |

**Prunes**: 26 entries removed from `vllm/framework_allowlist.json` and 14 from `vllm_server/framework_allowlist.json` whose CVEs no longer appear in the latest scan (full-scan coverage across all 4 variants confirmed).

**Reason refreshes**: 5 entries in `vllm_server/framework_allowlist.json` cited `go/stdlib 1.24.13`, but the actual scan reports `1.24.11` from the same `mooncake/libetcd_wrapper.so`. Reasons updated to match the live binary.

**Backfills**: `review_by` populated on all 15 retained `vllm_server` entries that were missing it (90 days for vendored, 180 days for CUDA contract).

## Test plan

- [ ] CI security tests pass for all affected vllm variants
- [ ] CI sanity tests pass
- [ ] CI vllm-specific tests pass