### PR TITLE
fix: pin ray sagemaker gpu test to AL2/CU12 inference AMI

### DIFF
--- a/docker/ray/Dockerfile.gpu
+++ b/docker/ray/Dockerfile.gpu
@@ -1,6 +1,5 @@
 # Multi-stage build for PyTorch Ray inference container (SageMaker + EC2)
 # GPU variant - NVIDIA CUDA 12.9 base on Amazon Linux 2023
-# (no-op change to trigger CI for sagemaker endpoint test debugging)
 
 #############
 # Stage 1: FFmpeg builder - needs CUDA devel image for nvcc + CUDA headers

--- a/docker/ray/Dockerfile.gpu
+++ b/docker/ray/Dockerfile.gpu
@@ -1,5 +1,6 @@
 # Multi-stage build for PyTorch Ray inference container (SageMaker + EC2)
 # GPU variant - NVIDIA CUDA 12.9 base on Amazon Linux 2023
+# (no-op change to trigger CI for sagemaker endpoint test debugging)
 
 #############
 # Stage 1: FFmpeg builder - needs CUDA devel image for nvcc + CUDA headers

--- a/test/ray/sagemaker/common.py
+++ b/test/ray/sagemaker/common.py
@@ -29,7 +29,7 @@ from ray.utils import (
 from sagemaker.core.resources import Endpoint, EndpointConfig, Model
 from sagemaker.core.shapes import ContainerDefinition, ProductionVariant
 from test_utils import clean_string, random_suffix_name
-from test_utils.constants import INFERENCE_AMI_VERSION, SAGEMAKER_ROLE
+from test_utils.constants import INFERENCE_AMI_VERSION_CU12, SAGEMAKER_ROLE
 
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
@@ -151,8 +151,8 @@ def make_model_endpoint_fixture(device, instance_type):
                 instance_type=instance_type,
             )
             if device == "gpu":
-                variant_kwargs["inference_ami_version"] = INFERENCE_AMI_VERSION
-                LOGGER.info(f"  Using inference AMI: {INFERENCE_AMI_VERSION}")
+                variant_kwargs["inference_ami_version"] = INFERENCE_AMI_VERSION_CU12
+                LOGGER.info(f"  Using inference AMI: {INFERENCE_AMI_VERSION_CU12}")
 
             endpoint_config = EndpointConfig.create(
                 endpoint_config_name=endpoint_name,

--- a/test/test_utils/constants.py
+++ b/test/test_utils/constants.py
@@ -2,6 +2,10 @@ DEFAULT_REGION = "us-west-2"
 EC2_INSTANCE_ROLE_NAME = "ec2TestInstanceRole"
 SAGEMAKER_ROLE = "SageMakerRole"
 # https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ProductionVariant.html
+# Tests should pick the AMI matching their container's CUDA major version.
+# AL2 AMI: NVIDIA driver 550 — for CUDA 12.x containers.
 INFERENCE_AMI_VERSION_CU12 = "al2-ami-sagemaker-inference-gpu-3-1"
+# AL2023 AMI: NVIDIA driver 580 — for CUDA 13.x containers.
 INFERENCE_AMI_VERSION_CU13 = "al2023-ami-sagemaker-inference-gpu-4-1"
+# Default for tests
 INFERENCE_AMI_VERSION = INFERENCE_AMI_VERSION_CU13

--- a/test/test_utils/constants.py
+++ b/test/test_utils/constants.py
@@ -2,4 +2,6 @@ DEFAULT_REGION = "us-west-2"
 EC2_INSTANCE_ROLE_NAME = "ec2TestInstanceRole"
 SAGEMAKER_ROLE = "SageMakerRole"
 # https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ProductionVariant.html
-INFERENCE_AMI_VERSION = "al2023-ami-sagemaker-inference-gpu-4-1"
+INFERENCE_AMI_VERSION_CU12 = "al2-ami-sagemaker-inference-gpu-3-1"
+INFERENCE_AMI_VERSION_CU13 = "al2023-ami-sagemaker-inference-gpu-4-1"
+INFERENCE_AMI_VERSION = INFERENCE_AMI_VERSION_CU13


### PR DESCRIPTION
## Purpose

The ray sagemaker gpu endpoint test has been failing since #6144 changed `INFERENCE_AMI_VERSION` to `al2023-ami-sagemaker-inference-gpu-4-1` (driver 580, CUDA 13.0 host). The CU13 AMI doesn't work with our CUDA 12.9 ray container — endpoints stuck in `Creating` with no CloudWatch logs.

Adds `INFERENCE_AMI_VERSION_CU12` and `INFERENCE_AMI_VERSION_CU13` constants and pins the ray sagemaker test to the CU12 AMI. Default `INFERENCE_AMI_VERSION` still points at CU13 so other frameworks are unaffected.

## Test Plan

- [x] PR CI: `pr-ray-sagemaker-gpu` endpoint test passes (was failing before this fix)