### PR TITLE
fix: align sglang AL2023 autorelease and promote to production

### DIFF
--- a/.github/config/image/sglang-ec2-amzn2023.yml
+++ b/.github/config/image/sglang-ec2-amzn2023.yml
@@ -35,7 +35,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
+  public_registry: true
   private_registry: true
   enable_soci: true
-  environment: gamma
+  environment: production

--- a/.github/config/image/sglang-ec2-amzn2023.yml
+++ b/.github/config/image/sglang-ec2-amzn2023.yml
@@ -35,7 +35,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: true
+  public_registry: false
   private_registry: true
   enable_soci: true
   environment: gamma

--- a/.github/config/image/sglang-sagemaker-amzn2023.yml
+++ b/.github/config/image/sglang-sagemaker-amzn2023.yml
@@ -18,8 +18,8 @@ common:
   device_type: "gpu"
   contributor: "None"
 build:
-  sglang_ref: "d9d719b270729eaf93a923677c2fef06b9f5fded"
-  sglang_kernel_version: "0.4.2.post2"
+  sglang_ref: "578d27e56acd6786eb7067b9e1583232fd1d998e"
+  sglang_kernel_version: "0.4.3"
   flashinfer_version: "0.6.11.post1"
   deepep_commit: "9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee"
   mooncake_version: "0.3.9"
@@ -36,7 +36,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: true
+  public_registry: false
   private_registry: true
   enable_soci: true
   environment: gamma

--- a/.github/config/image/sglang-sagemaker-amzn2023.yml
+++ b/.github/config/image/sglang-sagemaker-amzn2023.yml
@@ -36,7 +36,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
+  public_registry: true
   private_registry: true
   enable_soci: true
-  environment: gamma
+  environment: production

--- a/.github/workflows/autorelease-sglang-ec2-amzn2023.yml
+++ b/.github/workflows/autorelease-sglang-ec2-amzn2023.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           config-json: ${{ needs.load-config.outputs.config }}
           framework: ${{ needs.load-config.outputs.framework }}
-          target: sglang-ec2-amzn2023
+          target: sglang-ec2
           base-image: nvidia/cuda:13.0.3-devel-amzn2023
           framework-version: ${{ needs.load-config.outputs.framework-version }}
           container-type: ${{ needs.load-config.outputs.container-type }}

--- a/.github/workflows/autorelease-sglang-ec2-amzn2023.yml
+++ b/.github/workflows/autorelease-sglang-ec2-amzn2023.yml
@@ -45,6 +45,7 @@ jobs:
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
+      sglang-ref: ${{ steps.parse.outputs.sglang-ref }}
       python-version: ${{ steps.parse.outputs.python-version }}
       cuda-version: ${{ steps.parse.outputs.cuda-version }}
       os-version: ${{ steps.parse.outputs.os-version }}
@@ -70,6 +71,7 @@ jobs:
           echo '${{ steps.load.outputs.config }}' > config.json
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
+          echo "sglang-ref=$(jq -r '.build.sglang_ref // ""' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
           echo "cuda-version=$(jq -r '.common.cuda_version' config.json)" >> $GITHUB_OUTPUT
           echo "os-version=$(jq -r '.common.os_version' config.json)" >> $GITHUB_OUTPUT
@@ -152,6 +154,7 @@ jobs:
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
       framework-version: ${{ needs.load-config.outputs.framework-version }}
+      sglang-ref: ${{ needs.load-config.outputs.sglang-ref }}
       benchmark-start-command: >-
         docker run -d -it --rm --gpus=all
         -v ${HOME}/.cache/huggingface:/root/.cache/huggingface

--- a/.github/workflows/autorelease-sglang-ec2-amzn2023.yml
+++ b/.github/workflows/autorelease-sglang-ec2-amzn2023.yml
@@ -3,11 +3,14 @@ name: Auto Release - SGLang EC2 AMZN2023
 on:
   # schedule run must be on the default branch
   schedule:
-    # Runs at 9AM/10AM PST/PDT on Tuesdays and Thursdays
-    - cron: '00 19 * * 1,3'
-  # Trigger when an auto-update PR is merged
-  push:
-    branches: [main]
+    # Runs at 11AM/12PM PST/PDT on Tuesdays and Thursdays
+    - cron: '00 19 * * 2,4'
+
+  # PR triggers for testing
+  # pull_request:
+  #   paths:
+  #     - "**sglang**"
+  #     - "!docs/**"
 
   # Manual trigger
   workflow_dispatch:
@@ -27,19 +30,7 @@ env:
   CONFIG_FILE: '.github/config/image/sglang-ec2-amzn2023.yml'
 
 jobs:
-  # Gate: skip push events unless it's a merged auto-update PR for sglang
-  autocurrency-pr-gate:
-    if: >-
-      github.event_name != 'push' || (
-        contains(github.event.head_commit.message, '[Auto-Update] sglang') &&
-        github.event.head_commit.author.name == 'aws-deep-learning-containers-ci[bot]'
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Gate passed"
-
   load-config:
-    needs: [autocurrency-pr-gate]
     runs-on: ubuntu-latest
     outputs:
       config: ${{ steps.load.outputs.config }}

--- a/.github/workflows/autorelease-sglang-sagemaker-amzn2023.yml
+++ b/.github/workflows/autorelease-sglang-sagemaker-amzn2023.yml
@@ -3,11 +3,14 @@ name: Auto Release - SGLang SageMaker AMZN2023
 on:
   # schedule run must be on the default branch
   schedule:
-    # Runs at 9AM/10AM PST/PDT on Tuesdays and Thursdays
-    - cron: '00 19 * * 1,3'
-  # Trigger when an auto-update PR is merged
-  push:
-    branches: [main]
+    # Runs at 11AM/12PM PST/PDT on Tuesdays and Thursdays
+    - cron: '00 19 * * 2,4'
+
+  # PR triggers for testing
+  # pull_request:
+  #   paths:
+  #     - "**sglang**"
+  #     - "!docs/**"
 
   # Manual trigger
   workflow_dispatch:
@@ -27,19 +30,7 @@ env:
   CONFIG_FILE: '.github/config/image/sglang-sagemaker-amzn2023.yml'
 
 jobs:
-  # Gate: skip push events unless it's a merged auto-update PR for sglang
-  autocurrency-pr-gate:
-    if: >-
-      github.event_name != 'push' || (
-        contains(github.event.head_commit.message, '[Auto-Update] sglang') &&
-        github.event.head_commit.author.name == 'aws-deep-learning-containers-ci[bot]'
-      )
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Gate passed"
-
   load-config:
-    needs: [autocurrency-pr-gate]
     runs-on: ubuntu-latest
     outputs:
       config: ${{ steps.load.outputs.config }}

--- a/.github/workflows/autorelease-sglang-sagemaker-amzn2023.yml
+++ b/.github/workflows/autorelease-sglang-sagemaker-amzn2023.yml
@@ -99,7 +99,7 @@ jobs:
         with:
           config-json: ${{ needs.load-config.outputs.config }}
           framework: ${{ needs.load-config.outputs.framework }}
-          target: sglang-sagemaker-amzn2023
+          target: sglang-sagemaker
           base-image: nvidia/cuda:13.0.3-devel-amzn2023
           framework-version: ${{ needs.load-config.outputs.framework-version }}
           container-type: ${{ needs.load-config.outputs.container-type }}

--- a/.github/workflows/autorelease-sglang-sagemaker-amzn2023.yml
+++ b/.github/workflows/autorelease-sglang-sagemaker-amzn2023.yml
@@ -45,6 +45,7 @@ jobs:
       config: ${{ steps.load.outputs.config }}
       framework: ${{ steps.parse.outputs.framework }}
       framework-version: ${{ steps.parse.outputs.framework-version }}
+      sglang-ref: ${{ steps.parse.outputs.sglang-ref }}
       python-version: ${{ steps.parse.outputs.python-version }}
       cuda-version: ${{ steps.parse.outputs.cuda-version }}
       os-version: ${{ steps.parse.outputs.os-version }}
@@ -70,6 +71,7 @@ jobs:
           echo '${{ steps.load.outputs.config }}' > config.json
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
+          echo "sglang-ref=$(jq -r '.build.sglang_ref // ""' config.json)" >> $GITHUB_OUTPUT
           echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
           echo "cuda-version=$(jq -r '.common.cuda_version' config.json)" >> $GITHUB_OUTPUT
           echo "os-version=$(jq -r '.common.os_version' config.json)" >> $GITHUB_OUTPUT
@@ -152,6 +154,7 @@ jobs:
       aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
       framework-version: ${{ needs.load-config.outputs.framework-version }}
+      sglang-ref: ${{ needs.load-config.outputs.sglang-ref }}
       benchmark-start-command: >-
         docker run -d -it --rm --gpus=all
         -v ${HOME}/.cache/huggingface:/root/.cache/huggingface

--- a/.github/workflows/reusable-sglang-upstream-tests.yml
+++ b/.github/workflows/reusable-sglang-upstream-tests.yml
@@ -22,6 +22,11 @@ on:
         description: 'SGLang framework version (e.g., 0.5.9)'
         required: true
         type: string
+      sglang-ref:
+        description: 'SGLang git ref to check out for tests (tag or commit SHA). Defaults to v${framework-version}.'
+        required: false
+        type: string
+        default: ''
       benchmark-start-command:
         description: 'Docker run command to start the benchmark container (must output CONTAINER_ID)'
         required: true
@@ -104,7 +109,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           repository: sgl-project/sglang
-          ref: v${{ inputs.framework-version }}
+          ref: ${{ inputs.sglang-ref != '' && inputs.sglang-ref || format('v{0}', inputs.framework-version) }}
           path: sglang_source
 
       - name: Start container
@@ -143,9 +148,10 @@ jobs:
             # Workaround: sglang v0.5.12 has an incomplete suite rename
             # (stage-* -> base-*) causing validate_all_suites() to fail.
             # See: https://github.com/sgl-project/sglang/issues/25450
-            if [ "${{ inputs.framework-version }}" = "0.5.12" ]; then
+            case "${{ inputs.framework-version }}" in 0.5.12*)
               rm -f /workdir/test/registered/radix_cache/test_unified_radix_cache_kl_hicache.py
-            fi
+            ;;
+            esac
 
             # SRT backend Test with increased timeout
             cd /workdir/test


### PR DESCRIPTION
The SGLang AL2023 autorelease workflows were failing. This PR fixes two consecutive blockers on that path.

## Fix 1 — build target stage name

`build-image` failed with:

```
ERROR: failed to solve: target stage sglang-sagemaker-amzn2023 could not be found
```

The autorelease workflows requested targets `sglang-{ec2,sagemaker}-amzn2023`, but `docker/sglang/Dockerfile.amzn2023` only defines stages `sglang-ec2` / `sglang-sagemaker` (the PR workflows already use the bare names, which is why this only surfaced on the autorelease path). Pointed the two autorelease `--target` values at the existing bare stage names.

## Fix 2 — upstream-test checkout ref

After Fix 1, `upstream-tests / srt-backend-test` failed at "Checkout SGLang tests" with `git exit code 1`.

`reusable-sglang-upstream-tests.yml` checked out `sgl-project/sglang` at `ref: v${framework-version}`. The AL2023 configs set `framework_version: "0.5.12+dlc1"` (a PEP 440 local segment used for the CVE scanner), so the ref resolved to tag `v0.5.12+dlc1` — which doesn't exist upstream (real tag is `v0.5.12`).

Mirrored the **vLLM AL2023 pattern** (`reusable-vllm-upstream-tests.yml`), which decouples the upstream git ref from the framework version:
- Added an optional `sglang-ref` input that takes precedence over `v{framework-version}`:
  ```yaml
  ref: ${{ inputs.sglang-ref != '' && inputs.sglang-ref || format('v{0}', inputs.framework-version) }}
  ```
- Wired the existing `build.sglang_ref` config field (the exact build commit) through `load-config` in both AL2023 autorelease workflows.
- The fallback leaves the 4 Ubuntu callers (`framework_version: "0.5.12"`, no `sglang_ref`) unchanged.

Also widened the v0.5.12 suite-rename workaround from an exact match to a `0.5.12*` prefix, so it still fires for `0.5.12+dlc1`.

## Fix 3 — align SageMaker config with EC2

The SageMaker AL2023 config pinned an older `sglang_ref` (`d9d719b…` / `sglang_kernel_version: 0.4.2.post2`) than the EC2 config (`578d27e…` / `0.4.3`) by accident — all other build args were already identical. Aligned SageMaker to the later commit (`578d27e`, 2026-05-28 vs `d9d719b`, 2026-05-27) so both images build from the same source. Build sections are now identical between the two configs.

## Promote to production + align triggers with vLLM

Gamma release was validated end-to-end for both images: EC2 produced prod tag `server-cuda-v1` and SageMaker produced `server-sagemaker-cuda-v1` (both with `v1.0.0` + SOCI variants), and release-spec generation + tag construction work with `framework: "sglang_server"`.

- Flipped both AL2023 configs to `environment: production` with `public_registry: true` (matching every other released image).
- Mirrored the **vLLM AL2023** autorelease trigger pattern: removed the `push: branches:[main]` trigger and the `autocurrency-pr-gate` job, keeping a scheduled cron and manual `workflow_dispatch`.
- Moved the cron to **Tue/Thu 19:00 UTC (`00 19 * * 2,4`)** so it no longer collides with the vLLM/PyTorch autoreleases (Mon/Wed 17:00 UTC). 19:00 Tue/Thu is a free slot (sglang-ubuntu 17:00, ray/vllm-omni 20:00).
