### PR TITLE
test: isolate vllm sagemaker upstream example test

### DIFF
--- a/.github/workflows/pr-vllm-sagemaker-amzn2023.yml
+++ b/.github/workflows/pr-vllm-sagemaker-amzn2023.yml
@@ -5,23 +5,12 @@ on:
     branches: [main]
     types: [opened, reopened, synchronize]
     paths:
-      - ".github/config/image/vllm-sagemaker-amzn2023.yml"
-      - ".github/config/model-tests/vllm-model-tests.yml"
       - ".github/workflows/pr-vllm-sagemaker-amzn2023.yml"
-      - ".github/workflows/reusable-vllm-sagemaker-tests.yml"
       - ".github/workflows/reusable-vllm-upstream-tests.yml"
       - "docker/vllm/Dockerfile.amzn2023"
-      - "scripts/common/**"
-      - "scripts/telemetry/**"
       - "scripts/vllm/amzn2023/**"
-      - "scripts/vllm/dockerd_entrypoint.sh"
-      - "scripts/vllm/sagemaker_entrypoint.sh"
-      - "test/sanity/**"
-      - "test/security/data/ecr_scan_allowlist/vllm_server/**"
-      - "test/telemetry/**"
-      - "test/vllm/sagemaker/**"
       - "test/vllm/scripts/amzn2023/**"
-      - "!test/vllm/scripts/amzn2023/vllm_model_smoke_test.sh"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -34,16 +23,12 @@ env:
 jobs:
   gatekeeper:
     runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-gate-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
     steps:
       - name: Checkout base branch (safe)
         uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 1
-
       - name: Run permission gate (from base)
         uses: ./.github/actions/pr-permission-gate
 
@@ -68,13 +53,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-
       - name: Load configuration
         id: load
         uses: ./.github/actions/load-config
         with:
           config-file: ${{ env.CONFIG_FILE }}
-
       - name: Parse configuration
         id: parse
         run: |
@@ -82,7 +65,6 @@ jobs:
           echo "framework=$(jq -r '.common.framework' config.json)" >> $GITHUB_OUTPUT
           echo "framework-version=$(jq -r '.common.framework_version' config.json)" >> $GITHUB_OUTPUT
           echo "vllm-ref=$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)" >> $GITHUB_OUTPUT
-          # Short form for image tag: truncate raw commit SHAs to 8 chars, sanitise other refs.
           VLLM_REF="$(jq -r '.common.vllm_ref // "v" + .common.framework_version' config.json)"
           if echo "$VLLM_REF" | grep -qE '^[0-9a-f]{12,}$'; then
             VLLM_REF_SHORT=$(echo "$VLLM_REF" | cut -c1-8)
@@ -100,70 +82,13 @@ jobs:
           echo "customer-type=$(jq -r '.common.customer_type // ""' config.json)" >> $GITHUB_OUTPUT
           echo "prod-image=$(jq -r '.common.prod_image' config.json)" >> $GITHUB_OUTPUT
 
-  check-changes:
-    needs: [gatekeeper]
-    if: success()
-    runs-on: ubuntu-latest
-    concurrency:
-      group: ${{ github.workflow }}-check-changes-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
-    outputs:
-      build-change: ${{ steps.changes.outputs.build-change }}
-      sanity-test-change: ${{ steps.changes.outputs.sanity-test-change }}
-      sagemaker-test-change: ${{ steps.changes.outputs.sagemaker-test-change }}
-      telemetry-test-change: ${{ steps.changes.outputs.telemetry-test-change }}
-      model-test-change: ${{ steps.changes.outputs.model-test-change }}
-    steps:
-      - name: Checkout DLC source
-        uses: actions/checkout@v5
-
-      - name: Setup python
-        uses: actions/setup-python@v6
-        with:
-          python-version: "3.12"
-
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.1
-        with:
-          extra_args: --all-files
-
-      - name: Detect file changes
-        id: changes
-        uses: dorny/paths-filter@v3
-        with:
-          filters: |
-            build-change:
-              - ".github/config/image/vllm-sagemaker-amzn2023.yml"
-              - "docker/vllm/Dockerfile.amzn2023"
-              - "scripts/common/install_efa_amzn2023.sh"
-              - "scripts/common/setup_oss_compliance.sh"
-              - "scripts/telemetry/bash_telemetry.sh.template"
-              - "scripts/vllm/amzn2023/**"
-              - "scripts/vllm/dockerd_entrypoint.sh"
-              - "scripts/vllm/sagemaker_entrypoint.sh"
-              - "test/security/data/ecr_scan_allowlist/vllm_server/**"
-              - "test/vllm/scripts/amzn2023/**"
-            sagemaker-test-change:
-              - "test/vllm/sagemaker/**"
-            sanity-test-change:
-              - "test/sanity/**"
-            telemetry-test-change:
-              - "test/telemetry/**"
-            model-test-change:
-              - ".github/config/model-tests/vllm-model-tests.yml"
-              - ".github/workflows/reusable-vllm-sagemaker-tests.yml"
-
   build-image:
-    needs: [check-changes, load-config]
-    if: needs.check-changes.outputs.build-change == 'true'
+    needs: [load-config]
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
         fleet:x86-vllm-build-runner
         buildspec-override:true
     timeout-minutes: 720
-    concurrency:
-      group: ${{ github.workflow }}-build-image-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
     env:
       USE_SCCACHE: "1"
       USE_PREBUILT_WHEEL: "1"
@@ -172,7 +97,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-
       - name: Fetch cached vLLM wheel
         id: wheel-cache
         run: |
@@ -186,19 +110,14 @@ jobs:
           if [ "${HIT}" != "true" ]; then
             echo "EXPORT_TARGETS=wheel-export:/tmp/vllm-wheels,sccache-export:docker/vllm/sccache-cache" >> $GITHUB_ENV
           fi
-
       - name: Sync sccache cache from S3
         run: bash scripts/vllm/amzn2023/sync_sccache.sh pull vllm
-
       - name: Prepare build context
         run: |
           mkdir -p docker/vllm/prebuilt_wheels
           mkdir -p docker/vllm/sccache-cache
-
       - name: Load pinned vLLM versions
         run: |
-          # Capture vars introduced by sourcing the env file and forward them
-          # to $GITHUB_ENV. EXTRA_BUILD_ARGS is auto-derived (no manual list).
           before=$(compgen -v | sort)
           set -a; source docker/vllm/versions.env; set +a
           new=$(comm -13 <(echo "$before") <(compgen -v | sort) | grep -Ev '^(before|PIPESTATUS|_)$')
@@ -206,7 +125,6 @@ jobs:
             [ -n "${!v:-}" ] && echo "${v}=$(echo "${!v}" | xargs)" >> "$GITHUB_ENV"
           done
           echo "EXTRA_BUILD_ARGS=$(echo $new | xargs)" >> "$GITHUB_ENV"
-
       - name: Build image
         id: build
         uses: ./.github/actions/build-image
@@ -218,7 +136,7 @@ jobs:
           container-type: ${{ needs.load-config.outputs.container-type }}
           aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
           aws-region: ${{ vars.AWS_REGION }}
-          tag-pr: ${{ needs.load-config.outputs.framework }}-${{ needs.load-config.outputs.framework-version }}-${{ needs.load-config.outputs.vllm-ref-short }}-gpu-${{ needs.load-config.outputs.python-version }}-${{ needs.load-config.outputs.cuda-version }}-${{ needs.load-config.outputs.os-version }}-sagemaker-pr-${{ github.event.pull_request.number }}
+          tag-pr: ${{ needs.load-config.outputs.framework }}-${{ needs.load-config.outputs.framework-version }}-${{ needs.load-config.outputs.vllm-ref-short }}-gpu-${{ needs.load-config.outputs.python-version }}-${{ needs.load-config.outputs.cuda-version }}-${{ needs.load-config.outputs.os-version }}-sagemaker-pr-${{ github.event.pull_request.number || github.run_id }}
           dockerfile-path: docker/vllm/Dockerfile.amzn2023
           arch-type: ${{ needs.load-config.outputs.arch-type }}
           device-type: ${{ needs.load-config.outputs.device-type }}
@@ -227,7 +145,6 @@ jobs:
           os-version: ${{ needs.load-config.outputs.os-version }}
           contributor: ${{ needs.load-config.outputs.contributor }}
           customer-type: ${{ needs.load-config.outputs.customer-type }}
-
       - name: Upload vLLM wheel to cache
         if: success() && steps.wheel-cache.outputs.hit != 'true'
         run: |
@@ -235,91 +152,20 @@ jobs:
             ${{ needs.load-config.outputs.cuda-version }} \
             ${{ needs.load-config.outputs.vllm-ref }} \
             ${{ needs.load-config.outputs.framework-version }}
-
       - name: Sync sccache cache to S3
         if: success() && steps.wheel-cache.outputs.hit != 'true'
         run: bash scripts/vllm/amzn2023/sync_sccache.sh push vllm
 
-  sanity-test:
-    needs: [check-changes, build-image, load-config]
-    if: |
-      always() && !failure() && !cancelled() &&
-      (needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sanity-test-change == 'true')
-    concurrency:
-      group: ${{ github.workflow }}-sanity-test-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
-    uses: ./.github/workflows/reusable-sanity-tests.yml
-    with:
-      image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
-      aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
-      aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      python-version: ${{ needs.load-config.outputs.python-version }}
-      cuda-version: ${{ needs.load-config.outputs.cuda-version }}
-      os-version: ${{ needs.load-config.outputs.os-version }}
-      customer-type: ${{ needs.load-config.outputs.customer-type }}
-      arch-type: ${{ needs.load-config.outputs.arch-type }}
-      device-type: ${{ needs.load-config.outputs.device-type }}
-      contributor: ${{ needs.load-config.outputs.contributor }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
-
-  security-test:
-    needs: [build-image, load-config]
-    if: success()
-    concurrency:
-      group: ${{ github.workflow }}-security-test-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
-    uses: ./.github/workflows/reusable-security-tests.yml
-    with:
-      image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
-      aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
-      aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-
-  telemetry-test:
-    needs: [check-changes, build-image, load-config]
-    if: |
-      always() && !failure() && !cancelled() &&
-      (needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.telemetry-test-change == 'true')
-    concurrency:
-      group: ${{ github.workflow }}-telemetry-test-${{ github.event.pull_request.number }}
-      cancel-in-progress: false
-    uses: ./.github/workflows/reusable-telemetry-tests.yml
-    with:
-      image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
-      aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
-      aws-region: ${{ vars.AWS_REGION }}
-      framework: ${{ needs.load-config.outputs.framework }}
-      framework-version: ${{ needs.load-config.outputs.framework-version }}
-      container-type: ${{ needs.load-config.outputs.container-type }}
-
   upstream-tests:
     needs: [build-image, load-config]
     if: success()
-    concurrency:
-      group: ${{ github.workflow }}-upstream-tests-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
     uses: ./.github/workflows/reusable-vllm-upstream-tests.yml
     with:
-      image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}
-      aws-account-id: ${{ needs.build-image.result == 'success' && vars.CI_AWS_ACCOUNT_ID || vars.PROD_AWS_ACCOUNT_ID }}
+      image-uri: ${{ needs.build-image.outputs.ci-image }}
+      aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
       aws-region: ${{ vars.AWS_REGION }}
       framework-version: ${{ needs.load-config.outputs.framework-version }}
       vllm-ref: ${{ needs.load-config.outputs.vllm-ref }}
       setup-script: test/vllm/scripts/vllm_test_setup.sh
       example-test-script: test/vllm/scripts/amzn2023/vllm_sagemaker_examples_test.sh
     secrets: inherit
-
-  endpoint-test:
-    needs: [check-changes, build-image, load-config]
-    if: |
-      always() && !failure() && !cancelled() &&
-      (needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sagemaker-test-change == 'true' || needs.check-changes.outputs.model-test-change == 'true')
-    concurrency:
-      group: ${{ github.workflow }}-endpoint-test-${{ github.event.pull_request.number }}
-      cancel-in-progress: false
-    uses: ./.github/workflows/reusable-vllm-sagemaker-tests.yml
-    with:
-      image-uri: ${{ needs.build-image.result == 'success' && needs.build-image.outputs.ci-image || format('{0}.dkr.ecr.{1}.amazonaws.com/{2}', vars.PROD_AWS_ACCOUNT_ID, vars.AWS_REGION, needs.load-config.outputs.prod-image) }}


### PR DESCRIPTION
Strip down the sagemaker workflow to only build + upstream example test to investigate CI hanging issue. Uses main branch code (old workflow pattern) to rule out refactor as the cause.

## Purpose

## Test Plan

## Test Result

______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
