### PR TITLE
test(vllm): add IBM Granite-Speech-4.1-2B ASR smoke and SageMaker tests

### DIFF
--- a/.github/config/image/vllm-ec2-amzn2023.yml
+++ b/.github/config/image/vllm-ec2-amzn2023.yml
@@ -19,7 +19,7 @@ common:
   os_version: "amzn2023"
   customer_type: "ec2"
   arch_type: "x86"
-  prod_image: "vllm:server-cuda-v1"
+  prod_image: "vllm:server-cuda-v2"
   device_type: "gpu"
   contributor: "None"
 

--- a/.github/config/image/vllm-sagemaker-amzn2023.yml
+++ b/.github/config/image/vllm-sagemaker-amzn2023.yml
@@ -15,7 +15,7 @@ common:
   customer_type: "sagemaker"
   platform: "sagemaker"
   arch_type: "x86"
-  prod_image: "vllm:server-sagemaker-cuda-v1"
+  prod_image: "vllm:server-sagemaker-cuda-v2"
   device_type: "gpu"
   contributor: "None"
 release:

--- a/.github/config/model-tests/vllm-model-tests.yml
+++ b/.github/config/model-tests/vllm-model-tests.yml
@@ -48,6 +48,19 @@ smoke-test:
           audio_fixture: "asr_en.wav"
           validate: "json_field:text"
 
+    - name: "granite-speech-4-1-2b"
+      s3_model: "granite-speech-4.1-2b.tar.gz"
+      fleet: "x86-g6xl-runner"
+      extra_args: "--max-model-len 2048"
+      test_script: "vllm_asr_smoke_test.sh"
+      test_fixtures:
+        - "audio/asr_en.wav"
+      test_cases:
+        - name: "transcription-en"
+          route: "/v1/audio/transcriptions"
+          audio_fixture: "asr_en.wav"
+          validate: "json_field:text"
+
   runner-scale-sets: []
 
 benchmark:
@@ -390,6 +403,26 @@ sagemaker:
             model: "/opt/ml/model"
         validate: "json_field:text"
 
+  - name: "granite-speech-4-1-2b"
+    s3_model: "granite-speech-4.1-2b.tar.gz"
+    instance_type: "ml.g6.xlarge"
+    required_image_pattern: "amzn2023"
+    env:
+      SM_VLLM_MODEL: "/opt/ml/model"
+      SM_VLLM_MAX_MODEL_LEN: "2048"
+    test_cases:
+      - name: "transcription-en"
+        route: "/v1/audio/transcriptions"
+        content_type: "multipart/form-data"
+        request:
+          file_s3: "s3://dlc-cicd-models/test-fixtures/audio/asr_en.wav"
+          file_field: "file"
+          file_name: "test.wav"
+          file_content_type: "audio/wav"
+          fields:
+            model: "/opt/ml/model"
+        validate: "json_field:text"
+
   - name: "voxtral-mini-4b-network-isolated"
     s3_model: "voxtral-mini-4b-isolated.tar.gz"
     instance_type: "ml.g6.xlarge"
@@ -402,6 +435,28 @@ sagemaker:
       SM_VLLM_LOAD_FORMAT: "mistral"
       SM_VLLM_ENFORCE_EAGER: "true"
       SM_VLLM_MAX_MODEL_LEN: "8192"
+      STANDARD_PIP_ARGS: "--no-index --find-links /opt/ml/model/requirements -r /opt/ml/model/requirements.txt"
+    test_cases:
+      - name: "transcription-en-isolated"
+        route: "/v1/audio/transcriptions"
+        content_type: "multipart/form-data"
+        request:
+          file_s3: "s3://dlc-cicd-models/test-fixtures/audio/asr_en.wav"
+          file_field: "file"
+          file_name: "test.wav"
+          file_content_type: "audio/wav"
+          fields:
+            model: "/opt/ml/model"
+        validate: "json_field:text"
+
+  - name: "granite-speech-4-1-2b-network-isolated"
+    s3_model: "granite-speech-4.1-2b-isolated.tar.gz"
+    instance_type: "ml.g6.xlarge"
+    required_image_pattern: "amzn2023"
+    network_isolation: true
+    env:
+      SM_VLLM_MODEL: "/opt/ml/model"
+      SM_VLLM_MAX_MODEL_LEN: "2048"
       STANDARD_PIP_ARGS: "--no-index --find-links /opt/ml/model/requirements -r /opt/ml/model/requirements.txt"
     test_cases:
       - name: "transcription-en-isolated"

--- a/.github/config/model-tests/vllm-model-tests.yml
+++ b/.github/config/model-tests/vllm-model-tests.yml
@@ -382,7 +382,6 @@ sagemaker:
   - name: "voxtral-mini-4b"
     s3_model: "voxtral-mini-4b.tar.gz"
     instance_type: "ml.g6.xlarge"
-    required_image_pattern: "amzn2023"
     env:
       SM_VLLM_MODEL: "/opt/ml/model"
       SM_VLLM_TOKENIZER_MODE: "mistral"
@@ -406,7 +405,6 @@ sagemaker:
   - name: "granite-speech-4-1-2b"
     s3_model: "granite-speech-4.1-2b.tar.gz"
     instance_type: "ml.g6.xlarge"
-    required_image_pattern: "amzn2023"
     env:
       SM_VLLM_MODEL: "/opt/ml/model"
       SM_VLLM_MAX_MODEL_LEN: "2048"
@@ -426,7 +424,6 @@ sagemaker:
   - name: "voxtral-mini-4b-network-isolated"
     s3_model: "voxtral-mini-4b-isolated.tar.gz"
     instance_type: "ml.g6.xlarge"
-    required_image_pattern: "amzn2023"
     network_isolation: true
     env:
       SM_VLLM_MODEL: "/opt/ml/model"
@@ -452,7 +449,6 @@ sagemaker:
   - name: "granite-speech-4-1-2b-network-isolated"
     s3_model: "granite-speech-4.1-2b-isolated.tar.gz"
     instance_type: "ml.g6.xlarge"
-    required_image_pattern: "amzn2023"
     network_isolation: true
     env:
       SM_VLLM_MODEL: "/opt/ml/model"
@@ -483,7 +479,6 @@ sagemaker:
   - name: "qwen3-reranker-4b"
     s3_model: "qwen3-reranker-4b.tar.gz"
     instance_type: "ml.g6.xlarge"
-    required_image_pattern: "amzn2023"
     chat_template_file: "test/vllm/scripts/amzn2023/qwen3_reranker_chat_template.jinja"
     env:
       SM_VLLM_MODEL: "/opt/ml/model"

--- a/.github/workflows/pr-vllm-sagemaker-amzn2023.yml
+++ b/.github/workflows/pr-vllm-sagemaker-amzn2023.yml
@@ -6,6 +6,7 @@ on:
     types: [opened, reopened, synchronize]
     paths:
       - ".github/config/image/vllm-sagemaker-amzn2023.yml"
+      - ".github/config/model-tests/vllm-model-tests.yml"
       - ".github/workflows/pr-vllm-sagemaker-amzn2023.yml"
       - ".github/workflows/reusable-vllm-sagemaker-tests.yml"
       - ".github/workflows/reusable-vllm-upstream-tests.yml"
@@ -111,6 +112,7 @@ jobs:
       sanity-test-change: ${{ steps.changes.outputs.sanity-test-change }}
       sagemaker-test-change: ${{ steps.changes.outputs.sagemaker-test-change }}
       telemetry-test-change: ${{ steps.changes.outputs.telemetry-test-change }}
+      model-test-change: ${{ steps.changes.outputs.model-test-change }}
     steps:
       - name: Checkout DLC source
         uses: actions/checkout@v5
@@ -147,6 +149,9 @@ jobs:
               - "test/sanity/**"
             telemetry-test-change:
               - "test/telemetry/**"
+            model-test-change:
+              - ".github/config/model-tests/vllm-model-tests.yml"
+              - ".github/workflows/reusable-vllm-sagemaker-tests.yml"
 
   build-image:
     needs: [check-changes, load-config]
@@ -311,7 +316,7 @@ jobs:
     needs: [check-changes, build-image, load-config]
     if: |
       always() && !failure() && !cancelled() &&
-      (needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sagemaker-test-change == 'true')
+      (needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sagemaker-test-change == 'true' || needs.check-changes.outputs.model-test-change == 'true')
     concurrency:
       group: ${{ github.workflow }}-endpoint-test-${{ github.event.pull_request.number }}
       cancel-in-progress: false

--- a/test/vllm/sagemaker/amzn2023/test_sm_model_serving.py
+++ b/test/vllm/sagemaker/amzn2023/test_sm_model_serving.py
@@ -246,10 +246,6 @@ def _generate_test_params():
 def deployed_model(request, image_uri):
     _, model_cfg = request.param
 
-    pattern = model_cfg.get("required_image_pattern")
-    if pattern and pattern not in image_uri:
-        pytest.skip(f"Model requires image matching '{pattern}', got: {image_uri}")
-
     region = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
 
     endpoint_name, model, endpoint_config, endpoint = _deploy_endpoint(image_uri, model_cfg, region)


### PR DESCRIPTION
## Summary

- Adds `ibm-granite/granite-speech-4.1-2b` to the vLLM model test suite (audio-language model, multilingual ASR + speech translation).
- Three new entries in `.github/config/model-tests/vllm-model-tests.yml`:
  - **EC2 smoke** (codebuild-fleet, x86-g6xl-runner): reuses `vllm_asr_smoke_test.sh` with `asr_en.wav` fixture; only `--max-model-len 2048` required.
  - **SageMaker** (ml.g6.xlarge, amzn2023): non-isolated, pip-installs `av` + `soundfile` from PyPI at boot via the tar's `requirements.txt`.
  - **SageMaker network-isolated** (ml.g6.xlarge, amzn2023): bundled wheels via `STANDARD_PIP_ARGS=--no-index --find-links /opt/ml/model/requirements -r /opt/ml/model/requirements.txt`.

Both SM variants validated end-to-end against `vllm_server-0.22.1rc0-...amzn2023-sagemaker-pr-6152` before commit:
- non-iso: PASSED in 7m41s
- iso: PASSED in 7m10s

Model artifacts staged at:
- `s3://dlc-cicd-models/llm-models/granite-speech-4.1-2b.tar.gz`
- `s3://dlc-cicd-models/llm-models/granite-speech-4.1-2b-isolated.tar.gz`

> **Note:** The SageMaker `ModelName` regex disallows dots. The test-config `name` uses `granite-speech-4-1-2b` even though the S3 tarball keeps the upstream `4.1` version pattern.

## Test plan

- [x] Local SageMaker pytest passed for non-isolated entry (`SM_MODEL_NAME=granite-speech-4-1-2b`)
- [x] Local SageMaker pytest passed for network-isolated entry (`SM_MODEL_NAME=granite-speech-4-1-2b-network-isolated`)
- [ ] CI EC2 smoke run on this PR
- [ ] CI SageMaker endpoint runs on this PR (both isolated + non-isolated)