### PR TITLE
feat(vllm): bump to v0.22.1rc0 with CUDA 13.0.2

### DIFF
--- a/.github/config/image/vllm-ec2-amzn2023.yml
+++ b/.github/config/image/vllm-ec2-amzn2023.yml
@@ -11,11 +11,11 @@ image:
 #       (VLLM_VERSION, VLLM_REF). They are used here for image tags/labels/wheel-cache keys.
 common:
   framework: "vllm_server"
-  framework_version: "0.20.0.dev361"
-  vllm_ref: "3f5bd482f5c1a5dbdffbbf68d624e20bb7032013"
+  framework_version: "0.22.1rc0"
+  vllm_ref: "6aabe221a56052965e6bb0a95e9ec682d046a6e7"
   job_type: "general"
   python_version: "py312"
-  cuda_version: "cu129"
+  cuda_version: "cu130"
   os_version: "amzn2023"
   customer_type: "ec2"
   arch_type: "x86"

--- a/.github/config/image/vllm-hyperpod-amzn2023.yml
+++ b/.github/config/image/vllm-hyperpod-amzn2023.yml
@@ -10,11 +10,11 @@ common:
   framework: "vllm_server"
   # NOTE: keep framework_version and vllm_ref in sync with docker/vllm/versions.env
   #       (VLLM_VERSION, VLLM_REF). They are used here for image tags/labels/wheel-cache keys.
-  framework_version: "0.20.0.dev361"
-  vllm_ref: "3f5bd482f5c1a5dbdffbbf68d624e20bb7032013"
+  framework_version: "0.22.1rc0"
+  vllm_ref: "6aabe221a56052965e6bb0a95e9ec682d046a6e7"
   job_type: "general"
   python_version: "py312"
-  cuda_version: "cu129"
+  cuda_version: "cu130"
   os_version: "amzn2023"
   customer_type: "ec2"
   platform: "hyperpod"

--- a/.github/config/image/vllm-hyperpod-amzn2023.yml
+++ b/.github/config/image/vllm-hyperpod-amzn2023.yml
@@ -10,11 +10,11 @@ common:
   framework: "vllm_server"
   # NOTE: keep framework_version and vllm_ref in sync with docker/vllm/versions.env
   #       (VLLM_VERSION, VLLM_REF). They are used here for image tags/labels/wheel-cache keys.
-  framework_version: "0.22.1rc0"
-  vllm_ref: "6aabe221a56052965e6bb0a95e9ec682d046a6e7"
+  framework_version: "0.20.0.dev361"
+  vllm_ref: "3f5bd482f5c1a5dbdffbbf68d624e20bb7032013"
   job_type: "general"
   python_version: "py312"
-  cuda_version: "cu130"
+  cuda_version: "cu129"
   os_version: "amzn2023"
   customer_type: "ec2"
   platform: "hyperpod"
@@ -24,7 +24,7 @@ common:
   contributor: "None"
 
 release:
-  release: true
+  release: false
   force_release: false
   public_registry: true
   private_registry: true

--- a/.github/config/image/vllm-sagemaker-amzn2023.yml
+++ b/.github/config/image/vllm-sagemaker-amzn2023.yml
@@ -6,11 +6,11 @@ image:
 #       (VLLM_VERSION, VLLM_REF). They are used here for image tags/labels/wheel-cache keys.
 common:
   framework: "vllm_server"
-  framework_version: "0.20.0.dev361"
-  vllm_ref: "3f5bd482f5c1a5dbdffbbf68d624e20bb7032013"
+  framework_version: "0.22.1rc0"
+  vllm_ref: "6aabe221a56052965e6bb0a95e9ec682d046a6e7"
   job_type: "general"
   python_version: "py312"
-  cuda_version: "cu129"
+  cuda_version: "cu130"
   os_version: "amzn2023"
   customer_type: "sagemaker"
   platform: "sagemaker"

--- a/.github/config/model-tests/vllm-model-tests.yml
+++ b/.github/config/model-tests/vllm-model-tests.yml
@@ -355,7 +355,7 @@ benchmark:
 sagemaker:
   - name: "voxtral-mini-4b"
     s3_model: "voxtral-mini-4b.tar.gz"
-    instance_type: "ml.g5.xlarge"
+    instance_type: "ml.g6.xlarge"
     required_image_pattern: "amzn2023"
     env:
       SM_VLLM_MODEL: "/opt/ml/model"
@@ -379,7 +379,7 @@ sagemaker:
 
   - name: "voxtral-mini-4b-network-isolated"
     s3_model: "voxtral-mini-4b-isolated.tar.gz"
-    instance_type: "ml.g5.xlarge"
+    instance_type: "ml.g6.xlarge"
     required_image_pattern: "amzn2023"
     network_isolation: true
     env:

--- a/.github/config/model-tests/vllm-model-tests.yml
+++ b/.github/config/model-tests/vllm-model-tests.yml
@@ -26,7 +26,7 @@ smoke-test:
     - name: "qwen3-vl-embedding-2b"
       s3_model: "qwen3-vl-embedding-2b.tar.gz"
       fleet: "x86-g6xl-runner"
-      extra_args: "--runner pooling --dtype bfloat16 --max-model-len 8192 --trust-remote-code"
+      extra_args: "--runner pooling --dtype bfloat16 --max-model-len 2048 --trust-remote-code"
       test_script: "vllm_embedding_smoke_test.sh"
 
     - name: "voxtral-mini-4b"
@@ -56,7 +56,7 @@ benchmark:
     - name: "qwen3-vl-embedding-2b"
       s3_model: "qwen3-vl-embedding-2b.tar.gz"
       fleet: "x86-g6xl-runner"
-      extra_args: "--runner pooling --dtype bfloat16 --max-model-len 8192 --trust-remote-code"
+      extra_args: "--runner pooling --dtype bfloat16 --max-model-len 2048 --trust-remote-code"
       test_script: "vllm_embedding_benchmark_test.sh"
       min_rps: 3
 

--- a/.github/workflows/pr-vllm-hyperpod-amzn2023.yml
+++ b/.github/workflows/pr-vllm-hyperpod-amzn2023.yml
@@ -62,6 +62,7 @@ jobs:
       contributor: ${{ steps.parse.outputs.contributor }}
       customer-type: ${{ steps.parse.outputs.customer-type }}
       prod-image: ${{ steps.parse.outputs.prod-image }}
+      release: ${{ steps.parse.outputs.release }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -76,6 +77,7 @@ jobs:
         id: parse
         run: |
           echo '${{ steps.load.outputs.config }}' > config.json
+          echo "release=$(jq -r 'if .release.release then "true" else "false" end' config.json)" >> $GITHUB_OUTPUT
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "vllm-ref=$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)" >> $GITHUB_OUTPUT
@@ -130,7 +132,6 @@ jobs:
           filters: |
             build-change:
               - ".github/config/image/vllm-hyperpod-amzn2023.yml"
-              - "docker/vllm/Dockerfile.amzn2023"
               - "scripts/common/install_efa_amzn2023.sh"
               - "scripts/common/setup_oss_compliance.sh"
               - "scripts/telemetry/bash_telemetry.sh.template"
@@ -148,7 +149,7 @@ jobs:
 
   build-image:
     needs: [check-changes, load-config]
-    if: needs.check-changes.outputs.build-change == 'true'
+    if: needs.check-changes.outputs.build-change == 'true' && needs.load-config.outputs.release == 'true'
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
         fleet:x86-vllm-build-runner
@@ -245,6 +246,7 @@ jobs:
     needs: [check-changes, build-image, load-config]
     if: |
       always() && !failure() && !cancelled() &&
+      needs.load-config.outputs.release == 'true' &&
       (needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sanity-test-change == 'true')
     concurrency:
       group: ${{ github.workflow }}-sanity-test-${{ github.event.pull_request.number }}
@@ -283,6 +285,7 @@ jobs:
     needs: [check-changes, build-image, load-config]
     if: |
       always() && !failure() && !cancelled() &&
+      needs.load-config.outputs.release == 'true' &&
       (needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.telemetry-test-change == 'true')
     concurrency:
       group: ${{ github.workflow }}-telemetry-test-${{ github.event.pull_request.number }}
@@ -317,6 +320,7 @@ jobs:
     needs: [check-changes, build-image, load-config]
     if: |
       always() && !failure() && !cancelled() &&
+      needs.load-config.outputs.release == 'true' &&
       (needs.build-image.result == 'success' || needs.check-changes.outputs.model-test-change == 'true')
     concurrency:
       group: ${{ github.workflow }}-model-smoke-tests-${{ github.event.pull_request.number }}

--- a/.github/workflows/reusable-vllm-upstream-tests.yml
+++ b/.github/workflows/reusable-vllm-upstream-tests.yml
@@ -59,6 +59,11 @@ jobs:
           repository: vllm-project/vllm
           ref: ${{ inputs.vllm-ref != '' && inputs.vllm-ref || format('v{0}', inputs.framework-version) }}
           path: vllm_source
+          sparse-checkout: |
+            tests
+            examples
+            requirements
+            vllm
 
       - name: Start container
         run: |
@@ -100,6 +105,11 @@ jobs:
           repository: vllm-project/vllm
           ref: ${{ inputs.vllm-ref != '' && inputs.vllm-ref || format('v{0}', inputs.framework-version) }}
           path: vllm_source
+          sparse-checkout: |
+            tests
+            examples
+            requirements
+            vllm
 
       - name: Start container
         run: |
@@ -141,6 +151,11 @@ jobs:
           repository: vllm-project/vllm
           ref: ${{ inputs.vllm-ref != '' && inputs.vllm-ref || format('v{0}', inputs.framework-version) }}
           path: vllm_source
+          sparse-checkout: |
+            tests
+            examples
+            requirements
+            vllm
 
       - name: Start container
         run: |

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -297,7 +297,7 @@ ARG PYTHON="python3"
 ARG PYTHON_VERSION=3.12
 ARG CUDA_VERSION
 ARG DLC_MAJOR_VERSION=1
-ARG DLC_MINOR_VERSION=1
+ARG DLC_MINOR_VERSION=0
 
 LABEL maintainer="Amazon AI"
 LABEL dlc_major_version="${DLC_MAJOR_VERSION}"
@@ -372,6 +372,7 @@ FROM base AS vllm-ec2-amzn2023
 
 ARG CACHE_REFRESH=0
 RUN dnf upgrade -y --security --releasever latest --setopt=install_weak_deps=False \
+  && dnf upgrade -y --releasever latest cuda-compat-13-0 \
   && dnf clean all && rm -rf /var/cache/dnf /tmp/* \
   # dnf needs system python 3.9
   && ln -sf /opt/venv/bin/python3 /usr/bin/python3
@@ -386,6 +387,7 @@ FROM base AS vllm-sagemaker-amzn2023
 
 ARG CACHE_REFRESH=0
 RUN dnf upgrade -y --security --releasever latest --setopt=install_weak_deps=False \
+  && dnf upgrade -y --releasever latest cuda-compat-13-0 \
   && dnf install -y --setopt=install_weak_deps=False libsndfile \
   && dnf clean all && rm -rf /var/cache/dnf /tmp/* \
   # dnf needs system python 3.9
@@ -398,23 +400,19 @@ ENV PYTHONPATH="/usr/local/bin:${PYTHONPATH}"
 
 ENTRYPOINT ["/usr/local/bin/sagemaker_entrypoint.sh"]
 
-# ====================== hyperpod =========================================
-FROM base AS vllm-hyperpod-amzn2023
+# # ====================== hyperpod =========================================
+# FROM base AS vllm-hyperpod-amzn2023
 
-LABEL dlc_minor_version="2"
+# LABEL dlc_minor_version="0"
 
-# Override NIXL to include libfabric plugin for disaggregated P/D over EFA,
-# upstream vLLM caps nixl at <=0.10.1.
-RUN --mount=type=cache,target=/root/.cache/uv uv pip uninstall nixl-cu13 || true \
-  && uv pip install --force-reinstall --no-deps "nixl>=1.0.1" "nixl-cu13>=1.0.1"
+# ARG CACHE_REFRESH=0
+# RUN dnf upgrade -y --security --releasever latest --setopt=install_weak_deps=False \
+#   && dnf upgrade -y --releasever latest cuda-compat-13-0 \
+#   && dnf clean all && rm -rf /var/cache/dnf /tmp/* \
+#   # dnf needs system python 3.9
+#   && ln -sf /opt/venv/bin/python3 /usr/bin/python3
 
-ARG CACHE_REFRESH=0
-RUN dnf upgrade -y --security --releasever latest --setopt=install_weak_deps=False \
-  && dnf clean all && rm -rf /var/cache/dnf /tmp/* \
-  # dnf needs system python 3.9
-  && ln -sf /opt/venv/bin/python3 /usr/bin/python3
+# COPY ./scripts/vllm/dockerd_entrypoint.sh /usr/local/bin/dockerd_entrypoint.sh
+# RUN chmod +x /usr/local/bin/dockerd_entrypoint.sh
 
-COPY ./scripts/vllm/dockerd_entrypoint.sh /usr/local/bin/dockerd_entrypoint.sh
-RUN chmod +x /usr/local/bin/dockerd_entrypoint.sh
-
-ENTRYPOINT ["/usr/local/bin/dockerd_entrypoint.sh"]
+# ENTRYPOINT ["/usr/local/bin/dockerd_entrypoint.sh"]

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -1,7 +1,7 @@
-ARG CUDA_VERSION=12.9.1
+ARG CUDA_VERSION=13.0.2
 ARG PYTHON_VERSION=3.12
-ARG VLLM_VERSION=0.20.0.dev361
-ARG FLASHINFER_VERSION=0.6.8.post1
+ARG VLLM_VERSION=0.22.1rc0
+ARG FLASHINFER_VERSION=0.6.11.post2
 ARG DEEPEP_COMMIT_HASH=73b6ea4
 
 # =============================================================================
@@ -88,7 +88,7 @@ ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION:-${VLLM_VERS
 
 # --- Pre-built wheel support ---
 # Fetch wheels from S3 into docker/vllm/prebuilt_wheels/ BEFORE docker build:
-#   bash scripts/vllm/amzn2023/fetch_cached_wheels.sh cu129 v0.18.0
+#   bash scripts/vllm/amzn2023/fetch_cached_wheels.sh cu130 v0.22.1rc0
 # The directory is empty by default so COPY always succeeds.
 COPY docker/vllm/prebuilt_wheels/ /tmp/prebuilt_wheels/
 

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -220,9 +220,6 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     CUDA_MAJOR="${CUDA_VERSION%%.*}"; \
     CUDA_DASH=$(echo $CUDA_VERSION | cut -d. -f1,2 | tr '.' '-'); \
     if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \
-        if [ "$CUDA_MAJOR" -ge 13 ]; then \
-            uv pip install nixl-cu13; \
-        fi; \
         uv pip install -r /tmp/kv_connectors.txt --no-build || ( \
             dnf install -y --setopt=install_weak_deps=False \
                 libcusparse-devel-${CUDA_DASH} \
@@ -232,6 +229,9 @@ RUN --mount=type=cache,target=/root/.cache/uv \
             && dnf remove -y libcusparse-devel-${CUDA_DASH} libcublas-devel-${CUDA_DASH} libcusolver-devel-${CUDA_DASH} \
             && dnf clean all && rm -rf /var/cache/dnf \
         ); \
+        if [ "$CUDA_MAJOR" -ge 13 ]; then \
+            uv pip install --force-reinstall --no-deps nixl-cu13; \
+        fi; \
     fi
 
 # Download FlashInfer precompiled cubins after all pip installs are done
@@ -406,7 +406,7 @@ LABEL dlc_minor_version="2"
 # Override NIXL to include libfabric plugin for disaggregated P/D over EFA,
 # upstream vLLM caps nixl at <=0.10.1.
 RUN --mount=type=cache,target=/root/.cache/uv uv pip uninstall nixl-cu13 || true \
-  && uv pip install --force-reinstall --no-deps "nixl>=1.0.1" "nixl-cu12>=1.0.1"
+  && uv pip install --force-reinstall --no-deps "nixl>=1.0.1" "nixl-cu13>=1.0.1"
 
 ARG CACHE_REFRESH=0
 RUN dnf upgrade -y --security --releasever latest --setopt=install_weak_deps=False \

--- a/docker/vllm/versions.env
+++ b/docker/vllm/versions.env
@@ -11,18 +11,18 @@
 # (framework_version and vllm_ref) — these drive image tags and wheel-cache keys.
 #
 # Do NOT re-export CUDA_VERSION / PYTHON_VERSION here — those are managed
-# by the workflow (which exports cu129 / py312 shorthand as shell env) and
-# the Dockerfile uses its own ARG defaults (12.9.1 / 3.12) to construct
+# by the workflow (which exports cu130 / py312 shorthand as shell env) and
+# the Dockerfile uses its own ARG defaults (13.0.2 / 3.12) to construct
 # FROM lines. The Dockerfile defaults must match the image-config YAML.
 
 # ── vLLM source & version ──────────────────────────────────────
 export VLLM_REPO="https://github.com/vllm-project/vllm.git"
-# Pin to upstream commit (https://github.com/vllm-project/vllm/commit/3f5bd482f5c1a5dbdffbbf68d624e20bb7032013)
-# First included in upstream tag v0.20.2.
-export VLLM_REF="3f5bd482f5c1a5dbdffbbf68d624e20bb7032013"
+# Pin to v0.22.1rc0 tag (https://github.com/vllm-project/vllm/commit/6aabe221a56052965e6bb0a95e9ec682d046a6e7)
+# PR #43971 merge commit — tagged as v0.22.1rc0.
+export VLLM_REF="6aabe221a56052965e6bb0a95e9ec682d046a6e7"
 # Base release tag used for wheel versioning / manifest / image tag only
 # (source checkout is pinned via VLLM_REF above).
-export VLLM_VERSION="0.20.0.dev361"
+export VLLM_VERSION="0.22.1rc0"
 
 # Wheel version tag — PEP 440 local-version encoding the pinned ref for
 # traceability. Commit SHAs truncated to 8 chars; tags/branches sanitised.
@@ -35,10 +35,10 @@ export SETUPTOOLS_SCM_PRETEND_VERSION="${VLLM_VERSION}+amzn2023.${_VLLM_REF_TAG}
 unset _VLLM_REF_TAG
 
 # ── Accelerator libraries ──────────────────────────────────────
-# Matches upstream vllm/docker/Dockerfile at v0.20.2:
-export FLASHINFER_VERSION="0.6.8.post1"
+# Matches upstream vllm/docker/Dockerfile at v0.22.1rc0:
+export FLASHINFER_VERSION="0.6.11.post2"
 export DEEPEP_COMMIT_HASH="73b6ea4"
 
 # ── DLC image versioning ───────────────────────────────────────
-export DLC_MAJOR_VERSION="1"
-export DLC_MINOR_VERSION="4"
+export DLC_MAJOR_VERSION="2"
+export DLC_MINOR_VERSION="0"

--- a/scripts/vllm/dockerd_entrypoint.sh
+++ b/scripts/vllm/dockerd_entrypoint.sh
@@ -3,4 +3,4 @@
 # Execute telemetry script if it exists, suppress errors
 bash /usr/local/bin/bash_telemetry.sh >/dev/null 2>&1 || true
 
-python3 -m vllm.entrypoints.openai.api_server "$@"
+vllm serve "$@"

--- a/test/security/data/ecr_scan_allowlist/vllm_server/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/vllm_server/framework_allowlist.json
@@ -70,11 +70,6 @@
         "review_by": "2026-08-30"
     },
     {
-        "vulnerability_id": "CVE-2026-44222",
-        "reason": "False positive: image ships vllm 0.20.0.dev361 (361 commits after v0.20.0 which contains the fix). PEP 440 dev version string causes scanner to report as pre-release.",
-        "review_by": "2026-08-30"
-    },
-    {
         "vulnerability_id": "CVE-2026-39821",
         "reason": "golang.org/x/net v0.38.0 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
         "review_by": "2026-08-30"

--- a/test/vllm/sagemaker/test_sm_endpoint.py
+++ b/test/vllm/sagemaker/test_sm_endpoint.py
@@ -91,7 +91,7 @@ def model_endpoint(aws_session, image_uri, model_id, instance_type):
         _cleanup([endpoint, endpoint_config, model])
 
 
-@pytest.mark.parametrize("instance_type", ["ml.g5.xlarge"], indirect=True)
+@pytest.mark.parametrize("instance_type", ["ml.g6.xlarge"], indirect=True)
 @pytest.mark.parametrize("model_id", ["deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"], indirect=True)
 def test_vllm_sagemaker_endpoint(model_endpoint):
     endpoint = model_endpoint


### PR DESCRIPTION
- vLLM: 0.20.0.dev361 → 0.22.1rc0 (commit 6aabe22, PR #43971)
- CUDA: 12.9.1 → 13.0.2 (SageMaker AMI gpu-4-1 supports driver 580 + CUDA 13.0)
- FlashInfer: 0.6.8.post1 → 0.6.11.post2
- DLC version: 1.4 → 2.0

## Purpose

## Test Plan

## Test Result

______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
