### PR TITLE
add: huggingface-vllm v0.22

### DIFF
--- a/.github/config/image/huggingface-vllm-sagemaker.yml
+++ b/.github/config/image/huggingface-vllm-sagemaker.yml
@@ -20,7 +20,7 @@ release:
   # TODO: set to true whenever PR is validated by AWS team
   release: false
   force_release: false
-  public_registry: true
+  public_registry: false
   private_registry: true
   enable_soci: true
   environment: production

--- a/.github/config/image/huggingface-vllm-sagemaker.yml
+++ b/.github/config/image/huggingface-vllm-sagemaker.yml
@@ -1,0 +1,26 @@
+image:
+  name: "huggingface-vllm-sagemaker"
+  description: "Hugging Face vLLM for SageMaker (layered on the AWS vLLM DLC)"
+common:
+  framework: "huggingface_vllm"
+  framework_version: "0.22.1"
+  transformers_version: "5.10.2"
+  job_type: "general"
+  python_version: "py312"
+  cuda_version: "cu130"
+  os_version: "ubuntu22.04"
+  customer_type: "sagemaker"
+  platform: "sagemaker"
+  arch_type: "x86"
+  # TODO: confirm the production ECR repo before wiring autorelease/release.
+  prod_image: "huggingface-vllm:server-sagemaker-cuda-v1"
+  device_type: "gpu"
+  contributor: "None"
+release:
+  # TODO: set to true whenever PR is validated by AWS team
+  release: false
+  force_release: false
+  public_registry: true
+  private_registry: true
+  enable_soci: true
+  environment: production

--- a/.github/workflows/pr-huggingface-vllm-sagemaker.yml
+++ b/.github/workflows/pr-huggingface-vllm-sagemaker.yml
@@ -1,0 +1,217 @@
+name: PR - Hugging Face vLLM SageMaker
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize]
+    paths:
+      - ".github/config/image/huggingface-vllm-sagemaker.yml"
+      - ".github/workflows/pr-huggingface-vllm-sagemaker.yml"
+      - "docker/huggingface/vllm/**"
+      - "scripts/huggingface/vllm/**"
+      - "test/sanity/**"
+      - "test/telemetry/**"
+      - "test/security/data/ecr_scan_allowlist/huggingface_vllm/**"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  FORCE_COLOR: "1"
+  CONFIG_FILE: ".github/config/image/huggingface-vllm-sagemaker.yml"
+  BASE_IMAGE: "public.ecr.aws/deep-learning-containers/vllm:0.22.1-gpu-py312-cu130-ubuntu22.04-sagemaker-v1.0"
+
+jobs:
+  gatekeeper:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-gate-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout base branch (safe)
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+
+      - name: Run permission gate (from base)
+        uses: ./.github/actions/pr-permission-gate
+
+  load-config:
+    needs: [gatekeeper]
+    if: success()
+    runs-on: ubuntu-latest
+    outputs:
+      framework: ${{ steps.parse.outputs.framework }}
+      framework-version: ${{ steps.parse.outputs.framework-version }}
+      transformers-version: ${{ steps.parse.outputs.transformers-version }}
+      python-version: ${{ steps.parse.outputs.python-version }}
+      cuda-version: ${{ steps.parse.outputs.cuda-version }}
+      os-version: ${{ steps.parse.outputs.os-version }}
+      container-type: ${{ steps.parse.outputs.container-type }}
+      device-type: ${{ steps.parse.outputs.device-type }}
+      arch-type: ${{ steps.parse.outputs.arch-type }}
+      contributor: ${{ steps.parse.outputs.contributor }}
+      customer-type: ${{ steps.parse.outputs.customer-type }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Load configuration
+        id: load
+        uses: ./.github/actions/load-config
+        with:
+          config-file: ${{ env.CONFIG_FILE }}
+
+      - name: Parse configuration
+        id: parse
+        run: |
+          echo '${{ steps.load.outputs.config }}' > config.json
+          echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
+          echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
+          echo "transformers-version=$(jq -r '.common.transformers_version // ""' config.json)" >> $GITHUB_OUTPUT
+          echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
+          echo "cuda-version=$(jq -r '.common.cuda_version' config.json)" >> $GITHUB_OUTPUT
+          echo "os-version=$(jq -r '.common.os_version' config.json)" >> $GITHUB_OUTPUT
+          echo "container-type=$(jq -r '.common.job_type' config.json)" >> $GITHUB_OUTPUT
+          echo "device-type=$(jq -r '.common.device_type // "gpu"' config.json)" >> $GITHUB_OUTPUT
+          echo "arch-type=$(jq -r '.common.arch_type // "x86"' config.json)" >> $GITHUB_OUTPUT
+          echo "contributor=$(jq -r '.common.contributor // "None"' config.json)" >> $GITHUB_OUTPUT
+          echo "customer-type=$(jq -r '.common.customer_type // ""' config.json)" >> $GITHUB_OUTPUT
+
+  check-changes:
+    needs: [gatekeeper]
+    if: success()
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-check-changes-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    outputs:
+      build-change: ${{ steps.changes.outputs.build-change }}
+      sanity-test-change: ${{ steps.changes.outputs.sanity-test-change }}
+      telemetry-test-change: ${{ steps.changes.outputs.telemetry-test-change }}
+    steps:
+      - name: Checkout DLC source
+        uses: actions/checkout@v5
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.1
+        with:
+          extra_args: --all-files
+
+      - name: Detect file changes
+        id: changes
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            build-change:
+              - ".github/config/image/huggingface-vllm-sagemaker.yml"
+              - "docker/huggingface/vllm/**"
+              - "scripts/huggingface/vllm/**"
+              - "scripts/common/setup_oss_compliance.sh"
+              - "test/security/data/ecr_scan_allowlist/huggingface_vllm/**"
+            sanity-test-change:
+              - "test/sanity/**"
+            telemetry-test-change:
+              - "test/telemetry/**"
+
+  build-image:
+    needs: [check-changes, load-config]
+    if: needs.check-changes.outputs.build-change == 'true'
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:x86-build-runner
+        buildspec-override:true
+    timeout-minutes: 120
+    concurrency:
+      group: ${{ github.workflow }}-build-image-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    outputs:
+      ci-image: ${{ steps.build.outputs.image-uri }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Load pinned HF versions
+        run: |
+          before=$(compgen -v | sort)
+          set -a; source docker/huggingface/vllm/versions.env; set +a
+          new=$(comm -13 <(echo "$before") <(compgen -v | sort) | grep -Ev '^(before|PIPESTATUS|_)$')
+          for v in $new; do
+            [ -n "${!v:-}" ] && echo "${v}=$(echo "${!v}" | xargs)" >> "$GITHUB_ENV"
+          done
+          echo "EXTRA_BUILD_ARGS=$(echo $new | xargs)" >> "$GITHUB_ENV"
+
+      - name: Build image
+        id: build
+        uses: ./.github/actions/build-image
+        with:
+          framework: ${{ needs.load-config.outputs.framework }}
+          target: huggingface-vllm-sagemaker
+          base-image: ${{ env.BASE_IMAGE }}
+          framework-version: ${{ needs.load-config.outputs.framework-version }}
+          container-type: ${{ needs.load-config.outputs.container-type }}
+          transformers-version: ${{ needs.load-config.outputs.transformers-version }}
+          aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+          tag-pr: ${{ needs.load-config.outputs.framework }}-${{ needs.load-config.outputs.framework-version }}-gpu-${{ needs.load-config.outputs.python-version }}-${{ needs.load-config.outputs.cuda-version }}-${{ needs.load-config.outputs.os-version }}-sagemaker-pr-${{ github.event.pull_request.number }}
+          dockerfile-path: docker/huggingface/vllm/Dockerfile
+          arch-type: ${{ needs.load-config.outputs.arch-type }}
+          device-type: ${{ needs.load-config.outputs.device-type }}
+          cuda-version: ${{ needs.load-config.outputs.cuda-version }}
+          python-version: ${{ needs.load-config.outputs.python-version }}
+          os-version: ${{ needs.load-config.outputs.os-version }}
+          contributor: ${{ needs.load-config.outputs.contributor }}
+          customer-type: ${{ needs.load-config.outputs.customer-type }}
+
+  # TODO: tests run against the freshly built CI image. There is no prod-image
+  # fallback yet (this image is not released) so test-only PRs that don't
+  # rebuild won't have an image to test. Add a fallback once it's released.
+  sanity-test:
+    needs: [check-changes, build-image, load-config]
+    if: always() && needs.build-image.result == 'success'
+    uses: ./.github/workflows/reusable-sanity-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      transformers-version: ${{ needs.load-config.outputs.transformers-version }}
+      python-version: ${{ needs.load-config.outputs.python-version }}
+      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
+      os-version: ${{ needs.load-config.outputs.os-version }}
+      customer-type: ${{ needs.load-config.outputs.customer-type }}
+      arch-type: ${{ needs.load-config.outputs.arch-type }}
+      device-type: ${{ needs.load-config.outputs.device-type }}
+      contributor: ${{ needs.load-config.outputs.contributor }}
+      container-type: ${{ needs.load-config.outputs.container-type }}
+
+  security-test:
+    needs: [build-image, load-config]
+    if: always() && needs.build-image.result == 'success'
+    uses: ./.github/workflows/reusable-security-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+
+  telemetry-test:
+    needs: [check-changes, build-image, load-config]
+    if: always() && needs.build-image.result == 'success'
+    uses: ./.github/workflows/reusable-telemetry-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      container-type: ${{ needs.load-config.outputs.container-type }}

--- a/.github/workflows/release-huggingface-vllm-sagemaker.yml
+++ b/.github/workflows/release-huggingface-vllm-sagemaker.yml
@@ -1,0 +1,189 @@
+name: Release - Hugging Face vLLM SageMaker
+
+on:
+  # Manual trigger only (no schedule/auto-update for this image yet).
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: "1"
+  CONFIG_FILE: ".github/config/image/huggingface-vllm-sagemaker.yml"
+  BASE_IMAGE: "public.ecr.aws/deep-learning-containers/vllm:0.22.1-gpu-py312-cu130-ubuntu22.04-sagemaker-v1.0"
+
+jobs:
+  load-config:
+    runs-on: ubuntu-latest
+    outputs:
+      config: ${{ steps.load.outputs.config }}
+      framework: ${{ steps.parse.outputs.framework }}
+      framework-version: ${{ steps.parse.outputs.framework-version }}
+      transformers-version: ${{ steps.parse.outputs.transformers-version }}
+      python-version: ${{ steps.parse.outputs.python-version }}
+      cuda-version: ${{ steps.parse.outputs.cuda-version }}
+      os-version: ${{ steps.parse.outputs.os-version }}
+      container-type: ${{ steps.parse.outputs.container-type }}
+      device-type: ${{ steps.parse.outputs.device-type }}
+      arch-type: ${{ steps.parse.outputs.arch-type }}
+      contributor: ${{ steps.parse.outputs.contributor }}
+      customer-type: ${{ steps.parse.outputs.customer-type }}
+      prod-image: ${{ steps.parse.outputs.prod-image }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Load configuration
+        id: load
+        uses: ./.github/actions/load-config
+        with:
+          config-file: ${{ env.CONFIG_FILE }}
+
+      - name: Parse configuration
+        id: parse
+        run: |
+          echo '${{ steps.load.outputs.config }}' > config.json
+          echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
+          echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
+          echo "transformers-version=$(jq -r '.common.transformers_version // ""' config.json)" >> $GITHUB_OUTPUT
+          echo "python-version=$(jq -r '.common.python_version' config.json)" >> $GITHUB_OUTPUT
+          echo "cuda-version=$(jq -r '.common.cuda_version' config.json)" >> $GITHUB_OUTPUT
+          echo "os-version=$(jq -r '.common.os_version' config.json)" >> $GITHUB_OUTPUT
+          echo "container-type=$(jq -r '.common.job_type' config.json)" >> $GITHUB_OUTPUT
+          echo "device-type=$(jq -r '.common.device_type // "gpu"' config.json)" >> $GITHUB_OUTPUT
+          echo "arch-type=$(jq -r '.common.arch_type // "x86"' config.json)" >> $GITHUB_OUTPUT
+          echo "contributor=$(jq -r '.common.contributor // "None"' config.json)" >> $GITHUB_OUTPUT
+          echo "customer-type=$(jq -r '.common.customer_type // ""' config.json)" >> $GITHUB_OUTPUT
+          echo "prod-image=$(jq -r '.common.prod_image' config.json)" >> $GITHUB_OUTPUT
+
+  build-image:
+    needs: [load-config]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:x86-build-runner
+        buildspec-override:true
+    timeout-minutes: 120
+    outputs:
+      ci-image: ${{ steps.build.outputs.image-uri }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Load pinned HF versions
+        run: |
+          before=$(compgen -v | sort)
+          set -a; source docker/huggingface/vllm/versions.env; set +a
+          new=$(comm -13 <(echo "$before") <(compgen -v | sort) | grep -Ev '^(before|PIPESTATUS|_)$')
+          for v in $new; do
+            [ -n "${!v:-}" ] && echo "${v}=$(echo "${!v}" | xargs)" >> "$GITHUB_ENV"
+          done
+          echo "EXTRA_BUILD_ARGS=$(echo $new | xargs)" >> "$GITHUB_ENV"
+
+      - name: Build image
+        id: build
+        uses: ./.github/actions/build-image
+        with:
+          framework: ${{ needs.load-config.outputs.framework }}
+          target: huggingface-vllm-sagemaker
+          base-image: ${{ env.BASE_IMAGE }}
+          framework-version: ${{ needs.load-config.outputs.framework-version }}
+          container-type: ${{ needs.load-config.outputs.container-type }}
+          transformers-version: ${{ needs.load-config.outputs.transformers-version }}
+          aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+          tag-pr: ${{ needs.load-config.outputs.framework }}-${{ needs.load-config.outputs.framework-version }}-gpu-${{ needs.load-config.outputs.python-version }}-${{ needs.load-config.outputs.cuda-version }}-${{ needs.load-config.outputs.os-version }}-sagemaker-${{ github.run_id }}
+          dockerfile-path: docker/huggingface/vllm/Dockerfile
+          arch-type: ${{ needs.load-config.outputs.arch-type }}
+          device-type: ${{ needs.load-config.outputs.device-type }}
+          cuda-version: ${{ needs.load-config.outputs.cuda-version }}
+          python-version: ${{ needs.load-config.outputs.python-version }}
+          os-version: ${{ needs.load-config.outputs.os-version }}
+          contributor: ${{ needs.load-config.outputs.contributor }}
+          customer-type: ${{ needs.load-config.outputs.customer-type }}
+
+  sanity-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-sanity-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      transformers-version: ${{ needs.load-config.outputs.transformers-version }}
+      python-version: ${{ needs.load-config.outputs.python-version }}
+      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
+      os-version: ${{ needs.load-config.outputs.os-version }}
+      customer-type: ${{ needs.load-config.outputs.customer-type }}
+      arch-type: ${{ needs.load-config.outputs.arch-type }}
+      device-type: ${{ needs.load-config.outputs.device-type }}
+      contributor: ${{ needs.load-config.outputs.contributor }}
+      container-type: ${{ needs.load-config.outputs.container-type }}
+
+  security-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-security-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+
+  telemetry-test:
+    needs: [build-image, load-config]
+    uses: ./.github/workflows/reusable-telemetry-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+      aws-region: ${{ vars.AWS_REGION }}
+      framework: ${{ needs.load-config.outputs.framework }}
+      framework-version: ${{ needs.load-config.outputs.framework-version }}
+      container-type: ${{ needs.load-config.outputs.container-type }}
+
+  endpoint-test:
+    needs: [build-image]
+    uses: ./.github/workflows/reusable-vllm-sagemaker-tests.yml
+    with:
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+
+  generate-release-spec:
+    needs: [load-config, build-image, sanity-test, security-test, telemetry-test, endpoint-test]
+    runs-on: ubuntu-latest
+    outputs:
+      release-spec: ${{ steps.generate.outputs.release-spec }}
+      should-release: ${{ steps.check-release.outputs.should-release }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Check if release is enabled
+        id: check-release
+        run: |
+          echo '${{ needs.load-config.outputs.config }}' > config.json
+          RELEASE_ENABLED=$(jq -r '.release.release // false' config.json)
+          echo "Release enabled: ${RELEASE_ENABLED}"
+          echo "should-release=${RELEASE_ENABLED}" >> $GITHUB_OUTPUT
+
+      - name: Generate release spec
+        id: generate
+        if: steps.check-release.outputs.should-release == 'true'
+        uses: ./.github/actions/generate-release-spec
+        with:
+          config-json: ${{ needs.load-config.outputs.config }}
+
+  release-image:
+    needs: [load-config, build-image, generate-release-spec]
+    if: needs.generate-release-spec.outputs.should-release == 'true'
+    uses: ./.github/workflows/reusable-release-image.yml
+    with:
+      source-image-uri: ${{ needs.build-image.outputs.ci-image }}
+      release-spec: ${{ needs.generate-release-spec.outputs.release-spec }}
+      environment: ${{ fromJson(needs.load-config.outputs.config).release.environment }}
+      aws-region: ${{ vars.AWS_REGION }}
+      runner-fleet: default-runner
+    secrets: inherit

--- a/docker/huggingface/vllm/Dockerfile
+++ b/docker/huggingface/vllm/Dockerfile
@@ -24,6 +24,8 @@ RUN uv pip install --system \
   "huggingface-hub==${HUGGINGFACE_HUB_VERSION}" \
   "hf-xet==${HF_XET_VERSION}" \
   "grpcio>=1.79.3" \
+  "cryptography>=48.0.1" \
+  "starlette>=1.3.1" \
   && uv cache clean \
   && rm -rf /tmp/uv*
 
@@ -61,10 +63,11 @@ RUN apt-get purge -y ffmpeg libav* || true && apt-get autoremove -y
 
 ARG FFMPEG_TAG=n8.1
 
-# Patch openssl/libssl3 CVEs carried by the ubuntu22.04 base
-# (CVE-2026-45447 CRITICAL, CVE-2026-34180/45445/7383/9076 HIGH;
-# fixed in 3.0.2-0ubuntu1.25).
-RUN apt-get update && apt-get install -y --only-upgrade openssl libssl3 \
+# Patch OS CVEs carried by the ubuntu22.04 base (openssl, mesa, ...). Hold
+# cuda/nvidia/libnv packages first so the broad upgrade can't bump the toolkit
+# or driver (same pattern as docker/vllm).
+RUN dpkg -l | grep -E "cuda|nvidia|libnv" | awk '{print $2}' | xargs apt-mark hold \
+  && apt-get update && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
     pkg-config \
     nasm \

--- a/docker/huggingface/vllm/Dockerfile
+++ b/docker/huggingface/vllm/Dockerfile
@@ -1,8 +1,5 @@
 # syntax=docker/dockerfile:1
 
-# AWS-published vLLM DLC this image layers on top of. The build workflow passes
-# the resolved base via --build-arg BASE_IMAGE (build_image.sh always forwards
-# it); this default keeps standalone `docker build` working.
 ARG BASE_IMAGE=public.ecr.aws/deep-learning-containers/vllm:0.22.1-gpu-py312-cu130-ubuntu22.04-sagemaker-v1.0
 
 FROM ${BASE_IMAGE} AS base
@@ -10,9 +7,6 @@ FROM ${BASE_IMAGE} AS base
 LABEL maintainer="Hugging Face"
 LABEL hf_dlc_major_version="1"
 
-# Build-args the DLC harness (build_image.sh) always forwards. Declared so they
-# are consumed (no "unconsumed build-arg" warnings); the SageMaker dlc.* labels
-# themselves are attached by the harness, not here.
 ARG FRAMEWORK
 ARG FRAMEWORK_VERSION
 ARG CONTAINER_TYPE
@@ -30,7 +24,17 @@ RUN uv pip install --system \
   "huggingface-hub==${HUGGINGFACE_HUB_VERSION}" \
   "hf-xet==${HF_XET_VERSION}" \
   "grpcio>=1.79.3" \
-  && uv cache clean
+  && uv cache clean \
+  && rm -rf /tmp/uv*
+
+
+COPY ./scripts/telemetry/bash_telemetry.sh.template /tmp/bash_telemetry.sh.template
+RUN sed -e "s/{{FRAMEWORK}}/${FRAMEWORK}/g" \
+  -e "s/{{FRAMEWORK_VERSION}}/${FRAMEWORK_VERSION}/g" \
+  -e "s/{{CONTAINER_TYPE}}/${CONTAINER_TYPE}/g" \
+  /tmp/bash_telemetry.sh.template >/usr/local/bin/bash_telemetry.sh \
+  && chmod +x /usr/local/bin/bash_telemetry.sh \
+  && rm /tmp/bash_telemetry.sh.template
 
 # HF auto-optimization layer. Sourced by the entrypoint to set performance
 # defaults at run time: expandable_segments allocator and LMCache CPU
@@ -42,13 +46,10 @@ COPY --chmod=755 ./scripts/huggingface/vllm/hf_optimizations.sh /usr/local/bin/h
 
 FROM base AS huggingface-vllm-sagemaker
 
-# Daily cache-bust knob forwarded by build_image.sh (date stamp), matching the
-# docker/vllm convention.
 ARG CACHE_REFRESH=0
 
 ENV HF_HUB_USER_AGENT_ORIGIN="aws:sagemaker:gpu-cuda:inference:hf-vllm"
 
-# Copy CUDA compat and entrypoint scripts
 COPY --chmod=755 ./scripts/huggingface/vllm/start_cuda_compat.sh /usr/local/bin/start_cuda_compat.sh
 COPY --chmod=755 ./scripts/huggingface/vllm/sagemaker_entrypoint.sh /usr/local/bin/sagemaker_entrypoint.sh
 
@@ -57,16 +58,20 @@ RUN apt-get purge -y ffmpeg libav* || true && apt-get autoremove -y
 
 ARG FFMPEG_TAG=n8.1
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  pkg-config \
-  nasm \
-  yasm \
-  libmp3lame-dev \
-  libopus-dev \
-  libvorbis-dev \
-  libvpx-dev \
-  libx264-dev \
-  libx265-dev \
+# Patch openssl/libssl3 CVEs carried by the ubuntu22.04 base
+# (CVE-2026-45447 CRITICAL, CVE-2026-34180/45445/7383/9076 HIGH;
+# fixed in 3.0.2-0ubuntu1.25).
+RUN apt-get update && apt-get install -y --only-upgrade openssl libssl3 \
+  && apt-get install -y --no-install-recommends \
+    pkg-config \
+    nasm \
+    yasm \
+    libmp3lame-dev \
+    libopus-dev \
+    libvorbis-dev \
+    libvpx-dev \
+    libx264-dev \
+    libx265-dev \
   && git clone https://git.ffmpeg.org/ffmpeg.git /tmp/ffmpeg \
   && cd /tmp/ffmpeg \
   && git checkout "${FFMPEG_TAG}" \
@@ -104,6 +109,7 @@ RUN HOME_DIR=/root \
   && chmod +x /usr/local/bin/testOSSCompliance \
   && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
   && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} python3 \
-  && rm -rf ${HOME_DIR}/oss_compliance*
+  && rm -rf ${HOME_DIR}/oss_compliance* \
+  && rm -rf /tmp/uv* /tmp/tmp*
 
 ENTRYPOINT ["/usr/local/bin/sagemaker_entrypoint.sh"]

--- a/docker/huggingface/vllm/Dockerfile
+++ b/docker/huggingface/vllm/Dockerfile
@@ -1,0 +1,109 @@
+# syntax=docker/dockerfile:1
+
+# AWS-published vLLM DLC this image layers on top of. The build workflow passes
+# the resolved base via --build-arg BASE_IMAGE (build_image.sh always forwards
+# it); this default keeps standalone `docker build` working.
+ARG BASE_IMAGE=public.ecr.aws/deep-learning-containers/vllm:0.22.1-gpu-py312-cu130-ubuntu22.04-sagemaker-v1.0
+
+FROM ${BASE_IMAGE} AS base
+
+LABEL maintainer="Hugging Face"
+LABEL hf_dlc_major_version="1"
+
+# Build-args the DLC harness (build_image.sh) always forwards. Declared so they
+# are consumed (no "unconsumed build-arg" warnings); the SageMaker dlc.* labels
+# themselves are attached by the harness, not here.
+ARG FRAMEWORK
+ARG FRAMEWORK_VERSION
+ARG CONTAINER_TYPE
+
+ARG TRANSFORMERS_VERSION=5.10.2
+ARG HUGGINGFACE_HUB_VERSION=1.17.0
+ARG HF_XET_VERSION=1.5.0
+
+RUN apt-get update -y \
+  && apt-get install -y --no-install-recommends curl unzip \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN uv pip install --system \
+  "transformers==${TRANSFORMERS_VERSION}" \
+  "huggingface-hub==${HUGGINGFACE_HUB_VERSION}" \
+  "hf-xet==${HF_XET_VERSION}" \
+  "grpcio>=1.79.3" \
+  && uv cache clean
+
+# HF auto-optimization layer. Sourced by the entrypoint to set performance
+# defaults at run time: expandable_segments allocator and LMCache CPU
+# KV-offload. The bundled accelerators it enables (LMCache / NIXL /
+# runai-streamer) already ship in the AWS base. See inference/vllm/README.md
+# for the toggles.
+COPY --chmod=755 ./scripts/huggingface/vllm/hf_optimizations.sh /usr/local/bin/hf_optimizations.sh
+
+
+FROM base AS huggingface-vllm-sagemaker
+
+# Daily cache-bust knob forwarded by build_image.sh (date stamp), matching the
+# docker/vllm convention.
+ARG CACHE_REFRESH=0
+
+ENV HF_HUB_USER_AGENT_ORIGIN="aws:sagemaker:gpu-cuda:inference:hf-vllm"
+
+# Copy CUDA compat and entrypoint scripts
+COPY --chmod=755 ./scripts/huggingface/vllm/start_cuda_compat.sh /usr/local/bin/start_cuda_compat.sh
+COPY --chmod=755 ./scripts/huggingface/vllm/sagemaker_entrypoint.sh /usr/local/bin/sagemaker_entrypoint.sh
+
+# Fix ffmpeg related vulnerabilities CVE-2024-35366 / CVE-2024-35367 / CVE-2024-35368
+RUN apt-get purge -y ffmpeg libav* || true && apt-get autoremove -y
+
+ARG FFMPEG_TAG=n8.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  pkg-config \
+  nasm \
+  yasm \
+  libmp3lame-dev \
+  libopus-dev \
+  libvorbis-dev \
+  libvpx-dev \
+  libx264-dev \
+  libx265-dev \
+  && git clone https://git.ffmpeg.org/ffmpeg.git /tmp/ffmpeg \
+  && cd /tmp/ffmpeg \
+  && git checkout "${FFMPEG_TAG}" \
+  && ./configure \
+    --prefix=/usr/local \
+    --disable-debug \
+    --disable-doc \
+    --enable-gpl \
+    --enable-libmp3lame \
+    --enable-libopus \
+    --enable-libvorbis \
+    --enable-libvpx \
+    --enable-libx264 \
+    --enable-libx265 \
+  && make -j"$(nproc)" \
+  && make install \
+  && which ffmpeg \
+  && ffmpeg -version \
+  && ffprobe -version \
+  && rm -rf /tmp/ffmpeg \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+# NOTE: the mooncake-transfer-engine (CVE-2026-33186) and openssh
+# (CVE-2026-35385/35414/35386) backports the v0.21 image carried are dropped
+# here: the 0.22.1 base already ships the fixed versions
+# (mooncake-transfer-engine 0.3.10.post2, openssh 1:8.9p1-3ubuntu0.15).
+# ffmpeg above is still required (the base ships the vulnerable 4.4.2).
+
+RUN HOME_DIR=/root \
+  && uv pip install --system --upgrade pip requests PTable \
+  && curl -o ${HOME_DIR}/oss_compliance.zip https://aws-dlinfra-utilities.s3.amazonaws.com/oss_compliance.zip \
+  && unzip ${HOME_DIR}/oss_compliance.zip -d ${HOME_DIR}/ \
+  && cp ${HOME_DIR}/oss_compliance/test/testOSSCompliance /usr/local/bin/testOSSCompliance \
+  && chmod +x /usr/local/bin/testOSSCompliance \
+  && chmod +x ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh \
+  && ${HOME_DIR}/oss_compliance/generate_oss_compliance.sh ${HOME_DIR} python3 \
+  && rm -rf ${HOME_DIR}/oss_compliance*
+
+ENTRYPOINT ["/usr/local/bin/sagemaker_entrypoint.sh"]

--- a/docker/huggingface/vllm/Dockerfile
+++ b/docker/huggingface/vllm/Dockerfile
@@ -28,11 +28,14 @@ RUN uv pip install --system \
   && rm -rf /tmp/uv*
 
 
+# Same as vllm Dockerfile to make telemetry work
+COPY ./scripts/telemetry/deep_learning_container.py /usr/local/bin/deep_learning_container.py
 COPY ./scripts/telemetry/bash_telemetry.sh.template /tmp/bash_telemetry.sh.template
-RUN sed -e "s/{{FRAMEWORK}}/${FRAMEWORK}/g" \
-  -e "s/{{FRAMEWORK_VERSION}}/${FRAMEWORK_VERSION}/g" \
-  -e "s/{{CONTAINER_TYPE}}/${CONTAINER_TYPE}/g" \
-  /tmp/bash_telemetry.sh.template >/usr/local/bin/bash_telemetry.sh \
+RUN chmod +x /usr/local/bin/deep_learning_container.py \
+  && sed -e "s/{{FRAMEWORK}}/${FRAMEWORK}/g" \
+    -e "s/{{FRAMEWORK_VERSION}}/${FRAMEWORK_VERSION}/g" \
+    -e "s/{{CONTAINER_TYPE}}/${CONTAINER_TYPE}/g" \
+    /tmp/bash_telemetry.sh.template >/usr/local/bin/bash_telemetry.sh \
   && chmod +x /usr/local/bin/bash_telemetry.sh \
   && rm /tmp/bash_telemetry.sh.template
 

--- a/docker/huggingface/vllm/versions.env
+++ b/docker/huggingface/vllm/versions.env
@@ -1,0 +1,27 @@
+# versions.env — Pinned build-args for the Hugging Face vLLM image.
+# Source this file: source docker/huggingface/vllm/versions.env
+#
+# These override the Dockerfile ARG defaults at build time. Every var exported
+# here is auto-forwarded as --build-arg to docker buildx by the workflow (via
+# EXTRA_BUILD_ARGS).
+#
+# This image is a thin Hugging Face layer on top of the AWS-published vLLM DLC.
+# It does NOT build vLLM from source. The base image is passed by the workflow
+# as the `base-image` input (forwarded as --build-arg BASE_IMAGE), NOT exported
+# here — same convention as docker/vllm/versions.env. The Dockerfile's
+# BASE_IMAGE default must stay in sync with that workflow input.
+
+# ── Hugging Face libraries ─────────────────────────────────────
+export TRANSFORMERS_VERSION="5.10.2"
+export HUGGINGFACE_HUB_VERSION="1.17.0"
+export HF_XET_VERSION="1.5.0"
+
+# ── System dependencies ────────────────────────────────────────
+# ffmpeg is rebuilt from source to patch CVE-2024-35366/35367/35368
+# (the base ships the vulnerable 4.4.2).
+export FFMPEG_TAG="n8.1"
+
+# ── DLC image versioning ───────────────────────────────────────
+# Forwarded as build-args and consumed by the workflow for image tags/labels.
+export DLC_MAJOR_VERSION="1"
+export DLC_MINOR_VERSION="0"

--- a/scripts/huggingface/vllm/hf_optimizations.sh
+++ b/scripts/huggingface/vllm/hf_optimizations.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# HuggingFace vLLM auto-optimization layer.
+
+# ---- feature toggles -------------------------------------------------------
+: "${HF_ENABLE_EXPANDABLE_SEGMENTS:=1}"
+: "${HF_ENABLE_LMCACHE:=1}"
+: "${HF_ENABLE_RUNAI_STREAMER:=0}"  # opt-in
+: "${HF_LMCACHE_CPU_FRACTION:=0.5}" # share of total RAM for the LMCache CPU pool
+export HF_ENABLE_RUNAI_STREAMER
+
+hf_opt_log() { echo "[hf-opt] $*"; }
+
+# ---- 1. CUDA caching allocator: reduce fragmentation / OOM ------------------
+# expandable_segments (the CUDA VMM allocator) is INCOMPATIBLE with KV connectors
+# that pin/register KV memory: the allocator can remap KV virtual addresses to
+# different physical pages and invalidate those registrations, so vLLM rejects
+# the combination. LMCache (our default KV connector) therefore takes precedence
+# and we only set the allocator when LMCache is off.
+if [[ "${HF_ENABLE_EXPANDABLE_SEGMENTS}" == "1" && -z "${PYTORCH_CUDA_ALLOC_CONF:-}" ]]; then
+  if [[ "${HF_ENABLE_LMCACHE}" == "1" ]]; then
+    hf_opt_log "expandable_segments skipped (incompatible with the LMCache KV connector); LMCache takes precedence"
+  else
+    export PYTORCH_CUDA_ALLOC_CONF="expandable_segments:True"
+    hf_opt_log "PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True"
+  fi
+fi
+
+# ---- 2. LMCache CPU KV-offload ---------------------------------------------
+HF_LMCACHE_KV_CONFIG=""
+if [[ "${HF_ENABLE_LMCACHE}" == "1" ]]; then
+  _total_gb="$(awk '/MemTotal/{printf "%d", $2/1024/1024}' /proc/meminfo 2>/dev/null)"
+  : "${_total_gb:=0}"
+  _cpu_gb="$(awk "BEGIN{v=${_total_gb}*${HF_LMCACHE_CPU_FRACTION}; if(v<5)v=5; printf \"%d\", v}")"
+  : "${LMCACHE_LOCAL_CPU:=True}"
+  export LMCACHE_LOCAL_CPU
+  : "${LMCACHE_MAX_LOCAL_CPU_SIZE:=${_cpu_gb}}"
+  export LMCACHE_MAX_LOCAL_CPU_SIZE
+  : "${LMCACHE_CHUNK_SIZE:=256}"
+  export LMCACHE_CHUNK_SIZE
+  HF_LMCACHE_KV_CONFIG='{"kv_connector":"LMCacheConnectorV1","kv_role":"kv_both"}'
+  hf_opt_log "LMCache CPU offload enabled (LMCACHE_MAX_LOCAL_CPU_SIZE=${LMCACHE_MAX_LOCAL_CPU_SIZE} GB, chunk=${LMCACHE_CHUNK_SIZE})"
+  unset _total_gb _cpu_gb
+fi
+export HF_LMCACHE_KV_CONFIG

--- a/scripts/huggingface/vllm/sagemaker_entrypoint.sh
+++ b/scripts/huggingface/vllm/sagemaker_entrypoint.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+# Entrypoint for the SageMaker AI (server-sagemaker, omni-sagemaker) targets.
+#
+# Mirrors the AWS base contract — maps SM_VLLM_* env vars to vLLM CLI flags,
+# auto-detects the model from /opt/ml/model or HF_MODEL_ID, and launches via
+# standard-supervisor for process auto-recovery — and layers HF's performance
+# defaults on top. Anything the user sets via SM_VLLM_* always wins.
+
+# 1. CUDA forward-compat (sourced: may export LD_LIBRARY_PATH).
+if [[ -f /usr/local/bin/start_cuda_compat.sh ]]; then
+  source /usr/local/bin/start_cuda_compat.sh || true
+fi
+
+# 2. Telemetry (best-effort; present on the AWS base, absent upstream).
+[[ -f /usr/local/bin/bash_telemetry.sh ]] && bash /usr/local/bin/bash_telemetry.sh >/dev/null 2>&1 || true
+
+# 3. HF auto-optimization layer (sets env defaults + HF_LMCACHE_KV_CONFIG).
+source /usr/local/bin/hf_optimizations.sh
+
+# LMCache: expose the kv-transfer-config through the SM_VLLM_ contract so the
+# mapping below turns it into --kv-transfer-config, unless the user set one.
+#
+# standard-supervisor (the default, PROCESS_AUTO_RECOVERY=true) flattens argv
+# into a single string that supervisord re-parses with shlex — which strips the
+# JSON's double quotes and makes vLLM fail with "key must be a string". We
+# single-quote-wrap the value so shlex hands the clean JSON back. In direct mode
+# (PROCESS_AUTO_RECOVERY=false) argv is exec'd verbatim, so pass raw JSON.
+if [[ -n "${HF_LMCACHE_KV_CONFIG:-}" && -z "${SM_VLLM_KV_TRANSFER_CONFIG:-}" ]]; then
+  _auto_recovery="$(echo "${PROCESS_AUTO_RECOVERY:-true}" | tr '[:upper:]' '[:lower:]')"
+  if [[ "${_auto_recovery}" == "true" || "${_auto_recovery}" == "1" ]]; then
+    export SM_VLLM_KV_TRANSFER_CONFIG="'${HF_LMCACHE_KV_CONFIG}'"
+  else
+    export SM_VLLM_KV_TRANSFER_CONFIG="${HF_LMCACHE_KV_CONFIG}"
+  fi
+  unset _auto_recovery
+fi
+
+# runai-model-streamer (opt-in): default the load format for object-storage models.
+if [[ "${HF_ENABLE_RUNAI_STREAMER:-0}" == "1" && -z "${SM_VLLM_LOAD_FORMAT:-}" ]]; then
+  case "${SM_VLLM_MODEL:-${HF_MODEL_ID:-}}" in
+  s3://* | gs://* | azure://*) export SM_VLLM_LOAD_FORMAT="runai_streamer" ;;
+  esac
+fi
+
+PREFIX="SM_VLLM_"
+ARG_PREFIX="--"
+ARGS=(--port 8080)
+
+# Model auto-detection (when SM_VLLM_MODEL is not provided).
+if [[ -z "${SM_VLLM_MODEL:-}" ]]; then
+  if [[ -d /opt/ml/model && -n "$(ls -A /opt/ml/model 2>/dev/null)" ]]; then
+    echo "INFO: SM_VLLM_MODEL not set, auto-detected model at /opt/ml/model"
+    ARGS+=(--model /opt/ml/model)
+  elif [[ -n "${HF_MODEL_ID:-}" ]]; then
+    echo "INFO: SM_VLLM_MODEL not set, using HF_MODEL_ID=${HF_MODEL_ID}"
+    ARGS+=(--model "${HF_MODEL_ID}")
+  else
+    echo "WARNING: No model specified. Set SM_VLLM_MODEL, HF_MODEL_ID, or mount a model to /opt/ml/model."
+  fi
+fi
+
+# Map SM_VLLM_* -> --flag [value]; booleans: true=flag only, false=skip.
+while IFS='=' read -r key value; do
+  arg_name=$(echo "${key#"${PREFIX}"}" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+  lower_value=$(echo "${value}" | tr '[:upper:]' '[:lower:]')
+  if [[ "${lower_value}" == "true" ]]; then
+    ARGS+=("${ARG_PREFIX}${arg_name}")
+  elif [[ "${lower_value}" == "false" ]]; then
+    continue
+  else
+    ARGS+=("${ARG_PREFIX}${arg_name}")
+    [[ -n "${value}" ]] && ARGS+=("${value}")
+  fi
+done < <(env | grep "^${PREFIX}")
+
+# SageMaker routing middleware when the base provides it.
+if [[ -f /usr/local/bin/sagemaker_serve.py ]]; then
+  ARGS+=(--middleware sagemaker_serve.SageMakerRouteMiddleware)
+fi
+
+if command -v standard-supervisor >/dev/null 2>&1; then
+  exec standard-supervisor python3 -m vllm.entrypoints.openai.api_server "${ARGS[@]}"
+fi
+exec python3 -m vllm.entrypoints.openai.api_server "${ARGS[@]}"

--- a/scripts/huggingface/vllm/start_cuda_compat.sh
+++ b/scripts/huggingface/vllm/start_cuda_compat.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# SOURCE this from an entrypoint (it must export LD_LIBRARY_PATH into the parent
+# shell). It activates the CUDA forward-compatibility libraries when the host
+# NVIDIA driver is older than the toolkit baked into the image; if the host
+# driver is new enough, the compat layer is skipped and the host driver is used.
+#
+# Source-safe: defines a function and uses `return`, with no global `set -e`,
+# so it never terminates the entrypoint that sources it.
+
+_hf_start_cuda_compat() {
+  local compat_dir="/usr/local/cuda/compat"
+
+  if [[ ! -d "${compat_dir}" ]]; then
+    echo "[cuda-compat] no compat libraries present, using host driver"
+    return 0
+  fi
+
+  local compat_ver host_ver
+  compat_ver="$(cat "${compat_dir}/version" 2>/dev/null || echo "0")"
+  host_ver="$(nvidia-smi --query-gpu=driver_version --format=csv,noheader 2>/dev/null | head -n1 || echo "0")"
+  echo "[cuda-compat] host driver=${host_ver:-unknown} compat driver=${compat_ver}"
+
+  # verlte A B  -> true when A <= B
+  if [[ -n "${host_ver}" ]] && [[ "${compat_ver}" == "$(printf '%s\n%s' "${compat_ver}" "${host_ver}" | sort -V | head -n1)" ]]; then
+    echo "[cuda-compat] host driver is new enough, skipping compat layer"
+  else
+    echo "[cuda-compat] enabling forward-compat libraries from ${compat_dir}"
+    export LD_LIBRARY_PATH="${compat_dir}:${LD_LIBRARY_PATH:-}"
+  fi
+}
+
+_hf_start_cuda_compat

--- a/scripts/telemetry/deep_learning_container.py
+++ b/scripts/telemetry/deep_learning_container.py
@@ -242,6 +242,7 @@ def parse_args():
             "lambda",
             "ray",
             "vllm_omni",
+            "huggingface_vllm",
         ],
         help="framework of container image.",
         required=True,

--- a/test/security/data/ecr_scan_allowlist/huggingface_vllm/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/huggingface_vllm/framework_allowlist.json
@@ -1,0 +1,82 @@
+[
+    {
+        "vulnerability_id": "CVE-2026-32281",
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-33186",
+        "reason": "google.golang.org/grpc v1.59.0 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-25679",
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-32283",
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-32280",
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2025-68121",
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2025-61726",
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2025-23339",
+        "reason": "cuda-toolkit-config-common (12.9.79 \u2192 0:13.0.48-1) cuda is a key dependency that cannot be upgraded",
+        "review_by": "2026-11-28"
+    },
+    {
+        "vulnerability_id": "CVE-2025-23308",
+        "reason": "cuda-toolkit-config-common (12.9.79 \u2192 0:13.0.48-1) cuda is a key dependency that cannot be upgraded",
+        "review_by": "2026-11-28"
+    },
+    {
+        "vulnerability_id": "CVE-2026-33811",
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-39820",
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-33814",
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-39836",
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-42499",
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-39821",
+        "reason": "golang.org/x/net v0.38.0 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-42504",
+        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    }
+]


### PR DESCRIPTION
## Purpose

Add the first Hugging Face DLC under build system v2: the
**HF vLLM 0.22.1 SageMaker** image. It layers the HF stack (`transformers`,
`huggingface-hub`, `hf-xet`), a runtime optimization layer (LMCache CPU
KV-offload + expandable-segments), an HF SageMaker entrypoint, and an ffmpeg
CVE rebuild on top of the AWS-published vLLM DLC (no source build).

Also wires the PR CI: `pr-huggingface-vllm-sagemaker.yml` (build + sanity +
security + telemetry), image config, and a seeded ECR scan allowlist.
Release/endpoint tests are out of scope (`release: false`, `prod_image` is a TODO).

## Test Plan

The new `PR - Hugging Face vLLM SageMaker` workflow builds the image and runs
sanity, security (ECR scan), and telemetry tests.

## Test Result

- ✅ `pre-commit run --all-files` and `docker build --check` pass locally.
- ⏳ build/sanity/security/telemetry run in this PR's CI (need AWS runners).
______________________________________________________________________

## PR Checklist

- [x] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).
