### PR TITLE
docs: add Text Embeddings Inference (TEI) documentation

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -4,6 +4,7 @@ nav:
     - user_guide/index.md
     - vLLM: vllm
     - vLLM-Omni: vllm-omni
+    - TEI: tei
     - Ray: ray
     - PyTorch: pytorch
     - Base: base

--- a/docs/src/data/huggingface-tei/1.8.2-cpu-sagemaker.yml
+++ b/docs/src/data/huggingface-tei/1.8.2-cpu-sagemaker.yml
@@ -1,0 +1,12 @@
+framework: TEI
+version: "1.8.2"
+accelerator: cpu
+python: py310
+os: ubuntu22.04
+platform: sagemaker
+ecr_repository: tei-cpu
+example_ecr_account: "683313688378"
+example_region: "us-east-1"
+
+tags:
+  - "2.0.1-tei1.8.2-cpu-py310-ubuntu22.04"

--- a/docs/src/data/huggingface-tei/1.8.2-cpu-sagemaker.yml
+++ b/docs/src/data/huggingface-tei/1.8.2-cpu-sagemaker.yml
@@ -1,7 +1,6 @@
 framework: TEI
 version: "1.8.2"
 accelerator: cpu
-python: py310
 os: ubuntu22.04
 platform: sagemaker
 ecr_repository: tei-cpu

--- a/docs/src/data/huggingface-tei/1.8.2-gpu-sagemaker.yml
+++ b/docs/src/data/huggingface-tei/1.8.2-gpu-sagemaker.yml
@@ -1,0 +1,13 @@
+framework: TEI
+version: "1.8.2"
+accelerator: gpu
+python: py310
+cuda: cu122
+os: ubuntu22.04
+platform: sagemaker
+ecr_repository: tei
+example_ecr_account: "683313688378"
+example_region: "us-east-1"
+
+tags:
+  - "2.0.1-tei1.8.2-gpu-py310-cu122-ubuntu22.04"

--- a/docs/src/data/huggingface-tei/1.8.2-gpu-sagemaker.yml
+++ b/docs/src/data/huggingface-tei/1.8.2-gpu-sagemaker.yml
@@ -1,7 +1,6 @@
 framework: TEI
 version: "1.8.2"
 accelerator: gpu
-python: py310
 cuda: cu122
 os: ubuntu22.04
 platform: sagemaker

--- a/docs/src/global.yml
+++ b/docs/src/global.yml
@@ -88,7 +88,7 @@ display_names:
     huggingface-pytorch-inference: "HuggingFace PyTorch Inference"
     huggingface-vllm: "HuggingFace vLLM Inference"
     huggingface-sglang: "HuggingFace SGLang Inference"
-    huggingface-tei: "HuggingFace TEI Inference"
+    huggingface-tei: "HuggingFace Text Embeddings Inference"
     huggingface-vllm-inference-neuronx: "HuggingFace vLLM Inference NeuronX"
     huggingface-pytorch-training-neuronx: "HuggingFace PyTorch Training NeuronX"
     huggingface-pytorch-inference-neuronx: "HuggingFace PyTorch Inference NeuronX"

--- a/docs/src/global.yml
+++ b/docs/src/global.yml
@@ -88,6 +88,7 @@ display_names:
     huggingface-pytorch-inference: "HuggingFace PyTorch Inference"
     huggingface-vllm: "HuggingFace vLLM Inference"
     huggingface-sglang: "HuggingFace SGLang Inference"
+    huggingface-tei: "HuggingFace TEI Inference"
     huggingface-vllm-inference-neuronx: "HuggingFace vLLM Inference NeuronX"
     huggingface-pytorch-training-neuronx: "HuggingFace PyTorch Training NeuronX"
     huggingface-pytorch-inference-neuronx: "HuggingFace PyTorch Inference NeuronX"
@@ -200,6 +201,7 @@ table_order:
   - huggingface-pytorch-inference
   - huggingface-vllm
   - huggingface-sglang
+  - huggingface-tei
   - huggingface-vllm-inference-neuronx
   - huggingface-pytorch-training-neuronx
   - huggingface-pytorch-inference-neuronx

--- a/docs/src/tables/huggingface-tei.yml
+++ b/docs/src/tables/huggingface-tei.yml
@@ -2,8 +2,6 @@
 columns:
   - field: framework_version
     header: "Framework"
-  - field: python
-    header: "Python"
   - field: cuda
     header: "CUDA"
   - field: accelerator

--- a/docs/src/tables/huggingface-tei.yml
+++ b/docs/src/tables/huggingface-tei.yml
@@ -1,0 +1,14 @@
+# Table Configuration - HuggingFace TEI
+columns:
+  - field: framework_version
+    header: "Framework"
+  - field: python
+    header: "Python"
+  - field: cuda
+    header: "CUDA"
+  - field: accelerator
+    header: "Accelerator"
+  - field: platform
+    header: "Platform"
+  - field: example_url
+    header: "Example URL"

--- a/docs/tei/.nav.yml
+++ b/docs/tei/.nav.yml
@@ -1,0 +1,4 @@
+nav:
+  - Overview: index.md
+  - Deployment:
+    - Amazon SageMaker AI: deployment/sagemaker.md

--- a/docs/tei/deployment/sagemaker.md
+++ b/docs/tei/deployment/sagemaker.md
@@ -1,6 +1,7 @@
 # Amazon SageMaker AI Deployment
 
-Deploy Text Embeddings Inference (TEI) on Amazon SageMaker AI endpoints. The container accepts model configuration via environment variables and serves on port 8080.
+Deploy Text Embeddings Inference (TEI) on Amazon SageMaker AI endpoints. The container accepts model configuration via environment variables and
+serves on port 8080.
 
 ## Specifying the Model
 

--- a/docs/tei/deployment/sagemaker.md
+++ b/docs/tei/deployment/sagemaker.md
@@ -1,0 +1,187 @@
+# Amazon SageMaker AI Deployment
+
+Deploy TEI on Amazon SageMaker AI endpoints. The container accepts model configuration via environment variables and serves on port 8080.
+
+## Specifying the Model
+
+Set **`HF_MODEL_ID`** to a Hugging Face Hub model ID (e.g. `BAAI/bge-base-en-v1.5`). The container exits at startup if it is not set. For gated or
+private models, also pass `HF_TOKEN`.
+
+To serve model artifacts from S3 instead, provide them via `ModelDataUrl`/`ModelDataSource` — SageMaker mounts them at `/opt/ml/model` — and set
+`HF_MODEL_ID=/opt/ml/model`.
+
+## SageMaker Python SDK v2
+
+```python
+from sagemaker.huggingface import HuggingFaceModel, get_huggingface_llm_image_uri
+
+model = HuggingFaceModel(
+    # Resolves the TEI GPU image for your session's region.
+    # For CPU instances, use the "huggingface-tei-cpu" backend instead.
+    image_uri=get_huggingface_llm_image_uri("huggingface-tei", version="1.8.2"),
+    role="arn:aws:iam::<account_id>:role/<role_name>",
+    env={"HF_MODEL_ID": "BAAI/bge-base-en-v1.5"},
+)
+
+predictor = model.deploy(
+    instance_type="ml.g5.xlarge",
+    initial_instance_count=1,
+)
+
+response = predictor.predict({"inputs": "What is deep learning?"})
+print(response)  # [[0.0123, -0.0456, ...]]
+
+# Cleanup
+predictor.delete_model()
+predictor.delete_endpoint(delete_endpoint_config=True)
+```
+
+## SageMaker Python SDK v3
+
+```python
+import json
+
+import boto3
+from sagemaker.core import image_uris
+from sagemaker.core.resources import Endpoint, EndpointConfig, Model
+from sagemaker.core.shapes import ContainerDefinition, ProductionVariant
+
+# Requires a configured AWS region (always set inside SageMaker environments).
+region = boto3.session.Session().region_name
+
+# Resolves the TEI GPU image for `region`. For CPU instances, use the
+# "huggingface-tei-cpu" framework instead.
+image = image_uris.retrieve(
+    framework="huggingface-tei",
+    region=region,
+    version="1.8.2",
+    image_scope="inference",
+    instance_type="ml.g5.xlarge",
+)
+
+model = Model.create(
+    model_name="tei-model",
+    primary_container=ContainerDefinition(
+        image=image,
+        environment={"HF_MODEL_ID": "BAAI/bge-base-en-v1.5"},
+    ),
+    execution_role_arn="arn:aws:iam::<account_id>:role/<role_name>",
+    region=region,
+)
+
+ep_cfg = EndpointConfig.create(
+    endpoint_config_name="tei-config",
+    production_variants=[
+        ProductionVariant(
+            variant_name="default",
+            model_name="tei-model",
+            instance_type="ml.g5.xlarge",
+            initial_instance_count=1,
+        ),
+    ],
+    region=region,
+)
+
+endpoint = Endpoint.create(
+    endpoint_name="tei-endpoint",
+    endpoint_config_name="tei-config",
+    region=region,
+)
+endpoint.wait_for_status("InService")
+
+smrt = boto3.client("sagemaker-runtime", region_name=region)
+resp = smrt.invoke_endpoint(
+    EndpointName="tei-endpoint",
+    ContentType="application/json",
+    Body=json.dumps({"inputs": "What is deep learning?"}),
+)
+print(json.loads(resp["Body"].read()))  # [[0.0123, -0.0456, ...]]
+
+# Cleanup
+endpoint.delete()
+ep_cfg.delete()
+model.delete()
+```
+
+## Boto3
+
+```python
+import json
+
+import boto3
+
+# TEI 1.8.2 GPU image in us-east-1. The image URI is region-specific (both the
+# account ID and the region segment) — for other regions, replace `region` and
+# `image` together using the region table: ../index.md#images
+region = "us-east-1"
+image = "683313688378.dkr.ecr.us-east-1.amazonaws.com/tei:2.0.1-tei1.8.2-gpu-py310-cu122-ubuntu22.04"
+
+# Clients are pinned to the same region as the image so the model, endpoint,
+# and container stay co-located.
+sm = boto3.client("sagemaker", region_name=region)
+smrt = boto3.client("sagemaker-runtime", region_name=region)
+
+sm.create_model(
+    ModelName="tei-model-boto3",
+    PrimaryContainer={
+        "Image": image,
+        "Environment": {"HF_MODEL_ID": "BAAI/bge-base-en-v1.5"},
+    },
+    ExecutionRoleArn="arn:aws:iam::<account_id>:role/<role_name>",
+)
+
+sm.create_endpoint_config(
+    EndpointConfigName="tei-config-boto3",
+    ProductionVariants=[{
+        "VariantName": "default",
+        "ModelName": "tei-model-boto3",
+        "InstanceType": "ml.g5.xlarge",
+        "InitialInstanceCount": 1,
+    }],
+)
+
+sm.create_endpoint(
+    EndpointName="tei-endpoint-boto3",
+    EndpointConfigName="tei-config-boto3",
+)
+sm.get_waiter("endpoint_in_service").wait(EndpointName="tei-endpoint-boto3")
+
+resp = smrt.invoke_endpoint(
+    EndpointName="tei-endpoint-boto3",
+    ContentType="application/json",
+    Body=json.dumps({"inputs": "What is deep learning?"}),
+)
+print(json.loads(resp["Body"].read()))  # [[0.0123, -0.0456, ...]]
+
+# Cleanup
+sm.delete_endpoint(EndpointName="tei-endpoint-boto3")
+sm.delete_endpoint_config(EndpointConfigName="tei-config-boto3")
+sm.delete_model(ModelName="tei-model-boto3")
+```
+
+## Configuration
+
+TEI is configured through environment variables that mirror its [CLI arguments](https://huggingface.co/docs/text-embeddings-inference/cli_arguments).
+Commonly used options:
+
+| Environment Variable | Purpose |
+| --- | --- |
+| `HF_MODEL_ID` | Hugging Face Hub model ID to serve |
+| `HF_TOKEN` | Hub token for gated/private models |
+| `MAX_CONCURRENT_REQUESTS` | Maximum number of concurrent requests |
+| `MAX_BATCH_TOKENS` | Token budget per batch (controls throughput vs. memory) |
+| `MAX_CLIENT_BATCH_SIZE` | Maximum number of inputs in a single request |
+| `MAX_BATCH_REQUESTS` | Optional cap on requests per batch |
+| `DTYPE` | Activation dtype (`float16`, `float32`) |
+| `POOLING` | Override pooling method (`cls`, `mean`, `splade`, `last-token`) |
+| `AUTO_TRUNCATE` | Truncate inputs longer than the model's maximum sequence length instead of rejecting them |
+
+## Notes
+
+- Choose the GPU image (`tei`) for GPU instances (e.g. `ml.g5`, `ml.g6`) and the CPU image (`tei-cpu`) for CPU instances (e.g. `ml.c6i`, `ml.c7i`,
+  `ml.m6i`). For the CPU SDK v2 helper, use `get_huggingface_llm_image_uri("huggingface-tei-cpu", version="1.8.2")`. Embedding models are small
+  relative to LLMs — single-GPU and CPU instances are usually sufficient.
+- Rerankers and classifiers deploy with the same images and code — only `HF_MODEL_ID` and the request payload change (e.g. `BAAI/bge-reranker-v2-m3`
+  with `{"query": "...", "texts": ["...", "..."]}`). See [API Endpoints](../index.md#api-endpoints) for the payload per model type.
+- Inputs longer than the model's maximum sequence length are rejected unless you request truncation, either per request
+  (`{"inputs": "...", "truncate": true}`) or globally (`AUTO_TRUNCATE=true`).

--- a/docs/tei/deployment/sagemaker.md
+++ b/docs/tei/deployment/sagemaker.md
@@ -1,6 +1,6 @@
 # Amazon SageMaker AI Deployment
 
-Deploy TEI on Amazon SageMaker AI endpoints. The container accepts model configuration via environment variables and serves on port 8080.
+Deploy Text Embeddings Inference (TEI) on Amazon SageMaker AI endpoints. The container accepts model configuration via environment variables and serves on port 8080.
 
 ## Specifying the Model
 

--- a/docs/tei/index.md
+++ b/docs/tei/index.md
@@ -1,0 +1,88 @@
+# Embedding Serving using TEI DLC
+
+Production-ready Docker images for serving embedding, reranker, and sequence-classification models with
+[Text Embeddings Inference (TEI)](https://github.com/huggingface/text-embeddings-inference) on {{ sagemaker }}. Built and published by
+[Hugging Face](https://huggingface.co) in collaboration with {{ aws }}.
+
+TEI is a high-performance toolkit written in Rust for serving text embedding models, with dynamic batching, optimized transformer kernels (using Flash
+Attention, Candle, and cuBLASLt), and small, fast-booting images.
+
+## Images
+
+| Accelerator | Image (`us-east-1` example) | Default Port |
+| --- | --- | --- |
+| GPU | `683313688378.dkr.ecr.us-east-1.amazonaws.com/tei:2.0.1-tei1.8.2-gpu-py310-cu122-ubuntu22.04` | 8080 |
+| CPU | `683313688378.dkr.ecr.us-east-1.amazonaws.com/tei-cpu:2.0.1-tei1.8.2-cpu-py310-ubuntu22.04` | 8080 |
+
+Unlike most {{ dlc_long }}, the TEI images are hosted in a different {{ ecr_short }} account in each region. The simplest way to get the right URI is
+the SageMaker Python SDK helper, which resolves the account for your session's region:
+
+```python
+from sagemaker.huggingface import get_huggingface_llm_image_uri
+
+gpu_image = get_huggingface_llm_image_uri("huggingface-tei", version="1.8.2")
+cpu_image = get_huggingface_llm_image_uri("huggingface-tei-cpu", version="1.8.2")
+```
+
+The per-region registry account IDs are listed below.
+
+| Region | Account ID |
+| --- | --- |
+| `af-south-1` | 510948584623 |
+| `ap-east-1` | 651117190479 |
+| `ap-northeast-1` | 354813040037 |
+| `ap-northeast-2` | 366743142698 |
+| `ap-northeast-3` | 867004704886 |
+| `ap-south-1` | 720646828776 |
+| `ap-south-2` | 628508329040 |
+| `ap-southeast-1` | 121021644041 |
+| `ap-southeast-2` | 783357654285 |
+| `ap-southeast-3` | 951798379941 |
+| `ap-southeast-4` | 106583098589 |
+| `ca-central-1` | 341280168497 |
+| `ca-west-1` | 190319476487 |
+| `cn-north-1` | 450853457545 |
+| `cn-northwest-1` | 451049120500 |
+| `eu-central-1` | 492215442770 |
+| `eu-central-2` | 680994064768 |
+| `eu-north-1` | 662702820516 |
+| `eu-south-1` | 978288397137 |
+| `eu-south-2` | 104374241257 |
+| `eu-west-1` | 141502667606 |
+| `eu-west-2` | 764974769150 |
+| `eu-west-3` | 659782779980 |
+| `il-central-1` | 898809789911 |
+| `me-central-1` | 272398656194 |
+| `me-south-1` | 801668240914 |
+| `sa-east-1` | 737474898029 |
+| `us-east-1` | 683313688378 |
+| `us-east-2` | 257758044811 |
+| `us-gov-east-1` | 237065988967 |
+| `us-gov-west-1` | 414596584902 |
+| `us-iso-east-1` | 833128469047 |
+| `us-isob-east-1` | 281123927165 |
+| `us-west-1` | 746614075791 |
+| `us-west-2` | 246618743249 |
+
+## API Endpoints
+
+On {{ sagemaker }}, all traffic goes through `POST /invocations` (with `GET /ping` for health checks). At startup, the container binds `/invocations`
+to the task matching the loaded model type:
+
+| Model Type | Task | Payload |
+| --- | --- | --- |
+| Embedding | Embeddings | `{"inputs": "..."}` or `{"inputs": ["...", "..."]}` |
+| Reranker | Reranking | `{"query": "...", "texts": ["...", "..."]}` |
+| Classifier | Sequence classification | `{"inputs": "..."}` |
+
+Refer to the [TEI API documentation](https://huggingface.github.io/text-embeddings-inference/) for request/response schemas.
+
+## How They're Built
+
+- **Released with TEI** — image versions track upstream [TEI releases](https://github.com/huggingface/text-embeddings-inference/releases) and are
+  published by Hugging Face to the regional SageMaker registries.
+- **Discoverable via the SageMaker SDK** — current versions are registered in the
+  [SageMaker Python SDK image URI config](https://github.com/aws/sagemaker-python-sdk/blob/master-v2/src/sagemaker/image_uri_config/huggingface-tei.json),
+  so `get_huggingface_llm_image_uri` always resolves a valid URI.
+
+For deployment walkthroughs, see [{{ sagemaker }} Deployment](deployment/sagemaker.md).

--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -4,6 +4,7 @@ Choose a framework to get started:
 
 - **[vLLM](../vllm/index.md)** — serve large language models on {{ ec2_short }}, {{ eks_short }}, or {{ sagemaker }}
 - **[vLLM-Omni](../vllm-omni/index.md)** — serve multimodal models (TTS, image, video, audio, omni-chat)
+- **[TEI](../tei/index.md)** — serve text embedding, reranker, and classification models with Text Embeddings Inference on {{ sagemaker }}
 - **[Ray](../ray/index.md)** — deploy any ML model with Ray Serve (NLP, vision, audio, tabular)
 - **[PyTorch](../pytorch/index.md)** — distributed training with EFA, NCCL, flash-attn, and DeepSpeed pre-installed
 - **[Base](../base/index.md)** — lightweight CUDA + Python images for building your own AI/ML container


### PR DESCRIPTION
## Purpose
Add documentation for the Hugging Face Text Embeddings Inference (TEI) DLCs so users can find which image to use to serve embedding, reranker, and sequence-classification models on Amazon SageMaker AI:

## PR Checklist

- [x] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).
