### PR TITLE
chore: trigger vllm pr ci on framework_allowlist.json changes

### DIFF
--- a/.github/workflows/pr-vllm-ec2-amzn2023.yml
+++ b/.github/workflows/pr-vllm-ec2-amzn2023.yml
@@ -17,6 +17,7 @@ on:
       - "scripts/vllm/dockerd_entrypoint.sh"
       - "scripts/vllm/sagemaker_entrypoint.sh"
       - "test/sanity/**"
+      - "test/security/data/ecr_scan_allowlist/vllm_server/**"
       - "test/telemetry/**"
       - "test/vllm/scripts/amzn2023/**"
 
@@ -137,6 +138,7 @@ jobs:
               - "scripts/vllm/amzn2023/**"
               - "scripts/vllm/dockerd_entrypoint.sh"
               - "scripts/vllm/sagemaker_entrypoint.sh"
+              - "test/security/data/ecr_scan_allowlist/vllm_server/**"
               - "test/vllm/scripts/amzn2023/**"
             sanity-test-change:
               - "test/sanity/**"

--- a/.github/workflows/pr-vllm-ec2.yml
+++ b/.github/workflows/pr-vllm-ec2.yml
@@ -16,6 +16,7 @@ on:
       - "scripts/vllm/**"
       - "test/efa/**"
       - "test/sanity/**"
+      - "test/security/data/ecr_scan_allowlist/vllm/**"
       - "test/telemetry/**"
       - "test/vllm/**"
       - "!test/vllm/scripts/amzn2023/**"
@@ -131,6 +132,7 @@ jobs:
               - "scripts/common/setup_oss_compliance.sh"
               - "scripts/telemetry/bash_telemetry.sh.template"
               - "scripts/vllm/*"
+              - "test/security/data/ecr_scan_allowlist/vllm/**"
               - "test/vllm/scripts/**"
             sanity-test-change:
               - "test/sanity/**"

--- a/.github/workflows/pr-vllm-sagemaker-amzn2023.yml
+++ b/.github/workflows/pr-vllm-sagemaker-amzn2023.yml
@@ -16,6 +16,7 @@ on:
       - "scripts/vllm/dockerd_entrypoint.sh"
       - "scripts/vllm/sagemaker_entrypoint.sh"
       - "test/sanity/**"
+      - "test/security/data/ecr_scan_allowlist/vllm_server/**"
       - "test/telemetry/**"
       - "test/vllm/sagemaker/**"
       - "test/vllm/scripts/amzn2023/**"
@@ -138,6 +139,7 @@ jobs:
               - "scripts/vllm/amzn2023/**"
               - "scripts/vllm/dockerd_entrypoint.sh"
               - "scripts/vllm/sagemaker_entrypoint.sh"
+              - "test/security/data/ecr_scan_allowlist/vllm_server/**"
               - "test/vllm/scripts/amzn2023/**"
             sagemaker-test-change:
               - "test/vllm/sagemaker/**"

--- a/.github/workflows/pr-vllm-sagemaker.yml
+++ b/.github/workflows/pr-vllm-sagemaker.yml
@@ -15,6 +15,7 @@ on:
       - "scripts/telemetry/**"
       - "scripts/vllm/**"
       - "test/sanity/**"
+      - "test/security/data/ecr_scan_allowlist/vllm/**"
       - "test/telemetry/**"
       - "test/vllm/**"
       - "!test/vllm/scripts/amzn2023/**"
@@ -130,6 +131,7 @@ jobs:
               - "scripts/common/setup_oss_compliance.sh"
               - "scripts/telemetry/bash_telemetry.sh.template"
               - "scripts/vllm/*"
+              - "test/security/data/ecr_scan_allowlist/vllm/**"
               - "test/vllm/scripts/**"
             sagemaker-test-change:
               - "test/vllm/sagemaker/**"


### PR DESCRIPTION
## Summary

- Add `test/security/data/ecr_scan_allowlist/vllm/**` to `pr-vllm-ec2` and `pr-vllm-sagemaker` workflow triggers
- Add `test/security/data/ecr_scan_allowlist/vllm_server/**` to `pr-vllm-ec2-amzn2023` and `pr-vllm-sagemaker-amzn2023` workflow triggers

Mirrors #6154 which did the same for vllm-omni workflows.

## Test plan

- [ ] Verify this PR itself triggers all 4 vllm workflows (since it modifies their workflow files)
- [ ] Future allowlist-only PRs trigger the correct workflow and run security-test

🤖 Generated with [Claude Code](https://claude.com/claude-code)