### PR TITLE
fix: use python3 -m pip in xgboost 3.0.5 release unit-test image

### DIFF
--- a/.github/workflows/dispatch-release-sagemaker-xgboost-3.0.5.yml
+++ b/.github/workflows/dispatch-release-sagemaker-xgboost-3.0.5.yml
@@ -123,7 +123,7 @@ jobs:
         run: |
           CI_IMAGE_URI="${{ needs.build-image.outputs.ci-image }}"
           cd /tmp/xgboost-unit
-          printf "FROM ${CI_IMAGE_URI}\nADD . /app\nWORKDIR /app\nRUN pip install --no-deps -e . && pip install black coverage docker flake8 isort mock pytest pytest-cov pytest-xdist 'sagemaker>=2.0,<3.0' 'protobuf>=3.20.0,<=3.20.3' tox setuptools" > Dockerfile.test
+          printf "FROM ${CI_IMAGE_URI}\nADD . /app\nWORKDIR /app\nRUN python3 -m pip install --no-deps -e . && python3 -m pip install black coverage docker flake8 isort mock pytest pytest-cov pytest-xdist 'sagemaker>=2.0,<3.0' 'protobuf>=3.20.0,<=3.20.3' tox setuptools" > Dockerfile.test
           docker build -t test-xgboost -f Dockerfile.test .
       - name: Run unit tests
         run: |


### PR DESCRIPTION
## Problem

The XGBoost 3.0.5 release workflow's `unit-test` job fails with:

```
/miniconda3/bin/python3: No module named pytest
```

## Root cause

The 3.0.5 image (`docker/xgboost/3.0-5/Dockerfile`) uses Miniforge, where `python3` resolves to `/miniconda3/bin/python3`, while `/usr/local/bin` is also on `PATH`. The release workflow installed test dependencies with bare `pip`, which resolves to a different interpreter than the `python3 -m pytest` run command. pytest therefore landed in the wrong site-packages and was not importable at test time.

## Fix

Pin the install to the test interpreter with `python3 -m pip`, making the release workflow's test-image build byte-identical to the already-passing PR workflow (`pr-sagemaker-xgboost-3.0.5.yml`).

Scope: 3.0.5 only. The 3.2.0 workflows use a `uv` venv (`/opt/venv/bin` first on PATH) where bare `pip` and `python3` resolve to the same interpreter, so they are unaffected and left unchanged.