### PR TITLE
pr-pytorch: fetch full history so version detection works

### DIFF
--- a/.github/workflows/pr-pytorch-ec2-cpu.yml
+++ b/.github/workflows/pr-pytorch-ec2-cpu.yml
@@ -64,6 +64,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # Full history so `git diff origin/main...HEAD` can resolve the
+          # merge-base for version detection (shallow clone has no origin/main).
+          fetch-depth: 0
 
       - name: Setup python
         uses: actions/setup-python@v6

--- a/.github/workflows/pr-pytorch-ec2-cuda.yml
+++ b/.github/workflows/pr-pytorch-ec2-cuda.yml
@@ -68,6 +68,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # Full history so `git diff origin/main...HEAD` can resolve the
+          # merge-base for version detection (shallow clone has no origin/main).
+          fetch-depth: 0
 
       - name: Setup python
         uses: actions/setup-python@v6

--- a/.github/workflows/pr-pytorch-sagemaker-cpu.yml
+++ b/.github/workflows/pr-pytorch-sagemaker-cpu.yml
@@ -64,6 +64,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # Full history so `git diff origin/main...HEAD` can resolve the
+          # merge-base for version detection (shallow clone has no origin/main).
+          fetch-depth: 0
 
       - name: Setup python
         uses: actions/setup-python@v6

--- a/.github/workflows/pr-pytorch-sagemaker-cuda.yml
+++ b/.github/workflows/pr-pytorch-sagemaker-cuda.yml
@@ -64,6 +64,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          # Full history so `git diff origin/main...HEAD` can resolve the
+          # merge-base for version detection (shallow clone has no origin/main).
+          fetch-depth: 0
 
       - name: Setup python
         uses: actions/setup-python@v6


### PR DESCRIPTION
## Problem
The `check-changes` job in the four `pr-pytorch-*` workflows detects which PyTorch versions a PR touches via:

    git diff --name-only origin/main...HEAD | grep -oP '...' 

But the job's checkout uses the default shallow depth (`fetch-depth: 1`), where `origin/main` is not present. The diff fails with `fatal: ambiguous argument 'origin/main...HEAD'`, so the detected set comes back empty and the job silently falls back to `LATEST_PYTORCH_VERSION` on **every** run. A PR touching only a specific version would never be detected — the fallback version gets built/tested instead.

## Fix
Set `fetch-depth: 0` on the `check-changes` checkout in all four workflows so `origin/main` resolves and the diff works. The `gatekeeper` checkout keeps `fetch-depth: 1` (it's an intentional safe shallow checkout of the base ref).

Same issue and fix as the base workflows in #6215 (https://github.com/aws/deep-learning-containers/pull/6215), which flagged this as a pytorch follow-up.

## Files
- `.github/workflows/pr-pytorch-ec2-cpu.yml`
- `.github/workflows/pr-pytorch-ec2-cuda.yml`
- `.github/workflows/pr-pytorch-sagemaker-cpu.yml`
- `.github/workflows/pr-pytorch-sagemaker-cuda.yml`

## Testing
- `actionlint` clean on all four; `check-github-workflows` (Actions schema) passes.