### PR TITLE
[auto-cve-patch] [ray] allowlist 2 vendored aiohttp CVEs

### DIFF
--- a/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
@@ -18,5 +18,15 @@
     "vulnerability_id": "CVE-2026-34480",
     "reason": "ray bundles log4j-core 2.25.3 in ray_dist.jar, cannot patch without upstream ray rebuild",
     "review_by": "2026-08-24"
+  },
+  {
+    "vulnerability_id": "CVE-2026-47265",
+    "reason": "aiohttp 3.13.5 vendored in Ray's _private/runtime_env/agent/thirdparty_files; cannot patch without upstream ray rebuild",
+    "review_by": "2026-09-13"
+  },
+  {
+    "vulnerability_id": "CVE-2026-34993",
+    "reason": "aiohttp 3.13.5 vendored in Ray's _private/runtime_env/agent/thirdparty_files; cannot patch without upstream ray rebuild",
+    "review_by": "2026-09-13"
   }
 ]


### PR DESCRIPTION
## Purpose

Patch CVEs across Ray DLC images.

## Images affected

`ray:serve-ml-sagemaker-cpu-v1`

## CVEs handled

| CVE | Package | Severity | Affected images | Action | Notes |
|---|---|---|---|---|---|
| CVE-2026-47265 | aiohttp 3.13.5 | HIGH | serve-ml-sagemaker-cpu-v1 | allowlist | vendored in Ray's `_private/runtime_env/agent/thirdparty_files`; fix needs upstream ray rebuild |
| CVE-2026-34993 | aiohttp 3.13.5 | HIGH | serve-ml-sagemaker-cpu-v1 | allowlist | vendored in Ray's `_private/runtime_env/agent/thirdparty_files`; fix needs upstream ray rebuild |

## Test plan

- [ ] CI security tests pass for cpu and gpu
- [ ] CI sanity tests pass for cpu and gpu
- [ ] CI Ray-specific tests pass

---
🤖 Generated by [Claude Code](https://claude.com/claude-code).