### PR TITLE
docs(sglang): document v1.1 AL2023 release (NIXL + runai-model-streamer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ ______________________________________________________________________
 
 ### 🚀 Release Highlights
 
+- **[2026/06/29]** [SGLang Server v1.1 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `server-cuda-v1.1` · SageMaker: `server-sagemaker-cuda-v1.1` · SGLang `0.5.13`; adds NIXL KV connector for prefill/decode disaggregation and `runai-model-streamer[s3,gcs,azure]` for fast weight streaming from object storage; starlette CVE patch.
 - **[2026/06/14]** [vLLM v0.23.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.23.0-gpu-py312-ec2` · SageMaker: `0.23.0-gpu-py312` · Step-3.7-Flash, Cosmos3 Reasoner, Gemma 4 Unified (encoder-free), Granite Speech Plus, Cohere Mini Code; Anthropic Messages API structured output.
 - **[2026/06/13]** [SGLang v0.5.13](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.13-gpu-py312-ec2` · SageMaker: `0.5.13-gpu-py312` · DeepSeek V4 (BCG, HiSparse PD, PP+PD), Kimi-K2.5, MiMo-V2, Ideogram 4 (FP8/NVFP4); SM120 + FP4 indexer support.
 - **[2026/06/12]** [SGLang Server v1.0 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `server-cuda-v1.0` · SageMaker: `server-sagemaker-cuda-v1.0` · First Amazon Linux 2023 SGLang Server images, built from upstream source; OpenAI-compatible API (port 30000 EC2/EKS, 8080 SageMaker); CUDA 13.0 for H100 + Blackwell; PyTorch 2.11.0; EFA, DeepEP, and Mooncake KV-cache bundled.

--- a/docs/sglang/changelog/index.md
+++ b/docs/sglang/changelog/index.md
@@ -4,6 +4,27 @@ Changelog for the Amazon Linux 2023-based SGLang images (`server-cuda`, `server-
 
 * * *
 
+## v1.1.0 — 2026-06-29
+
+**Tags:** `server-cuda-v1.1` · `server-sagemaker-cuda-v1.1`
+
+**SGLang source:** [66ab5c9](https://github.com/sgl-project/sglang/commit/66ab5c9c7a425ef746725b8a8d7210d434eadac2) (`0.5.13+amzn2023.66ab5c9`)
+
+**Bundled versions:** CUDA 13.0.3 · Python 3.12 · PyTorch 2.11.0 · sgl-kernel 0.4.3 · FlashInfer 0.6.11.post1 · Mooncake 0.3.9 · NCCL 2.28.3
+
+### Highlights
+
+- Bumped SGLang to `0.5.13` (upstream commit `66ab5c9`)
+- Added **[NIXL](https://github.com/ai-dynamo/nixl)** KV connector (`nixl` + matching `nixl-cu13`) for prefill/decode disaggregation KV transfer
+- Added **[runai-model-streamer](https://github.com/run-ai/runai-model-streamer)** with the `[s3,gcs,azure]` extras for fast weight streaming from object storage (`sglang[all]` omits the `[s3]` extra)
+
+### Security
+
+- Patched starlette CVE [GHSA-82w8-qh3p-5jfq](https://github.com/advisories/GHSA-82w8-qh3p-5jfq) — pinned `starlette>=1.3.1`
+- Removed the build-only `rust/` source tree from the runtime stage (only the compiled `sglang-router` binary ships); resolves a pyo3 CVE [GHSA-36hh-v3qg-5jq4](https://github.com/advisories/GHSA-36hh-v3qg-5jq4) flagged on the leftover `Cargo.lock`
+
+* * *
+
 ## v1.0.0 — 2026-06-12
 
 **Tags:** `server-cuda-v1.0` · `server-sagemaker-cuda-v1.0`

--- a/docs/sglang/changelog/index.md
+++ b/docs/sglang/changelog/index.md
@@ -16,12 +16,14 @@ Changelog for the Amazon Linux 2023-based SGLang images (`server-cuda`, `server-
 
 - Bumped SGLang to `0.5.13` (upstream commit `66ab5c9`)
 - Added **[NIXL](https://github.com/ai-dynamo/nixl)** KV connector (`nixl` + matching `nixl-cu13`) for prefill/decode disaggregation KV transfer
-- Added **[runai-model-streamer](https://github.com/run-ai/runai-model-streamer)** with the `[s3,gcs,azure]` extras for fast weight streaming from object storage (`sglang[all]` omits the `[s3]` extra)
+- Added **[runai-model-streamer](https://github.com/run-ai/runai-model-streamer)** with the `[s3,gcs,azure]` extras for fast weight streaming from
+  object storage (`sglang[all]` omits the `[s3]` extra)
 
 ### Security
 
 - Patched starlette CVE [GHSA-82w8-qh3p-5jfq](https://github.com/advisories/GHSA-82w8-qh3p-5jfq) — pinned `starlette>=1.3.1`
-- Removed the build-only `rust/` source tree from the runtime stage (only the compiled `sglang-router` binary ships); resolves a pyo3 CVE [GHSA-36hh-v3qg-5jq4](https://github.com/advisories/GHSA-36hh-v3qg-5jq4) flagged on the leftover `Cargo.lock`
+- Removed the build-only `rust/` source tree from the runtime stage (only the compiled `sglang-router` binary ships); resolves a pyo3 CVE
+  [GHSA-36hh-v3qg-5jq4](https://github.com/advisories/GHSA-36hh-v3qg-5jq4) flagged on the leftover `Cargo.lock`
 
 * * *
 

--- a/docs/sglang/index.md
+++ b/docs/sglang/index.md
@@ -20,6 +20,9 @@ In addition to SGLang and its core stack (PyTorch 2.11, CUDA 13.0, NCCL, Python 
 - **[FlashInfer](https://github.com/flashinfer-ai/flashinfer)** — fused attention kernels with precompiled cubins for fast cold start
 - **[DeepEP](https://github.com/deepseek-ai/DeepEP)** — expert-parallel kernels for large MoE models (DeepSeek, Qwen MoE)
 - **[Mooncake](https://github.com/kvcache-ai/Mooncake)** — KV-cache transfer engine for disaggregated prefill/decode
+- **[NIXL](https://github.com/ai-dynamo/nixl)** — KV connector for prefill/decode (PD) disaggregation KV transfer
+- **[runai-model-streamer](https://github.com/run-ai/runai-model-streamer)** — fast weight streaming from object storage, with the `s3`, `gcs`, and
+  `azure` extras enabled
 - **[sgl-kernel](https://github.com/sgl-project/sglang/tree/main/sgl-kernel)** — SGLang's custom CUDA kernels, built from source for the bundled CUDA
   arch list
 - **[EFA](https://aws.amazon.com/hpc/efa/) and [OpenMPI](https://www.open-mpi.org/)** — high-throughput multi-node networking on supported instances


### PR DESCRIPTION
## Description

Documentation-only update for the **SGLang Server v1.1 (AL2023)** release shipped in #6266 (SGLang `0.5.12` → `0.5.13`, DLC minor `0` → `1`, source commit `66ab5c9`).

### Changes
- **`README.md`** — new Release Highlights entry for SGLang Server v1.1 with the `server-cuda-v1.1` / `server-sagemaker-cuda-v1.1` tags.
- **`docs/sglang/changelog/index.md`** — new `v1.1.0 — 2026-06-29` section covering the SGLang source bump, NIXL KV connector + `runai-model-streamer[s3,gcs,azure]` additions, and the starlette/pyo3 CVE notes.
- **`docs/sglang/index.md`** — add NIXL and runai-model-streamer to the "What's Included" list.

### What v1.1 adds (from #6266)
- **NIXL** KV connector (`nixl` + `nixl-cu13`) for prefill/decode disaggregation KV transfer.
- **runai-model-streamer** with `[s3,gcs,azure]` extras (the `[s3]` extra is omitted by `sglang[all]`).
- starlette CVE patch (`starlette>=1.3.1`) and removal of the build-only `rust/` source tree from the runtime stage.

### Notes for reviewers
- Tag names (`server-cuda-v1.1` / `server-sagemaker-cuda-v1.1`) were derived from `dlc_minor_version: 1` in the image config and the existing v1.0 convention — please confirm against the published ECR gallery tags.
- Date `2026-06-29` matches the autorelease run; adjust if the prod promotion completed on a different day.

Docs-only; no code or container changes.