### PR TITLE
[ci] trigger xgboost PR workflow on allowlist edits

### DIFF
--- a/.github/workflows/pr-sagemaker-xgboost-3.0.5.yml
+++ b/.github/workflows/pr-sagemaker-xgboost-3.0.5.yml
@@ -9,6 +9,7 @@ on:
       - "docker/xgboost/resources/**"
       - ".github/config/image/sagemaker-xgboost-3.0.yml"
       - ".github/workflows/pr-sagemaker-xgboost-3.0.5.yml"
+      - "test/security/data/ecr_scan_allowlist/xgboost/**"
       - "!docs/**"
 
 permissions:

--- a/.github/workflows/pr-sagemaker-xgboost-3.0.5.yml
+++ b/.github/workflows/pr-sagemaker-xgboost-3.0.5.yml
@@ -9,7 +9,8 @@ on:
       - "docker/xgboost/resources/**"
       - ".github/config/image/sagemaker-xgboost-3.0.yml"
       - ".github/workflows/pr-sagemaker-xgboost-3.0.5.yml"
-      - "test/security/data/ecr_scan_allowlist/xgboost/**"
+      - "test/security/data/ecr_scan_allowlist/xgboost/framework_allowlist.json"
+      - "test/security/data/ecr_scan_allowlist/xgboost/xgboost-3.0.5.json"
       - "!docs/**"
 
 permissions:

--- a/.github/workflows/pr-sagemaker-xgboost.yml
+++ b/.github/workflows/pr-sagemaker-xgboost.yml
@@ -11,7 +11,8 @@ on:
       - "docker/xgboost/resources/**"
       - ".github/config/image/sagemaker-xgboost.yml"
       - ".github/workflows/pr-sagemaker-xgboost.yml"
-      - "test/security/data/ecr_scan_allowlist/xgboost/**"
+      - "test/security/data/ecr_scan_allowlist/xgboost/framework_allowlist.json"
+      - "test/security/data/ecr_scan_allowlist/xgboost/xgboost-3.2.0.json"
       - "!docs/**"
 
 permissions:

--- a/.github/workflows/pr-sagemaker-xgboost.yml
+++ b/.github/workflows/pr-sagemaker-xgboost.yml
@@ -11,6 +11,7 @@ on:
       - "docker/xgboost/resources/**"
       - ".github/config/image/sagemaker-xgboost.yml"
       - ".github/workflows/pr-sagemaker-xgboost.yml"
+      - "test/security/data/ecr_scan_allowlist/xgboost/**"
       - "!docs/**"
 
 permissions:


### PR DESCRIPTION
## Purpose

Trigger the xgboost PR CI workflows when only `test/security/data/ecr_scan_allowlist/xgboost/**` files change. Currently allowlist-only edits don't trigger a build/test run.

## Files changed

- `.github/workflows/pr-sagemaker-xgboost.yml` — added `framework_allowlist.json` and `xgboost-3.2.0.json` to `on.pull_request.paths`
- `.github/workflows/pr-sagemaker-xgboost-3.0.5.yml` — added `framework_allowlist.json` and `xgboost-3.0.5.json` to `on.pull_request.paths`

## Notes

- `xgboost-3.2.0.json` does not exist yet — added to the path filter proactively so the 3.2.0 workflow triggers when the file is created.
- Used per-version paths (instead of a wildcard glob) so edits to `xgboost-3.0.5.json` don't trigger a wasted run of the 3.2.0 workflow.