### PR TITLE
Force-align boto3/botocore/awscli/s3transfer in PT 2.10 GPU SM image

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -63,8 +63,8 @@ use_new_test_structure = false
 ### On by default
 sanity_tests = true
 security_tests = true
-  safety_check_test = false
-  ecr_scan_allowlist_feature = false
+  safety_check_test = true
+  ecr_scan_allowlist_feature = true
 ecs_tests = true
 eks_tests = true
 ec2_tests = true
@@ -98,11 +98,11 @@ ipv6_vpc_name = ""
 # run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = true
 # run efa sagemaker tests
-sagemaker_efa_tests = false
+sagemaker_efa_tests = true
 # run release_candidate_integration tests
-sagemaker_rc_tests = false
+sagemaker_rc_tests = true
 # run sagemaker benchmark tests
-sagemaker_benchmark_tests = false
+sagemaker_benchmark_tests = true
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = ""
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-sm.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -63,8 +63,8 @@ use_new_test_structure = false
 ### On by default
 sanity_tests = true
 security_tests = true
-  safety_check_test = true
-  ecr_scan_allowlist_feature = true
+  safety_check_test = false
+  ecr_scan_allowlist_feature = false
 ecs_tests = true
 eks_tests = true
 ec2_tests = true
@@ -98,11 +98,11 @@ ipv6_vpc_name = ""
 # run standard sagemaker remote tests from test/sagemaker_tests
 sagemaker_remote_tests = true
 # run efa sagemaker tests
-sagemaker_efa_tests = true
+sagemaker_efa_tests = false
 # run release_candidate_integration tests
-sagemaker_rc_tests = true
+sagemaker_rc_tests = false
 # run sagemaker benchmark tests
-sagemaker_benchmark_tests = true
+sagemaker_benchmark_tests = false
 
 # SM remote EFA test instance type
 sagemaker_remote_efa_instance_type = ""
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-sm.yml"
+dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/pytorch/training/docker/2.10/py3/cu130/Dockerfile.gpu
+++ b/pytorch/training/docker/2.10/py3/cu130/Dockerfile.gpu
@@ -277,6 +277,22 @@ RUN pip install --no-cache-dir -U \
     "greenlet>=3.4.0" \
     "starlette>=1.0.0"
 
+# Force-upgrade boto3/botocore/awscli/s3transfer above the ceiling that
+# aiobotocore (transitively pulled by s3fs>=2026.2.0) declares (botocore<1.43.1).
+# boto3>=1.43.34 imports DocumentModifiedShape from botocore.docs.utils, which
+# only exists in botocore>=1.43.34, so the boto3/botocore pair must stay
+# aligned on the 1.43.x line. This also keeps the four AWS SDK packages at or
+# above the prior released image's baseline so test_package_version_regression
+# does not regress (awscli>=1.45.14, boto3>=1.43.14, botocore>=1.43.0,
+# s3transfer>=0.17.0). pip will print an aiobotocore-vs-botocore conflict
+# warning here but installation proceeds; aiobotocore is only exercised via
+# smclarify's s3fs path, not at container boot.
+RUN pip install --no-cache-dir -U \
+    "boto3>=1.43.34" \
+    "botocore>=1.43.34" \
+    "awscli>=1.45.34" \
+    "s3transfer>=0.19.0"
+
 COPY setup_oss_compliance.sh setup_oss_compliance.sh
 RUN bash setup_oss_compliance.sh ${PYTHON} && rm setup_oss_compliance.sh
 


### PR DESCRIPTION
The PyTorch 2.10 SageMaker training GPU image installs `s3fs>=2026.2.0`, which transitively pulls `aiobotocore` with a `botocore<1.43.1` ceiling. At the same time, `boto3>=1.43.34` imports `DocumentModifiedShape` from `botocore.docs.utils`, a symbol that only exists in `botocore>=1.43.34`. Without an explicit override, pip leaves botocore on the aiobotocore- capped version and `import boto3` fails at container boot:

    ImportError: cannot import name 'DocumentModifiedShape' from
    'botocore.docs.utils'

Force-upgrade the four AWS SDK packages after the s3fs install so the boto3/botocore pair stays aligned on the 1.43.x line. Pins also clear `test_package_version_regression`'s baseline (awscli>=1.45.14, boto3>=1.43.14, botocore>=1.43.0, s3transfer>=0.17.0). pip will emit an aiobotocore-vs-botocore warning during the build, but installation proceeds and aiobotocore is only exercised via smclarify's s3fs path, not at container boot.

## Purpose

## Test Plan

## Test Result
[d849b20](https://github.com/aws/deep-learning-containers/pull/6280/commits/d849b2020d695684dee2b7171c0685f3f688604e) - passing all tests
______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
