### PR TITLE
[xgboost][3.0-5] patch requests, idna, and wheel CVEs

### DIFF
--- a/docker/xgboost/3.0-5/Dockerfile
+++ b/docker/xgboost/3.0-5/Dockerfile
@@ -206,7 +206,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Security patches — Python packages
-RUN python3 -m pip install --no-cache-dir "protobuf>=3.20.0,<=3.20.3" "fonttools>=4.60.2" "idna>=3.7" "setuptools>=80.9.0,<81"
+RUN python3 -m pip install --no-cache-dir "protobuf>=3.20.0,<=3.20.3" "fonttools>=4.60.2" "idna>=3.15" "setuptools>=80.9.0,<81"
 
 # Patch collections.Mapping deprecation in sagemaker-containers
 RUN sed -i 's/collections\.Mapping/collections.abc.Mapping/g' \

--- a/docker/xgboost/3.0-5/requirements.txt
+++ b/docker/xgboost/3.0-5/requirements.txt
@@ -21,7 +21,7 @@ psutil==5.8.0
 pynvml==11.4.1
 python-dateutil==2.8.2
 PyYAML==6.0.1
-requests==2.32.3
+requests==2.33.0
 retrying==1.3.3
 sagemaker-containers==2.8.6.post2
 sagemaker-inference==1.5.5
@@ -30,4 +30,4 @@ scipy==1.15.0
 setuptools<81
 urllib3==1.26.20
 Werkzeug==0.15.6
-wheel==0.45.1
+wheel==0.46.2


### PR DESCRIPTION
## Purpose

Eradicate fixable CVEs in the XGBoost 3.0-5 (Ubuntu 20.04) DLC image via package bumps in the security-patch layer.

## Images affected

`sagemaker-xgboost:3.0-5-cpu-py3`

## CVEs handled

| CVE | Package | Severity | Action |
|---|---|---|---|
| CVE-2026-25645 | requests | MEDIUM | bump 2.32.3 → 2.33.0 (requirements.txt) |
| CVE-2024-47081 | requests | MEDIUM | bump 2.32.3 → 2.33.0 (requirements.txt) |
| CVE-2026-24049 | wheel | MEDIUM | bump 0.45.1 → 0.46.2 (requirements.txt) |
| CVE-2026-45409 | idna | MEDIUM | raise floor to >=3.15 (Dockerfile security-patch layer) |

## Notes

This image is built on Ubuntu 20.04. Its remaining CRITICAL/HIGH findings (legacy Flask/Werkzeug/Jinja stack pinned by the serving framework, and kernel-header CVEs with fixes only in extended-support channels) are already tracked in the allowlist and are not addressable by a source bump on this base. This PR handles the CVEs that a package bump can eradicate.

## Test plan

- [ ] CI security tests pass for the xgboost 3.0-5 variant
- [ ] CI sanity tests pass
- [ ] Reviewer runs the Release - SageMaker XGBoost workflow on this branch before merging (Dockerfile/package change)

---
🤖 Generated by [Claude Code](https://claude.com/claude-code).