### PR TITLE
[auto-cve-patch] [xgboost] prune 5 stale allowlist entries (3.2.0)

### DIFF
--- a/test/security/data/ecr_scan_allowlist/xgboost/xgboost-3.2.0.json
+++ b/test/security/data/ecr_scan_allowlist/xgboost/xgboost-3.2.0.json
@@ -1,22 +1,7 @@
 [
     {
-        "vulnerability_id": "CVE-2025-23339",
-        "reason": "cuda-toolkit-config-common from NVIDIA CUDA repo — cuobjdump not used in XGBoost serving/training.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-23308",
-        "reason": "cuda-toolkit-config-common from NVIDIA CUDA repo — nvdisasm not used in XGBoost serving/training.",
-        "review_by": "2026-08-30"
-    },
-    {
         "vulnerability_id": "CVE-2026-0994",
         "reason": "protobuf pinned to 3.20.x — required by smdebug. Cannot upgrade to 6.x.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-23949",
-        "reason": "jaraco.context vendored inside setuptools. tarball() not used in serving/training.",
         "review_by": "2026-08-30"
     },
     {
@@ -212,16 +197,6 @@
     {
         "vulnerability_id": "CVE-2026-21441",
         "reason": "urllib3 2.4.0 — streaming API vulnerability. Pinned by dask-cuda compatibility.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-66471",
-        "reason": "urllib3 2.4.0 — streaming API vulnerability. Pinned by dask-cuda compatibility.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-66418",
-        "reason": "urllib3 2.4.0 — decompression chain vulnerability. Pinned by dask-cuda compatibility.",
         "review_by": "2026-08-30"
     },
     {


### PR DESCRIPTION
## Purpose

Patch CVEs across XGBoost DLC images for framework_version 3.2.0.

## Images affected

`sagemaker-xgboost:3.2-0-cpu-py3`

## CVEs handled

**Prunes:** Pruned 5 entries from `xgboost-3.2.0.json` that no longer fire against the rebuilt image: 2 cuda-toolkit-config-common (cuobjdump/nvdisasm subpackages no longer installed; base image bumped to cuda-toolkit-config-common 13.x), 2 urllib3 (now at 2.7.0 ≥ fixedInVersion), 1 jaraco-vendored-in-setuptools (setuptools now 80.10.2). Verified on devbox: `rpm -q cuda-nvdisasm-12-9` returns "not installed", `pip show urllib3` returns 2.7.0, `pip show setuptools` returns 80.10.2.

## Test plan

- [ ] CI security tests pass for affected xgboost variant
- [ ] CI sanity tests pass
- [ ] **Reviewer must manually run the [Release - SageMaker XGBoost workflow](https://github.com/aws/deep-learning-containers/actions/workflows/dispatch-release-sagemaker-xgboost.yml) on this branch before merging.** PR CI does NOT include the upstream-repo integration tests (~2 hr); they only run in the release workflow. Required for any change that touches the Dockerfile or installed packages.

---
🤖 Generated by [Claude Code](https://claude.com/claude-code).
