### PR TITLE
docs(readme): add PyTorch v2.12.1 to release highlights

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ ______________________________________________________________________
 
 ### 🚀 Release Highlights
 
+- **[2026/07/02]** [PyTorch v2.12.1](https://gallery.ecr.aws/deep-learning-containers/pytorch) — EC2: `2.12.1-cu130-amzn2023` · SageMaker: `2.12.1-cu130-amzn2023-sagemaker` · Amazon Linux 2023 with EFA, flash-attn, and Transformer Engine; PyTorch 2.12.1 bug-fix release (B200/Triton correctness fixes).
 - **[2026/07/01]** [vLLM v0.24.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.24.0-gpu-py312-ec2` · SageMaker: `0.24.0-gpu-py312` · MiniMax-M3, DiffusionGemma (+CPU), Hierarchical Reasoning Model, OpenMOSS; streaming parser engine (Qwen3, MiniMax-M2, GLM-4.7/5.1/5.2, Nemotron V3); DeepSeek-V4 fixes.
 - **[2026/06/29]** [SGLang Server v1.1 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `server-cuda-v1.1` · SageMaker: `server-sagemaker-cuda-v1.1` · SGLang `0.5.13`; adds NIXL KV connector for prefill/decode disaggregation and `runai-model-streamer[s3,gcs,azure]` for fast weight streaming from object storage; starlette CVE patch.
 - **[2026/06/29]** [SGLang v0.5.14](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.14-gpu-py312-ec2` · SageMaker: `0.5.14-gpu-py312` · GLM 5.2, LiquidAI LFM2.5, Kimi-K2.7-Code, DeepSeek V4 on GB300.
 - **[2026/06/14]** [vLLM v0.23.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.23.0-gpu-py312-ec2` · SageMaker: `0.23.0-gpu-py312` · Step-3.7-Flash, Cosmos3 Reasoner, Gemma 4 Unified (encoder-free), Granite Speech Plus, Cohere Mini Code; Anthropic Messages API structured output.
 - **[2026/06/13]** [SGLang v0.5.13](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.13-gpu-py312-ec2` · SageMaker: `0.5.13-gpu-py312` · DeepSeek V4 (BCG, HiSparse PD, PP+PD), Kimi-K2.5, MiMo-V2, Ideogram 4 (FP8/NVFP4); SM120 + FP4 indexer support.
 - **[2026/06/12]** [SGLang Server v1.0 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `server-cuda-v1.0` · SageMaker: `server-sagemaker-cuda-v1.0` · First Amazon Linux 2023 SGLang Server images, built from upstream source; OpenAI-compatible API (port 30000 EC2/EKS, 8080 SageMaker); CUDA 13.0 for H100 + Blackwell; PyTorch 2.11.0; EFA, DeepEP, and Mooncake KV-cache bundled.
-- **[2026/06/05]** [vLLM v0.22.1](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.22.1-gpu-py312-ec2` · SageMaker: `0.22.1-gpu-py312` · JetBrains Mellum v2; DeepSeek-V4, OlmoHybrid, HyperCLOVAX fixes; AMD Zen CPU zentorch kernels.
 
 ### 📢 Support Updates
 


### PR DESCRIPTION
## Summary
Add the PyTorch v2.12.1 (Amazon Linux 2023) release highlight to the README, and drop the oldest entry (vLLM v0.22.1) to keep the Release Highlights list at 7.

## Details
- **New entry:** PyTorch v2.12.1 — EC2 `2.12.1-cu130-amzn2023` · SageMaker `2.12.1-cu130-amzn2023-sagemaker`
- Version/tags sourced from the 2.12 image configs (`framework_version: 2.12.1`, `cuda_version: 13.0.2`, `os_version: amzn2023`).
- 2.12.1 is an upstream PyTorch bug-fix release (B200/Triton correctness fixes).
- Format mirrors the prior PyTorch v2.11.0 highlight entry.
- **Removed:** oldest highlight (vLLM v0.22.1, 2026/06/05).