### PR TITLE
ci(xgboost): promote XGBoost 3.2.0 SageMaker image to production

### DIFF
--- a/.github/config/image/xgboost/sagemaker.yml
+++ b/.github/config/image/xgboost/sagemaker.yml
@@ -28,4 +28,4 @@ release:
   public_registry: false
   private_registry: true
   enable_soci: false
-  environment: "preprod"
+  environment: "production"


### PR DESCRIPTION
## Description

Promote the XGBoost 3.2.0 SageMaker image release environment from `preprod` to `production`.

- `.github/config/image/xgboost/sagemaker.yml`: `environment: "preprod"` -> `"production"`

This follows the established promotion path for this image (gamma -> preprod -> production).

## Tests

N/A — config-only change to the release target environment.