### PR TITLE
docs: add vLLM 0.22.0 to README release highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ ______________________________________________________________________
 
 ### 🚀 Release Highlights
 
+- **[2026/05/30]** [vLLM v0.22.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.22.0-gpu-py312-ec2` · SageMaker: `0.22.0-gpu-py312` · MiniCPM-V 4.6, InternS2 Preview, OpenVLA, EXAONE-4.5; DeepSeek V4 maturity (NVFP4 fused MoE, MTP speculative decoding); Blackwell SM12x support.
 - **[2026/05/18]** [SGLang v0.5.12](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.12-gpu-py312-ec2` · SageMaker: `0.5.12-gpu-py312` · DeepSeek V4, Intern-S2-Preview, MiniCPM-V 4.6, Laguna-XS.2, Ring-2.6-1T, Gemma 4 MTP.
 - **[2026/05/16]** [vLLM v0.21.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.21.0-gpu-py312-ec2` · SageMaker: `0.21.0-gpu-py312` · MiMo-V2.5, Laguna XS.2, Moondream3, Cohere MoE/Eagle; DeepSeek V4 on AMD + pipeline parallelism.
 - **[2026/05/13]** [vLLM-Omni v0.20.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `omni-cuda-v1.1` · SageMaker: `omni-sagemaker-cuda-v1.1` · Adds `/v1/audio/generate` (stable-audio-open) and `/v1/videos/sync` (unblocks video on SageMaker); supports CosyVoice3, ERNIE-Image-Turbo, Wan2.1-VACE-1.3B; CUDA 13.0 + PyTorch 2.11.0.
@@ -35,7 +36,6 @@ ______________________________________________________________________
 - **[2026/05/06]** [SGLang v0.5.11](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.11-gpu-py312-ec2` · SageMaker: `0.5.11-gpu-py312` · Model support for Gemma 4, GLM-5.1, Qwen 3.4, and more
 - **[2026/05/05]** [vLLM v0.20.1](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.20.1-gpu-py312-ec2` · SageMaker: `0.20.1-gpu-py312` · Bug fixes for DeepSeek V4.
 - **[2026/04/30]** [PyTorch v2.11.0](https://gallery.ecr.aws/deep-learning-containers/pytorch) — EC2: `2.11.0-cu130-amzn2023` · SageMaker: `2.11.0-cu130-amzn2023-sagemaker` · Amazon Linux 2023 with EFA, flash-attn, and transformer-engine.
-- **[2026/04/28]** [vLLM v0.20.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.20.0-gpu-py312-ec2` · SageMaker: `0.20.0-gpu-py312` · Introduces support for DeepSeek V4.
 
 ### 📢 Support Updates
 


### PR DESCRIPTION
## Summary
- Add vLLM v0.22.0 release entry (2026/05/30) with EC2/SageMaker tags and highlights: MiniCPM-V 4.6, InternS2 Preview, OpenVLA, EXAONE-4.5, DeepSeek V4 maturity, Blackwell SM12x support
- Remove oldest vLLM entry (v0.20.0) to maintain rolling list

## Test plan
- [ ] Verify README renders correctly on GitHub