### PR TITLE
Fix test_pip_check regex for ipython psutil environment marker

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -154,7 +154,7 @@ dlc-pr-tensorflow-2-habana-training = ""
 ### INFERENCE PR JOBS ###
 
 # Standard Framework Inference
-dlc-pr-pytorch-inference = "pytorch/inference/buildspec-2-6-ec2.yml"
+dlc-pr-pytorch-inference = "pytorch/inference/buildspec-2-6-sm.yml"
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,11 +37,11 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = true
+build_training = false
 build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
@@ -154,7 +154,7 @@ dlc-pr-tensorflow-2-habana-training = ""
 ### INFERENCE PR JOBS ###
 
 # Standard Framework Inference
-dlc-pr-pytorch-inference = ""
+dlc-pr-pytorch-inference = "pytorch/inference/buildspec-2-6-ec2.yml"
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,11 +37,11 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
-build_training = false
+build_training = true
 build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
@@ -154,7 +154,7 @@ dlc-pr-tensorflow-2-habana-training = ""
 ### INFERENCE PR JOBS ###
 
 # Standard Framework Inference
-dlc-pr-pytorch-inference = "pytorch/inference/buildspec-2-6-sm.yml"
+dlc-pr-pytorch-inference = ""
 dlc-pr-tensorflow-2-inference = ""
 dlc-pr-autogluon-inference = ""
 

--- a/pytorch/inference/docker/2.6/py3/Dockerfile.ec2.arm64.cpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.6/py3/Dockerfile.ec2.arm64.cpu.os_scan_allowlist.json
@@ -148,6 +148,35 @@
       "status": "ACTIVE",
       "title": "CVE-2025-55552 - torch",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "A syntax error in the component proxy_tensor.py of pytorch v2.7.0 allows attackers to cause a Denial of Service (DoS).",
+      "vulnerability_id": "CVE-2025-55553",
+      "name": "CVE-2025-55553",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.6.0+cpu.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.6.0+cpu",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55553",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-55553 - torch",
+      "reason_to_ignore": "N/A"
     }
   ]
 }

--- a/pytorch/inference/docker/2.6/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.6/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
@@ -148,6 +148,35 @@
       "status": "ACTIVE",
       "title": "CVE-2025-55552 - torch",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "A syntax error in the component proxy_tensor.py of pytorch v2.7.0 allows attackers to cause a Denial of Service (DoS).",
+      "vulnerability_id": "CVE-2025-55553",
+      "name": "CVE-2025-55553",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.6.0+cpu.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.6.0+cpu",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55553",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-55553 - torch",
+      "reason_to_ignore": "N/A"
     }
   ]
 }

--- a/pytorch/inference/docker/2.6/py3/Dockerfile.sagemaker.arm64.cpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.6/py3/Dockerfile.sagemaker.arm64.cpu.os_scan_allowlist.json
@@ -1,64 +1,64 @@
 {
   "dpkg": [
     {
-      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.", 
-      "vulnerability_id": "CVE-2025-6297", 
-      "name": "CVE-2025-6297", 
-      "package_name": "dpkg", 
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "dpkg",
       "package_details": {
-        "file_path": null, 
-        "name": "dpkg", 
-        "package_manager": "OS", 
-        "version": "1.21.1ubuntu2.3", 
+        "file_path": null,
+        "name": "dpkg",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
         "release": null
-        }, 
-        "remediation": {
-          "recommendation": {
-            "text": "None Provided"
-          }
-        }, 
-        "cvss_v3_score": 8.2, 
-        "cvss_v30_score": 0.0, 
-        "cvss_v31_score": 8.2, 
-        "cvss_v2_score": 0.0, 
-        "cvss_v3_severity": "HIGH", 
-        "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html", 
-        "source": "UBUNTU_CVE", 
-        "severity": "HIGH", 
-        "status": "ACTIVE", 
-        "title": "CVE-2025-6297 - dpkg, libdpkg-perl", 
-        "reason_to_ignore": "N/A"
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
     }
-  ], 
+  ],
   "libdpkg-perl": [
     {
-      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.", 
-      "vulnerability_id": "CVE-2025-6297", 
-      "name": "CVE-2025-6297", 
-      "package_name": "libdpkg-perl", 
+      "description": "It was discovered that dpkg-deb does not properly sanitize directory permissions when extracting a control member into a temporary directory, which is documented as being a safe operation even on untrusted data. This may result in leaving temporary files behind on cleanup. Given automated and repeated execution of dpkg-deb commands on adversarial .deb packages or with well compressible files, placed inside a directory with permissions not allowing removal by a non-root user, this can end up in a DoS scenario due to causing disk quota exhaustion or disk full conditions.",
+      "vulnerability_id": "CVE-2025-6297",
+      "name": "CVE-2025-6297",
+      "package_name": "libdpkg-perl",
       "package_details": {
-        "file_path": null, 
-        "name": "libdpkg-perl", 
-        "package_manager": "OS", 
-        "version": "1.21.1ubuntu2.3", 
+        "file_path": null,
+        "name": "libdpkg-perl",
+        "package_manager": "OS",
+        "version": "1.21.1ubuntu2.3",
         "release": null
-        }, 
-        "remediation": {
-          "recommendation": {
-            "text": "None Provided"
-          }
-        }, 
-        "cvss_v3_score": 8.2, 
-        "cvss_v30_score": 0.0, 
-        "cvss_v31_score": 8.2, 
-        "cvss_v2_score": 0.0, 
-        "cvss_v3_severity": "HIGH", 
-        "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html", 
-        "source": "UBUNTU_CVE", 
-        "severity": "HIGH", 
-        "status": "ACTIVE", 
-        "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
-        "reason_to_ignore": "N/A"
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.2,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.2,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2025/CVE-2025-6297.html",
+      "source": "UBUNTU_CVE",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-6297 - dpkg, libdpkg-perl",
+      "reason_to_ignore": "N/A"
     }
   ],
   "torch": [
@@ -147,6 +147,35 @@
       "severity": "HIGH",
       "status": "ACTIVE",
       "title": "CVE-2025-55552 - torch",
+      "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "A syntax error in the component proxy_tensor.py of pytorch v2.7.0 allows attackers to cause a Denial of Service (DoS).",
+      "vulnerability_id": "CVE-2025-55553",
+      "name": "CVE-2025-55553",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.6.0+cpu.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.6.0+cpu",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55553",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-55553 - torch",
       "reason_to_ignore": "N/A"
     }
   ]

--- a/pytorch/inference/docker/2.6/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.6/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
@@ -86,6 +86,35 @@
       "status": "ACTIVE",
       "title": "CVE-2025-55552 - torch",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "A syntax error in the component proxy_tensor.py of pytorch v2.7.0 allows attackers to cause a Denial of Service (DoS).",
+      "vulnerability_id": "CVE-2025-55553",
+      "name": "CVE-2025-55553",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.6.0+cpu.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.6.0+cpu",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55553",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-55553 - torch",
+      "reason_to_ignore": "N/A"
     }
   ]
 }

--- a/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.ec2.arm64.gpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.ec2.arm64.gpu.os_scan_allowlist.json
@@ -148,6 +148,35 @@
       "status": "ACTIVE",
       "title": "CVE-2025-55552 - torch",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "A syntax error in the component proxy_tensor.py of pytorch v2.7.0 allows attackers to cause a Denial of Service (DoS).",
+      "vulnerability_id": "CVE-2025-55553",
+      "name": "CVE-2025-55553",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.6.0+cu124.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.6.0+cu124",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55553",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-55553 - torch",
+      "reason_to_ignore": "N/A"
     }
   ]
 }

--- a/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.ec2.gpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.ec2.gpu.os_scan_allowlist.json
@@ -148,6 +148,35 @@
       "status": "ACTIVE",
       "title": "CVE-2025-55552 - torch",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "A syntax error in the component proxy_tensor.py of pytorch v2.7.0 allows attackers to cause a Denial of Service (DoS).",
+      "vulnerability_id": "CVE-2025-55553",
+      "name": "CVE-2025-55553",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.6.0+cu124.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.6.0+cu124",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55553",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-55553 - torch",
+      "reason_to_ignore": "N/A"
     }
   ]
 }

--- a/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
+++ b/pytorch/inference/docker/2.6/py3/cu124/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
@@ -148,6 +148,35 @@
       "status": "ACTIVE",
       "title": "CVE-2025-55552 - torch",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "A syntax error in the component proxy_tensor.py of pytorch v2.7.0 allows attackers to cause a Denial of Service (DoS).",
+      "vulnerability_id": "CVE-2025-55553",
+      "name": "CVE-2025-55553",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.6.0+cu124.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.6.0+cu124",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55553",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-55553 - torch",
+      "reason_to_ignore": "N/A"
     }
   ]
 }

--- a/test/dlc_tests/sanity/test_pre_release.py
+++ b/test/dlc_tests/sanity/test_pre_release.py
@@ -706,10 +706,10 @@ def test_pip_check(image):
     # This is a version conflict between TorchServe and ipython's transitive deps.
     # Note: don't use ^...$ anchors — re.findall without re.MULTILINE won't match non-first lines.
     allowed_exceptions.append(
-        r"ipython \d+(\.\d+)* has requirement psutil>=\d+, but you have psutil \d+(\.\d+)*\."
+        r"ipython \d+(\.\d+)* has requirement psutil>=\d+[^,]*, but you have psutil \d+(\.\d+)*\."
     )
     allowed_exceptions.append(
-        r"ipython \d+(\.\d+)* requires psutil>=\d+, but you have psutil \d+(\.\d+)* which is incompatible\."
+        r"ipython \d+(\.\d+)* requires psutil>=\d+[^,]*, but you have psutil \d+(\.\d+)* which is incompatible\."
     )
 
     # tox and pyproject-api require packaging>=25, but packaging is pinned to 24.2 in some images


### PR DESCRIPTION
## Summary
- Fix `test_pip_check` regex to handle ipython 9.14.0+ psutil environment marker
- Allowlist CVE-2025-55553 for PT 2.6 inference images (torch proxy_tensor.py DoS, affects v2.7.0+)

## Changes
1. **test/dlc_tests/sanity/test_pre_release.py** — Updated ipython/psutil regex from `psutil>=\d+` to `psutil>=\d+[^,]*` to match the new environment marker `; sys_platform != "emscripten"` that ipython 9.14.0+ adds to its psutil requirement
2. **pytorch/inference/docker/2.6/py3/\*os_scan_allowlist.json** (7 files) — Added CVE-2025-55553 (torch proxy_tensor.py syntax error DoS) to all CPU/GPU, EC2/SageMaker/arm64 allowlists

## Root Cause
- **test_pip_check**: ipython 9.14.0 changed `psutil>=7` to `psutil>=7; sys_platform != "emscripten"`. `pip check` output now includes the marker text, which broke the existing regex
- **CVE-2025-55553**: Newly published torch CVE affecting v2.7.0+. Cannot upgrade torch in a 2.6 image

## What this fixes
- Unblocks the PT 2.6 inference BuildRC pipeline (both EC2 and SageMaker variants)
- The `test_pip_check` fix also applies to all other PyTorch inference images that have ipython >= 9.14.0 with pinned psutil

## Test plan
- [x] PT 2.6 inference EC2 x86 — `test_pip_check` PASSED, `test_ecr_enhanced_scan` PASSED
- [x] PT 2.6 inference SageMaker x86 — `test_pip_check` PASSED, `test_ecr_enhanced_scan` PASSED