### PR TITLE
docs(vllm): vLLM Server v2.1 (0.24.0) + vLLM-Omni v1.4 AL2023 releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ ______________________________________________________________________
 
 ### 🚀 Release Highlights
 
+- **[2026/07/02]** [vLLM Server v2.1 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `server-cuda-v2.1` · SageMaker: `server-sagemaker-cuda-v2.1` · vLLM `0.24.0`; adds JetBrains Mellum2-12B-A2.5B-Thinking (`MellumForCausalLM`); FlashInfer 0.6.12; drops the `transformers<5.10` pin (now requires transformers ≥ 5.5.3).
+- **[2026/07/02]** [vLLM-Omni v1.4 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `omni-cuda-v1.4` · SageMaker: `omni-sagemaker-cuda-v1.4` · SageMaker `/v1/videos` and `/v1/videos/sync` accept `application/json` again (JSON→multipart conversion restored); no framework bump (vLLM-Omni 0.21.0rc1).
 - **[2026/07/02]** [PyTorch v2.12.1](https://gallery.ecr.aws/deep-learning-containers/pytorch) — EC2: `2.12.1-cu130-amzn2023` · SageMaker: `2.12.1-cu130-amzn2023-sagemaker` · Amazon Linux 2023 with EFA, flash-attn, and Transformer Engine; PyTorch 2.12.1 bug-fix release (B200/Triton correctness fixes).
 - **[2026/07/01]** [vLLM v0.24.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.24.0-gpu-py312-ec2` · SageMaker: `0.24.0-gpu-py312` · MiniMax-M3, DiffusionGemma (+CPU), Hierarchical Reasoning Model, OpenMOSS; streaming parser engine (Qwen3, MiniMax-M2, GLM-4.7/5.1/5.2, Nemotron V3); DeepSeek-V4 fixes.
 - **[2026/06/29]** [SGLang Server v1.1 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `server-cuda-v1.1` · SageMaker: `server-sagemaker-cuda-v1.1` · SGLang `0.5.13`; adds NIXL KV connector for prefill/decode disaggregation and `runai-model-streamer[s3,gcs,azure]` for fast weight streaming from object storage; starlette CVE patch.
 - **[2026/06/29]** [SGLang v0.5.14](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.14-gpu-py312-ec2` · SageMaker: `0.5.14-gpu-py312` · GLM 5.2, LiquidAI LFM2.5, Kimi-K2.7-Code, DeepSeek V4 on GB300.
 - **[2026/06/14]** [vLLM v0.23.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.23.0-gpu-py312-ec2` · SageMaker: `0.23.0-gpu-py312` · Step-3.7-Flash, Cosmos3 Reasoner, Gemma 4 Unified (encoder-free), Granite Speech Plus, Cohere Mini Code; Anthropic Messages API structured output.
-- **[2026/06/13]** [SGLang v0.5.13](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.13-gpu-py312-ec2` · SageMaker: `0.5.13-gpu-py312` · DeepSeek V4 (BCG, HiSparse PD, PP+PD), Kimi-K2.5, MiMo-V2, Ideogram 4 (FP8/NVFP4); SM120 + FP4 indexer support.
-- **[2026/06/12]** [SGLang Server v1.0 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `server-cuda-v1.0` · SageMaker: `server-sagemaker-cuda-v1.0` · First Amazon Linux 2023 SGLang Server images, built from upstream source; OpenAI-compatible API (port 30000 EC2/EKS, 8080 SageMaker); CUDA 13.0 for H100 + Blackwell; PyTorch 2.11.0; EFA, DeepEP, and Mooncake KV-cache bundled.
 
 ### 📢 Support Updates
 

--- a/docs/src/data/vllm-server/0.24.0+amzn2023.7b3d595e-gpu-ec2.yml
+++ b/docs/src/data/vllm-server/0.24.0+amzn2023.7b3d595e-gpu-ec2.yml
@@ -1,0 +1,12 @@
+framework: vLLM
+version: "0.24.0+amzn2023.7b3d595e"
+ecr_repository: vllm
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: ec2
+public_registry: true
+
+tags:
+  - "server-cuda-v2.1"

--- a/docs/src/data/vllm-server/0.24.0+amzn2023.7b3d595e-gpu-sagemaker.yml
+++ b/docs/src/data/vllm-server/0.24.0+amzn2023.7b3d595e-gpu-sagemaker.yml
@@ -1,0 +1,12 @@
+framework: vLLM
+version: "0.24.0+amzn2023.7b3d595e"
+ecr_repository: vllm
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: sagemaker
+public_registry: true
+
+tags:
+  - "server-sagemaker-cuda-v2.1"

--- a/docs/vllm-omni/changelog/index.md
+++ b/docs/vllm-omni/changelog/index.md
@@ -4,6 +4,27 @@ Changelog for the Amazon Linux 2023-based vLLM-Omni images (`omni-cuda`, `omni-s
 
 * * *
 
+## v1.4.0 — 2026-07-02
+
+**Tags:** `omni-cuda-v1.4` · `omni-sagemaker-cuda-v1.4`
+
+**vLLM-Omni source:** [v0.21.0rc1](https://github.com/vllm-project/vllm-omni/releases/tag/v0.21.0rc1) (unchanged from v1.3)
+
+**DLC PR:** [#6298](https://github.com/aws/deep-learning-containers/pull/6298)
+
+### Changes
+
+- **SageMaker `/v1/videos` and `/v1/videos/sync` now accept `application/json` again.** The routing middleware restores JSON→multipart
+  conversion for the form-data video routes, so clients can send a plain JSON body instead of hand-building multipart. The existing
+  `multipart/form-data` path is unchanged (byte-for-byte passthrough), so callers already sending multipart need no changes.
+
+### Notes
+
+- No framework bump — still tracks vLLM-Omni 0.21.0rc1 (upstream vLLM v0.21.0). This is a DLC-minor release (v1.3 → v1.4) scoped to the SageMaker
+  video-route change above.
+
+* * *
+
 ## v1.3.0 — 2026-05-21
 
 **Tags:** `omni-cuda-v1.3` · `omni-sagemaker-cuda-v1.3`

--- a/docs/vllm-omni/changelog/index.md
+++ b/docs/vllm-omni/changelog/index.md
@@ -14,9 +14,9 @@ Changelog for the Amazon Linux 2023-based vLLM-Omni images (`omni-cuda`, `omni-s
 
 ### Changes
 
-- **SageMaker `/v1/videos` and `/v1/videos/sync` now accept `application/json` again.** The routing middleware restores JSON→multipart
-  conversion for the form-data video routes, so clients can send a plain JSON body instead of hand-building multipart. The existing
-  `multipart/form-data` path is unchanged (byte-for-byte passthrough), so callers already sending multipart need no changes.
+- **SageMaker `/v1/videos` and `/v1/videos/sync` now accept `application/json` again.** The routing middleware restores JSON→multipart conversion for
+  the form-data video routes, so clients can send a plain JSON body instead of hand-building multipart. The existing `multipart/form-data` path is
+  unchanged (byte-for-byte passthrough), so callers already sending multipart need no changes.
 
 ### Notes
 

--- a/docs/vllm-omni/deployment/sagemaker.md
+++ b/docs/vllm-omni/deployment/sagemaker.md
@@ -67,9 +67,10 @@ response = predictor.predict(
 )
 ```
 
-The `/v1/videos` and `/v1/videos/sync` routes require `multipart/form-data`. As of `omni-sagemaker-cuda-v1.2`, the routing middleware no longer
-converts JSON to multipart — clients must build the multipart body locally and pass it through `InvokeEndpoint`'s `ContentType`. SageMaker forwards
-the body and `ContentType` to the model server unchanged.
+The `/v1/videos` and `/v1/videos/sync` routes accept either `application/json` or `multipart/form-data`. As of `omni-sagemaker-cuda-v1.4`, the
+routing middleware again converts a JSON body to multipart for these routes (this was disabled in `v1.2` and restored in `v1.4`), so sending JSON —
+as in the image and chat examples above — works. The `multipart/form-data` path below is still supported unchanged and remains useful when you want
+byte-for-byte control over the request body.
 
 ```python
 import uuid

--- a/docs/vllm-omni/deployment/sagemaker.md
+++ b/docs/vllm-omni/deployment/sagemaker.md
@@ -67,9 +67,9 @@ response = predictor.predict(
 )
 ```
 
-The `/v1/videos` and `/v1/videos/sync` routes accept either `application/json` or `multipart/form-data`. As of `omni-sagemaker-cuda-v1.4`, the
-routing middleware again converts a JSON body to multipart for these routes (this was disabled in `v1.2` and restored in `v1.4`), so sending JSON —
-as in the image and chat examples above — works. The `multipart/form-data` path below is still supported unchanged and remains useful when you want
+The `/v1/videos` and `/v1/videos/sync` routes accept either `application/json` or `multipart/form-data`. As of `omni-sagemaker-cuda-v1.4`, the routing
+middleware again converts a JSON body to multipart for these routes (this was disabled in `v1.2` and restored in `v1.4`), so sending JSON — as in the
+image and chat examples above — works. The `multipart/form-data` path below is still supported unchanged and remains useful when you want
 byte-for-byte control over the request body.
 
 ```python

--- a/docs/vllm/changelog/index.md
+++ b/docs/vllm/changelog/index.md
@@ -4,6 +4,34 @@ Changelog for the Amazon Linux 2023-based vLLM images (`server-cuda`, `server-sa
 
 * * *
 
+## v2.1.0 — 2026-07-02
+
+**Tags:** `server-cuda-v2.1` · `server-sagemaker-cuda-v2.1`
+
+**vLLM source:** [7b3d595](https://github.com/vllm-project/vllm/commit/7b3d595eb197d714052ce296cc8b124f0dc8af31) (`0.24.0+amzn2023.7b3d595e`)
+
+**Bundled versions:** CUDA 13.0.2 · Python 3.12 · FlashInfer 0.6.12 · DeepEP [73b6ea4](https://github.com/deepseek-ai/DeepEP/commit/73b6ea4)
+
+### Highlights
+
+- **vLLM 0.24.0** — minor version bump from 0.22.1rc0 (v2.0)
+- **FlashInfer 0.6.12** — upgraded from 0.6.11.post2
+- **transformers `<5.10` pin removed** — vLLM 0.24.0 requires transformers ≥ 5.5.3, so the previous pin is dropped
+- **`mistral_common` now an optional import** — audio dependencies (`mistral_common[audio]`, av, scipy, soundfile) are installed explicitly for
+  Voxtral / ASR serving
+
+### New Model Support
+
+- Mellum2-12B-A2.5B-Thinking (`MellumForCausalLM`)
+
+### Notes
+
+- GPU device selection refactor upstream: vLLM no longer sets `CUDA_VISIBLE_DEVICES` internally and adds a `--device-ids` flag. Single-server
+  tensor-parallel serving is unaffected.
+- Models removed upstream (ERNIE, Xverse, Dots1, Bamba, Mono-InternVL) are not part of the DLC test matrix.
+
+* * *
+
 ## v2.0.0 — 2026-06-05
 
 **Tags:** `server-cuda-v2.0` · `server-sagemaker-cuda-v2.0`

--- a/docs/vllm/models/index.md
+++ b/docs/vllm/models/index.md
@@ -26,6 +26,7 @@ release. A *Smoke + Benchmark* tag means both apply.
 |  | [google/gemma-4-31B-it](https://huggingface.co/google/gemma-4-31B-it) | Benchmark |
 |  | [google/gemma-4-E4B-it](https://huggingface.co/google/gemma-4-E4B-it) | Benchmark |
 | **GPT-OSS** | [openai/gpt-oss-20b](https://huggingface.co/openai/gpt-oss-20b) | Benchmark |
+| **JetBrains** | [JetBrains/Mellum2-12B-A2.5B-Thinking](https://huggingface.co/JetBrains/Mellum2-12B-A2.5B-Thinking) | Smoke + Benchmark |
 
 ## Model-Specific Tuning
 


### PR DESCRIPTION
## Summary

Documents the four AL2023 auto-releases that shipped on 2026-07-02 but whose docs were not fully updated by the release pipeline. The pipeline's `step4-docs-pr` only regenerates the *Ubuntu* vLLM gallery data (`docs/src/data/vllm/`) and skips vLLM-Omni entirely (`vllm_omni: Not defined in tracker config`), so the AL2023 `server-cuda` / `omni-cuda` gallery entries and changelogs were missing.

### vLLM Server (AL2023) — v2.1 / vLLM 0.24.0
- **Gallery data:** add `docs/src/data/vllm-server/0.24.0+amzn2023.7b3d595e-gpu-{ec2,sagemaker}.yml` → tags `server-cuda-v2.1`, `server-sagemaker-cuda-v2.1`.
- **Changelog:** new `v2.1.0` entry — vLLM 0.24.0, FlashInfer 0.6.12, `transformers<5.10` pin dropped (now requires transformers ≥ 5.5.3), `mistral_common` now optional.
- **Models:** add JetBrains **Mellum2-12B-A2.5B-Thinking** (`MellumForCausalLM`, Smoke + Benchmark).

### vLLM-Omni (AL2023) — v1.4
- **Changelog:** new `v1.4.0` entry — SageMaker `/v1/videos` and `/v1/videos/sync` accept `application/json` again (JSON→multipart conversion restored). No framework bump (still vLLM-Omni 0.21.0rc1).
- **SageMaker deployment doc:** updated the video-route note — JSON works again as of `omni-sagemaker-cuda-v1.4`; the multipart path remains supported.

### README
- Add both AL2023 releases to **Release Highlights**; drop the two oldest entries (SGLang v0.5.13, SGLang Server v1.0) to keep the list bounded.

## Testing
- `python docs/src/main.py --verbose` — generation passes; `available_images.md` renders the new `server-cuda-v2.1` / `server-sagemaker-cuda-v2.1` rows.
- `mkdocs build --strict` — passes (exit 0).
- Docs prose wrapped at 150 cols to match the `flowmark` hook; no trailing whitespace; YAML validates.