### PR TITLE
docs(pytorch): add PyTorch 2.12 to changelog, docs, and gallery data

### DIFF
--- a/docs/pytorch/changelog/index.md
+++ b/docs/pytorch/changelog/index.md
@@ -1,6 +1,21 @@
 # Changelog
 
-Changelog for the Amazon Linux 2023-based PyTorch images (`2.11-cu130-amzn2023`, `2.11-cpu-amzn2023`, and the corresponding `*-sagemaker` variants).
+Changelog for the Amazon Linux 2023-based PyTorch images (`2.12-cu130-amzn2023`, `2.12-cpu-amzn2023`, and the corresponding `*-sagemaker` variants).
+
+* * *
+
+## PyTorch 2.12 — 2026-07-02
+
+**Tags:** `2.12-cu130-amzn2023` · `2.12-cpu-amzn2023` · `2.12-cu130-amzn2023-sagemaker` · `2.12-cpu-amzn2023-sagemaker`
+
+**Bundled versions:** PyTorch 2.12.1 · `torchvision` 0.27.1 · `torchaudio` 2.11.0 · CUDA 13.0.2 · Python 3.12 · NCCL 2.26.2 · EFA 1.47.0 · GDRCopy
+2.4.4 · flash-attn 2.8.3 · Transformer Engine 2.12.0 · DeepSpeed 0.18.8
+
+### Highlights
+
+- Bumped PyTorch to 2.12.1, with `torchvision` 0.27.1
+- 2.12.1 fixes a Triton illegal-memory-access in the `convolution2d_bwd_weight` kernel on B100/B200 (sm100) GPUs
+  ([pytorch#187081](https://github.com/pytorch/pytorch/issues/187081))
 
 * * *
 

--- a/docs/pytorch/deployment/ec2.md
+++ b/docs/pytorch/deployment/ec2.md
@@ -7,7 +7,7 @@ The PyTorch DLC is a training image — it does not serve a model out of the box
 ```bash
 docker run --rm -it --gpus all --shm-size=16g --ipc=host \
   -v $(pwd):/workspace \
-  public.ecr.aws/deep-learning-containers/pytorch:2.11-cu130-amzn2023 \
+  public.ecr.aws/deep-learning-containers/pytorch:2.12-cu130-amzn2023 \
   python train.py
 ```
 
@@ -20,7 +20,7 @@ Use `torchrun` to spawn one process per GPU:
 ```bash
 docker run --rm -it --gpus all --shm-size=16g --ipc=host \
   -v $(pwd):/workspace \
-  public.ecr.aws/deep-learning-containers/pytorch:2.11-cu130-amzn2023 \
+  public.ecr.aws/deep-learning-containers/pytorch:2.12-cu130-amzn2023 \
   torchrun --standalone --nproc_per_node=8 train.py
 ```
 
@@ -38,7 +38,7 @@ Run the container with `--privileged` (or grant the EFA capabilities via `--devi
 docker run --rm -it --gpus all --privileged --network host \
   --shm-size=16g --ipc=host \
   -v $(pwd):/workspace \
-  public.ecr.aws/deep-learning-containers/pytorch:2.11-cu130-amzn2023 \
+  public.ecr.aws/deep-learning-containers/pytorch:2.12-cu130-amzn2023 \
   torchrun --nnodes=2 --nproc_per_node=8 \
     --rdzv_id=demo --rdzv_backend=c10d --rdzv_endpoint=<head_node>:29500 \
     train.py

--- a/docs/pytorch/deployment/sagemaker.md
+++ b/docs/pytorch/deployment/sagemaker.md
@@ -10,7 +10,7 @@ Use the SageMaker variants for training jobs launched via the SageMaker Python S
 from sagemaker.pytorch import PyTorch
 
 estimator = PyTorch(
-    image_uri="public.ecr.aws/deep-learning-containers/pytorch:2.11-cu130-amzn2023-sagemaker",
+    image_uri="public.ecr.aws/deep-learning-containers/pytorch:2.12-cu130-amzn2023-sagemaker",
     role="arn:aws:iam::<account_id>:role/<role_name>",
     entry_point="train.py",
     source_dir="src",
@@ -43,7 +43,7 @@ job = TrainingJob.create(
     training_job_name="pytorch-train",
     role_arn="arn:aws:iam::<account_id>:role/<role_name>",
     algorithm_specification=AlgorithmSpecification(
-        training_image="public.ecr.aws/deep-learning-containers/pytorch:2.11-cu130-amzn2023-sagemaker",
+        training_image="public.ecr.aws/deep-learning-containers/pytorch:2.12-cu130-amzn2023-sagemaker",
         training_input_mode="File",
     ),
     resource_config=ResourceConfig(

--- a/docs/pytorch/index.md
+++ b/docs/pytorch/index.md
@@ -10,10 +10,10 @@ collectives, flash-attn and Transformer Engine for fused attention/FP8 kernels, 
 
 | Platform | Variant | Image |
 | --- | --- | --- |
-| {{ ec2_short }} / {{ eks_short }} | GPU | `public.ecr.aws/deep-learning-containers/pytorch:2.11-cu130-amzn2023` |
-| {{ ec2_short }} / {{ eks_short }} | CPU | `public.ecr.aws/deep-learning-containers/pytorch:2.11-cpu-amzn2023` |
-| {{ sagemaker }} | GPU | `public.ecr.aws/deep-learning-containers/pytorch:2.11-cu130-amzn2023-sagemaker` |
-| {{ sagemaker }} | CPU | `public.ecr.aws/deep-learning-containers/pytorch:2.11-cpu-amzn2023-sagemaker` |
+| {{ ec2_short }} / {{ eks_short }} | GPU | `public.ecr.aws/deep-learning-containers/pytorch:2.12-cu130-amzn2023` |
+| {{ ec2_short }} / {{ eks_short }} | CPU | `public.ecr.aws/deep-learning-containers/pytorch:2.12-cpu-amzn2023` |
+| {{ sagemaker }} | GPU | `public.ecr.aws/deep-learning-containers/pytorch:2.12-cu130-amzn2023-sagemaker` |
+| {{ sagemaker }} | CPU | `public.ecr.aws/deep-learning-containers/pytorch:2.12-cpu-amzn2023-sagemaker` |
 
 All images are also available on the [ECR Public Gallery](https://gallery.ecr.aws/deep-learning-containers/pytorch). For private ECR URIs, see
 [Image Access](../get_started/index.md).
@@ -22,7 +22,7 @@ All images are also available on the [ECR Public Gallery](https://gallery.ecr.aw
 
 The GPU images bundle the full distributed-training stack so you can launch multi-GPU and multi-node training without building a custom image:
 
-- **PyTorch 2.11.0** with `torchvision` 0.26.0 and `torchaudio` 2.11.0 (CUDA 13.0 wheels for the GPU variant, CPU wheels for the CPU variant)
+- **PyTorch 2.12.1** with `torchvision` 0.27.1 and `torchaudio` 2.11.0 (CUDA 13.0 wheels for the GPU variant, CPU wheels for the CPU variant)
 - **CUDA 13.0.2** with cuDNN and **NCCL 2.26.2** for multi-GPU collectives
 - **[EFA](https://aws.amazon.com/hpc/efa/) 1.47.0** with **OpenMPI** and the **AWS NCCL OFI plugin** for low-latency multi-node communication on
   EFA-capable instances

--- a/docs/src/data/pytorch/2.12-cpu-ec2.yml
+++ b/docs/src/data/pytorch/2.12-cpu-ec2.yml
@@ -1,0 +1,13 @@
+framework: PyTorch
+version: "2.12"
+accelerator: cpu
+python: py312
+os: amzn2023
+platform: ec2
+ga: "2026-07-02"
+eop: "2027-07-02"
+public_registry: true
+
+tags:
+  - "2.12.1-cpu-amzn2023"
+  - "2.12-cpu-amzn2023"

--- a/docs/src/data/pytorch/2.12-cpu-sagemaker.yml
+++ b/docs/src/data/pytorch/2.12-cpu-sagemaker.yml
@@ -1,0 +1,13 @@
+framework: PyTorch
+version: "2.12"
+accelerator: cpu
+python: py312
+os: amzn2023
+platform: sagemaker
+ga: "2026-07-02"
+eop: "2027-07-02"
+public_registry: true
+
+tags:
+  - "2.12.1-cpu-amzn2023-sagemaker"
+  - "2.12-cpu-amzn2023-sagemaker"

--- a/docs/src/data/pytorch/2.12-cuda-ec2.yml
+++ b/docs/src/data/pytorch/2.12-cuda-ec2.yml
@@ -1,0 +1,14 @@
+framework: PyTorch
+version: "2.12"
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: ec2
+ga: "2026-07-02"
+eop: "2027-07-02"
+public_registry: true
+
+tags:
+  - "2.12.1-cu130-amzn2023"
+  - "2.12-cu130-amzn2023"

--- a/docs/src/data/pytorch/2.12-cuda-sagemaker.yml
+++ b/docs/src/data/pytorch/2.12-cuda-sagemaker.yml
@@ -1,0 +1,14 @@
+framework: PyTorch
+version: "2.12"
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: sagemaker
+ga: "2026-07-02"
+eop: "2027-07-02"
+public_registry: true
+
+tags:
+  - "2.12.1-cu130-amzn2023-sagemaker"
+  - "2.12-cu130-amzn2023-sagemaker"


### PR DESCRIPTION
## Summary
Document the PyTorch **2.12** (2.12.1) Amazon Linux 2023 release across all PyTorch doc surfaces.

## Changes

**Changelog** (`docs/pytorch/changelog/index.md`)
- New `## PyTorch 2.12 — 2026-07-02` section, using the `Bundled versions:` snapshot + `Highlights` convention from the vLLM/SGLang changelogs.
- Notes the upstream 2.12.1 Triton illegal-memory-access fix in the `convolution2d_bwd_weight` kernel on B100/B200 (sm100) GPUs ([pytorch#187081](https://github.com/pytorch/pytorch/issues/187081)).

**Image docs**
- `docs/pytorch/index.md` — Images table tags + `What's Included` torch/torchvision line.
- `docs/pytorch/deployment/ec2.md` — `docker run` image URIs.
- `docs/pytorch/deployment/sagemaker.md` — `image_uri` examples (SDK v2 + v3).

**Gallery data** (`docs/src/data/pytorch/`)
- Added `2.12-{cpu,cuda}-{ec2,sagemaker}.yml` (4 files), mirroring the 2.11 entries.

## Version pins
Sourced from the `2.12-*.yml` image configs: torch `2.12.1`, torchvision `0.27.1`, torchaudio `2.11.0`; CUDA 13.0.2, Python 3.12, NCCL 2.26.2, EFA 1.47.0, GDRCopy 2.4.4, flash-attn 2.8.3, Transformer Engine 2.12.0, DeepSpeed 0.18.8 (unchanged from 2.11).

## Notes
- Gallery `eop` set to GA + 1 year (`2027-07-02`), matching the 2.11 files' offset.
- `pre-commit` passes on all changed files.