### PR TITLE
feat(vllm-omni): accept application/json on video routes

### DIFF
--- a/.github/config/image/vllm-omni/ec2-amzn2023.yml
+++ b/.github/config/image/vllm-omni/ec2-amzn2023.yml
@@ -25,7 +25,7 @@ build:
   torch_cuda_arch_list: "7.5;8.0;8.6;8.9;9.0;10.0;11.0;12.0+PTX"
   install_kv_connectors: "true"
   dlc_major_version: "1"
-  dlc_minor_version: "3"
+  dlc_minor_version: "4"
   use_sccache: "true"
 
 release:

--- a/.github/config/image/vllm-omni/sagemaker-amzn2023.yml
+++ b/.github/config/image/vllm-omni/sagemaker-amzn2023.yml
@@ -26,7 +26,7 @@ build:
   torch_cuda_arch_list: "7.5;8.0;8.6;8.9;9.0;10.0;11.0;12.0+PTX"
   install_kv_connectors: "true"
   dlc_major_version: "1"
-  dlc_minor_version: "3"
+  dlc_minor_version: "4"
   use_sccache: "true"
 
 release:

--- a/.github/config/model-tests/vllm-omni-model-tests.yml
+++ b/.github/config/model-tests/vllm-omni-model-tests.yml
@@ -104,6 +104,21 @@ smoke-test:
       test_request: 'prompt=a dog running on a beach&num_frames=17&num_inference_steps=4&size=480x320&seed=42'
       validate: "binary_size_gt:1000"
 
+    # Sync route via application/json: the SageMaker routing middleware
+    # (omni_sagemaker_serve.py) converts the JSON object into a
+    # multipart/form-data body before handing it to the upstream
+    # /v1/videos/sync handler, which only accepts form data. Exercises the
+    # JSON content-type path so SageMaker callers can send JSON instead of
+    # building a multipart body by hand.
+    - name: "wan2.1-t2v-1.3b-sync-json"
+      s3_model: "wan2.1-t2v-1.3b.tar.gz"
+      fleet: "x86-g6exl-runner"
+      extra_args: ""
+      route: "/v1/videos/sync"
+      content_type: "application/json"
+      test_request: '{"prompt": "a dog running on a beach", "num_frames": 17, "num_inference_steps": 4, "size": "480x320", "seed": 42}'
+      validate: "binary_size_gt:1000"
+
     # Wan2.1-VACE: unified video creation/editing pipeline (WanVACEPipeline,
     # added in vllm-omni #1885). Distinct from WanPipeline T2V — accepts
     # text + optional video/mask/reference image. 1.3B variant fits L40S.

--- a/.github/config/model-tests/vllm-omni-model-tests.yml
+++ b/.github/config/model-tests/vllm-omni-model-tests.yml
@@ -110,9 +110,15 @@ smoke-test:
     # /v1/videos/sync handler, which only accepts form data. Exercises the
     # JSON content-type path so SageMaker callers can send JSON instead of
     # building a multipart body by hand.
+    #
+    # sagemaker-only: the JSON->multipart conversion lives in the SageMaker
+    # routing middleware, which is not loaded on the EC2 image (plain
+    # `vllm serve`). On EC2 this JSON body reaches the Form-only upstream
+    # handler and returns 400, so the test is gated to the sagemaker config.
     - name: "wan2.1-t2v-1.3b-sync-json"
       s3_model: "wan2.1-t2v-1.3b.tar.gz"
       fleet: "x86-g6exl-runner"
+      customer_type: "sagemaker"
       extra_args: ""
       route: "/v1/videos/sync"
       content_type: "application/json"

--- a/.github/workflows/vllm-omni.pr.yml
+++ b/.github/workflows/vllm-omni.pr.yml
@@ -1,7 +1,6 @@
 name: "PR - vLLM-Omni"
 
 on:
-  workflow_dispatch:
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize]

--- a/.github/workflows/vllm-omni.pr.yml
+++ b/.github/workflows/vllm-omni.pr.yml
@@ -1,6 +1,7 @@
 name: "PR - vLLM-Omni"
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [main]
     types: [opened, reopened, synchronize]

--- a/.github/workflows/vllm-omni.tests-model.yml
+++ b/.github/workflows/vllm-omni.tests-model.yml
@@ -59,7 +59,7 @@ jobs:
           uv venv --python 3.12
           source .venv/bin/activate
           uv pip install pyyaml
-          python3 scripts/ci/parse_model_config.py --config .github/config/model-tests/vllm-omni-model-tests.yml --runner-type codebuild-fleet
+          python3 scripts/ci/parse_model_config.py --config .github/config/model-tests/vllm-omni-model-tests.yml --runner-type codebuild-fleet --customer-type "${{ steps.config.outputs.customer-type }}"
 
   smoke-test:
     name: smoke-test (${{ matrix.model.name }})

--- a/.github/workflows/vllm.pr-amzn2023.yml
+++ b/.github/workflows/vllm.pr-amzn2023.yml
@@ -13,6 +13,8 @@ on:
       - "scripts/docker/common/**"
       - "scripts/docker/telemetry/**"
       - "scripts/docker/vllm/**"
+      # omni_* scripts belong to vllm_omni only
+      - "!scripts/docker/vllm/omni_*"
       - "test/efa/**"
       - "test/sanity/**"
       - "test/security/data/ecr_scan_allowlist/vllm_server/**"

--- a/.github/workflows/vllm.pr-ubuntu.yml
+++ b/.github/workflows/vllm.pr-ubuntu.yml
@@ -13,6 +13,8 @@ on:
       - "scripts/docker/common/**"
       - "scripts/docker/telemetry/**"
       - "scripts/docker/vllm/**"
+      # omni_* scripts belong to vllm_omni only
+      - "!scripts/docker/vllm/omni_*"
       - "test/efa/**"
       - "test/sanity/**"
       - "test/security/data/ecr_scan_allowlist/vllm/**"

--- a/scripts/ci/parse_model_config.py
+++ b/scripts/ci/parse_model_config.py
@@ -62,7 +62,24 @@ def load_yaml(path: str) -> dict:
     return json.loads(result.stdout)
 
 
-def parse_config(config_path: str, section: str, runner_type: str) -> dict[str, str]:
+def matches_customer_type(model: dict, customer_type: str) -> bool:
+    """A model runs on a config unless it pins a different customer_type.
+
+    Models without a ``customer_type`` field run everywhere (backward
+    compatible). A model that pins e.g. ``customer_type: sagemaker`` only runs
+    when the config's customer type matches — used to gate tests for features
+    that exist on only one container variant (e.g. the SageMaker routing
+    middleware, which adds the JSON->multipart video path absent on EC2).
+    """
+    pinned = model.get("customer_type")
+    if not pinned or not customer_type:
+        return True
+    return pinned == customer_type
+
+
+def parse_config(
+    config_path: str, section: str, runner_type: str, customer_type: str = ""
+) -> dict[str, str]:
     cfg = load_yaml(config_path)
 
     s3_prefix = cfg.get("s3_prefix", "")
@@ -73,6 +90,7 @@ def parse_config(config_path: str, section: str, runner_type: str) -> dict[str, 
 
     for rt in types:
         models = cfg.get(section, {}).get(rt, []) or []
+        models = [m for m in models if matches_customer_type(m, customer_type)]
         transformed = [transform_model(m, s3_prefix, fixtures_prefix) for m in models]
         key = rt if runner_type == "all" else "matrix"
         results[key] = json.dumps(transformed, separators=(",", ":"))
@@ -91,13 +109,19 @@ def main():
         default="all",
         help="Runner type: all, codebuild-fleet, or runner-scale-sets",
     )
+    parser.add_argument(
+        "--customer-type",
+        default="",
+        help="Config customer type (e.g. ec2, sagemaker). When set, drops models "
+        "that pin a different customer_type. Empty = include all models.",
+    )
     args = parser.parse_args()
 
     if not os.path.isfile(args.config):
         print(f"ERROR: Config file not found: {args.config}", file=sys.stderr)
         sys.exit(1)
 
-    results = parse_config(args.config, args.section, args.runner_type)
+    results = parse_config(args.config, args.section, args.runner_type, args.customer_type)
 
     output_file = os.environ.get("GITHUB_OUTPUT")
     if output_file:

--- a/scripts/docker/vllm/omni_sagemaker_serve.py
+++ b/scripts/docker/vllm/omni_sagemaker_serve.py
@@ -8,11 +8,15 @@ header. Clients specify the target endpoint via route=<path>, e.g.:
 If no route is specified, falls through to vLLM's built-in /invocations
 handler (chat/completion/embed).
 
-Clients targeting routes that require multipart/form-data (e.g. /v1/videos)
-must send the request with ContentType="multipart/form-data; boundary=..."
-and a pre-built multipart body. SageMaker InvokeEndpoint accepts arbitrary
-ContentType values and forwards them to the model server unchanged, so no
-in-middleware conversion is needed.
+Some routes (e.g. /v1/videos, /v1/videos/sync) are implemented upstream as
+multipart/form-data handlers. Clients may target them either with a
+pre-built multipart/form-data body, or — for convenience over SageMaker
+InvokeEndpoint — with a plain application/json object. When the resolved
+route is one of FORM_DATA_ROUTES and the request arrives as application/json,
+this middleware transparently converts the JSON object into a
+multipart/form-data body (each top-level key becomes a form field) so the
+upstream handler receives the encoding it expects. multipart/form-data bodies
+are passed through unchanged.
 
 Usage: vllm serve --omni --middleware omni_sagemaker_serve.SageMakerRouteMiddleware
 
@@ -25,12 +29,18 @@ removes the `args.middleware` loop in `build_app`, this loader will silently
 no-op and SageMaker /invocations will return 404 for non-default routes.
 """
 
+import json
 import logging
 import re
+import uuid
 
-from starlette.types import ASGIApp, Receive, Scope, Send
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 logger = logging.getLogger("omni_sagemaker")
+
+# Routes whose upstream handlers expect multipart/form-data. A JSON body
+# targeting one of these is converted to multipart before it reaches vLLM.
+FORM_DATA_ROUTES = frozenset({"/v1/videos", "/v1/videos/sync"})
 
 
 def _parse_route(headers: list[tuple[bytes, bytes]]) -> str | None:
@@ -42,11 +52,79 @@ def _parse_route(headers: list[tuple[bytes, bytes]]) -> str | None:
     return None
 
 
+def _content_type(headers: list[tuple[bytes, bytes]]) -> str:
+    """Return the bare content-type (no parameters), lowercased."""
+    for key, value in headers:
+        if key.lower() == b"content-type":
+            return value.decode().split(";", 1)[0].strip().lower()
+    return ""
+
+
+def _field_value(value: object) -> str:
+    """Render a non-null JSON value as a multipart form field string.
+
+    Scalars map to their natural string form; bool maps to "true"/"false";
+    nested objects/arrays are re-encoded as JSON. None is handled by the
+    caller (_build_multipart drops null keys) and never reaches here.
+    """
+    if isinstance(value, str):
+        return value
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    return json.dumps(value)
+
+
+def _escape_field_name(name: str) -> str:
+    """Escape a form-field name for the Content-Disposition header.
+
+    RFC 7578 requires CR/LF and double-quote to be escaped inside name="...".
+    Without this a key containing " or a newline would corrupt the header.
+    """
+    return name.replace("\\", "\\\\").replace('"', '\\"').replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _build_multipart(fields: dict, boundary: str) -> bytes:
+    # JSON null has no faithful form-data representation: a form field is
+    # always a present string. Emitting the literal "null" would make the
+    # upstream handler see a present-but-bogus value instead of an absent one,
+    # bypassing its default-on-missing logic. Dropping the key reproduces what
+    # a caller omitting the field would send, which is the closest match.
+    parts = [
+        f'--{boundary}\r\nContent-Disposition: form-data; name="{_escape_field_name(k)}"'
+        f"\r\n\r\n{_field_value(v)}\r\n"
+        for k, v in fields.items()
+        if v is not None
+    ]
+    parts.append(f"--{boundary}--\r\n")
+    return "".join(parts).encode()
+
+
+def _replay(body: bytes) -> Receive:
+    """Build a receive callable that yields `body` as a single http.request."""
+    sent = False
+
+    async def receive() -> Message:
+        nonlocal sent
+        if not sent:
+            sent = True
+            return {"type": "http.request", "body": body, "more_body": False}
+        return {"type": "http.disconnect"}
+
+    return receive
+
+
 class SageMakerRouteMiddleware:
     """ASGI middleware that reroutes /invocations based on CustomAttributes.
 
     Explicit route via header -> rewrites path to that endpoint.
     No route specified -> falls through to vLLM's built-in /invocations handler.
+
+    When the resolved route expects multipart/form-data (FORM_DATA_ROUTES) but
+    the body arrives as application/json, the JSON object is converted to a
+    multipart/form-data body so the upstream handler receives its expected
+    encoding.
     """
 
     def __init__(self, app: ASGIApp) -> None:
@@ -61,4 +139,50 @@ class SageMakerRouteMiddleware:
                 scope["path"] = route
                 scope["raw_path"] = route.encode()
 
+                if (
+                    route in FORM_DATA_ROUTES
+                    and _content_type(scope.get("headers", [])) == "application/json"
+                ):
+                    scope, receive = await self._json_to_multipart(scope, receive)
+
         await self.app(scope, receive, send)
+
+    async def _json_to_multipart(self, scope: Scope, receive: Receive) -> tuple[Scope, Receive]:
+        """Drain the JSON body, convert it to multipart, and return a new
+        (scope, receive) carrying the rewritten content-type and body.
+
+        On any failure (non-object JSON, parse error) the original body is
+        replayed untouched so the upstream handler produces its normal error
+        response rather than this middleware masking it.
+        """
+        body = b""
+        more_body = True
+        while more_body:
+            message = await receive()
+            body += message.get("body", b"")
+            more_body = message.get("more_body", False)
+
+        try:
+            parsed = json.loads(body)
+            if not isinstance(parsed, dict):
+                raise ValueError("JSON body for a form route must be an object")
+        except (ValueError, json.JSONDecodeError) as exc:
+            logger.warning("Could not convert JSON body to multipart: %s", exc)
+            return scope, _replay(body)
+
+        boundary = uuid.uuid4().hex
+        new_body = _build_multipart(parsed, boundary)
+        content_type = f"multipart/form-data; boundary={boundary}".encode()
+
+        headers = [
+            (k, v)
+            for k, v in scope["headers"]
+            if k.lower() not in (b"content-type", b"content-length")
+        ]
+        headers.append((b"content-type", content_type))
+        headers.append((b"content-length", str(len(new_body)).encode()))
+        scope = dict(scope)
+        scope["headers"] = headers
+
+        logger.info("Converted application/json body to multipart/form-data")
+        return scope, _replay(new_body)

--- a/test/security/data/ecr_scan_allowlist/vllm_omni/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/vllm_omni/framework_allowlist.json
@@ -70,6 +70,11 @@
         "review_by": "2026-08-25"
     },
     {
+        "vulnerability_id": "CVE-2026-27145",
+        "reason": "go/stdlib in mooncake/libetcd_wrapper.so, unpatchable without mooncake upgrade",
+        "review_by": "2026-08-25"
+    },
+    {
         "vulnerability_id": "RUSTSEC-2026-0185",
         "reason": "quinn-proto in uv binary, upstream uv has not released a fix yet",
         "review_by": "2026-09-25"

--- a/test/vllm-omni/sagemaker/test_sagemaker_middleware.py
+++ b/test/vllm-omni/sagemaker/test_sagemaker_middleware.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import re
 import sys
 
 # Allow importing omni_sagemaker_serve from scripts/docker/vllm/
@@ -9,8 +10,15 @@ sys.path.insert(
     0, os.path.join(os.path.dirname(__file__), "..", "..", "..", "scripts", "docker", "vllm")
 )
 
+import json
+
 import pytest
-from omni_sagemaker_serve import SageMakerRouteMiddleware, _parse_route
+from omni_sagemaker_serve import (
+    FORM_DATA_ROUTES,
+    SageMakerRouteMiddleware,
+    _build_multipart,
+    _parse_route,
+)
 
 
 class TestParseRoute:
@@ -143,3 +151,274 @@ class TestMiddleware:
         assert captured["path"] == "/v1/videos"
         assert body_captured["body"] == form_body
         assert captured["headers"][b"content-type"] == b"multipart/form-data; boundary=boundary"
+
+
+def _parse_multipart(body: bytes, content_type: str) -> dict:
+    """Minimal multipart/form-data parser for test assertions.
+
+    Splits on the boundary from the content-type and extracts
+    name -> value for each simple form-data part.
+    """
+    boundary = content_type.split("boundary=", 1)[1]
+    delimiter = f"--{boundary}".encode()
+    fields = {}
+    for part in body.split(delimiter):
+        if not part.strip() or part.strip() == b"--":
+            continue
+        head, _, value = part.partition(b"\r\n\r\n")
+        m = re.search(rb'name="([^"]+)"', head)
+        if m:
+            fields[m.group(1).decode()] = value.rstrip(b"\r\n").decode()
+    return fields
+
+
+class TestJsonToMultipart:
+    """JSON bodies targeting a form-data route are converted to multipart."""
+
+    def _capture(self, route, body, content_type=b"application/json", chunks=None):
+        captured = {}
+
+        async def app(scope, receive, send):
+            captured["path"] = scope["path"]
+            captured["headers"] = dict(scope["headers"])
+            collected = b""
+            more = True
+            while more:
+                msg = await receive()
+                collected += msg.get("body", b"")
+                more = msg.get("more_body", False)
+            captured["body"] = collected
+
+        middleware = SageMakerRouteMiddleware(app)
+
+        # When `chunks` is provided, deliver the body across multiple
+        # http.request messages to exercise the streamed-body drain loop.
+        messages = (
+            [
+                {"type": "http.request", "body": c, "more_body": i < len(chunks) - 1}
+                for i, c in enumerate(chunks)
+            ]
+            if chunks is not None
+            else [{"type": "http.request", "body": body, "more_body": False}]
+        )
+        msg_iter = iter(messages)
+
+        async def receive():
+            return next(msg_iter)
+
+        scope = {
+            "type": "http",
+            "path": "/invocations",
+            "raw_path": b"/invocations",
+            "headers": [
+                (b"x-amzn-sagemaker-custom-attributes", f"route={route}".encode()),
+                (b"content-type", content_type),
+            ],
+        }
+        asyncio.get_event_loop().run_until_complete(middleware(scope, receive, None))
+        return captured
+
+    def test_video_sync_json_converted_to_multipart(self):
+        payload = {
+            "prompt": "A cat playing with a ball",
+            "num_frames": 17,
+            "num_inference_steps": 30,
+            "size": "480x320",
+        }
+        captured = self._capture("/v1/videos/sync", json.dumps(payload).encode())
+
+        assert captured["path"] == "/v1/videos/sync"
+        ctype = captured["headers"][b"content-type"].decode()
+        assert ctype.startswith("multipart/form-data; boundary=")
+        fields = _parse_multipart(captured["body"], ctype)
+        assert fields == {
+            "prompt": "A cat playing with a ball",
+            "num_frames": "17",
+            "num_inference_steps": "30",
+            "size": "480x320",
+        }
+
+    def test_content_length_matches_new_body(self):
+        captured = self._capture("/v1/videos/sync", json.dumps({"prompt": "hi"}).encode())
+        assert captured["headers"][b"content-length"] == str(len(captured["body"])).encode()
+
+    def test_async_videos_route_also_converted(self):
+        assert "/v1/videos" in FORM_DATA_ROUTES
+        captured = self._capture("/v1/videos", json.dumps({"prompt": "hi"}).encode())
+        assert captured["headers"][b"content-type"].decode().startswith("multipart/form-data")
+
+    def test_bool_and_nested_values_rendered(self):
+        payload = {"flag": True, "opts": {"seed": 42}}
+        captured = self._capture("/v1/videos/sync", json.dumps(payload).encode())
+        ctype = captured["headers"][b"content-type"].decode()
+        fields = _parse_multipart(captured["body"], ctype)
+        assert fields["flag"] == "true"
+        assert json.loads(fields["opts"]) == {"seed": 42}
+
+    def test_non_form_route_json_passes_through(self):
+        """JSON to a non-form route (e.g. TTS) is left untouched."""
+        body = json.dumps({"input": "hello"}).encode()
+        captured = self._capture("/v1/audio/speech", body)
+        assert captured["path"] == "/v1/audio/speech"
+        assert captured["headers"][b"content-type"] == b"application/json"
+        assert captured["body"] == body
+
+    def test_multipart_to_form_route_passes_through(self):
+        """An explicit multipart body to a form route is not re-encoded."""
+        form_body = (
+            b'--b\r\nContent-Disposition: form-data; name="prompt"\r\n\r\na dog\r\n--b--\r\n'
+        )
+        captured = self._capture(
+            "/v1/videos/sync",
+            form_body,
+            content_type=b"multipart/form-data; boundary=b",
+        )
+        assert captured["body"] == form_body
+        assert captured["headers"][b"content-type"] == b"multipart/form-data; boundary=b"
+
+    def test_invalid_json_passes_through_untouched(self):
+        """Malformed JSON is replayed verbatim so upstream returns its own error."""
+        bad = b"{not valid json"
+        captured = self._capture("/v1/videos/sync", bad)
+        assert captured["body"] == bad
+        # content-type unchanged because conversion bailed out
+        assert captured["headers"][b"content-type"] == b"application/json"
+
+    def test_non_object_json_passes_through_untouched(self):
+        """A JSON array (not an object) cannot become form fields -> passthrough."""
+        arr = b'["a", "b"]'
+        captured = self._capture("/v1/videos/sync", arr)
+        assert captured["body"] == arr
+        assert captured["headers"][b"content-type"] == b"application/json"
+
+    def test_chunked_json_body_is_reassembled(self):
+        """A JSON body split across multiple http.request messages is drained
+        in full before conversion."""
+        payload = {"prompt": "a dog running on a beach", "num_frames": 17}
+        raw = json.dumps(payload).encode()
+        mid = len(raw) // 2
+        captured = self._capture("/v1/videos/sync", raw, chunks=[raw[:mid], raw[mid:]])
+        ctype = captured["headers"][b"content-type"].decode()
+        assert ctype.startswith("multipart/form-data")
+        fields = _parse_multipart(captured["body"], ctype)
+        assert fields == {"prompt": "a dog running on a beach", "num_frames": "17"}
+
+    def test_null_value_field_is_dropped(self):
+        """JSON null has no form-data equivalent — the key is omitted so the
+        upstream handler applies its default-on-missing behavior rather than
+        receiving the literal string "null"."""
+        payload = {"prompt": "a dog", "seed": None}
+        captured = self._capture("/v1/videos/sync", json.dumps(payload).encode())
+        ctype = captured["headers"][b"content-type"].decode()
+        fields = _parse_multipart(captured["body"], ctype)
+        assert fields == {"prompt": "a dog"}
+        assert "seed" not in fields
+
+    def test_field_name_with_quote_is_escaped(self):
+        """A key containing a double-quote must not corrupt the
+        Content-Disposition header."""
+        captured = self._capture("/v1/videos/sync", json.dumps({'a"b': "v"}).encode())
+        body = captured["body"]
+        # The raw quote in the key is backslash-escaped, so there is exactly
+        # one well-formed name="..." part and the upstream parser sees a"b.
+        assert b'name="a\\"b"' in body
+
+
+class TestBuildMultipart:
+    def test_roundtrip(self):
+        boundary = "abc123"
+        body = _build_multipart({"prompt": "hi", "n": "1"}, boundary)
+        fields = _parse_multipart(body, f"multipart/form-data; boundary={boundary}")
+        assert fields == {"prompt": "hi", "n": "1"}
+
+
+class TestVideoInvocationContentTypes:
+    """Coverage of the two supported content-type combinations a SageMaker
+    caller uses against the video routes:
+
+      1. multipart/form-data + route=/v1/videos/sync  -> passthrough
+      2. application/json     + route=/v1/videos/sync  -> converted to multipart
+
+    Both require route=/v1/videos/sync. JSON without a route is not supported
+    (it falls through to vLLM's chat handler); that fall-through is already
+    covered by TestMiddleware::test_falls_through_without_route.
+
+    Asserts what the upstream vllm-omni handler ends up receiving (path,
+    content-type, body), since the upstream handler only accepts
+    multipart/form-data.
+    """
+
+    VIDEO_FIELDS = {
+        "prompt": "A cat playing with a ball",
+        "num_frames": 17,
+        "num_inference_steps": 30,
+        "size": "480x320",
+    }
+
+    def _capture(self, headers, body):
+        captured = {}
+
+        async def app(scope, receive, send):
+            captured["path"] = scope["path"]
+            captured["headers"] = dict(scope["headers"])
+            collected = b""
+            more = True
+            while more:
+                msg = await receive()
+                collected += msg.get("body", b"")
+                more = msg.get("more_body", False)
+            captured["body"] = collected
+
+        middleware = SageMakerRouteMiddleware(app)
+
+        async def receive():
+            return {"type": "http.request", "body": body, "more_body": False}
+
+        scope = {
+            "type": "http",
+            "path": "/invocations",
+            "raw_path": b"/invocations",
+            "headers": headers,
+        }
+        asyncio.get_event_loop().run_until_complete(middleware(scope, receive, None))
+        return captured
+
+    def test_case1_multipart_with_route_passthrough(self):
+        """multipart/form-data + route -> reaches /v1/videos/sync unchanged."""
+        boundary = "case1boundary"
+        body = _build_multipart({k: str(v) for k, v in self.VIDEO_FIELDS.items()}, boundary)
+        captured = self._capture(
+            headers=[
+                (b"x-amzn-sagemaker-custom-attributes", b"route=/v1/videos/sync"),
+                (b"content-type", f"multipart/form-data; boundary={boundary}".encode()),
+            ],
+            body=body,
+        )
+        assert captured["path"] == "/v1/videos/sync"
+        # Body and content-type pass through untouched.
+        assert captured["body"] == body
+        assert captured["headers"][b"content-type"] == (
+            f"multipart/form-data; boundary={boundary}".encode()
+        )
+
+    def test_case2_json_with_route_converted(self):
+        """application/json + route -> converted to multipart (the fix). This
+        is the combination that previously returned 400."""
+        captured = self._capture(
+            headers=[
+                (b"x-amzn-sagemaker-custom-attributes", b"route=/v1/videos/sync"),
+                (b"content-type", b"application/json"),
+            ],
+            body=json.dumps(self.VIDEO_FIELDS).encode(),
+        )
+        assert captured["path"] == "/v1/videos/sync"
+        ctype = captured["headers"][b"content-type"].decode()
+        assert ctype.startswith("multipart/form-data; boundary=")
+        fields = _parse_multipart(captured["body"], ctype)
+        # int values arrive as form strings; FastAPI coerces them back to int.
+        assert fields == {
+            "prompt": "A cat playing with a ball",
+            "num_frames": "17",
+            "num_inference_steps": "30",
+            "size": "480x320",
+        }

--- a/test/vllm/scripts/vllm_regression_test.sh
+++ b/test/vllm/scripts/vllm_regression_test.sh
@@ -9,5 +9,6 @@ fi
 
 # Regression Test # 7min
 cd vllm_source/tests
-uv pip install $UV_FLAGS modelscope
+# modelscope 1.38.0 dropped get_model_files(revision=), breaks vllm 0.24.0
+uv pip install $UV_FLAGS 'modelscope<1.38'
 pytest -v -s test_regression.py


### PR DESCRIPTION
Restores JSON->multipart conversion in the SageMaker routing middleware for the form-data video routes (`/v1/videos`, `/v1/videos/sync`), so callers can send `application/json` instead of multipart. The proven multipart path is unchanged (byte-for-byte passthrough).

Stays on vllm-omni 0.21.0rc1 — no framework bump. Bumps `dlc_minor_version` 3 -> 4.