### PR TITLE
Enable XGBoost 3.0.5 SageMaker release to preprod

### DIFF
--- a/.github/config/image/sagemaker-xgboost-3.0.yml
+++ b/.github/config/image/sagemaker-xgboost-3.0.yml
@@ -19,9 +19,9 @@ common:
   contributor: "None"
 
 release:
-  release: false
+  release: true
   force_release: false
   public_registry: true
   private_registry: true
   enable_soci: false
-  environment: gamma
+  environment: preprod


### PR DESCRIPTION
## Purpose

Enable the SageMaker XGBoost 3.0.5 image to be released, targeting the **preprod** environment first.

A customer support case (account on `sagemaker-xgboost:3.0-5`) flagged CVE-2026-31431. The CVE itself is a kernel-header finding (`linux-libc-dev` / `kmod`) with no fixed Ubuntu 20.04 package — it is already allowlisted in our scan as non-applicable-in-container. This change publishes a freshly-rebuilt 3.0-5 image so customers still on the 3.0 line pick up the latest available OS package patches (for all other packages) and a refreshed image SHA.

## Change

`.github/config/image/sagemaker-xgboost-3.0.yml`:
- `release: false` -> `true`
- `environment: gamma` -> `preprod`

Release is cut via the existing `dispatch-release-sagemaker-xgboost-3.0.5.yml` (`workflow_dispatch`), which rebuilds from `docker/xgboost/3.0-5/Dockerfile` + the `release-3.0.5` container branch and runs security/unit/integ tests before publishing.

## Notes

- Preprod first — promote to `production` in a follow-up once preprod is verified.
- This rebuild refreshes all OS packages but does not clear CVE-2026-31431 (no fixed Ubuntu 20.04 kernel-headers package exists). The clean-scan path for that specific CVE is migrating to the XGBoost 3.2.0 AL2023 image.
