### PR TITLE
[DJL] Add LMI v27 (0.36.0/lmi27.0.0-cu130) inference release image

### DIFF
--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -165,3 +165,17 @@ release_images:
       example: False
       disable_sm_tag: True
       force_release: False
+  13:
+    framework: "djl"
+    version: "0.36.0"
+    arch_type: "x86"
+    inference:
+      device_types: [ "gpu" ]
+      python_versions: [ "py312" ]
+      os_version: "ubuntu24.04"
+      lmi_version: "27.0.0"
+      cuda_version: "cu130"
+      example: False
+      disable_sm_tag: True
+      force_release: False
+      public_registry: True


### PR DESCRIPTION
Adding DJL-LMI v27 release image entry:
- framework: djl
- version: 0.36.0
- lmi_version: 27.0.0
- cuda_version: cu130 (torch 2.11.0, vLLM 0.23.1)
- disable_sm_tag: True
- public_registry: True

This enables the region build pipeline for LMI v27.