### PR TITLE
fix(autocurrency): bump config build.base_image on version update

### DIFF
--- a/.github/config/autocurrency-tracker.yml
+++ b/.github/config/autocurrency-tracker.yml
@@ -16,8 +16,10 @@ frameworks:
     config_files:
       - path: ".github/config/image/vllm/ec2-ubuntu.yml"
         prod_image_template: "vllm:{major}.{minor}-gpu-py312-ec2"
+        base_image_template: "vllm/vllm-openai:v{version}"
       - path: ".github/config/image/vllm/sagemaker-ubuntu.yml"
         prod_image_template: "vllm:{major}.{minor}-gpu-py312"
+        base_image_template: "vllm/vllm-openai:v{version}"
     dockerfiles:
       - path: "docker/vllm/Dockerfile"
         base_image_template: "vllm/vllm-openai:v{version}"
@@ -29,8 +31,10 @@ frameworks:
     config_files:
       - path: ".github/config/image/sglang/ec2-ubuntu.yml"
         prod_image_template: "sglang:{major}.{minor}-gpu-py312-ec2"
+        base_image_template: "lmsysorg/sglang:v{version}"
       - path: ".github/config/image/sglang/sagemaker-ubuntu.yml"
         prod_image_template: "sglang:{major}.{minor}-gpu-py312"
+        base_image_template: "lmsysorg/sglang:v{version}"
     dockerfiles:
       - path: "docker/sglang/Dockerfile"
         base_image_template: "lmsysorg/sglang:v{version}"

--- a/scripts/ci/autocurrency/update-configs.sh
+++ b/scripts/ci/autocurrency/update-configs.sh
@@ -9,15 +9,17 @@ source "${SCRIPT_DIR}/utils.sh"
 
 ###############################################################################
 # update_config_files(framework_key, new_version, config_entries_json)
-#   Iterates over config file entries, updates common.framework_version and
-#   common.prod_image using yq. Echoes the list of updated file paths
-#   (one per line).
+#   Iterates over config file entries, updates metadata.framework_version and
+#   metadata.prod_image using yq. When an entry has an optional
+#   "base_image_template", also updates build.base_image (upstream-base images).
+#   Echoes the list of updated file paths (one per line).
 #
 #   Arguments:
 #     framework_key       — Framework identifier (e.g., "vllm")
 #     new_version         — New upstream version string (e.g., "0.17.0")
-#     config_entries_json — JSON array of objects with "path" and
-#                           "prod_image_template" fields
+#     config_entries_json — JSON array of objects with "path",
+#                           "prod_image_template", and optional
+#                           "base_image_template" fields
 #
 #   Usage:
 #     updated=$(update_config_files "vllm" "0.17.0" '[
@@ -58,6 +60,13 @@ update_config_files() {
     local new_prod_image
     new_prod_image="$(render_prod_image "${template}" "${new_version}")"
     yq eval -i ".metadata.prod_image = \"${new_prod_image}\"" "${config_path}"
+
+    # Update build.base_image when the entry provides a template (upstream-base images)
+    local base_image_template
+    base_image_template="$(echo "${config_entries_json}" | jq -r ".[$i].base_image_template // empty")"
+    if [[ -n "${base_image_template}" ]]; then
+      yq eval -i ".build.base_image = \"${base_image_template//\{version\}/${new_version}}\"" "${config_path}"
+    fi
 
     echo "${config_path}"
   done


### PR DESCRIPTION
## Description

The upstream release tracker bumps `metadata.framework_version` and the Dockerfile `ARG BASE_IMAGE`, but **not** the config `build.base_image`. Since `resolve_build_args.py` forwards `build.base_image` as `--build-arg BASE_IMAGE` (overriding the Dockerfile default), the ubuntu vLLM/SGLang images were built `FROM` the *old* base image and shipped the previous framework version — failing the sanity `test_framework_version` check on every currency PR (seen on vLLM 0.24.0, PR #6314, and latent on SGLang 0.5.14).

## Change

- `update_config_files()` now also sets `build.base_image` when a `config_files` entry provides an optional `base_image_template`.
- Added `base_image_template` to the vLLM and SGLang `config_files` entries in the tracker.

Opt-in by design: entries without `base_image_template` are untouched (source-built configs with no `base_image` are unaffected).

## Testing

- `bash -n` + YAML validation pass.
- Functional test: bumping a vLLM ubuntu config 0.24.0 → 0.25.0 updates `framework_version`, `prod_image`, **and** `base_image` (`vllm/vllm-openai:v0.25.0`).
- Backward-compat test: an entry without `base_image_template` produces no error and adds no `base_image` key.

Follow-up to PR #6314 (ASIMOV-TRN-5726).
