### PR TITLE
fix: route xgboost images to SageMaker ECR account in upload-allowlists cron

### DIFF
--- a/.github/actions/upload-ecr-allowlists/action.yml
+++ b/.github/actions/upload-ecr-allowlists/action.yml
@@ -3,8 +3,12 @@ description: 'Upload per-image security scan allowlists to S3 based on image con
 
 inputs:
   aws-account-id:
-    description: 'AWS account ID for ECR'
+    description: 'AWS account ID for ECR (default framework images)'
     required: true
+  aws-account-id-sagemaker:
+    description: 'AWS account ID for SageMaker built-in algorithm images (xgboost, sklearn, etc.). Falls back to aws-account-id if empty.'
+    required: false
+    default: ''
   aws-region:
     description: 'AWS region'
     required: true
@@ -40,5 +44,6 @@ runs:
         python3 "${{ github.action_path }}/upload_ecr_allowlists.py" ${ARGS}
       env:
         ECR_ACCOUNT_ID: ${{ inputs.aws-account-id }}
+        ECR_ACCOUNT_ID_SAGEMAKER: ${{ inputs.aws-account-id-sagemaker }}
         AWS_REGION: ${{ inputs.aws-region }}
         SCANNER_ALLOWLIST_S3_BUCKET: ${{ inputs.s3-bucket }}

--- a/.github/actions/upload-ecr-allowlists/upload_ecr_allowlists.py
+++ b/.github/actions/upload-ecr-allowlists/upload_ecr_allowlists.py
@@ -28,8 +28,21 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
 CONFIG_DIR = REPO_ROOT / ".github" / "config" / "image"
 ALLOWLIST_DIR = REPO_ROOT / "test" / "security" / "data" / "ecr_scan_allowlist"
 ECR_ACCOUNT = os.environ.get("ECR_ACCOUNT_ID", "")
+# SageMaker built-in algorithm images (xgboost) live in a separate ECR account
+# from the standard DLC framework account. Empty string falls back to ECR_ACCOUNT.
+ECR_ACCOUNT_SAGEMAKER = os.environ.get("ECR_ACCOUNT_ID_SAGEMAKER", "") or ECR_ACCOUNT
 ECR_REGION = os.environ.get("AWS_REGION", "us-west-2")
 S3_BUCKET = os.environ.get("SCANNER_ALLOWLIST_S3_BUCKET", "")
+
+# Frameworks whose ECR repositories live in the SageMaker built-in algorithm account.
+SAGEMAKER_BUILTIN_FRAMEWORKS = {"xgboost"}
+
+
+def ecr_account_for_framework(framework):
+    """Return the ECR account ID that hosts images for the given framework."""
+    if framework in SAGEMAKER_BUILTIN_FRAMEWORKS:
+        return ECR_ACCOUNT_SAGEMAKER
+    return ECR_ACCOUNT
 
 
 def load_image_configs():
@@ -60,11 +73,11 @@ def load_image_configs():
     return configs
 
 
-def get_image_sha(ecr_client, repo, tag):
+def get_image_sha(ecr_client, ecr_account, repo, tag):
     """Look up image digest from ECR. Returns sha string or None."""
     try:
         resp = ecr_client.describe_images(
-            registryId=ECR_ACCOUNT,
+            registryId=ecr_account,
             repositoryName=repo,
             imageIds=[{"imageTag": tag}],
         )
@@ -198,9 +211,12 @@ def main():
             continue
         seen.add(image_key)
 
-        LOG.info(f"{image_key} (framework={framework}, config={source_file})")
+        ecr_account = ecr_account_for_framework(framework)
+        LOG.info(
+            f"{image_key} (framework={framework}, ecr_account={ecr_account}, config={source_file})"
+        )
 
-        sha = get_image_sha(ecr_client, repo, tag)
+        sha = get_image_sha(ecr_client, ecr_account, repo, tag)
         if not sha:
             LOG.warning("  skip: image not found in ECR")
             skipped += 1

--- a/.github/workflows/_scheduled.upload-ecr-allowlists.yml
+++ b/.github/workflows/_scheduled.upload-ecr-allowlists.yml
@@ -41,6 +41,7 @@ jobs:
         uses: ./.github/actions/upload-ecr-allowlists
         with:
           aws-account-id: ${{ vars.PROD_AWS_ACCOUNT_ID }}
+          aws-account-id-sagemaker: ${{ vars.PROD_AWS_ACCOUNT_ID_SAGEMAKER }}
           aws-region: ${{ vars.AWS_REGION }}
           s3-bucket: ${{ vars.SCANNER_ALLOWLIST_S3_BUCKET }}
           dry-run: ${{ inputs.dry-run || 'false' }}


### PR DESCRIPTION
## Problem

The daily `Upload ECR Allowlists to Scanner S3` cron authenticates to a single ECR account and looks up each image there. xgboost images live in a different ECR account, so `describe_images` returns `ImageNotFoundException` and the image is silently skipped. No allowlist gets written to S3 for xgboost.

## Fix
- Add optional `aws-account-id-sagemaker` input to the action (falls  back to `aws-account-id` — backwards compatible).
- Workflow passes new `vars.PROD_AWS_ACCOUNT_ID_SAGEMAKER`.
- Script routes `xgboost` framework to the SageMaker account via `SAGEMAKER_BUILTIN_FRAMEWORKS` + `ecr_account_for_framework()`.

## Test Plan

- [x] Local dry-run — verified xgboost entries route to the SageMaker ECR account and both get their per-version allowlists merged correctly (132 entries for 3.0.5, 2 entries for 3.2.0). All other frameworks unchanged.