### PR TITLE
test(vllm): add MiniCPM5-1B model tests (smoke-test + sagemaker)

### DIFF
--- a/.github/config/model-tests/vllm-model-tests.yml
+++ b/.github/config/model-tests/vllm-model-tests.yml
@@ -20,6 +20,17 @@ smoke-test:
       fleet: "x86-g6xl-runner"
       extra_args: "--tensor-parallel-size 1 --max-model-len 4096 --dtype bfloat16"
 
+    # MiniCPM5-1B — dense 1B LlamaForCausalLM, bf16 (~2GB), no custom code.
+    # Standard architecture, loads with plain `vllm serve` (no --trust-remote-code).
+    # Hybrid reasoning emits <think> blocks; default smoke test only checks for a
+    # non-empty /v1/completions response, so no reasoning parser is required here.
+    # Fits a single L4 (g6.xl, 24GB) at tp=1. Validated offline on server-cuda-v2
+    # at --max-model-len 8192 (model's native max is 131072; capped for KV cache).
+    - name: "minicpm5-1b"
+      s3_model: "minicpm5-1b.tar.gz"
+      fleet: "x86-g6xl-runner"
+      extra_args: "--tensor-parallel-size 1 --max-model-len 8192 --dtype bfloat16"
+
     # JetBrains Mellum2 reasoning MoE (12B total / 2.5B active, bf16 ~23GB).
     # MellumForCausalLM support added upstream in vLLM 0.23.0 (PR #43992).
     # Fits a single L40S (g6e.xl, 48GB) at tp=1; qwen3 reasoning parser emits <think> blocks.
@@ -79,6 +90,33 @@ smoke-test:
 # sends requests to the configured route, and validates the response.
 # Test script: test/vllm/sagemaker/test_sm_model_serving.py
 sagemaker:
+  # MiniCPM5-1B — dense 1B LlamaForCausalLM, bf16. Standard chat model served via
+  # the OpenAI /v1/chat/completions route. Validated offline on
+  # server-sagemaker-cuda-v2 with SM_VLLM_MAX_MODEL_LEN=8192. Hybrid reasoning
+  # emits a <think> block, so message.content is non-empty; json_field validation
+  # (non-empty check) mirrors the other entries' validate rule.
+  - name: "minicpm5-1b"
+    s3_model: "minicpm5-1b.tar.gz"
+    instance_type: "ml.g6.xlarge"
+    required_image_pattern: "amzn2023"
+    env:
+      SM_VLLM_MODEL: "/opt/ml/model"
+      SM_VLLM_MAX_MODEL_LEN: "8192"
+      SM_VLLM_DTYPE: "bfloat16"
+    test_cases:
+      - name: "chat-completion"
+        route: "/v1/chat/completions"
+        content_type: "application/json"
+        request:
+          body:
+            model: "/opt/ml/model"
+            messages:
+              - role: "user"
+                content: "What is the capital of France?"
+            max_tokens: 256
+            temperature: 0
+        validate: "json_field:choices.0.message.content"
+
   - name: "voxtral-mini-4b"
     s3_model: "voxtral-mini-4b.tar.gz"
     instance_type: "ml.g6.xlarge"

--- a/.github/workflows/vllm.pr-amzn2023.yml
+++ b/.github/workflows/vllm.pr-amzn2023.yml
@@ -105,7 +105,7 @@ jobs:
       run-telemetry-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.telemetry-test-change == 'true' }}
       run-upstream-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.upstream-test-change == 'true' }}
       run-model-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.model-test-change == 'true' }}
-      run-sagemaker-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sagemaker-test-change == 'true' }}
+      run-sagemaker-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sagemaker-test-change == 'true' || needs.check-changes.outputs.model-test-change == 'true' }}
       run-efa-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.efa-test-change == 'true' }}
       release: false
     secrets: inherit

--- a/.github/workflows/vllm.pr-amzn2023.yml
+++ b/.github/workflows/vllm.pr-amzn2023.yml
@@ -105,7 +105,7 @@ jobs:
       run-telemetry-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.telemetry-test-change == 'true' }}
       run-upstream-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.upstream-test-change == 'true' }}
       run-model-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.model-test-change == 'true' }}
-      run-sagemaker-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sagemaker-test-change == 'true' || needs.check-changes.outputs.model-test-change == 'true' }}
+      run-sagemaker-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sagemaker-test-change == 'true' }}
       run-efa-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.efa-test-change == 'true' }}
       release: false
     secrets: inherit


### PR DESCRIPTION
## What

Adds **MiniCPM5-1B** (dense 1B `LlamaForCausalLM`, bf16) to the vLLM model-test config in both suites:

- **smoke-test** (EC2): served on `x86-g6xl-runner`, `--max-model-len 8192 --dtype bfloat16`. Uses the default smoke test (`/v1/completions` non-empty check).
- **sagemaker**: `ml.g6.xlarge` endpoint, `amzn2023` image, `SM_VLLM_MAX_MODEL_LEN=8192`, with a `/v1/chat/completions` test case validated via `json_field:choices.0.message.content`.

## Why

MiniCPM5-1B is the first plain chat/text-generation model in the SageMaker suite (existing entries are ASR / rerank). Standard architecture, loads with plain `vllm serve` — no `--trust-remote-code`.

## Validation

Validated offline on a GPU devbox (L4) against both AL2023 DLC images:

- `server-cuda-v2` (EC2): `/v1/chat/completions` -> HTTP 200, correct output, `finish_reason: stop`
- `server-sagemaker-cuda-v2` (SageMaker): `/invocations` -> HTTP 200, correct output, `finish_reason: stop`

Both at `--max-model-len 8192` (model native max is 131072; capped to keep KV cache modest on the L4).

## Model artifact

Uploaded to `s3://dlc-cicd-models/llm-models/minicpm5-1b.tar.gz` (matches the `s3_model` reference).

## Note

Opened as a same-repo branch (not a fork) so the image-preflight step can resolve account/region and the model-test matrix actually runs (fork PRs skip these).