### PR TITLE
[Docs Update] SGLang Server AL2023 v1.0 (EC2 + SageMaker)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@ __pycache__
 .gem-config
 
 # Generated docs
-docs/index.md
 docs/tutorials
 docs/releasenotes/*/
 docs/reference/available_images.md

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
         language: python
         additional_dependencies: [flowmark]
         files: ^docs/
-        exclude: (\.template\.md$|(README|DEVELOPMENT)\.md$)
+        exclude: (\.template\.md$|(README|DEVELOPMENT)\.md$|^docs/index\.md$)
         types: [markdown]
 
   - repo: https://github.com/hukkin/mdformat

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -4,6 +4,7 @@ nav:
     - user_guide/index.md
     - vLLM: vllm
     - vLLM-Omni: vllm-omni
+    - SGLang: sglang
     - TEI: tei
     - Ray: ray
     - PyTorch: pytorch

--- a/docs/get_started/using_dlcs.md
+++ b/docs/get_started/using_dlcs.md
@@ -1,7 +1,7 @@
 # Using {{ dlc }}
 
 This page shows common deployment patterns across frameworks. For framework-specific deep dives, see the dedicated guides: [vLLM](../vllm/index.md),
-[vLLM-Omni](../vllm-omni/index.md), [Ray](../ray/index.md).
+[SGLang](../sglang/index.md), [vLLM-Omni](../vllm-omni/index.md), [Ray](../ray/index.md).
 
 ## Additional Resources
 
@@ -18,7 +18,7 @@ This page shows common deployment patterns across frameworks. For framework-spec
 from sagemaker.model import Model
 
 model = Model(
-    image_uri="{{ images.latest_sglang_sagemaker }}",
+    image_uri="{{ images.latest_sglang_server_sagemaker }}",
     role="arn:aws:iam::<account_id>:role/<role_name>",
     env={
         "SM_SGLANG_MODEL_PATH": "meta-llama/Llama-3.1-8B-Instruct",
@@ -64,7 +64,7 @@ sagemaker = boto3.client("sagemaker")
 sagemaker.create_model(
     ModelName="sglang-model",
     PrimaryContainer={
-        "Image": "{{ images.latest_sglang_sagemaker }}",
+        "Image": "{{ images.latest_sglang_server_sagemaker }}",
         "Environment": {
             "SM_SGLANG_MODEL_PATH": "meta-llama/Llama-3.1-8B-Instruct",
             "HF_TOKEN": "<your_hf_token>",
@@ -81,7 +81,7 @@ sagemaker.create_endpoint_config(
             "ModelName": "sglang-model",
             "InstanceType": "ml.g5.2xlarge",
             "InitialInstanceCount": 1,
-            "InferenceAmiVersion": "al2-ami-sagemaker-inference-gpu-3-1",
+            "InferenceAmiVersion": "al2023-ami-sagemaker-inference-gpu-4-1",
         }
     ],
 )
@@ -150,5 +150,6 @@ docker run -it --gpus all -v /local/data:/data {{ images.latest_pytorch_training
 - [Available Images](../reference/available_images.md) - Browse all container images
 - [Support Policy](../reference/support_policy.md) - Framework versions and timelines
 - [vLLM Guide](../vllm/index.md) - Detailed vLLM deployment (EC2, SageMaker, EKS)
+- [SGLang Guide](../sglang/index.md) - Detailed SGLang deployment (EC2, SageMaker, EKS)
 - [Ray Guide](../ray/index.md) - Ray Serve deployment with examples
 - [vLLM-Omni Guide](../vllm-omni/index.md) - Multimodal serving (TTS, image, video)

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,45 +44,45 @@ LLM serving is just one example. DLCs cover a range of AI/ML workloads — explo
 
 <div class="grid cards" style="grid-template-columns: repeat(3, 1fr);" markdown>
 
-- **Serve Large Language Models**
+-   **Serve Large Language Models**
 
-  * * *
+    ---
 
-  Deploy large language models with vLLM or SGLang on EC2, EKS, or Amazon SageMaker AI.
+    Deploy large language models with vLLM or SGLang on EC2, EKS, or Amazon SageMaker AI.
 
-  [vLLM Guide](vllm/index.md) · [SGLang Guide](sglang/index.md)
+    [vLLM Guide](vllm/index.md) · [SGLang Guide](sglang/index.md)
 
-- **Serve Multimodal Models**
+-   **Serve Multimodal Models**
 
-  * * *
+    ---
 
-  Serve TTS, image generation, video generation, and omni-chat models with vLLM-Omni.
+    Serve TTS, image generation, video generation, and omni-chat models with vLLM-Omni.
 
-  [vLLM-Omni Guide](vllm-omni/index.md)
+    [vLLM-Omni Guide](vllm-omni/index.md)
 
-- **Serve ML Models**
+-   **Serve ML Models**
 
-  * * *
+    ---
 
-  Deploy any ML model with Ray Serve on EC2 or Amazon SageMaker AI — NLP, vision, audio, and tabular.
+    Deploy any ML model with Ray Serve on EC2 or Amazon SageMaker AI — NLP, vision, audio, and tabular.
 
-  [Ray Guide](ray/index.md)
+    [Ray Guide](ray/index.md)
 
-- **Train Models**
+-   **Train Models**
 
-  * * *
+    ---
 
-  Run distributed training with PyTorch on GPU or CPU, with EFA, NCCL, flash-attn, and DeepSpeed pre-installed.
+    Run distributed training with PyTorch on GPU or CPU, with EFA, NCCL, flash-attn, and DeepSpeed pre-installed.
 
-  [PyTorch Guide](pytorch/index.md)
+    [PyTorch Guide](pytorch/index.md)
 
-- **Build Your Own Image**
+-   **Build Your Own Image**
 
-  * * *
+    ---
 
-  Use the lightweight Base images (CUDA + Python on Amazon Linux 2023) as the `FROM` for your custom AI/ML container.
+    Use the lightweight Base images (CUDA + Python on Amazon Linux 2023) as the `FROM` for your custom AI/ML container.
 
-  [Base Guide](base/index.md)
+    [Base Guide](base/index.md)
 
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -49,9 +49,9 @@ LLM serving is just one example. DLCs cover a range of AI/ML workloads — explo
 
     ---
 
-    Deploy large language models with vLLM on EC2, EKS, or Amazon SageMaker AI.
+    Deploy large language models with vLLM or SGLang on EC2, EKS, or Amazon SageMaker AI.
 
-    [vLLM Guide](vllm/index.md) · [SGLang Images](reference/available_images.md#sglang)
+    [vLLM Guide](vllm/index.md) · [SGLang Guide](sglang/index.md)
 
 -   **Serve Multimodal Models**
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,24 +3,23 @@ hide:
   - navigation
   - toc
 ---
-
-<div align="center">
-<img src="assets/logos/AWS_logo_RGB.svg#only-light" alt="AWS Logo" width="30%">
-<img src="assets/logos/AWS_logo_RGB_REV.svg#only-dark" alt="AWS Logo" width="30%">
-</div>
+<div align="center"> <img src="assets/logos/AWS_logo_RGB.svg#only-light" alt="AWS Logo" width="30%">
+<img src="assets/logos/AWS_logo_RGB_REV.svg#only-dark" alt="AWS Logo" width="30%"> </div>
 
 <h1 align="center">AWS Deep Learning Containers</h1>
 
-<p align="center"><strong>Pre-built Docker images for running AI/ML workloads on AWS.</strong></p>
-<p align="center">Tested for performance and patched for security vulnerabilities.</p>
+<p align="center"><strong>Pre-built Docker images for running AI/ML workloads on AWS.</strong></p> <p align="center">Tested for performance and
+patched for security vulnerabilities.</p>
 
----
+* * *
 
 ## What are DLCs?
 
-AWS Deep Learning Containers (DLCs) are Docker images pre-configured with deep learning frameworks and tools. AWS builds, tests, and security-patches them so you can focus on your workload instead of environment setup.
+AWS Deep Learning Containers (DLCs) are Docker images pre-configured with deep learning frameworks and tools. AWS builds, tests, and security-patches
+them so you can focus on your workload instead of environment setup.
 
-Each image includes a framework (e.g. vLLM, PyTorch, Ray), its dependencies, and optimized libraries — ready to run on AWS compute services. All DLC images are provided at no cost — you only pay for the compute resources you use.
+Each image includes a framework (e.g. vLLM, PyTorch, Ray), its dependencies, and optimized libraries — ready to run on AWS compute services. All DLC
+images are provided at no cost — you only pay for the compute resources you use.
 
 ## Getting Started
 
@@ -45,57 +44,55 @@ LLM serving is just one example. DLCs cover a range of AI/ML workloads — explo
 
 <div class="grid cards" style="grid-template-columns: repeat(3, 1fr);" markdown>
 
--   **Serve Large Language Models**
+- **Serve Large Language Models**
 
-    ---
+  * * *
 
-    Deploy large language models with vLLM or SGLang on EC2, EKS, or Amazon SageMaker AI.
+  Deploy large language models with vLLM or SGLang on EC2, EKS, or Amazon SageMaker AI.
 
-    [vLLM Guide](vllm/index.md) · [SGLang Guide](sglang/index.md)
+  [vLLM Guide](vllm/index.md) · [SGLang Guide](sglang/index.md)
 
--   **Serve Multimodal Models**
+- **Serve Multimodal Models**
 
-    ---
+  * * *
 
-    Serve TTS, image generation, video generation, and omni-chat models with vLLM-Omni.
+  Serve TTS, image generation, video generation, and omni-chat models with vLLM-Omni.
 
-    [vLLM-Omni Guide](vllm-omni/index.md)
+  [vLLM-Omni Guide](vllm-omni/index.md)
 
--   **Serve ML Models**
+- **Serve ML Models**
 
-    ---
+  * * *
 
-    Deploy any ML model with Ray Serve on EC2 or Amazon SageMaker AI — NLP, vision, audio, and tabular.
+  Deploy any ML model with Ray Serve on EC2 or Amazon SageMaker AI — NLP, vision, audio, and tabular.
 
-    [Ray Guide](ray/index.md)
+  [Ray Guide](ray/index.md)
 
--   **Train Models**
+- **Train Models**
 
-    ---
+  * * *
 
-    Run distributed training with PyTorch on GPU or CPU, with EFA, NCCL, flash-attn, and DeepSpeed pre-installed.
+  Run distributed training with PyTorch on GPU or CPU, with EFA, NCCL, flash-attn, and DeepSpeed pre-installed.
 
-    [PyTorch Guide](pytorch/index.md)
+  [PyTorch Guide](pytorch/index.md)
 
--   **Build Your Own Image**
+- **Build Your Own Image**
 
-    ---
+  * * *
 
-    Use the lightweight Base images (CUDA + Python on Amazon Linux 2023) as the `FROM` for your custom AI/ML container.
+  Use the lightweight Base images (CUDA + Python on Amazon Linux 2023) as the `FROM` for your custom AI/ML container.
 
-    [Base Guide](base/index.md)
+  [Base Guide](base/index.md)
 
 </div>
 
-For step-by-step walkthroughs on EKS, SageMaker, and more, see our [blog posts](tutorials/index.md). You can also [subscribe to release notifications](get_started/release_notifications.md) to stay up to date with new images.
+For step-by-step walkthroughs on EKS, SageMaker, and more, see our [blog posts](tutorials/index.md). You can also
+[subscribe to release notifications](get_started/release_notifications.md) to stay up to date with new images.
 
 Looking for something else? [Let us know on GitHub](https://github.com/aws/deep-learning-containers/issues).
 
----
+* * *
 
-<p align="center">
-<a href="https://github.com/aws/deep-learning-containers">GitHub</a> ·
-<a href="https://gallery.ecr.aws/deep-learning-containers">ECR Gallery</a> ·
-<a href="reference/support_policy/">Support Policy</a> ·
-<a href="security/">Security</a>
-</p>
+<p align="center"> <a href="https://github.com/aws/deep-learning-containers">GitHub</a> ·
+<a href="https://gallery.ecr.aws/deep-learning-containers">ECR Gallery</a> · <a href="reference/support_policy/">Support Policy</a> ·
+<a href="security/">Security</a> </p>

--- a/docs/sglang/.nav.yml
+++ b/docs/sglang/.nav.yml
@@ -3,6 +3,7 @@ nav:
   - Supported Models: models/index.md
   - Deployment:
     - EC2: deployment/ec2.md
+    - EKS: deployment/eks.md
     - Amazon SageMaker AI: deployment/sagemaker.md
   - Configuration: configuration.md
   - Changelog: changelog/index.md

--- a/docs/sglang/.nav.yml
+++ b/docs/sglang/.nav.yml
@@ -1,0 +1,8 @@
+nav:
+  - Overview: index.md
+  - Supported Models: models/index.md
+  - Deployment:
+    - EC2: deployment/ec2.md
+    - Amazon SageMaker AI: deployment/sagemaker.md
+  - Configuration: configuration.md
+  - Changelog: changelog/index.md

--- a/docs/sglang/changelog/index.md
+++ b/docs/sglang/changelog/index.md
@@ -1,0 +1,24 @@
+# Changelog
+
+Changelog for the Amazon Linux 2023-based SGLang images (`server-cuda`, `server-sagemaker-cuda`).
+
+* * *
+
+## v1.0.0 — 2026-06-12
+
+**Tags:** `server-cuda-v1.0` · `server-sagemaker-cuda-v1.0`
+
+**SGLang source:** [578d27e](https://github.com/sgl-project/sglang/commit/578d27e56acd6786eb7067b9e1583232fd1d998e) (`0.5.12+amzn2023.578d27e`)
+
+**Bundled versions:** CUDA 13.0.3 · Python 3.12 · PyTorch 2.11.0 · sgl-kernel 0.4.3 · FlashInfer 0.6.11.post1 · Mooncake 0.3.9 · NCCL 2.28.3
+
+### Highlights
+
+- Initial release of SGLang Server containers on Amazon Linux 2023
+- Built from upstream SGLang source (not the pre-built `lmsysorg/sglang` image)
+- Simplified tag format: `server-cuda[-vMAJOR[.MINOR[.PATCH]]]`
+- OpenAI-compatible API server on port 30000 (EC2 / EKS) and 8080 (SageMaker)
+- Multi-GPU inference via tensor parallelism with NCCL
+- CUDA 13.0 build targeting H100 (sm_90) and Blackwell (sm_100, sm_103)
+- EFA support for multi-node deployments
+- DeepEP expert-parallel kernels and Mooncake KV-cache transfer bundled for large MoE models

--- a/docs/sglang/configuration.md
+++ b/docs/sglang/configuration.md
@@ -43,12 +43,11 @@ flag entirely.
 | `SM_SGLANG_DTYPE` | Data type (auto, bfloat16, float16) | `auto` |
 | `SM_SGLANG_QUANTIZATION` | Quantization method (fp8, awq, gptq, …) | None |
 | `SM_SGLANG_TRUST_REMOTE_CODE` | Allow custom model code from the Hub | `false` |
-| `SM_SGLANG_PORT` | Server port | `8080` |
-| `SM_SGLANG_HOST` | Bind address | `0.0.0.0` |
 | `HF_TOKEN` | Hugging Face token for gated models | — |
 
-The entrypoint always supplies `--port 8080`, `--host 0.0.0.0`, and `--model-path /opt/ml/model` unless you override them via the matching
-`SM_SGLANG_*` variable.
+The entrypoint defaults to `--port 8080` and `--host 0.0.0.0`, and you should leave them there: SageMaker forwards `/ping` and `/invocations` to
+port 8080, so changing the port or host breaks endpoint routing. The `--model-path` defaults to `/opt/ml/model` (where SageMaker mounts model
+artifacts) unless you set `SM_SGLANG_MODEL_PATH`.
 
 ## Full Reference
 

--- a/docs/sglang/configuration.md
+++ b/docs/sglang/configuration.md
@@ -1,0 +1,56 @@
+# Configuration
+
+## EC2 / EKS (`server-cuda`)
+
+Pass SGLang server arguments directly to `docker run`. The entrypoint forwards them to `python3 -m sglang.launch_server`:
+
+```bash
+docker run --gpus all -p 30000:30000 \
+  public.ecr.aws/deep-learning-containers/sglang:server-cuda \
+  --model-path openai/gpt-oss-20b \
+  --tp 4 \
+  --context-length 4096
+```
+
+| Argument | Description | Default |
+| --- | --- | --- |
+| `--model-path` | Model ID or path (required) | — |
+| `--host` | Bind address | `127.0.0.1` |
+| `--port` | Server port | `30000` |
+| `--tp` | Tensor-parallel size (number of GPUs) | `1` |
+| `--context-length` | Maximum sequence length | Model default |
+| `--mem-fraction-static` | Fraction of GPU memory for the KV cache pool | Auto |
+| `--dtype` | Data type (auto, bfloat16, float16) | `auto` |
+| `--quantization` | Quantization method (fp8, awq, gptq, …) | None |
+| `--trust-remote-code` | Allow custom model code from the Hub | `false` |
+| `--disable-piecewise-cuda-graph` | Disable experimental piecewise CUDA graph capture | `false` |
+
+For gated models (Llama, Gemma, etc.), pass `-e HF_TOKEN=<your_hf_token>`.
+
+## Amazon SageMaker AI (`server-sagemaker-cuda`)
+
+The SageMaker image serves on **port 8080** and accepts SGLang flags via `SM_SGLANG_*` environment variables. Each variable is converted to the
+corresponding SGLang flag — the name is lowercased and underscores become hyphens (e.g., `SM_SGLANG_CONTEXT_LENGTH=4096` → `--context-length 4096`).
+Boolean values follow shell convention: `true` becomes a bare flag (`SM_SGLANG_TRUST_REMOTE_CODE=true` → `--trust-remote-code`), and `false` omits the
+flag entirely.
+
+| Variable | Description | Default |
+| --- | --- | --- |
+| `SM_SGLANG_MODEL_PATH` | Model ID or path (defaults to `/opt/ml/model` when SageMaker mounts artifacts) | `/opt/ml/model` |
+| `SM_SGLANG_TP` | Tensor-parallel size (number of GPUs) | `1` |
+| `SM_SGLANG_CONTEXT_LENGTH` | Maximum sequence length | Model default |
+| `SM_SGLANG_MEM_FRACTION_STATIC` | Fraction of GPU memory for the KV cache pool | Auto |
+| `SM_SGLANG_DTYPE` | Data type (auto, bfloat16, float16) | `auto` |
+| `SM_SGLANG_QUANTIZATION` | Quantization method (fp8, awq, gptq, …) | None |
+| `SM_SGLANG_TRUST_REMOTE_CODE` | Allow custom model code from the Hub | `false` |
+| `SM_SGLANG_PORT` | Server port | `8080` |
+| `SM_SGLANG_HOST` | Bind address | `0.0.0.0` |
+| `HF_TOKEN` | Hugging Face token for gated models | — |
+
+The entrypoint always supplies `--port 8080`, `--host 0.0.0.0`, and `--model-path /opt/ml/model` unless you override them via the matching
+`SM_SGLANG_*` variable.
+
+## Full Reference
+
+- [SGLang server arguments](https://docs.sglang.ai/advanced_features/server_arguments.html)
+- [SGLang hyperparameter tuning](https://docs.sglang.ai/advanced_features/hyperparameter_tuning.html)

--- a/docs/sglang/configuration.md
+++ b/docs/sglang/configuration.md
@@ -45,9 +45,9 @@ flag entirely.
 | `SM_SGLANG_TRUST_REMOTE_CODE` | Allow custom model code from the Hub | `false` |
 | `HF_TOKEN` | Hugging Face token for gated models | — |
 
-The entrypoint defaults to `--port 8080` and `--host 0.0.0.0`, and you should leave them there: SageMaker forwards `/ping` and `/invocations` to
-port 8080, so changing the port or host breaks endpoint routing. The `--model-path` defaults to `/opt/ml/model` (where SageMaker mounts model
-artifacts) unless you set `SM_SGLANG_MODEL_PATH`.
+The entrypoint defaults to `--port 8080` and `--host 0.0.0.0`, and you should leave them there: SageMaker forwards `/ping` and `/invocations` to port
+8080, so changing the port or host breaks endpoint routing. The `--model-path` defaults to `/opt/ml/model` (where SageMaker mounts model artifacts)
+unless you set `SM_SGLANG_MODEL_PATH`.
 
 ## Full Reference
 

--- a/docs/sglang/deployment/ec2.md
+++ b/docs/sglang/deployment/ec2.md
@@ -1,0 +1,52 @@
+# EC2 Deployment
+
+The container runs the SGLang OpenAI-compatible API server on port 30000. Any `sglang.launch_server` flag may be appended to `docker run`. See
+[Configuration](../configuration.md) for the full list of server arguments.
+
+## Single GPU
+
+```bash
+docker run --gpus all -p 30000:30000 \
+  public.ecr.aws/deep-learning-containers/sglang:server-cuda \
+  --model-path openai/gpt-oss-20b \
+  --host 0.0.0.0 --port 30000
+```
+
+For gated models (Llama, Gemma, etc.), pass `-e HF_TOKEN=<your_hf_token>`.
+
+Send a request:
+
+```bash
+curl http://localhost:30000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "openai/gpt-oss-20b",
+    "messages": [{"role": "user", "content": "What is deep learning?"}],
+    "max_tokens": 256
+  }'
+```
+
+## Multi-GPU (Tensor Parallelism)
+
+For models that require multiple GPUs (e.g., 70B+):
+
+```bash
+docker run --gpus all --ipc=host -p 30000:30000 \
+  -e HF_TOKEN=<your_hf_token> \
+  public.ecr.aws/deep-learning-containers/sglang:server-cuda \
+  --model-path meta-llama/Llama-3.3-70B-Instruct \
+  --tp 8 \
+  --host 0.0.0.0 --port 30000
+```
+
+`--ipc=host` enables shared memory between GPU processes.
+
+## Model-Specific Tuning
+
+For recommended serving flags, hardware configurations, and quantization options per model, see the
+[SGLang hyperparameter tuning guide](https://docs.sglang.ai/advanced_features/hyperparameter_tuning.html). A few notes from our regression suite:
+
+- **FP8 MoE models** (e.g., Qwen3 Coder, Qwen3.5-35B-A3B): block-quantized weights require each tensor-parallel shard's gate/up `output_size` to be a
+  multiple of 128. On an 8-GPU host, use `--tp 4` rather than `--tp 8`.
+- **Large dense models** (e.g., Llama 3.3 70B): pass `--mem-fraction-static 0.88` and `--disable-piecewise-cuda-graph` to reduce compile-time host
+  memory during warmup.

--- a/docs/sglang/deployment/eks.md
+++ b/docs/sglang/deployment/eks.md
@@ -1,0 +1,82 @@
+# EKS Deployment
+
+The SGLang container works directly with Kubernetes manifests on Amazon EKS. It serves the OpenAI-compatible API on port 30000 — the same as
+[EC2](ec2.md) — so any `sglang.launch_server` flag may be passed via the container `args`.
+
+## Deployment Example
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sglang-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sglang-server
+  template:
+    metadata:
+      labels:
+        app: sglang-server
+    spec:
+      containers:
+        - name: sglang
+          image: public.ecr.aws/deep-learning-containers/sglang:server-cuda
+          args:
+            - "--model-path"
+            - "openai/gpt-oss-20b"
+            - "--host"
+            - "0.0.0.0"
+            - "--port"
+            - "30000"
+          ports:
+            - containerPort: 30000
+          resources:
+            limits:
+              nvidia.com/gpu: "1"
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 30000
+            initialDelaySeconds: 120
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 30000
+            initialDelaySeconds: 120
+```
+
+## Key Requirements
+
+- Request GPU resources via `resources.limits.nvidia.com/gpu`
+- Pass `--host 0.0.0.0` so the server binds to all interfaces
+- Use `/health` on port 30000 for liveness and readiness probes
+- Set `initialDelaySeconds` high enough for model loading (120s+ for large models)
+- For gated models, provide `HF_TOKEN` via a Kubernetes Secret:
+
+```yaml
+env:
+  - name: HF_TOKEN
+    valueFrom:
+      secretKeyRef:
+        name: hf-secret
+        key: token
+```
+
+## Multi-GPU
+
+For tensor parallelism across multiple GPUs on a single node:
+
+```yaml
+resources:
+  limits:
+    nvidia.com/gpu: "4"
+```
+
+Add `--tp 4` to the container args and ensure the node has 4+ GPUs available.
+
+## Model-Specific Tuning
+
+For recommended serving flags, hardware configurations, and quantization options per model, see the
+[SGLang hyperparameter tuning guide](https://docs.sglang.ai/advanced_features/hyperparameter_tuning.html) and [Supported Models](../models/index.md).

--- a/docs/sglang/deployment/sagemaker.md
+++ b/docs/sglang/deployment/sagemaker.md
@@ -29,7 +29,7 @@ model = Model(
 predictor = model.deploy(
     instance_type="ml.g5.2xlarge",
     initial_instance_count=1,
-    inference_ami_version="al2-ami-sagemaker-inference-gpu-3-1",
+    inference_ami_version="al2023-ami-sagemaker-inference-gpu-4-1",
     serializer=JSONSerializer(),
 )
 
@@ -70,7 +70,7 @@ ep_cfg = EndpointConfig.create(
             model_name="sglang-model",
             instance_type="ml.g5.2xlarge",
             initial_instance_count=1,
-            inference_ami_version="al2-ami-sagemaker-inference-gpu-3-1",
+            inference_ami_version="al2023-ami-sagemaker-inference-gpu-4-1",
         ),
     ],
 )
@@ -121,7 +121,7 @@ sm.create_endpoint_config(
         "ModelName": "sglang-model",
         "InstanceType": "ml.g5.2xlarge",
         "InitialInstanceCount": 1,
-        "InferenceAmiVersion": "al2-ami-sagemaker-inference-gpu-3-1",
+        "InferenceAmiVersion": "al2023-ami-sagemaker-inference-gpu-4-1",
     }],
 )
 

--- a/docs/sglang/deployment/sagemaker.md
+++ b/docs/sglang/deployment/sagemaker.md
@@ -1,0 +1,167 @@
+# Amazon SageMaker AI Deployment
+
+Deploy SGLang on Amazon SageMaker AI endpoints. The SageMaker image variant accepts model configuration via environment variables and serves on port
+8080\.
+
+## Specifying the Model
+
+The SageMaker image resolves the model in this order:
+
+1. **`SM_SGLANG_MODEL_PATH` environment variable** — explicit Hugging Face ID or path
+2. **`/opt/ml/model`** — when SageMaker mounts model artifacts via `ModelDataUrl` or `ModelDataSource`, the entrypoint uses this path by default
+
+For gated models, also pass `HF_TOKEN`.
+
+## SageMaker Python SDK v2
+
+```python
+from sagemaker.model import Model
+from sagemaker.predictor import Predictor
+from sagemaker.serializers import JSONSerializer
+
+model = Model(
+    image_uri="{{ images.latest_sglang_server_sagemaker }}",
+    role="arn:aws:iam::<account_id>:role/<role_name>",
+    predictor_cls=Predictor,
+    env={"SM_SGLANG_MODEL_PATH": "openai/gpt-oss-20b"},
+)
+
+predictor = model.deploy(
+    instance_type="ml.g5.2xlarge",
+    initial_instance_count=1,
+    inference_ami_version="al2-ami-sagemaker-inference-gpu-3-1",
+    serializer=JSONSerializer(),
+)
+
+response = predictor.predict({
+    "model": "openai/gpt-oss-20b",
+    "messages": [{"role": "user", "content": "What is deep learning?"}],
+    "max_tokens": 256,
+})
+print(response)
+
+# Cleanup
+predictor.delete_model()
+predictor.delete_endpoint(delete_endpoint_config=True)
+```
+
+## SageMaker Python SDK v3
+
+```python
+import json
+import boto3
+from sagemaker.core.resources import Endpoint, EndpointConfig, Model
+from sagemaker.core.shapes import ContainerDefinition, ProductionVariant
+
+model = Model.create(
+    model_name="sglang-model",
+    primary_container=ContainerDefinition(
+        image="{{ images.latest_sglang_server_sagemaker }}",
+        environment={"SM_SGLANG_MODEL_PATH": "openai/gpt-oss-20b"},
+    ),
+    execution_role_arn="arn:aws:iam::<account_id>:role/<role_name>",
+)
+
+ep_cfg = EndpointConfig.create(
+    endpoint_config_name="sglang-config",
+    production_variants=[
+        ProductionVariant(
+            variant_name="default",
+            model_name="sglang-model",
+            instance_type="ml.g5.2xlarge",
+            initial_instance_count=1,
+            inference_ami_version="al2-ami-sagemaker-inference-gpu-3-1",
+        ),
+    ],
+)
+
+endpoint = Endpoint.create(endpoint_name="sglang-endpoint", endpoint_config_name="sglang-config")
+endpoint.wait_for_status("InService")
+
+smrt = boto3.client("sagemaker-runtime")
+resp = smrt.invoke_endpoint(
+    EndpointName="sglang-endpoint",
+    ContentType="application/json",
+    Body=json.dumps({
+        "model": "openai/gpt-oss-20b",
+        "messages": [{"role": "user", "content": "What is deep learning?"}],
+        "max_tokens": 256,
+    }),
+)
+print(json.loads(resp["Body"].read()))
+
+# Cleanup
+endpoint.delete()
+ep_cfg.delete()
+model.delete()
+```
+
+## Boto3
+
+```python
+import json
+import boto3
+
+sm = boto3.client("sagemaker")
+smrt = boto3.client("sagemaker-runtime")
+
+sm.create_model(
+    ModelName="sglang-model",
+    PrimaryContainer={
+        "Image": "{{ images.latest_sglang_server_sagemaker }}",
+        "Environment": {"SM_SGLANG_MODEL_PATH": "openai/gpt-oss-20b"},
+    },
+    ExecutionRoleArn="arn:aws:iam::<account_id>:role/<role_name>",
+)
+
+sm.create_endpoint_config(
+    EndpointConfigName="sglang-config",
+    ProductionVariants=[{
+        "VariantName": "default",
+        "ModelName": "sglang-model",
+        "InstanceType": "ml.g5.2xlarge",
+        "InitialInstanceCount": 1,
+        "InferenceAmiVersion": "al2-ami-sagemaker-inference-gpu-3-1",
+    }],
+)
+
+sm.create_endpoint(EndpointName="sglang-endpoint", EndpointConfigName="sglang-config")
+sm.get_waiter("endpoint_in_service").wait(EndpointName="sglang-endpoint")
+
+resp = smrt.invoke_endpoint(
+    EndpointName="sglang-endpoint",
+    ContentType="application/json",
+    Body=json.dumps({
+        "model": "openai/gpt-oss-20b",
+        "messages": [{"role": "user", "content": "What is deep learning?"}],
+        "max_tokens": 256,
+    }),
+)
+print(json.loads(resp["Body"].read()))
+
+# Cleanup
+sm.delete_endpoint(EndpointName="sglang-endpoint")
+sm.delete_endpoint_config(EndpointConfigName="sglang-config")
+sm.delete_model(ModelName="sglang-model")
+```
+
+## Model Artifacts
+
+When `ModelDataUrl` (or `ModelDataSource`) points to a tarball/S3 prefix, SageMaker mounts the contents at `/opt/ml/model`. The entrypoint defaults
+`--model-path` to that location, so `SM_SGLANG_MODEL_PATH` can be omitted:
+
+```text
+model.tar.gz
+├── config.json              # standard model files (Hugging Face layout)
+├── tokenizer.json
+└── *.safetensors
+```
+
+## Notes
+
+- GPU deployments require `inference_ami_version` — the default SageMaker host AMI has incompatible NVIDIA drivers for CUDA 13 images. See
+  [ProductionVariant API reference](https://docs.aws.amazon.com/sagemaker/latest/APIReference/API_ProductionVariant.html) for valid values.
+- Any `SM_SGLANG_*` environment variable is converted to a `--<name>` SGLang server argument (e.g., `SM_SGLANG_CONTEXT_LENGTH=4096` →
+  `--context-length 4096`).
+
+For all configuration options including server arguments and SageMaker environment variables, see [Configuration](../configuration.md).

--- a/docs/sglang/index.md
+++ b/docs/sglang/index.md
@@ -1,0 +1,52 @@
+# LLM Serving using SGLang DLC
+
+Production-ready Docker images for serving large language models with [SGLang](https://docs.sglang.ai/) on {{ aws }}. Built on Amazon Linux 2023 with
+ongoing security patching.
+
+## Images
+
+| Platform | Image | Default Port |
+| --- | --- | --- |
+| {{ ec2_short }} / {{ eks_short }} | `public.ecr.aws/deep-learning-containers/sglang:server-cuda` | 30000 |
+| {{ sagemaker }} | `public.ecr.aws/deep-learning-containers/sglang:server-sagemaker-cuda` | 8080 |
+
+All images are also available on the [ECR Public Gallery](https://gallery.ecr.aws/deep-learning-containers/sglang). For private ECR URIs, see
+[Image Access](../get_started/index.md).
+
+## What's Included
+
+In addition to SGLang and its core stack (PyTorch 2.11, CUDA 13.0, NCCL, Python 3.12), the images bundle:
+
+- **[FlashInfer](https://github.com/flashinfer-ai/flashinfer)** — fused attention kernels with precompiled cubins for fast cold start
+- **[DeepEP](https://github.com/deepseek-ai/DeepEP)** — expert-parallel kernels for large MoE models (DeepSeek, Qwen MoE)
+- **[Mooncake](https://github.com/kvcache-ai/Mooncake)** — KV-cache transfer engine for disaggregated prefill/decode
+- **[sgl-kernel](https://github.com/sgl-project/sglang/tree/main/sgl-kernel)** — SGLang's custom CUDA kernels, built from source for the bundled CUDA arch list
+- **[EFA](https://aws.amazon.com/hpc/efa/) and [OpenMPI](https://www.open-mpi.org/)** — high-throughput multi-node networking on supported instances
+
+The images are built from SGLang source against the H100 (sm_90) and Blackwell (sm_100, sm_103) CUDA architectures.
+
+## API Endpoints
+
+The container runs SGLang's [OpenAI-compatible API server](https://docs.sglang.ai/basic_usage/openai_api.html). Common endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `POST /v1/chat/completions` | Chat-style generation |
+| `POST /v1/completions` | Legacy text completion |
+| `POST /v1/embeddings` | Generate embeddings (embedding models) |
+| `POST /generate` | SGLang-native generation API |
+| `GET /v1/models` | List loaded model(s) |
+| `GET /get_model_info` | Model metadata |
+| `GET /health`, `/health_generate` | Liveness probe |
+| `POST /flush_cache` | Flush the radix attention cache |
+| `GET /metrics` | Prometheus metrics |
+
+Refer to [SGLang's API documentation](https://docs.sglang.ai/basic_usage/openai_api.html) for request/response schemas and the full endpoint list.
+
+## How We Build
+
+These images are curated builds, not simple repackages of upstream releases:
+
+- **Built from upstream source** — images build SGLang from a pinned upstream commit, each gated by our regression test suite before publication.
+- **Regression-tested** — validated against a suite of models on every release. See [Supported Models](models/index.md) for the full list.
+- **Security-patched** — continuously maintained with security patches from {{ aws }} on an Amazon Linux 2023 base.

--- a/docs/sglang/index.md
+++ b/docs/sglang/index.md
@@ -20,7 +20,8 @@ In addition to SGLang and its core stack (PyTorch 2.11, CUDA 13.0, NCCL, Python 
 - **[FlashInfer](https://github.com/flashinfer-ai/flashinfer)** — fused attention kernels with precompiled cubins for fast cold start
 - **[DeepEP](https://github.com/deepseek-ai/DeepEP)** — expert-parallel kernels for large MoE models (DeepSeek, Qwen MoE)
 - **[Mooncake](https://github.com/kvcache-ai/Mooncake)** — KV-cache transfer engine for disaggregated prefill/decode
-- **[sgl-kernel](https://github.com/sgl-project/sglang/tree/main/sgl-kernel)** — SGLang's custom CUDA kernels, built from source for the bundled CUDA arch list
+- **[sgl-kernel](https://github.com/sgl-project/sglang/tree/main/sgl-kernel)** — SGLang's custom CUDA kernels, built from source for the bundled CUDA
+  arch list
 - **[EFA](https://aws.amazon.com/hpc/efa/) and [OpenMPI](https://www.open-mpi.org/)** — high-throughput multi-node networking on supported instances
 
 The images are built from SGLang source against the H100 (sm_90) and Blackwell (sm_100, sm_103) CUDA architectures.

--- a/docs/sglang/models/index.md
+++ b/docs/sglang/models/index.md
@@ -1,0 +1,33 @@
+# Supported Models
+
+All models listed below are regression-tested on every DLC SGLang release and work with the images listed on the [Overview](../index.md) page.
+
+The **Coverage** column indicates test depth: *Smoke* runs on every PR; *Benchmark* runs throughput and latency tests with pass/fail thresholds before
+release. A *Smoke + Benchmark* tag means both apply.
+
+## Tested Models
+
+| Family | Model | Coverage |
+| --- | --- | --- |
+| **Llama** | [meta-llama/Llama-3.3-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct) | Benchmark |
+| **Qwen** | [Qwen/Qwen3-32B](https://huggingface.co/Qwen/Qwen3-32B) | Benchmark |
+|  | [Qwen/Qwen3.5-0.8B](https://huggingface.co/Qwen/Qwen3.5-0.8B) | Smoke + Benchmark |
+|  | [Qwen/Qwen3.5-9B](https://huggingface.co/Qwen/Qwen3.5-9B) | Benchmark |
+|  | [Qwen/Qwen3.5-27B-FP8](https://huggingface.co/Qwen/Qwen3.5-27B-FP8) | Benchmark |
+|  | [Qwen/Qwen3.5-35B-A3B-FP8](https://huggingface.co/Qwen/Qwen3.5-35B-A3B-FP8) | Benchmark |
+|  | [Qwen/Qwen3-Coder-Next-FP8](https://huggingface.co/Qwen/Qwen3-Coder-Next-FP8) | Benchmark |
+| **GPT-OSS** | [openai/gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b) | Benchmark |
+| **DeepSeek** | [deepseek-ai/DeepSeek-V4-Flash](https://huggingface.co/deepseek-ai) | Benchmark |
+
+## Custom Models
+
+Any model supported by upstream SGLang should work. To serve a model not listed above:
+
+```bash
+docker run --gpus all -p 30000:30000 \
+  public.ecr.aws/deep-learning-containers/sglang:server-cuda \
+  --model-path <org>/<model-name>
+```
+
+Models can also be loaded from a local path (`-v /path:/model --model-path /model`). See the
+[SGLang supported models list](https://docs.sglang.ai/supported_models/generative_models.html) for the full upstream coverage.

--- a/docs/src/data/sglang-server/0.5.12+amzn2023.578d27e-gpu-ec2.yml
+++ b/docs/src/data/sglang-server/0.5.12+amzn2023.578d27e-gpu-ec2.yml
@@ -1,0 +1,12 @@
+framework: SGLang
+version: "0.5.12+amzn2023.578d27e"
+ecr_repository: sglang
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: ec2
+public_registry: true
+
+tags:
+  - "server-cuda-v1.0"

--- a/docs/src/data/sglang-server/0.5.12+amzn2023.578d27e-gpu-sagemaker.yml
+++ b/docs/src/data/sglang-server/0.5.12+amzn2023.578d27e-gpu-sagemaker.yml
@@ -1,0 +1,12 @@
+framework: SGLang
+version: "0.5.12+amzn2023.578d27e"
+ecr_repository: sglang
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: sagemaker
+public_registry: true
+
+tags:
+  - "server-sagemaker-cuda-v1.0"

--- a/docs/src/generate.py
+++ b/docs/src/generate.py
@@ -5,7 +5,6 @@ import logging
 import sorter as sorter_module
 from constants import (
     AVAILABLE_IMAGES_TABLE_HEADER,
-    DOCS_DIR,
     GLOBAL_CONFIG,
     PUBLIC_GALLERY_URL,
     REFERENCE_DIR,
@@ -279,27 +278,10 @@ def generate_available_images(dry_run: bool = False) -> str:
     return content
 
 
-def generate_index(dry_run: bool = False) -> str:
-    """Generate docs/index.md from the index template."""
-    output_path = DOCS_DIR / "index.md"
-    template_path = TEMPLATES_DIR / "index.template.md"
-    LOGGER.debug(f"Generating {output_path}")
-
-    content = load_jinja2(template_path)
-
-    if not dry_run:
-        write_output(output_path, content)
-        LOGGER.debug(f"Wrote {output_path}")
-
-    LOGGER.info("Generated index.md")
-    return content
-
-
 def generate_all(dry_run: bool = False) -> None:
     """Generate all documentation files."""
     LOGGER.info("Loaded global config")
 
-    generate_index(dry_run)
     generate_support_policy(dry_run)
     generate_available_images(dry_run)
 

--- a/docs/src/global.yml
+++ b/docs/src/global.yml
@@ -69,7 +69,8 @@ display_names:
     base: "Base"
     ray: "Ray"
     sagemaker-xgboost: "XGBoost"
-    sglang: "SGLang"
+    sglang: "SGLang (Ubuntu)"
+    sglang-server: "SGLang"
     vllm: "vLLM (Ubuntu)"
     vllm-server: "vLLM"
     vllm-arm64: "vLLM ARM64"
@@ -183,6 +184,7 @@ table_order:
   - base
   - ray
   - sglang
+  - sglang-server
   - vllm
   - vllm-server
   - vllm-arm64

--- a/docs/src/macros.py
+++ b/docs/src/macros.py
@@ -41,6 +41,8 @@ def define_env(env):
         "latest_vllm_server_ec2": get_latest_image_uri("vllm-server", "ec2"),
         "latest_vllm_server_sagemaker": get_latest_image_uri("vllm-server", "sagemaker"),
         "latest_sglang_sagemaker": get_latest_image_uri("sglang", "sagemaker"),
+        "latest_sglang_server_ec2": get_latest_image_uri("sglang-server", "ec2"),
+        "latest_sglang_server_sagemaker": get_latest_image_uri("sglang-server", "sagemaker"),
         "latest_ray_default_gpu": _get_latest_ray_uri("default", "gpu"),
         "latest_ray_default_cpu": _get_latest_ray_uri("default", "cpu"),
         "latest_ray_sagemaker_gpu": _get_latest_ray_uri("sagemaker", "gpu"),

--- a/docs/src/main.py
+++ b/docs/src/main.py
@@ -15,7 +15,6 @@ from constants import TUTORIALS_DIR, TUTORIALS_REPO
 from generate import (
     generate_all,
     generate_available_images,
-    generate_index,
     generate_support_policy,
 )
 from logger import ColoredFormatter
@@ -50,9 +49,6 @@ def main():
     exclusive_group.add_argument(
         "--clone-tutorials", action="store_true", help="Clone only aws-samples tutorials repository"
     )
-    exclusive_group.add_argument(
-        "--index-only", action="store_true", help="Generate only index.md from README.md"
-    )
     args = parser.parse_args()
 
     if args.verbose:
@@ -64,7 +60,6 @@ def main():
         "support_policy_only": lambda: generate_support_policy(args.dry_run),
         "available_images_only": lambda: generate_available_images(args.dry_run),
         "clone_tutorials": lambda: clone_git_repository(TUTORIALS_REPO, TUTORIALS_DIR),
-        "index_only": lambda: generate_index(args.dry_run),
     }
 
     for flag, action in actions.items():

--- a/docs/src/tables/sglang-server.yml
+++ b/docs/src/tables/sglang-server.yml
@@ -1,0 +1,14 @@
+# Table Configuration - SGLang Server (AMZN2023)
+columns:
+  - field: framework_version
+    header: "Framework"
+  - field: python
+    header: "Python"
+  - field: cuda
+    header: "CUDA"
+  - field: accelerator
+    header: "Accelerator"
+  - field: platform
+    header: "Platform"
+  - field: example_url
+    header: "Example URL"


### PR DESCRIPTION
## Description

Adds public documentation for the new Amazon Linux 2023 SGLang Server images (`server-cuda`, `server-sagemaker-cuda`), mirroring the existing vLLM Server AL2023 docs structure.

### What's added

- **New `docs/sglang/` prose section** — overview, configuration, EC2 and Amazon SageMaker AI deployment guides, supported models, and changelog (wired into the User Guide nav).
- **New `sglang-server` table key** — `docs/src/data/sglang-server/` v1.0 data files for EC2 and SageMaker, plus `docs/src/tables/sglang-server.yml`. The new images render in `available_images.md` under the **SGLang** heading.
- **Renamed** the existing `sglang` table display name to **SGLang (Ubuntu)** to distinguish the legacy Ubuntu images from the new AL2023 images (same precedent as `vllm` → "vLLM (Ubuntu)").
- **Added** `latest_sglang_server_{ec2,sagemaker}` image-URI macros.

### Image facts (grounded against the release config / entrypoints)

| | EC2 / EKS | SageMaker |
|---|---|---|
| Image | `sglang:server-cuda` | `sglang:server-sagemaker-cuda` |
| Default port | 30000 | 8080 |
| Config | `sglang.launch_server` flags | `SM_SGLANG_*` env vars → flags |

Bundled: CUDA 13.0.3 · Python 3.12 · PyTorch 2.11.0 · sgl-kernel 0.4.3 · FlashInfer 0.6.11.post1 · Mooncake 0.3.9 · NCCL 2.28.3. Built from SGLang source commit `578d27e`.

### Testing

- Ran `python docs/src/main.py --verbose` — generation passes (exit 0).
- Confirmed both **SGLang (Ubuntu)** and **SGLang** tables render in `available_images.md` with correct semantic tags (`server-cuda-v1.0`, `server-sagemaker-cuda-v1.0`).
- Verified the new `latest_sglang_server_*` macros resolve to valid ECR URIs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.