### PR TITLE
Allowlist mesa CVE-2026-40393 for PT 2.9 SM training (CPU + GPU cu130)

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -64,7 +64,7 @@ use_new_test_structure = false
 sanity_tests = true
 security_tests = true
   safety_check_test = false
-  ecr_scan_allowlist_feature = false
+  ecr_scan_allowlist_feature = true
 ecs_tests = true
 eks_tests = true
 ec2_tests = true
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = ""
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-9-sm.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -75,7 +75,7 @@ ec2_benchmark_tests = false
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = false
+ec2_tests_on_heavy_instances = true
 ### SM specific tests
 ### On by default
 sagemaker_local_tests = true
@@ -98,9 +98,9 @@ ipv6_vpc_name = ""
 # run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = true
 # run efa sagemaker tests
-sagemaker_efa_tests = false
+sagemaker_efa_tests = true
 # run release_candidate_integration tests
-sagemaker_rc_tests = false
+sagemaker_rc_tests = true
 # run sagemaker benchmark tests
 sagemaker_benchmark_tests = false
 
@@ -109,7 +109,7 @@ sagemaker_remote_efa_instance_type = ""
 
 # Run CI tests for nightly images
 # false by default
-nightly_pr_test_mode = false
+nightly_pr_test_mode = true
 
 [buildspec_override]
 # Assign the path to the required buildspec file from the deep-learning-containers folder

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -64,7 +64,7 @@ use_new_test_structure = false
 sanity_tests = true
 security_tests = true
   safety_check_test = false
-  ecr_scan_allowlist_feature = true
+  ecr_scan_allowlist_feature = false
 ecs_tests = true
 eks_tests = true
 ec2_tests = true
@@ -75,7 +75,7 @@ ec2_benchmark_tests = false
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = true
+ec2_tests_on_heavy_instances = false
 ### SM specific tests
 ### On by default
 sagemaker_local_tests = true
@@ -98,9 +98,9 @@ ipv6_vpc_name = ""
 # run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = true
 # run efa sagemaker tests
-sagemaker_efa_tests = true
+sagemaker_efa_tests = false
 # run release_candidate_integration tests
-sagemaker_rc_tests = true
+sagemaker_rc_tests = false
 # run sagemaker benchmark tests
 sagemaker_benchmark_tests = false
 
@@ -109,7 +109,7 @@ sagemaker_remote_efa_instance_type = ""
 
 # Run CI tests for nightly images
 # false by default
-nightly_pr_test_mode = true
+nightly_pr_test_mode = false
 
 [buildspec_override]
 # Assign the path to the required buildspec file from the deep-learning-containers folder
@@ -124,7 +124,7 @@ nightly_pr_test_mode = true
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-9-sm.yml"
+dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/pytorch/training/docker/2.9/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
@@ -1,4 +1,31 @@
 {
+  "mesa": [
+    {
+      "description": "In Mesa before 25.3.6 and 26 before 26.0.1, out-of-bounds memory access can occur in WebGPU because the amount of to-be-allocated data depends on an untrusted party, and is then used for alloca.",
+      "vulnerability_id": "CVE-2026-40393",
+      "name": "CVE-2026-40393",
+      "package_name": "mesa",
+      "package_details": {
+        "file_path": null,
+        "name": "mesa",
+        "package_manager": "OS",
+        "version": "23.0.4",
+        "release": "0ubuntu1~22.04.1"
+      },
+      "remediation": {"recommendation": {"text": "None Provided"}},
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2026/CVE-2026-40393.html",
+      "source": "UBUNTU_CVE",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2026-40393 - mesa",
+      "reason_to_ignore": "DLC training containers do not expose a WebGPU/rendering surface to untrusted content; mesa is pulled in transitively via libgl1-mesa-glx for OpenCV/visualization deps. Ubuntu 22.04 jammy has not provided a fixed mesa version (remediation: None Provided); awaiting upstream USN."
+    }
+  ],
   "black": [
     {
       "description": "Black is the uncompromising Python code formatter. Prior to 26.3.1, Black writes a cache file, the name of which is computed from various formatting options. The value of the --python-cell-magics option was placed in the filename without sanitization, which allowed an attacker who controls the value of this argument to write cache files to arbitrary file system locations. Fixed in Black 26.3.1.",

--- a/pytorch/training/docker/2.9/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
@@ -1,4 +1,31 @@
 {
+  "mesa": [
+    {
+      "description": "In Mesa before 25.3.6 and 26 before 26.0.1, out-of-bounds memory access can occur in WebGPU because the amount of to-be-allocated data depends on an untrusted party, and is then used for alloca.",
+      "vulnerability_id": "CVE-2026-40393",
+      "name": "CVE-2026-40393",
+      "package_name": "mesa",
+      "package_details": {
+        "file_path": null,
+        "name": "mesa",
+        "package_manager": "OS",
+        "version": "23.0.4",
+        "release": "0ubuntu1~22.04.1"
+      },
+      "remediation": {"recommendation": {"text": "None Provided"}},
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://people.canonical.com/~ubuntu-security/cve/2026/CVE-2026-40393.html",
+      "source": "UBUNTU_CVE",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2026-40393 - mesa",
+      "reason_to_ignore": "DLC training containers do not expose a WebGPU/rendering surface to untrusted content; mesa is pulled in transitively via libgl1-mesa-glx for OpenCV/visualization deps. Ubuntu 22.04 jammy has not provided a fixed mesa version (remediation: None Provided); awaiting upstream USN."
+    }
+  ],
   "black": [
     {
       "description": "Black is the uncompromising Python code formatter. Prior to 26.3.1, Black writes a cache file, the name of which is computed from various formatting options. The value of the --python-cell-magics option was placed in the filename without sanitization, which allowed an attacker who controls the value of this argument to write cache files to arbitrary file system locations. Fixed in Black 26.3.1.",


### PR DESCRIPTION
Adds an os_scan_allowlist entry for mesa CVE-2026-40393 (CVSS v3 9.8 CRITICAL, WebGPU OOB) to the PyTorch 2.9 SageMaker training CPU and GPU (cu130) allowlists. mesa is pulled in transitively (libgl1-mesa-glx for OpenCV/visualization deps); DLC training containers do not expose a WebGPU/rendering surface to untrusted content, so the vulnerable code path is not reachable. Ubuntu 22.04 jammy has not provided a fixed mesa version (remediation: None Provided); awaiting upstream USN.

## Purpose

## Test Plan

## Test Result
[ff42a42](https://github.com/aws/deep-learning-containers/pull/6272/commits/ff42a42193d609ef5135fa066768fdcb906cc9b1) - passed all tests
______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
