### PR TITLE
fix(efa): reclaim leaked Elastic IPs before EFA test to avoid AddressLimitExceeded

### DIFF
--- a/.github/scripts/efa/ec2_helpers.py
+++ b/.github/scripts/efa/ec2_helpers.py
@@ -24,12 +24,19 @@ DEFAULT_TIMEOUT = 600
 # Permanent SG looked up by name.
 EFA_SG_NAME = "dlc-cicd-efa-test"
 
-# Tag key applied to every EIP we allocate, so the stale-EIP sweep can tell our
-# leaked EIPs apart from any other (incl. a concurrent run's in-flight) EIP.
-EFA_EIP_TAG_KEY = "dlc-efa-test"
-# Tag recording allocation time (ISO-8601 UTC) so the sweep can apply an age guard;
-# describe_addresses does not return an allocation timestamp.
+# Ownership marker applied to every instance AND EIP this test creates, so the
+# stale-resource sweeps can tell our leaked resources apart from anything else
+# (incl. a concurrent run's in-flight EIP). Same key on both resource types.
+EFA_TEST_TAG_KEY = "dlc-efa-test"
+# Tag recording EIP allocation time (ISO-8601 UTC) so the EIP sweep can apply an
+# age guard; describe_addresses does not return an allocation timestamp.
+# (Instances need no equivalent — describe_instances returns LaunchTime.)
 EFA_EIP_ALLOCATED_AT_TAG_KEY = "dlc-efa-test-allocated-at"
+
+# Reap leaked instances/EIPs older than this. The job timeout is 60 min
+# (reusable-efa-tests.yml), so anything older than this cannot belong to a live
+# run — making it safe to terminate even if global concurrency were ever relaxed.
+EFA_STALE_AGE_MINUTES = 90
 
 
 def get_efa_devices(conn):
@@ -226,7 +233,12 @@ def _build_efa_run_params(ami_id, instance_type, key_name, network_interfaces, a
         "TagSpecifications": [
             {
                 "ResourceType": "instance",
-                "Tags": [{"Key": "Name", "Value": f"CI-CD EFA {name}"}],
+                "Tags": [
+                    {"Key": "Name", "Value": f"CI-CD EFA {name}"},
+                    # Ownership marker so cleanup_stale_instances can reap this if the
+                    # runner is killed before efa_instances' finally-block terminates it.
+                    {"Key": EFA_TEST_TAG_KEY, "Value": "true"},
+                ],
             },
         ],
         "IamInstanceProfile": {"Name": EC2_INSTANCE_ROLE_NAME},
@@ -382,7 +394,7 @@ def get_private_ip(aws_session, instance_id):
 def allocate_and_associate_eip(aws_session, instance_id, run_id=""):
     """Allocate an Elastic IP and associate it with the instance's primary network interface.
 
-    Tags the EIP with EFA_EIP_TAG_KEY (and the per-run `run_id`) so a leaked EIP — one
+    Tags the EIP with EFA_TEST_TAG_KEY (and the per-run `run_id`) so a leaked EIP — one
     whose owning run was killed before its `finally` released it — can later be reclaimed
     by cleanup_stale_eips without touching a concurrent run's in-flight EIP. An allocation
     timestamp is recorded in the EFA_EIP_ALLOCATED_AT_TAG_KEY tag so the sweep can apply an
@@ -398,7 +410,7 @@ def allocate_and_associate_eip(aws_session, instance_id, run_id=""):
             {
                 "ResourceType": "elastic-ip",
                 "Tags": [
-                    {"Key": EFA_EIP_TAG_KEY, "Value": "true"},
+                    {"Key": EFA_TEST_TAG_KEY, "Value": "true"},
                     {"Key": "Name", "Value": f"efa-test-{run_id}" if run_id else "efa-test"},
                     {"Key": "efa-test-run", "Value": run_id},
                     {
@@ -437,16 +449,85 @@ def release_eip(aws_session, alloc_id):
         LOGGER.warning(f"Failed to release EIP {alloc_id}: {e}")
 
 
-def cleanup_stale_eips(aws_session, min_age_minutes=60):
-    """Release leaked EIPs left by killed/crashed previous runs.
+def cleanup_stale_instances(aws_session, min_age_minutes=EFA_STALE_AGE_MINUTES):
+    """Terminate leaked EFA instances (and free their EIPs) left by killed/crashed runs.
 
-    The account/region EIP quota is small (default 5). A run whose process is killed
-    before its `finally` block never releases the 2 EIPs it allocated, so they leak
-    permanently and eventually exhaust the quota with AddressLimitExceeded.
+    This is the primary leak source: the cleanup in efa_instances() lives in a `finally`
+    block, which the CodeBuild runner skips when it is hard-killed — on job timeout
+    (timeout-minutes in reusable-efa-tests.yml), PR cancellation (cancel-in-progress),
+    or OOM. The 2 p4d instances then keep running for days, each holding an EIP, until
+    the EIP quota is exhausted (AddressLimitExceeded) — and that EIP is *associated*, so
+    cleanup_stale_eips alone can never reclaim it. We must reap the instance first.
+
+    No in-process mechanism (finally / atexit / signal handler) survives SIGKILL, so the
+    only reliable cleanup is this next-run reaper. EFA tests are globally serialized
+    (concurrency group efa-test-global, cancel-in-progress: false), so no live run can
+    own an instance older than the job timeout — the age guard makes termination safe.
+
+    Terminates instances that are ALL of:
+      - tagged with EFA_TEST_TAG_KEY (ours — never touches other instances)
+      - in a non-terminal state (pending/running/stopping/stopped)
+      - launched more than `min_age_minutes` ago (cannot belong to a live run)
+
+    For each reaped instance, releases any EIP currently associated with it (covers the
+    associated-EIP case directly, regardless of whether the EIP carries our tag — e.g.
+    EIPs allocated before tagging existed). Best-effort: logs and continues on error.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    resp = aws_session.ec2.describe_instances(
+        Filters=[
+            {"Name": f"tag:{EFA_TEST_TAG_KEY}", "Values": ["true"]},
+            {
+                "Name": "instance-state-name",
+                "Values": ["pending", "running", "stopping", "stopped"],
+            },
+        ]
+    )
+    instances = [i for r in resp.get("Reservations", []) for i in r.get("Instances", [])]
+
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=min_age_minutes)
+    reaped = 0
+    for inst in instances:
+        instance_id = inst["InstanceId"]
+        launch_time = inst.get("LaunchTime")
+        if launch_time and launch_time > cutoff:
+            # Too recent to be a leak — could be the current (or a queued) run.
+            continue
+
+        # Release any EIP associated with this leaked instance before terminating, so
+        # the address is returned to the quota rather than left dangling/unassociated.
+        eips = aws_session.ec2.describe_addresses(
+            Filters=[{"Name": "instance-id", "Values": [instance_id]}]
+        ).get("Addresses", [])
+        for eip in eips:
+            if eip.get("AllocationId"):
+                release_eip(aws_session, eip["AllocationId"])
+
+        try:
+            aws_session.ec2.terminate_instances(InstanceIds=[instance_id])
+            LOGGER.info(f"Reaped stale EFA instance {instance_id} (launched {launch_time})")
+            reaped += 1
+        except Exception as e:
+            LOGGER.warning(f"Failed to reap stale instance {instance_id}: {e}")
+
+    if reaped:
+        LOGGER.info(f"Reaped {reaped} stale EFA instance(s)")
+    else:
+        LOGGER.info("No stale EFA instances to reap")
+
+
+def cleanup_stale_eips(aws_session, min_age_minutes=EFA_STALE_AGE_MINUTES):
+    """Release leaked, *unassociated* EIPs left by killed/crashed previous runs.
+
+    Complements cleanup_stale_instances: this catches EIPs that have no instance to reap —
+    e.g. allocated but the instance launch failed, or the instance was already terminated
+    without the address being released. The account/region EIP quota is small, so these
+    leaks eventually exhaust it with AddressLimitExceeded.
 
     Only releases EIPs that are ALL of:
-      - tagged with EFA_EIP_TAG_KEY (ours — never touches other resources)
-      - unassociated (no AssociationId — a live instance is not using it)
+      - tagged with EFA_TEST_TAG_KEY (ours — never touches other resources)
+      - unassociated (no AssociationId — associated ones are handled via the instance reaper)
       - older than `min_age_minutes` (avoids racing a concurrent run that just
         allocated an EIP but hasn't associated it yet)
 
@@ -455,7 +536,7 @@ def cleanup_stale_eips(aws_session, min_age_minutes=60):
     from datetime import datetime, timedelta, timezone
 
     addrs = aws_session.ec2.describe_addresses(
-        Filters=[{"Name": f"tag:{EFA_EIP_TAG_KEY}", "Values": ["true"]}]
+        Filters=[{"Name": f"tag:{EFA_TEST_TAG_KEY}", "Values": ["true"]}]
     ).get("Addresses", [])
 
     cutoff = datetime.now(timezone.utc) - timedelta(minutes=min_age_minutes)
@@ -519,12 +600,14 @@ def efa_instances(
     try:
         key_name, key_path = aws_session.create_key_pair()
 
-        # Clean up stale runner SSH rules and leaked EIPs from any previous test that
-        # failed to clean up (e.g., runner process killed). Only touches resources our
-        # test tagged; the EIP sweep additionally skips anything allocated recently so a
-        # concurrent run's in-flight EIP is never reclaimed.
-        cleanup_stale_runner_ssh_rules(aws_session, sg_id)
+        # Reap resources leaked by previous runs whose runner was hard-killed (job
+        # timeout, PR cancellation, OOM) so the `finally` cleanup below never ran. Only
+        # touches resources our test tagged, and only past the job-timeout age, so a
+        # queued/live run is never affected. Order matters: reap instances first (frees
+        # their associated EIPs), then sweep any remaining unassociated EIPs, then SSH.
+        cleanup_stale_instances(aws_session)
         cleanup_stale_eips(aws_session)
+        cleanup_stale_runner_ssh_rules(aws_session, sg_id)
 
         # Authorize SSH from this runner's public IP on the permanent SG.
         # Permanent SG allows corp prefix list only; CodeBuild runner IPs aren't in it.

--- a/.github/scripts/efa/ec2_helpers.py
+++ b/.github/scripts/efa/ec2_helpers.py
@@ -24,18 +24,11 @@ DEFAULT_TIMEOUT = 600
 # Permanent SG looked up by name.
 EFA_SG_NAME = "dlc-cicd-efa-test"
 
-# Ownership marker applied to every instance AND EIP this test creates, so the
-# stale-resource sweeps can tell our leaked resources apart from anything else
-# (incl. a concurrent run's in-flight EIP). Same key on both resource types.
+# Ownership marker on every instance + EIP we create, so the sweeps only touch ours.
 EFA_TEST_TAG_KEY = "dlc-efa-test"
-# Tag recording EIP allocation time (ISO-8601 UTC) so the EIP sweep can apply an
-# age guard; describe_addresses does not return an allocation timestamp.
-# (Instances need no equivalent — describe_instances returns LaunchTime.)
+# EIP allocation time (ISO-8601); describe_addresses returns no allocation timestamp.
 EFA_EIP_ALLOCATED_AT_TAG_KEY = "dlc-efa-test-allocated-at"
-
-# Reap leaked instances/EIPs older than this. The job timeout is 60 min
-# (reusable-efa-tests.yml), so anything older than this cannot belong to a live
-# run — making it safe to terminate even if global concurrency were ever relaxed.
+# Resources older than this are leaks (well past the 60 min job timeout), safe to reap.
 EFA_STALE_AGE_MINUTES = 90
 
 
@@ -235,8 +228,7 @@ def _build_efa_run_params(ami_id, instance_type, key_name, network_interfaces, a
                 "ResourceType": "instance",
                 "Tags": [
                     {"Key": "Name", "Value": f"CI-CD EFA {name}"},
-                    # Ownership marker so cleanup_stale_instances can reap this if the
-                    # runner is killed before efa_instances' finally-block terminates it.
+                    # Lets cleanup_stale_instances reap this if the runner is killed.
                     {"Key": EFA_TEST_TAG_KEY, "Value": "true"},
                 ],
             },
@@ -394,12 +386,7 @@ def get_private_ip(aws_session, instance_id):
 def allocate_and_associate_eip(aws_session, instance_id, run_id=""):
     """Allocate an Elastic IP and associate it with the instance's primary network interface.
 
-    Tags the EIP with EFA_TEST_TAG_KEY (and the per-run `run_id`) so a leaked EIP — one
-    whose owning run was killed before its `finally` released it — can later be reclaimed
-    by cleanup_stale_eips without touching a concurrent run's in-flight EIP. An allocation
-    timestamp is recorded in the EFA_EIP_ALLOCATED_AT_TAG_KEY tag so the sweep can apply an
-    age guard (describe_addresses does not return an allocation time).
-
+    Tagged for ownership + allocation time so cleanup_stale_eips can reap it if leaked.
     Returns (allocation_id, public_ip).
     """
     from datetime import datetime, timezone
@@ -450,28 +437,15 @@ def release_eip(aws_session, alloc_id):
 
 
 def cleanup_stale_instances(aws_session, min_age_minutes=EFA_STALE_AGE_MINUTES):
-    """Terminate leaked EFA instances (and free their EIPs) left by killed/crashed runs.
+    """Terminate leaked EFA instances (and free their associated EIPs).
 
-    This is the primary leak source: the cleanup in efa_instances() lives in a `finally`
-    block, which the CodeBuild runner skips when it is hard-killed — on job timeout
-    (timeout-minutes in reusable-efa-tests.yml), PR cancellation (cancel-in-progress),
-    or OOM. The 2 p4d instances then keep running for days, each holding an EIP, until
-    the EIP quota is exhausted (AddressLimitExceeded) — and that EIP is *associated*, so
-    cleanup_stale_eips alone can never reclaim it. We must reap the instance first.
+    efa_instances() cleans up only in a `finally`, which the runner skips when hard-killed
+    (timeout, PR cancellation, OOM); the p4d instances then run for days holding EIPs until
+    the quota is exhausted. Those EIPs are associated, so cleanup_stale_eips can't reclaim
+    them — the instance must be reaped first, and only a next-run sweep survives SIGKILL.
 
-    No in-process mechanism (finally / atexit / signal handler) survives SIGKILL, so the
-    only reliable cleanup is this next-run reaper. EFA tests are globally serialized
-    (concurrency group efa-test-global, cancel-in-progress: false), so no live run can
-    own an instance older than the job timeout — the age guard makes termination safe.
-
-    Terminates instances that are ALL of:
-      - tagged with EFA_TEST_TAG_KEY (ours — never touches other instances)
-      - in a non-terminal state (pending/running/stopping/stopped)
-      - launched more than `min_age_minutes` ago (cannot belong to a live run)
-
-    For each reaped instance, releases any EIP currently associated with it (covers the
-    associated-EIP case directly, regardless of whether the EIP carries our tag — e.g.
-    EIPs allocated before tagging existed). Best-effort: logs and continues on error.
+    Reaps our tagged instances older than `min_age_minutes` (EFA tests are globally
+    serialized, so anything that old can't be a live run). Best-effort.
     """
     from datetime import datetime, timedelta, timezone
 
@@ -495,8 +469,7 @@ def cleanup_stale_instances(aws_session, min_age_minutes=EFA_STALE_AGE_MINUTES):
             # Too recent to be a leak — could be the current (or a queued) run.
             continue
 
-        # Release any EIP associated with this leaked instance before terminating, so
-        # the address is returned to the quota rather than left dangling/unassociated.
+        # Release the instance's EIP before terminating, else it leaks unassociated.
         eips = aws_session.ec2.describe_addresses(
             Filters=[{"Name": "instance-id", "Values": [instance_id]}]
         ).get("Addresses", [])
@@ -518,20 +491,11 @@ def cleanup_stale_instances(aws_session, min_age_minutes=EFA_STALE_AGE_MINUTES):
 
 
 def cleanup_stale_eips(aws_session, min_age_minutes=EFA_STALE_AGE_MINUTES):
-    """Release leaked, *unassociated* EIPs left by killed/crashed previous runs.
+    """Release leaked, *unassociated* EIPs (associated ones are handled by the reaper).
 
-    Complements cleanup_stale_instances: this catches EIPs that have no instance to reap —
-    e.g. allocated but the instance launch failed, or the instance was already terminated
-    without the address being released. The account/region EIP quota is small, so these
-    leaks eventually exhaust it with AddressLimitExceeded.
-
-    Only releases EIPs that are ALL of:
-      - tagged with EFA_TEST_TAG_KEY (ours — never touches other resources)
-      - unassociated (no AssociationId — associated ones are handled via the instance reaper)
-      - older than `min_age_minutes` (avoids racing a concurrent run that just
-        allocated an EIP but hasn't associated it yet)
-
-    Mirrors cleanup_stale_runner_ssh_rules. Best-effort: logs and continues on error.
+    Catches EIPs with no instance to reap (launch failed, or instance already gone). Only
+    releases our tagged, unassociated EIPs older than `min_age_minutes` — the age guard
+    avoids racing a concurrent run that just allocated but hasn't associated yet.
     """
     from datetime import datetime, timedelta, timezone
 
@@ -600,11 +564,8 @@ def efa_instances(
     try:
         key_name, key_path = aws_session.create_key_pair()
 
-        # Reap resources leaked by previous runs whose runner was hard-killed (job
-        # timeout, PR cancellation, OOM) so the `finally` cleanup below never ran. Only
-        # touches resources our test tagged, and only past the job-timeout age, so a
-        # queued/live run is never affected. Order matters: reap instances first (frees
-        # their associated EIPs), then sweep any remaining unassociated EIPs, then SSH.
+        # Reap resources leaked by prior hard-killed runs. Order: instances first (frees
+        # their EIPs), then any unassociated EIPs, then SSH rules.
         cleanup_stale_instances(aws_session)
         cleanup_stale_eips(aws_session)
         cleanup_stale_runner_ssh_rules(aws_session, sg_id)

--- a/.github/scripts/efa/ec2_helpers.py
+++ b/.github/scripts/efa/ec2_helpers.py
@@ -24,6 +24,13 @@ DEFAULT_TIMEOUT = 600
 # Permanent SG looked up by name.
 EFA_SG_NAME = "dlc-cicd-efa-test"
 
+# Tag key applied to every EIP we allocate, so the stale-EIP sweep can tell our
+# leaked EIPs apart from any other (incl. a concurrent run's in-flight) EIP.
+EFA_EIP_TAG_KEY = "dlc-efa-test"
+# Tag recording allocation time (ISO-8601 UTC) so the sweep can apply an age guard;
+# describe_addresses does not return an allocation timestamp.
+EFA_EIP_ALLOCATED_AT_TAG_KEY = "dlc-efa-test-allocated-at"
+
 
 def get_efa_devices(conn):
     """Get list of EFA device paths on an instance."""
@@ -372,12 +379,36 @@ def get_private_ip(aws_session, instance_id):
     return response["Reservations"][0]["Instances"][0]["PrivateIpAddress"]
 
 
-def allocate_and_associate_eip(aws_session, instance_id):
+def allocate_and_associate_eip(aws_session, instance_id, run_id=""):
     """Allocate an Elastic IP and associate it with the instance's primary network interface.
+
+    Tags the EIP with EFA_EIP_TAG_KEY (and the per-run `run_id`) so a leaked EIP — one
+    whose owning run was killed before its `finally` released it — can later be reclaimed
+    by cleanup_stale_eips without touching a concurrent run's in-flight EIP. An allocation
+    timestamp is recorded in the EFA_EIP_ALLOCATED_AT_TAG_KEY tag so the sweep can apply an
+    age guard (describe_addresses does not return an allocation time).
 
     Returns (allocation_id, public_ip).
     """
-    eip = aws_session.ec2.allocate_address(Domain="vpc")
+    from datetime import datetime, timezone
+
+    eip = aws_session.ec2.allocate_address(
+        Domain="vpc",
+        TagSpecifications=[
+            {
+                "ResourceType": "elastic-ip",
+                "Tags": [
+                    {"Key": EFA_EIP_TAG_KEY, "Value": "true"},
+                    {"Key": "Name", "Value": f"efa-test-{run_id}" if run_id else "efa-test"},
+                    {"Key": "efa-test-run", "Value": run_id},
+                    {
+                        "Key": EFA_EIP_ALLOCATED_AT_TAG_KEY,
+                        "Value": datetime.now(timezone.utc).isoformat(),
+                    },
+                ],
+            }
+        ],
+    )
     alloc_id = eip["AllocationId"]
     public_ip = eip["PublicIp"]
 
@@ -404,6 +435,58 @@ def release_eip(aws_session, alloc_id):
         LOGGER.info(f"Released EIP {alloc_id}")
     except Exception as e:
         LOGGER.warning(f"Failed to release EIP {alloc_id}: {e}")
+
+
+def cleanup_stale_eips(aws_session, min_age_minutes=60):
+    """Release leaked EIPs left by killed/crashed previous runs.
+
+    The account/region EIP quota is small (default 5). A run whose process is killed
+    before its `finally` block never releases the 2 EIPs it allocated, so they leak
+    permanently and eventually exhaust the quota with AddressLimitExceeded.
+
+    Only releases EIPs that are ALL of:
+      - tagged with EFA_EIP_TAG_KEY (ours — never touches other resources)
+      - unassociated (no AssociationId — a live instance is not using it)
+      - older than `min_age_minutes` (avoids racing a concurrent run that just
+        allocated an EIP but hasn't associated it yet)
+
+    Mirrors cleanup_stale_runner_ssh_rules. Best-effort: logs and continues on error.
+    """
+    from datetime import datetime, timedelta, timezone
+
+    addrs = aws_session.ec2.describe_addresses(
+        Filters=[{"Name": f"tag:{EFA_EIP_TAG_KEY}", "Values": ["true"]}]
+    ).get("Addresses", [])
+
+    cutoff = datetime.now(timezone.utc) - timedelta(minutes=min_age_minutes)
+    reclaimed = 0
+    for addr in addrs:
+        alloc_id = addr.get("AllocationId")
+        if not alloc_id or addr.get("AssociationId"):
+            # No allocation id, or in use by a live instance — leave it alone.
+            continue
+
+        # Age guard: only reclaim EIPs older than the cutoff, so a concurrent run that
+        # just allocated (but hasn't associated yet) is never touched. Read the time we
+        # stamped at allocation; if it's missing or unparsable, conservatively skip.
+        allocated_at = None
+        for tag in addr.get("Tags", []):
+            if tag.get("Key") == EFA_EIP_ALLOCATED_AT_TAG_KEY:
+                try:
+                    allocated_at = datetime.fromisoformat(tag["Value"])
+                except ValueError:
+                    allocated_at = None
+                break
+        if allocated_at is None or allocated_at > cutoff:
+            continue
+
+        release_eip(aws_session, alloc_id)
+        reclaimed += 1
+
+    if reclaimed:
+        LOGGER.info(f"Reclaimed {reclaimed} stale EFA-test EIP(s)")
+    else:
+        LOGGER.info("No stale EFA-test EIPs to reclaim")
 
 
 @contextmanager
@@ -436,9 +519,12 @@ def efa_instances(
     try:
         key_name, key_path = aws_session.create_key_pair()
 
-        # Clean up stale runner SSH rules from any previous test that failed to clean up
-        # (e.g., runner process killed). Only touches rules our test created.
+        # Clean up stale runner SSH rules and leaked EIPs from any previous test that
+        # failed to clean up (e.g., runner process killed). Only touches resources our
+        # test tagged; the EIP sweep additionally skips anything allocated recently so a
+        # concurrent run's in-flight EIP is never reclaimed.
         cleanup_stale_runner_ssh_rules(aws_session, sg_id)
+        cleanup_stale_eips(aws_session)
 
         # Authorize SSH from this runner's public IP on the permanent SG.
         # Permanent SG allows corp prefix list only; CodeBuild runner IPs aren't in it.
@@ -455,9 +541,14 @@ def efa_instances(
         aws_session.wait_for_instance_ready(master_id)
         aws_session.wait_for_instance_ready(worker_id)
 
-        # EIPs: multi-NIC EFA instances don't get auto public IPs.
-        master_eip_alloc, master_ip = allocate_and_associate_eip(aws_session, master_id)
-        worker_eip_alloc, worker_ip = allocate_and_associate_eip(aws_session, worker_id)
+        # EIPs: multi-NIC EFA instances don't get auto public IPs. Tagged with the run's
+        # key_name so cleanup_stale_eips can reclaim them if this run is killed mid-test.
+        master_eip_alloc, master_ip = allocate_and_associate_eip(
+            aws_session, master_id, run_id=key_name
+        )
+        worker_eip_alloc, worker_ip = allocate_and_associate_eip(
+            aws_session, worker_id, run_id=key_name
+        )
 
         master_conn = LoggedConnection(
             host=master_ip,

--- a/.github/workflows/pr-pytorch-ec2-cuda.yml
+++ b/.github/workflows/pr-pytorch-ec2-cuda.yml
@@ -13,6 +13,8 @@ on:
       - "scripts/common/**"
       - "scripts/pytorch/**"
       - "scripts/telemetry/**"
+      - ".github/scripts/efa/**"
+      - ".github/workflows/reusable-efa-tests.yml"
       - "test/pytorch/**"
       - "test/efa/**"
       - "test/sanity/**"


### PR DESCRIPTION
## Problem

The EFA integration test (`test/efa/test_efa.py::test_efa_sanity_and_nccl`) launches 2× `p4d.24xlarge` and allocates **one Elastic IP per instance** (multi-NIC EFA instances get no auto-assigned public IP). The PyTorch EC2 CUDA autorelease failed with:

```
botocore.exceptions.ClientError: An error occurred (AddressLimitExceeded) when calling
the AllocateAddress operation: The maximum number of addresses has been reached.
```

### Root cause

Cleanup in `efa_instances()` lives entirely in a Python `finally` block. That only runs if the interpreter survives — and the CodeBuild runner gets **hard-killed (SIGKILL)** in three routine cases, each skipping the `finally`:

1. **Job timeout** (`timeout-minutes: 60` in `reusable-efa-tests.yml`)
2. **PR cancellation** (`cancel-in-progress: true` on the efa-test job — a new commit mid-run kills the in-flight one)
3. **OOM / runner infra teardown**

When that happens, the 2 `p4d.24xlarge` instances **keep running for days**, each holding an **associated** EIP, until the EIP quota is exhausted. Because the leaked EIP is *associated with a live instance*, an unassociated-only EIP sweep can never reclaim it — the instance itself must be reaped.

No in-process mechanism (`finally` / `atexit` / signal handler) survives SIGKILL, so prevention at launch time is impossible. The only reliable cleanup is a **next-run reaper**. EFA tests are globally serialized (`concurrency: efa-test-global`, `cancel-in-progress: false`), so no live run can own an instance older than the job timeout — which makes age-based termination safe.

## Changes

**`.github/scripts/efa/ec2_helpers.py`** — self-healing cleanup, mirroring the existing `cleanup_stale_runner_ssh_rules` pattern:

- **Tag at creation** — every launched instance *and* every allocated EIP gets an ownership marker (`EFA_TEST_TAG_KEY = "dlc-efa-test"`), so the sweeps only ever touch resources this test created. EIPs additionally record an ISO-8601 allocation timestamp (`describe_addresses` returns no allocation time).
- **`cleanup_stale_instances()`** (primary fix) — at test startup, terminates tagged instances launched more than `EFA_STALE_AGE_MINUTES` (90 min, well past the 60-min job timeout) ago, **releasing each instance's associated EIP first**. Directly addresses the associated-EIP leak.
- **`cleanup_stale_eips()`** (complement) — releases tagged EIPs that are *unassociated* and older than the threshold (covers EIPs whose instance launch failed or was already gone). The age guard prevents racing a concurrent run that just allocated but hasn't associated yet.
- **Ordering at startup:** reap instances (frees their EIPs) → sweep remaining unassociated EIPs → sweep stale SSH rules.

**`.github/workflows/pr-pytorch-ec2-cuda.yml`** — the top-level `on.pull_request.paths` gate omitted `.github/scripts/efa/**` and `reusable-efa-tests.yml`, even though the inner `check-changes` filter already recognized them. As a result a PR that only edited the EFA helpers never started the workflow, so the EFA test couldn't run. Add the two missing paths.

## Performance

The startup reaper adds only a couple seconds: `terminate_instances` is asynchronous (returns at `shutting-down`, no waiter), and the no-leak common case is a single `describe_instances` call. The actual p4d teardown happens in the background after the function returns; EIP quota is freed synchronously via `release_address` before the current run allocates its own.

## Testing

- `python -m py_compile` clean
- `black --line-length 100` clean; `pre-commit` (incl. `typos`) green
- Public import surface of `efa_instances` unchanged; `test_efa.py` unaffected
- The path-gate fix triggers `efa-test` on this PR, providing live end-to-end validation

## Note

The 2 instances that caused the original failure were leaked **before** this change (untagged) and have been cleaned up manually. Going forward every launched instance carries the ownership tag, so the reaper handles future leaks automatically on the next run. A Service Quota increase for `EC2-VPC Elastic IPs` in the CI region remains a reasonable durable complement.