### PR TITLE
vllm: bump AL2023 image to vLLM 0.24.0 and add Mellum2 test

### DIFF
--- a/.github/config/image/vllm/ec2-amzn2023.yml
+++ b/.github/config/image/vllm/ec2-amzn2023.yml
@@ -4,7 +4,7 @@ image:
 
 metadata:
   framework: "vllm_server"
-  framework_version: "0.22.1rc0"
+  framework_version: "0.24.0"
   os_version: "amzn2023"
   customer_type: "ec2"
   arch_type: "x86"
@@ -17,11 +17,11 @@ build:
   target: "vllm-ec2-amzn2023"
   python_version: "3.12"
   cuda_version: "13.0.2"
-  vllm_ref: "6aabe221a56052965e6bb0a95e9ec682d046a6e7"
-  flashinfer_version: "0.6.11.post2"
+  vllm_ref: "7b3d595eb197d714052ce296cc8b124f0dc8af31"
+  flashinfer_version: "0.6.12"
   deepep_commit_hash: "73b6ea4"
   dlc_major_version: "2"
-  dlc_minor_version: "0"
+  dlc_minor_version: "1"
   use_sccache: "true"
 
 release:

--- a/.github/config/image/vllm/sagemaker-amzn2023.yml
+++ b/.github/config/image/vllm/sagemaker-amzn2023.yml
@@ -4,7 +4,7 @@ image:
 
 metadata:
   framework: "vllm_server"
-  framework_version: "0.22.1rc0"
+  framework_version: "0.24.0"
   os_version: "amzn2023"
   customer_type: "sagemaker"
   platform: "sagemaker"
@@ -18,11 +18,11 @@ build:
   target: "vllm-sagemaker-amzn2023"
   python_version: "3.12"
   cuda_version: "13.0.2"
-  vllm_ref: "6aabe221a56052965e6bb0a95e9ec682d046a6e7"
-  flashinfer_version: "0.6.11.post2"
+  vllm_ref: "7b3d595eb197d714052ce296cc8b124f0dc8af31"
+  flashinfer_version: "0.6.12"
   deepep_commit_hash: "73b6ea4"
   dlc_major_version: "2"
-  dlc_minor_version: "0"
+  dlc_minor_version: "1"
   use_sccache: "true"
 
 release:

--- a/.github/config/model-tests/vllm-model-tests.yml
+++ b/.github/config/model-tests/vllm-model-tests.yml
@@ -20,6 +20,14 @@ smoke-test:
       fleet: "x86-g6xl-runner"
       extra_args: "--tensor-parallel-size 1 --max-model-len 4096 --dtype bfloat16"
 
+    # JetBrains Mellum2 reasoning MoE (12B total / 2.5B active, bf16 ~23GB).
+    # MellumForCausalLM support added upstream in vLLM 0.23.0 (PR #43992).
+    # Fits a single L40S (g6e.xl, 48GB) at tp=1; qwen3 reasoning parser emits <think> blocks.
+    - name: "mellum2-12b-a2.5b-thinking"
+      s3_model: "mellum2-12b-a2.5b-thinking.tar.gz"
+      fleet: "x86-g6exl-runner"
+      extra_args: "--tensor-parallel-size 1 --max-model-len 4096 --dtype bfloat16 --reasoning-parser qwen3"
+
     - name: "qwen3-embedding-0.6b"
       s3_model: "qwen3-embedding-0.6b.tar.gz"
       fleet: "x86-g6xl-runner"

--- a/.github/config/model-tests/vllm-multimodal-benchmark-tests.yml
+++ b/.github/config/model-tests/vllm-multimodal-benchmark-tests.yml
@@ -21,9 +21,6 @@ benchmark:
       benchmark_profiles: "baseline,high_concurrency,sustained_load,burst"
 
   runner-scale-sets:
-    # On a 48GB L40S (vs the 24GB A10G these previously ran on), the encoder
-    # cache no longer saturates under concurrency — fixes voxtral's empty-embedding
-    # engine crash (broadcast shape [0, 5120]).
     - name: "qwen3-vl-embedding-2b"
       s3_model: "qwen3-vl-embedding-2b.tar.gz"
       runner_label: "gpu-l40s-1gpu-runners"
@@ -31,11 +28,14 @@ benchmark:
       test_script: "vllm_embedding_benchmark_test.sh"
       min_rps: 3
 
+    # Realtime model — benchmark via /v1/audio/transcriptions; it does not
+    # support chat audio_url (empty MM embeddings crash the engine).
     - name: "voxtral-mini-4b"
       s3_model: "voxtral-mini-4b.tar.gz"
       runner_label: "gpu-l40s-1gpu-runners"
       extra_args: "--tokenizer-mode mistral --config-format mistral --load-format mistral --max-model-len 8192 --enforce-eager"
       test_script: "vllm_asr_benchmark_test.sh"
+      benchmark_route: "/v1/audio/transcriptions"
       test_fixtures:
         - "audio/asr_en.wav"
       benchmark_audio_fixture: "asr_en.wav"

--- a/.github/config/model-tests/vllm-text-benchmark-tests.yml
+++ b/.github/config/model-tests/vllm-text-benchmark-tests.yml
@@ -32,6 +32,21 @@ benchmark:
       min_throughput: 1200
       min_rps: 5
 
+    # JetBrains Mellum2 reasoning MoE (12B total / 2.5B active, bf16 ~23GB).
+    # MellumForCausalLM support added upstream in vLLM 0.23.0 (PR #43992).
+    # Fits a single L40S (g6e.xl, 48GB) at tp=1; qwen3 reasoning parser emits <think> blocks.
+    # Provisional floors — tighten to ~50% of observed throughput after the first run.
+    - name: "mellum2-12b-a2.5b-thinking"
+      s3_model: "mellum2-12b-a2.5b-thinking.tar.gz"
+      fleet: "x86-g6exl-runner"
+      extra_args: "--tensor-parallel-size 1 --max-model-len 4096 --dtype bfloat16 --reasoning-parser qwen3"
+      input_len: 512
+      output_len: 128
+      num_prompts: 64
+      batch_size: 4
+      min_throughput: 100
+      min_rps: 1
+
     - name: "gemma-4-e4b-it"
       s3_model: "gemma-4-e4b-it.tar.gz"
       fleet: "x86-g6exl-runner"

--- a/.github/workflows/vllm.dispatch-benchmark.yml
+++ b/.github/workflows/vllm.dispatch-benchmark.yml
@@ -133,6 +133,7 @@ jobs:
             -e BENCHMARK_OUTPUT_LEN=${{ matrix.output_len || 128 }} \
             -e BENCHMARK_BATCH_SIZE=${{ matrix.batch_size || 4 }} \
             -e BENCHMARK_AUDIO_FIXTURE=${{ matrix.benchmark_audio_fixture || '' }} \
+            -e BENCHMARK_ROUTE=${{ matrix.benchmark_route || '/v1/chat/completions' }} \
             -e MODEL_DIR="/models/${{ matrix.name }}" \
             -e RESULTS_DIR=/tmp/benchmark_results \
             -e ARTIFACT_PREFIX="${{ matrix.name }}_${{ matrix.fleet }}" \
@@ -235,6 +236,7 @@ jobs:
             -e BENCHMARK_OUTPUT_LEN=${{ matrix.output_len || 128 }} \
             -e BENCHMARK_BATCH_SIZE=${{ matrix.batch_size || 4 }} \
             -e BENCHMARK_AUDIO_FIXTURE=${{ matrix.benchmark_audio_fixture || '' }} \
+            -e BENCHMARK_ROUTE=${{ matrix.benchmark_route || '/v1/chat/completions' }} \
             -e MODEL_DIR="/models/${{ matrix.name }}" \
             -e RESULTS_DIR=/tmp/benchmark_results \
             -e ARTIFACT_PREFIX="${{ matrix.name }}_gpu-efa-runners" \

--- a/docker/vllm/Dockerfile
+++ b/docker/vllm/Dockerfile
@@ -37,7 +37,7 @@ RUN uv pip install --system \
   "pillow>=12.1.1" \
   "xgrammar>=0.1.32" \
   "PyJWT>=2.12.0" \
-  "model-hosting-container-standards>=0.1.15,<1.0.0" \
+  "model-hosting-container-standards>=0.1.16,<1.0.0" \
   "pyasn1>=0.6.3" \
   && uv cache clean
 

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -1,7 +1,7 @@
 ARG CUDA_VERSION=13.0.2
 ARG PYTHON_VERSION=3.12
-ARG FRAMEWORK_VERSION=0.22.1rc0
-ARG FLASHINFER_VERSION=0.6.11.post2
+ARG FRAMEWORK_VERSION=0.24.0
+ARG FLASHINFER_VERSION=0.6.12
 ARG DEEPEP_COMMIT_HASH=73b6ea4
 
 # =============================================================================
@@ -86,7 +86,7 @@ ENV SETUPTOOLS_SCM_PRETEND_VERSION=${SETUPTOOLS_SCM_PRETEND_VERSION:-${FRAMEWORK
 
 # --- Pre-built wheel support ---
 # Fetch wheels from S3 into docker/vllm/prebuilt_wheels/ BEFORE docker build:
-#   bash scripts/docker/vllm/amzn2023/fetch_cached_wheels.sh cu130 v0.22.1rc0
+#   bash scripts/docker/vllm/amzn2023/fetch_cached_wheels.sh cu130 v0.24.0
 # The directory is empty by default so COPY always succeeds.
 COPY docker/vllm/prebuilt_wheels/ /tmp/prebuilt_wheels/
 
@@ -191,12 +191,6 @@ RUN --mount=type=cache,target=/root/.cache/uv ls /tmp/vllm-dist/*.whl \
   && uv pip install "${VLLM_WHL}" \
     --extra-index-url ${PYTORCH_CUDA_INDEX_BASE_URL}/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')
 
-# Pin transformers to <5.10 to avoid the prepare_inputs_layout->fetch_audio
-# AttributeError on voxtral with vllm 0.22.1rc0 + mistral-common 1.11.2.
-# See https://github.com/huggingface/transformers/blob/v5.10.1/src/transformers/processing_utils.py#L726
-# (call lacks hasattr guard; MistralCommonFeatureExtractor doesn't implement fetch_audio).
-RUN --mount=type=cache,target=/root/.cache/uv uv pip install "transformers<5.10"
-
 # Install FlashInfer jit-cache after vllm wheel (pin both flashinfer-python and
 # flashinfer-jit-cache to ensure version match for flashinfer download-cubin)
 ARG FLASHINFER_VERSION
@@ -207,6 +201,10 @@ RUN --mount=type=cache,target=/root/.cache/uv uv pip install \
 # Install serving extras
 RUN --mount=type=cache,target=/root/.cache/uv uv pip install accelerate modelscope \
   "bitsandbytes>=0.46.1" "timm>=1.0.17" "runai-model-streamer[s3,gcs,azure]>=0.15.7"
+
+# Audio deps for voxtral / ASR serving (mistral_common is an optional import in vLLM 0.24.0)
+RUN --mount=type=cache,target=/root/.cache/uv uv pip install \
+  av scipy soundfile "mistral_common[audio]"
 
 # Install DeepEP wheels from build stage
 COPY --from=build /tmp/ep_kernels_workspace/dist /tmp/ep_kernels/dist
@@ -300,8 +298,8 @@ FROM runtime AS base
 ARG PYTHON="python3"
 ARG PYTHON_VERSION=3.12
 ARG CUDA_VERSION
-ARG DLC_MAJOR_VERSION=1
-ARG DLC_MINOR_VERSION=0
+ARG DLC_MAJOR_VERSION=2
+ARG DLC_MINOR_VERSION=1
 
 LABEL maintainer="Amazon AI"
 LABEL dlc_major_version="${DLC_MAJOR_VERSION}"
@@ -329,7 +327,7 @@ RUN uv pip install --no-cache-dir \
   "cbor2>=5.9.0" \
   "starlette>=1.3.1" \
   "cryptography>=48.0.1" \
-  "model-hosting-container-standards>=0.1.15,<1.0.0"
+  "model-hosting-container-standards>=0.1.16,<1.0.0"
 
 COPY ./scripts/docker/telemetry/deep_learning_container.py /usr/local/bin/deep_learning_container.py
 COPY ./scripts/docker/telemetry/bash_telemetry.sh.template /tmp/bash_telemetry.sh.template

--- a/test/vllm/scripts/amzn2023/vllm_asr_smoke_test.sh
+++ b/test/vllm/scripts/amzn2023/vllm_asr_smoke_test.sh
@@ -39,11 +39,8 @@ echo "=== Model directory: ${MODEL_DIR} ==="
 echo "=== Test fixtures ==="
 ls -lh "${FIXTURES_DIR}"
 
-if [ -f "${MODEL_DIR}/requirements.txt" ]; then
-  echo "=== Installing model dependencies ==="
-  cat "${MODEL_DIR}/requirements.txt"
-  pip install --no-cache-dir -r "${MODEL_DIR}/requirements.txt"
-fi
+# Audio deps (mistral_common[audio], av, scipy, soundfile) ship in the image, so
+# no model-root requirements.txt install is needed.
 
 echo "=== Starting vLLM server ==="
 # shellcheck disable=SC2086

--- a/test/vllm/scripts/benchmark/vllm_asr_benchmark_test.sh
+++ b/test/vllm/scripts/benchmark/vllm_asr_benchmark_test.sh
@@ -63,6 +63,8 @@ done
 [ "${elapsed}" -ge "${HEALTH_TIMEOUT}" ] && echo "ERROR: timeout" && exit 1
 
 export MODEL_DIR RESULTS_DIR ARTIFACT_PREFIX VLLM_PORT
+export BENCHMARK_ROUTE="${BENCHMARK_ROUTE:-/v1/chat/completions}"
+export BENCHMARK_AUDIO_FIXTURE="${BENCHMARK_AUDIO_FIXTURE:-asr_en.wav}"
 
 # Default single-run env vars (used when BENCHMARK_PROFILES is not set)
 export MIN_THROUGHPUT="${MIN_THROUGHPUT_TOKENS_PER_SEC:-50}"
@@ -81,10 +83,21 @@ MODEL_DIR = os.environ["MODEL_DIR"]
 RESULTS_DIR = os.environ["RESULTS_DIR"]
 ARTIFACT_PREFIX = os.environ["ARTIFACT_PREFIX"]
 
+# Realtime models (voxtral) only support /v1/audio/transcriptions, not chat audio_url.
+ROUTE = os.environ.get("BENCHMARK_ROUTE", "/v1/chat/completions")
+FIXTURE_DIR = "/models/test-fixtures"
+AUDIO_FIXTURE = os.environ.get("BENCHMARK_AUDIO_FIXTURE") or "asr_en.wav"
+
 AUDIO_URLS = [
     "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_en.wav",
     "https://qianwen-res.oss-cn-beijing.aliyuncs.com/Qwen3-ASR-Repo/asr_zh.wav",
 ]
+
+# Transcriptions route uploads a local fixture file (multipart); preload its bytes.
+AUDIO_FILE_BYTES = None
+if ROUTE == "/v1/audio/transcriptions":
+    with open(os.path.join(FIXTURE_DIR, AUDIO_FIXTURE), "rb") as _f:
+        AUDIO_FILE_BYTES = _f.read()
 
 # Profile definitions: (num_requests, concurrency, min_throughput, min_rps, max_p99)
 PROFILES = {
@@ -103,25 +116,39 @@ def make_payload(audio_url):
         }],
     }
 
+async def send_chat(session, audio_url):
+    async with session.post(
+        f"http://localhost:{PORT}{ROUTE}",
+        json=make_payload(audio_url),
+        timeout=aiohttp.ClientTimeout(total=120),
+    ) as resp:
+        result = await resp.json()
+        content = result.get("choices", [{}])[0].get("message", {}).get("content", "")
+        tokens = result.get("usage", {}).get("completion_tokens", 0)
+        return resp.status, content, tokens
+
+async def send_transcription(session, _audio_url):
+    form = aiohttp.FormData()
+    form.add_field("file", AUDIO_FILE_BYTES, filename="test.wav", content_type="audio/wav")
+    form.add_field("model", MODEL_DIR)
+    async with session.post(
+        f"http://localhost:{PORT}{ROUTE}",
+        data=form,
+        timeout=aiohttp.ClientTimeout(total=120),
+    ) as resp:
+        result = await resp.json()
+        text = result.get("text", "")
+        # transcriptions has no usage; approximate tokens from word count for throughput
+        return resp.status, text, len(text.split())
+
 async def send_request(session, audio_url):
-    payload = make_payload(audio_url)
     start = time.perf_counter()
     try:
-        async with session.post(
-            f"http://localhost:{PORT}/v1/chat/completions",
-            json=payload,
-            timeout=aiohttp.ClientTimeout(total=120),
-        ) as resp:
-            result = await resp.json()
-            latency = time.perf_counter() - start
-        content = result.get("choices", [{}])[0].get("message", {}).get("content", "")
-        usage = result.get("usage", {})
-        return {
-            "latency": latency,
-            "text": content,
-            "status": resp.status,
-            "completion_tokens": usage.get("completion_tokens", 0),
-        }
+        if ROUTE == "/v1/audio/transcriptions":
+            status, text, tokens = await send_transcription(session, audio_url)
+        else:
+            status, text, tokens = await send_chat(session, audio_url)
+        return {"latency": time.perf_counter() - start, "text": text, "status": status, "completion_tokens": tokens}
     except Exception as e:
         return {"latency": time.perf_counter() - start, "text": "", "status": 0, "completion_tokens": 0, "error": str(e)}
 


### PR DESCRIPTION
## Summary

Bump vLLM-server AL2023 images (EC2 + SageMaker) `0.22.1rc0` → **v0.24.0** (`7b3d595e`), add a **Mellum2-12B-A2.5B-Thinking** smoke + benchmark test, route the voxtral benchmark to the transcriptions endpoint, and drop a redundant ASR-smoke dependency install. DLC minor bump (2.0 → 2.1); prod tags unchanged.

## Why v0.24.0

- **`MellumForCausalLM` support** ([vllm#43992](https://github.com/vllm-project/vllm/pull/43992), added in 0.23.0, retained in 0.24.0) — required to serve Mellum2.
- **Transformers v5**: vLLM 0.24.0 requires `transformers >= 5.5.3`, so the `transformers<5.10` pin is **removed**.
- **`mistral_common` is now an optional import** in 0.24.0, so audio deps (`mistral_common[audio]`, av, scipy, soundfile) are installed explicitly for voxtral / ASR serving.

### Breaking changes considered (0.22.1rc0 → 0.24.0)
- Transformers v4 deprecated → v5 required (handled by dropping the pin).
- Models removed upstream (ERNIE, Xverse, Dots1, Bamba, Mono-InternVL) — none in our test matrix.
- GPU device-selection refactor (no internal `CUDA_VISIBLE_DEVICES`; new `--device-ids`) — single-server TP unaffected; covered by smoke tests.
- FlashInfer stays at 0.6.12. No breaking changes to `--hf-overrides`, `--chat-template`, `--reasoning-parser`, or the audio/transcriptions endpoints.

## Changes

**Bump**
- `vllm/{ec2,sagemaker}-amzn2023.yml` — `framework_version` 0.24.0, `vllm_ref` `7b3d595e`, `flashinfer_version` 0.6.12, `dlc_minor_version` 0→1.
- `docker/vllm/Dockerfile.amzn2023` — bump ARG defaults; **remove `transformers<5.10` pin**; add audio deps; DLC 2.1; `model-hosting-container-standards>=0.1.16`.
- `docker/vllm/Dockerfile` — `model-hosting-container-standards>=0.1.16`.

**Mellum2**
- `vllm-model-tests.yml` + `vllm-text-benchmark-tests.yml` — add `mellum2-12b-a2.5b-thinking` (g6e.xl, tp=1, `--reasoning-parser qwen3`). Benchmark floors are provisional, to tighten after the first run.

**Voxtral benchmark fix**
- `vllm-multimodal-benchmark-tests.yml` + `vllm.dispatch-benchmark.yml` + `vllm_asr_benchmark_test.sh` — route the voxtral benchmark to `/v1/audio/transcriptions` (chat `audio_url` produces empty MM embeddings and crashes the engine). Adds a `benchmark_route` matrix field defaulting to `/v1/chat/completions`.

**Cleanup**
- `vllm_asr_smoke_test.sh` — drop the model-root `requirements.txt` install; audio deps now ship in the image.