### PR TITLE
[xgboost][3.2.0] patch requests and idna CVEs

### DIFF
--- a/docker/xgboost/pyproject.toml
+++ b/docker/xgboost/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pynvml==12.0.0",
     "python-dateutil==2.9.0",
     "PyYAML==6.0.1",
-    "requests==2.32.3",
+    "requests==2.33.0",
     "retrying==1.3.3",
     "sagemaker-containers==2.8.6.post2",
     "sagemaker-inference==1.5.5",
@@ -36,7 +36,7 @@ dependencies = [
     "pyarrow==22.0.0",
     "protobuf>=3.20.0,<=3.20.3",
     "fonttools>=4.60.2",
-    "idna>=3.7",
+    "idna>=3.15",
     "tornado>=6.5.6",
     "msgpack>=1.2.1",
 ]

--- a/docker/xgboost/uv.lock
+++ b/docker/xgboost/uv.lock
@@ -475,11 +475,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.13"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
@@ -954,7 +954,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.3"
+version = "2.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -962,9 +962,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload-time = "2024-05-29T15:37:49.536Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/64/8860370b167a9721e8956ae116825caff829224fbca0ca6e7bf8ddef8430/requests-2.33.0.tar.gz", hash = "sha256:c7ebc5e8b0f21837386ad0e1c8fe8b829fa5f544d8df3b2253bff14ef29d7652", size = 134232, upload-time = "2026-03-25T15:10:41.586Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928, upload-time = "2024-05-29T15:37:47.027Z" },
+    { url = "https://files.pythonhosted.org/packages/56/5d/c814546c2333ceea4ba42262d8c4d55763003e767fa169adc693bd524478/requests-2.33.0-py3-none-any.whl", hash = "sha256:3324635456fa185245e24865e810cecec7b4caf933d7eb133dcde67d48cee69b", size = 65017, upload-time = "2026-03-25T15:10:40.382Z" },
 ]
 
 [[package]]
@@ -1247,7 +1247,7 @@ requires-dist = [
     { name = "fonttools", specifier = ">=4.60.2" },
     { name = "gevent", specifier = "==26.4.0" },
     { name = "gunicorn", specifier = "==25.3.0" },
-    { name = "idna", specifier = ">=3.7" },
+    { name = "idna", specifier = ">=3.15" },
     { name = "matplotlib", specifier = "==3.10.9" },
     { name = "msgpack", specifier = ">=1.2.1" },
     { name = "multi-model-server", specifier = "==1.1.2" },
@@ -1261,7 +1261,7 @@ requires-dist = [
     { name = "pynvml", specifier = "==12.0.0" },
     { name = "python-dateutil", specifier = "==2.9.0" },
     { name = "pyyaml", specifier = "==6.0.1" },
-    { name = "requests", specifier = "==2.32.3" },
+    { name = "requests", specifier = "==2.33.0" },
     { name = "retrying", specifier = "==1.3.3" },
     { name = "sagemaker-containers", specifier = "==2.8.6.post2" },
     { name = "sagemaker-inference", specifier = "==1.5.5" },


### PR DESCRIPTION
## Purpose

Eradicate fixable CVEs in the XGBoost 3.2.0 (Amazon Linux 2023) DLC image via package bumps.

## Images affected

`sagemaker-xgboost:3.2-0-cpu-py3`

## CVEs handled

| CVE | Package | Severity | Action |
|---|---|---|---|
| CVE-2026-25645 | requests | MEDIUM | bump 2.32.3 → 2.33.0 (pyproject.toml + uv.lock) |
| CVE-2024-47081 | requests | MEDIUM | bump 2.32.3 → 2.33.0 (pyproject.toml + uv.lock) |
| CVE-2026-45409 | idna | MEDIUM | raise floor to >=3.15 (resolves to 3.18 in uv.lock) |

## Test plan

- [ ] CI security tests pass for the xgboost 3.2.0 variant
- [ ] CI sanity tests pass
- [ ] Reviewer runs the Release - SageMaker XGBoost workflow on this branch before merging (Dockerfile/package change)

---
🤖 Generated by [Claude Code](https://claude.com/claude-code).