### PR TITLE
chore(xgboost): promote SageMaker release environments

### DIFF
--- a/.github/config/image/xgboost/sagemaker-3.0.yml
+++ b/.github/config/image/xgboost/sagemaker-3.0.yml
@@ -28,4 +28,4 @@ release:
   public_registry: false
   private_registry: true
   enable_soci: false
-  environment: "preprod"
+  environment: "production"

--- a/.github/config/image/xgboost/sagemaker.yml
+++ b/.github/config/image/xgboost/sagemaker.yml
@@ -28,4 +28,4 @@ release:
   public_registry: false
   private_registry: true
   enable_soci: false
-  environment: "gamma"
+  environment: "preprod"


### PR DESCRIPTION
## Description

Promote the XGBoost SageMaker release environments:

- `.github/config/image/xgboost/sagemaker-3.0.yml` (XGBoost 3.0.5): `preprod` → `production`
- `.github/config/image/xgboost/sagemaker.yml` (XGBoost 3.2.0): `gamma` → `preprod`

## Changes

```yaml
# sagemaker-3.0.yml
release:
  environment: "production"   # was: preprod

# sagemaker.yml
release:
  environment: "preprod"      # was: gamma
```
