### PR TITLE
[auto-cve-patch] [sglang] bump aiohttp >=3.14.0; prune resolved entries; refresh review_by

### DIFF
--- a/docker/sglang/Dockerfile
+++ b/docker/sglang/Dockerfile
@@ -36,6 +36,7 @@ RUN pip install \
 
 # patch CVEs
 RUN pip install \
+  "aiohttp>=3.14.0" \
   "black>=26.3.1" \
   "diffusers>=0.38.0" \
   "lxml>=6.1.0" \

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -279,7 +279,7 @@ RUN uv pip install --system --no-cache --prerelease=allow \
   "python_multipart>=0.0.22" \
   "xgrammar>=0.1.32" \
   "setuptools>=78.1.1" \
-  "aiohttp>=3.13.4" \
+  "aiohttp>=3.14.0" \
   # kernels<0.15: 0.15.x breaks transformers hub_kernels LayerRepository() init
   "kernels<0.15"
 

--- a/test/security/data/ecr_scan_allowlist/sglang/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/sglang/framework_allowlist.json
@@ -1,86 +1,37 @@
 [
     {
-        "vulnerability_id": "CVE-2026-25537",
-        "reason": "sglang0.5.9 jsonwebtoken 9.3.1 is a RUST package bundled with uv binary, cannot be patched independently"
-    },
-    {
-        "vulnerability_id": "CVE-2026-33186",
-        "reason": "sglang0.5.9 google.golang.org/grpc is a go package installed during build time but is not used in runtime."
-    },
-    {
-        "vulnerability_id": "CVE-2026-33055",
-        "reason": "sglang0.5.9 tar 0.4.44 is a RUST package bundled with uv binary, cannot be patched independently"
-    },
-    {
-        "vulnerability_id": "CVE-2026-27572",
-        "reason": "sglang0.5.10 wasmtime 38.0.4 is a RUST dependency in sgl-model-gateway Cargo.lock, cannot be patched without upstream SGLang update"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34987",
-        "reason": "sglang0.5.10 wasmtime 38.0.4 is a RUST dependency in sgl-model-gateway Cargo.lock, cannot be patched without upstream SGLang update"
-    },
-    {
-        "vulnerability_id": "CVE-2025-68263",
-        "reason": "linux-libc-dev 6.8.0 is a kernel header package from the Ubuntu base image, fix not yet available in upstream base image"
-    },
-    {
-        "vulnerability_id": "CVE-2025-68121",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32283",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32281",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32280",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+"
-    },
-    {
-        "vulnerability_id": "CVE-2026-25679",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+"
-    },
-    {
-        "vulnerability_id": "CVE-2026-44513",
-        "reason": "diffusers 0.37.0 trust_remote_code bypass - transitive dependency not directly used by sglang serving, upgrade requires broader compatibility testing"
-    },
-    {
         "vulnerability_id": "CVE-2026-39820",
-        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+"
+        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-33811",
-        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+"
+        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-33814",
-        "reason": "go/stdlib 1.25.9 and golang.org/x/net v0.48.0 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild"
+        "reason": "go/stdlib 1.25.9 and golang.org/x/net v0.48.0 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild",
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-42499",
-        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+"
+        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-39836",
-        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+"
+        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-39821",
-        "reason": "golang.org/x/net v0.48.0 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild"
-    },
-    {
-        "vulnerability_id": "CVE-2025-23339",
-        "reason": "cuda-toolkit-config-common 12.9.79 is an OS package from NVIDIA CUDA repo, upgrade to 13.x requires CUDA major version bump"
-    },
-    {
-        "vulnerability_id": "CVE-2025-23308",
-        "reason": "cuda-toolkit-config-common 12.9.79 is an OS package from NVIDIA CUDA repo, upgrade to 13.x requires CUDA major version bump"
+        "reason": "golang.org/x/net v0.48.0 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild",
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-42504",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.4+"
+        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, MIME header parsing CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
+        "review_by": "2026-09-10"
     }
 ]

--- a/test/security/data/ecr_scan_allowlist/sglang_server/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/sglang_server/framework_allowlist.json
@@ -1,92 +1,67 @@
 [
     {
-        "vulnerability_id": "CVE-2026-25537",
-        "reason": "jsonwebtoken 9.3.1 is a RUST package bundled with uv binary, cannot be patched independently",
-        "review_by": "2026-08-30"
-    },
-    {
         "vulnerability_id": "CVE-2026-33186",
         "reason": "google.golang.org/grpc is a go package statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-33055",
-        "reason": "tar 0.4.44 is a RUST package bundled with uv binary, cannot be patched independently",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-27572",
-        "reason": "wasmtime 38.0.4 is a RUST dependency in sgl-model-gateway Cargo.lock, cannot be patched without upstream SGLang update",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34987",
-        "reason": "wasmtime 38.0.4 is a RUST dependency in sgl-model-gateway Cargo.lock, cannot be patched without upstream SGLang update",
-        "review_by": "2026-08-30"
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2025-68121",
         "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-08-30"
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-32283",
         "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-08-30"
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-32281",
         "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-08-30"
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-32280",
         "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-08-30"
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-25679",
         "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-44513",
-        "reason": "diffusers 0.37.0 trust_remote_code bypass - transitive dependency not directly used by sglang serving, upgrade requires broader compatibility testing",
-        "review_by": "2026-08-30"
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-39820",
         "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
-        "review_by": "2026-08-30"
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-33811",
         "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
-        "review_by": "2026-08-30"
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-33814",
         "reason": "go/stdlib 1.25.9 and golang.org/x/net v0.48.0 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild",
-        "review_by": "2026-08-30"
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-42499",
         "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
-        "review_by": "2026-08-30"
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-39836",
         "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
-        "review_by": "2026-08-30"
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-39821",
         "reason": "golang.org/x/net v0.48.0 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild",
-        "review_by": "2026-08-30"
+        "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-42504",
         "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, MIME header parsing CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
-        "review_by": "2026-08-30"
+        "review_by": "2026-09-10"
     }
 ]


### PR DESCRIPTION
## Purpose

Patch CVEs across sglang DLC images.

## Images affected

- `sglang:0.5-gpu-py312-ec2`
- `sglang:0.5-gpu-py312`
- `sglang:server-cuda-v1`
- `sglang:server-sagemaker-cuda-v1`

## CVEs handled

| CVE | Package | Severity | Affected images | Action | Notes |
|---|---|---|---|---|---|
| CVE-2026-34993 | aiohttp 3.13.5 → 3.14.0 | HIGH | `0.5-gpu-py312-ec2`, `0.5-gpu-py312` | Bump in `docker/sglang/Dockerfile` inline pip block | |
| CVE-2026-47265 | aiohttp 3.13.5 → 3.14.0 | HIGH | `0.5-gpu-py312-ec2`, `0.5-gpu-py312` | Bump in `docker/sglang/Dockerfile` inline pip block | |

Also raised `aiohttp` floor in `docker/sglang/Dockerfile.amzn2023` from `>=3.13.4` → `>=3.14.0` for consistency. The AL2023 image already resolves to 3.14.1 today, so no behavior change.

**Prunes:** removed 14 stale entries from `sglang/framework_allowlist.json` and 5 stale entries from `sglang_server/framework_allowlist.json` whose CVEs no longer fire on the current images. The pruned entries cover uv-vendored Rust crates (cleaned out at runtime on Ubuntu), older `mooncake` Go-stdlib 1.24.12 findings (mooncake bumped to a Go 1.25.x build), `cuda-toolkit-config-common 12.9.79` (CUDA bumped to 13.0.3), `linux-libc-dev 6.8.0`, and `diffusers 0.37.0`.

**Backfills:** added `review_by: 2026-09-10` to the remaining 7 `sglang/` entries that were missing it (90-day VENDORED clock per allowlist schema). `sglang_server/` already had `review_by` populated; refreshed to 2026-09-10 for the 13 entries kept.

**Reason refresh:** updated `CVE-2026-42504` reason in `sglang/framework_allowlist.json` from "go/stdlib 1.24.12" to "go/stdlib 1.25.9" — the underlying mooncake binary in the Ubuntu image has been rebuilt against Go 1.25.9 since the entry was last written.

## Test plan

- [x] CI security tests pass for all affected sglang variants
- [x] CI sanity tests pass
- [x] CI sglang-specific tests pass

---
🤖 Generated by [Claude Code](https://claude.com/claude-code).
