### PR TITLE
xgboost: align security upgrade with rest of DLC family

### DIFF
--- a/docker/xgboost/Dockerfile
+++ b/docker/xgboost/Dockerfile
@@ -88,7 +88,7 @@ RUN pip install --no-cache-dir git+https://github.com/awslabs/sagemaker-debugger
 
 # Remove build-time packages to reduce CVE surface
 RUN dnf remove -y kernel-headers gcc gcc-c++ make cpp || true \
-  && dnf update -y --security nginx glib2 gnutls \
+  && dnf upgrade -y --security --releasever latest \
   && dnf clean all
 
 # Patch sagemaker-inference decoder.py (CWE-502 fix)


### PR DESCRIPTION
## Purpose

Align the xgboost 3.2 Dockerfile's security-upgrade line with the pattern every other AL2023 DLC image uses (pytorch, base, ray, vllm, vllm-omni).

## Change

```diff
-  && dnf update -y --security nginx glib2 gnutls \
+  && dnf upgrade -y --security --releasever latest \
```

## Why

The narrow `dnf update -y --security nginx glib2 gnutls` line is missing `--releasever latest`. Without that flag, dnf only sees fixes for the releasever the base image was pinned to, not the latest published patches. Empirically the 3 named packages were not actually being upgraded by this line.

`dnf upgrade -y --security --releasever latest` matches what pytorch / base / ray / vllm / vllm-omni Dockerfiles use today.

## Test plan

- [x] CI security tests pass for `sagemaker-xgboost:3.2-0-cpu-py3`
- [x] CI sanity tests pass
- [x] Release [workflow](https://github.com/aws/deep-learning-containers/actions/runs/27238613408) pass 