### PR TITLE
fix(release): forward container_type for base and ray releases

### DIFF
--- a/.github/actions/generate-release-spec/generate_release_spec.sh
+++ b/.github/actions/generate-release-spec/generate_release_spec.sh
@@ -39,6 +39,7 @@ DEVICE_TYPE=$(yq '.metadata.device_type // ""' "$CONFIG_FILE")
 OS_VERSION=$(yq '.metadata.os_version // ""' "$CONFIG_FILE")
 CUSTOMER_TYPE=$(yq '.metadata.customer_type // ""' "$CONFIG_FILE")
 PLATFORM=$(yq '.metadata.platform // ""' "$CONFIG_FILE")
+CONTAINER_TYPE=$(yq '.metadata.container_type // ""' "$CONFIG_FILE")
 
 # Derived fields
 PYTHON_RAW=$(yq '.build.python_version // ""' "$CONFIG_FILE")
@@ -84,6 +85,7 @@ SPEC+="version: \"${VERSION}\""$'\n'
 [[ -n "$CUDA_VERSION" ]]    && SPEC+="cuda_version: \"${CUDA_VERSION}\""$'\n'
 [[ -n "$TRANSFORMERS_VERSION" ]] && SPEC+="transformers_version: \"${TRANSFORMERS_VERSION}\""$'\n'
 [[ -n "$PLATFORM" ]]        && SPEC+="platform: \"${PLATFORM}\""$'\n'
+[[ -n "$CONTAINER_TYPE" ]]  && SPEC+="container_type: \"${CONTAINER_TYPE}\""$'\n'
 [[ -n "$FORCE_RELEASE" ]]   && SPEC+="force_release: ${FORCE_RELEASE}"$'\n'
 [[ -n "$PUBLIC_REGISTRY" ]] && SPEC+="public_registry: ${PUBLIC_REGISTRY}"$'\n'
 [[ -n "$PRIVATE_REGISTRY" ]] && SPEC+="private_registry: ${PRIVATE_REGISTRY}"$'\n'

--- a/.github/config/image/base/cu129-devel.yml
+++ b/.github/config/image/base/cu129-devel.yml
@@ -10,6 +10,7 @@ metadata:
   arch_type: "x86"
   device_type: "gpu"
   job_type: "general"
+  container_type: "devel"
   prod_image: "base:devel-cu129-amzn2023"
 
 build:

--- a/.github/config/image/base/cu129-runtime.yml
+++ b/.github/config/image/base/cu129-runtime.yml
@@ -10,6 +10,7 @@ metadata:
   arch_type: "x86"
   device_type: "gpu"
   job_type: "general"
+  container_type: "runtime"
   prod_image: "base:runtime-cu129-amzn2023"
 
 build:

--- a/.github/config/image/base/cu130-devel.yml
+++ b/.github/config/image/base/cu130-devel.yml
@@ -10,6 +10,7 @@ metadata:
   arch_type: "x86"
   device_type: "gpu"
   job_type: "general"
+  container_type: "devel"
   prod_image: "base:devel-cu130-amzn2023"
 
 build:

--- a/.github/config/image/base/cu130-runtime.yml
+++ b/.github/config/image/base/cu130-runtime.yml
@@ -10,6 +10,7 @@ metadata:
   arch_type: "x86"
   device_type: "gpu"
   job_type: "general"
+  container_type: "runtime"
   prod_image: "base:runtime-cu130-amzn2023"
 
 build:

--- a/.github/config/image/ray/ec2-cpu.yml
+++ b/.github/config/image/ray/ec2-cpu.yml
@@ -10,6 +10,7 @@ metadata:
   arch_type: "x86"
   device_type: "cpu"
   job_type: "inference"
+  container_type: "serve-ml"
   prod_image: "ray:serve-ml-cpu"
 
 build:

--- a/.github/config/image/ray/ec2-gpu.yml
+++ b/.github/config/image/ray/ec2-gpu.yml
@@ -10,6 +10,7 @@ metadata:
   arch_type: "x86"
   device_type: "gpu"
   job_type: "inference"
+  container_type: "serve-ml"
   prod_image: "ray:serve-ml-cuda"
 
 build:

--- a/.github/config/image/ray/sagemaker-cpu.yml
+++ b/.github/config/image/ray/sagemaker-cpu.yml
@@ -11,6 +11,7 @@ metadata:
   arch_type: "x86"
   device_type: "cpu"
   job_type: "inference"
+  container_type: "serve-ml"
   prod_image: "ray:serve-ml-sagemaker-cpu"
 
 build:

--- a/.github/config/image/ray/sagemaker-gpu.yml
+++ b/.github/config/image/ray/sagemaker-gpu.yml
@@ -11,6 +11,7 @@ metadata:
   arch_type: "x86"
   device_type: "gpu"
   job_type: "inference"
+  container_type: "serve-ml"
   prod_image: "ray:serve-ml-sagemaker-cuda"
 
 build:


### PR DESCRIPTION
## Summary
base and ray auto-releases fail at tag construction:
```
ValueError("Tag template '{container_type}-{cuda_version}-{os_version}' requires variable 'container_type' but it was not provided")
```
The deployed release logic derives base_dlc/ray release tags from a `container_type` template, but `generate_release_spec.sh` never forwarded that field and the base/ray configs never declared it.

- `generate_release_spec.sh`: emit `metadata.container_type` into the release spec
- base configs: add `container_type` (`runtime` / `devel`)
- ray configs: add `container_type` (`serve-ml`; the `-sagemaker` suffix comes from the existing `platform` field)

This works against the currently deployed release logic — no release-logic change or deploy is required.

## Testing
Ran the release-spec field mapping against all 8 base/ray configs and fed the output through `ReleaseSpec.from_yaml` + `construct_tags` (deployed release logic). Resulting tags are byte-identical to the previous `prod_image` values: `runtime-cu130-amzn2023`, `devel-cu130-amzn2023`, `runtime-cu129-amzn2023`, `devel-cu129-amzn2023`, `serve-ml-cuda`, `serve-ml-cpu`, `serve-ml-sagemaker-cuda`, `serve-ml-sagemaker-cpu`.
