### PR TITLE
ci(xgboost): enable preprod release for XGBoost 3.2.0 SageMaker image

### DIFF
--- a/.github/config/image/xgboost/sagemaker.yml
+++ b/.github/config/image/xgboost/sagemaker.yml
@@ -23,7 +23,7 @@ build:
   dlc_minor_version: "0"
 
 release:
-  release: false
+  release: true
   force_release: false
   public_registry: false
   private_registry: true


### PR DESCRIPTION
## Summary

Enable preprod release for the XGBoost 3.2.0 SageMaker image by flipping `release.release` from `false` to `true` in `.github/config/image/xgboost/sagemaker.yml`.

The `environment` was already `preprod`, so this makes the config eligible for the preprod autorelease workflow.

## Change

```diff
 release:
-  release: false
+  release: true
   force_release: false
   public_registry: false
   private_registry: true
   enable_soci: false
   environment: "preprod"
```

## Notes

- Release only fires from an `.autorelease` / `.dispatch-release` workflow on `main`; this just makes the config eligible.
