### PR TITLE
Upgrade DLC EKS clusters to Kubernetes 1.36

### DIFF
--- a/eks_infrastructure/build_param.json
+++ b/eks_infrastructure/build_param.json
@@ -1,12 +1,13 @@
 {
-    "operation": "create",
+    "operation": "upgrade_cluster",
     "contexts": [
+        "PR",
         "MAINLINE"
     ],
     "eks_clusters": [
         "dlc-pytorch",
         "dlc-tensorflow"
     ],
-    "eks_version": "1.35",
+    "eks_version": "1.36",
     "cluster_autoscalar_image_version": "v1.35.0"
 }

--- a/eks_infrastructure/env_setup.sh
+++ b/eks_infrastructure/env_setup.sh
@@ -5,7 +5,7 @@ set -ex
 
 # The below url/version is based on EKS v1.32.0. The same needs to be updated for EKS version upgrade.
 # https://docs.aws.amazon.com/eks/latest/userguide/install-kubectl.html find the link
-KUBECTL_CLIENT="https://s3.us-west-2.amazonaws.com/amazon-eks/1.35.0/2026-01-29/bin/linux/amd64/kubectl"
+KUBECTL_CLIENT="https://s3.us-west-2.amazonaws.com/amazon-eks/1.35.3/2026-04-08/bin/linux/amd64/kubectl"
 EKSCTL_CLIENT="https://github.com/eksctl-io/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz"
 # https://github.com/kubernetes-sigs/aws-iam-authenticator/releases?page=1 to find the version support
 AWS_IAM_AUTHENTICATOR="https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.7.10/aws-iam-authenticator_0.7.10_linux_amd64"


### PR DESCRIPTION
## Description

Upgrades the DLC EKS clusters (`dlc-pytorch`, `dlc-tensorflow`) from Kubernetes 1.35 to 1.36 for the PR and MAINLINE contexts.

Changes:
- `eks_infrastructure/build_param.json`: `operation` -> `upgrade_cluster`, add `PR` to `contexts`, `eks_version` -> `1.36`.
- `eks_infrastructure/env_setup.sh`: bump kubectl client pin to `1.35.3` (2026-04-08), which is version-skew compatible with a 1.36 control plane.

`cluster_autoscalar_image_version` intentionally stays at `v1.35.0` until a matching 1.36 cluster-autoscaler image is published; it is within the supported one-minor skew.

## Tests
Cluster upgrade runs via the `eks-code-build` job after merge; monitored per account.

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*