### PR TITLE
[DJL] Add LMI v27 (0.36.0-lmi27.0.0-cu130) to available images docs

### DIFF
--- a/docs/src/data/djl-inference/0.36-lmi26.0.0-gpu.yml
+++ b/docs/src/data/djl-inference/0.36-lmi26.0.0-gpu.yml
@@ -2,7 +2,7 @@ framework: DJLServing
 version: "0.36"
 accelerator: gpu
 cuda: cu130
-engine: "LMI 26.0.0, vLLM 0.22.0"
+engine: "LMI 26.0.0, vLLM 0.22.1"
 platform: sagemaker
 
 tags:

--- a/docs/src/data/djl-inference/0.36-lmi26.0.0-gpu.yml
+++ b/docs/src/data/djl-inference/0.36-lmi26.0.0-gpu.yml
@@ -1,0 +1,9 @@
+framework: DJLServing
+version: "0.36"
+accelerator: gpu
+cuda: cu130
+engine: "LMI 26.0.0, vLLM 0.22.0"
+platform: sagemaker
+
+tags:
+  - "0.36.0-lmi26.0.0-cu130"

--- a/docs/src/data/djl-inference/0.36-lmi27.0.0-gpu.yml
+++ b/docs/src/data/djl-inference/0.36-lmi27.0.0-gpu.yml
@@ -1,0 +1,9 @@
+framework: DJLServing
+version: "0.36"
+accelerator: gpu
+cuda: cu130
+engine: "LMI 27.0.0, vLLM 0.23.1"
+platform: sagemaker
+
+tags:
+  - "0.36.0-lmi27.0.0-cu130"


### PR DESCRIPTION
## Summary
Adds the LMI v27 inference image to the auto-generated available-images documentation.

- New file: `docs/src/data/djl-inference/0.36-lmi27.0.0-gpu.yml`
- Image: `763104351884.dkr.ecr.<region>.amazonaws.com/djl-inference:0.36.0-lmi27.0.0-cu130`
- Engine: LMI 27.0.0, vLLM 0.23.1 / DJL Serving 0.36.0 / CUDA 13.0

This is the post-release docs step (the release_images_inference.yml entry merged in #6289). `available_images.md` is now auto-generated from `docs/src/data/`, so this per-version YAML is the correct surface to update.

## Testing
- Mirrors the existing `0.36-lmi26.0.0-gpu.yml` schema exactly.

🤖 Draft PR — do not merge without release owner approval.