### PR TITLE
[auto-cve-patch] [ray] allowlist 3 HIGH CVEs blocking ray 2.55.1 auto-release

### DIFF
--- a/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
@@ -78,5 +78,20 @@
     "vulnerability_id": "CVE-2026-54275",
     "reason": "aiohttp 3.13.5 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, cannot patch without upstream ray release",
     "review_by": "2026-09-29"
+  },
+  {
+    "vulnerability_id": "CVE-2026-57516",
+    "reason": "ray[serve]==2.55.1 exact pin (autorelease-managed core contract); fix in ray 2.56.0 needs a Ray version bump",
+    "review_by": "2027-01-02"
+  },
+  {
+    "vulnerability_id": "CVE-2026-54277",
+    "reason": "aiohttp 3.13.5 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, cannot patch without upstream ray release",
+    "review_by": "2026-10-04"
+  },
+  {
+    "vulnerability_id": "RUSTSEC-2026-0195",
+    "reason": "quick-xml 0.39.2 vendored in the uv binary; fix (0.41.0) not shipped in any stable uv release (latest 0.11.26 still ships 0.39.2)",
+    "review_by": "2026-10-04"
   }
 ]


### PR DESCRIPTION
## Purpose

Patch CVEs blocking the Ray auto-release `security-test / ecr-vulnerability-scan` gate. The scheduled Ray SageMaker and EC2 auto-releases failed because 3 non-allowlisted HIGH CVEs were flagged on the Ray 2.55.1 images.

## Images affected

`ray:ray-sagemaker-cpu-2.55.1`, `ray:ray-sagemaker-gpu-2.55.1`, `ray:ray-ec2-cpu-2.55.1`, `ray:ray-ec2-gpu-2.55.1`

## CVEs handled

| CVE | Package | Severity | Affected images | Action | Notes |
|---|---|---|---|---|---|
| CVE-2026-57516 | ray 2.55.1 | HIGH | cpu, gpu (sagemaker + ec2) | allowlist | fix in ray 2.56.0; `ray[serve]` is an exact autorelease-managed pin (core contract), needs a Ray version bump |
| CVE-2026-54277 | aiohttp 3.13.5 | HIGH | cpu, gpu (sagemaker + ec2) | allowlist | vendored in Ray's `thirdparty_files/`; cannot patch without upstream ray release |
| RUSTSEC-2026-0195 | quick-xml 0.39.2 | HIGH | cpu, gpu (sagemaker + ec2) | allowlist | vendored in the `uv` binary; fix (0.41.0) not shipped in any stable uv release (latest 0.11.26 still ships 0.39.2) |

## Test plan

- [ ] CI security tests pass for cpu and gpu
- [ ] CI sanity tests pass for cpu and gpu
- [ ] CI Ray-specific tests pass

---
🤖 Generated by [Claude Code](https://claude.com/claude-code).
