### PR TITLE
ci: embed immediate Slack failure notification in release pipelines (alt to #6337)

### DIFF
--- a/.github/actions/notify-slack-failure/action.yml
+++ b/.github/actions/notify-slack-failure/action.yml
@@ -1,0 +1,54 @@
+name: 'Notify Slack Failure'
+description: 'Post a failed auto-release run to a Slack Workflow Builder webhook.'
+
+inputs:
+  webhook-url:
+    description: 'Slack Workflow Builder webhook URL (secret).'
+    required: true
+  workflow-name:
+    description: 'Workflow display name (github.workflow). "Auto Release - " prefix is stripped.'
+    required: true
+  config-file:
+    description: 'Path to the image config YAML; its basename identifies which config failed.'
+    required: true
+  run-url:
+    description: 'URL of the failed workflow run.'
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Send Slack notification
+      shell: bash
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.webhook-url }}
+        WORKFLOW_NAME: ${{ inputs.workflow-name }}
+        CONFIG_FILE: ${{ inputs.config-file }}
+        RUN_URL: ${{ inputs.run-url }}
+      run: |
+        if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
+          echo "::error::webhook-url is empty — set the SLACK_RELEASE_FAILURE_WEBHOOK_URL secret."
+          exit 1
+        fi
+
+        # Include the config basename: one workflow releases several configs via matrix.
+        workflow="${WORKFLOW_NAME#Auto Release - } ($(basename "${CONFIG_FILE}"))"
+
+        payload=$(jq -n \
+          --arg workflow "${workflow}" \
+          --arg url "${RUN_URL}" \
+          '{
+            workflow: $workflow,
+            url: $url
+          }')
+
+        http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+          --max-time 10 \
+          -X POST "${SLACK_WEBHOOK_URL}" \
+          -H 'Content-Type: application/json' \
+          --data "${payload}")
+
+        echo "Slack webhook responded with HTTP ${http_code}"
+        if [[ "${http_code}" != "200" ]]; then
+          echo "::warning::Slack notification failed (HTTP ${http_code})"
+        fi

--- a/.github/workflows/base.pipeline.yml
+++ b/.github/workflows/base.pipeline.yml
@@ -119,3 +119,23 @@ jobs:
       environment: ${{ needs.release-gate.outputs.environment }}
       aws-region: ${{ vars.AWS_REGION }}
     secrets: inherit
+
+  notify-failure:
+    # Notify Slack immediately when an auto-release/dispatch-release run fails.
+    # Guarded on release context so PR runs never notify.
+    if: >-
+      failure() &&
+      github.ref == 'refs/heads/main' &&
+      (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
+      !contains(github.workflow_ref, '.pr') &&
+      inputs.release
+    needs: [build, sanity-test, security-test, release-gate, release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook-url: ${{ secrets.SLACK_RELEASE_FAILURE_WEBHOOK_URL }}
+          workflow-name: ${{ github.workflow }}
+          config-file: ${{ inputs.config-file }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/huggingface-vllm.pipeline.yml
+++ b/.github/workflows/huggingface-vllm.pipeline.yml
@@ -151,3 +151,23 @@ jobs:
       environment: ${{ needs.release-gate.outputs.environment }}
       aws-region: ${{ vars.AWS_REGION }}
     secrets: inherit
+
+  notify-failure:
+    # Notify Slack immediately when an auto-release/dispatch-release run fails.
+    # Guarded on release context so PR runs never notify.
+    if: >-
+      failure() &&
+      github.ref == 'refs/heads/main' &&
+      (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
+      !contains(github.workflow_ref, '.pr') &&
+      inputs.release
+    needs: [build, sanity-test, security-test, telemetry-test, sagemaker-tests, release-gate, release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook-url: ${{ secrets.SLACK_RELEASE_FAILURE_WEBHOOK_URL }}
+          workflow-name: ${{ github.workflow }}
+          config-file: ${{ inputs.config-file }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/lambda.pipeline.yml
+++ b/.github/workflows/lambda.pipeline.yml
@@ -202,3 +202,23 @@ jobs:
       environment: ${{ needs.release-gate.outputs.environment }}
       aws-region: ${{ vars.AWS_REGION }}
     secrets: inherit
+
+  notify-failure:
+    # Notify Slack immediately when an auto-release/dispatch-release run fails.
+    # Guarded on release context so PR runs never notify.
+    if: >-
+      failure() &&
+      github.ref == 'refs/heads/main' &&
+      (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
+      !contains(github.workflow_ref, '.pr') &&
+      inputs.release
+    needs: [build, sanity-test, security-test, telemetry-test, validation-test, release-gate, release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook-url: ${{ secrets.SLACK_RELEASE_FAILURE_WEBHOOK_URL }}
+          workflow-name: ${{ github.workflow }}
+          config-file: ${{ inputs.config-file }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/openfold3.pipeline.yml
+++ b/.github/workflows/openfold3.pipeline.yml
@@ -145,3 +145,23 @@ jobs:
       environment: ${{ needs.release-gate.outputs.environment }}
       aws-region: ${{ vars.AWS_REGION }}
     secrets: inherit
+
+  notify-failure:
+    # Notify Slack immediately when an auto-release/dispatch-release run fails.
+    # Guarded on release context so PR runs never notify.
+    if: >-
+      failure() &&
+      github.ref == 'refs/heads/main' &&
+      (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
+      !contains(github.workflow_ref, '.pr') &&
+      inputs.release
+    needs: [ci-config, build, sanity-test, security-test, sagemaker-tests, release-gate, release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook-url: ${{ secrets.SLACK_RELEASE_FAILURE_WEBHOOK_URL }}
+          workflow-name: ${{ github.workflow }}
+          config-file: ${{ inputs.config-file }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/pytorch.pipeline.yml
+++ b/.github/workflows/pytorch.pipeline.yml
@@ -249,3 +249,23 @@ jobs:
       environment: ${{ needs.release-gate.outputs.environment }}
       aws-region: ${{ vars.AWS_REGION }}
     secrets: inherit
+
+  notify-failure:
+    # Notify Slack immediately when an auto-release/dispatch-release run fails.
+    # Guarded on release context so PR runs never notify.
+    if: >-
+      failure() &&
+      github.ref == 'refs/heads/main' &&
+      (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
+      !contains(github.workflow_ref, '.pr') &&
+      inputs.release
+    needs: [ci-config, build, sanity-test, security-test, telemetry-test, unit-test, single-gpu-test, multi-gpu-test, multi-node-gpu-test, efa-test, sagemaker-test, release-gate, release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook-url: ${{ secrets.SLACK_RELEASE_FAILURE_WEBHOOK_URL }}
+          workflow-name: ${{ github.workflow }}
+          config-file: ${{ inputs.config-file }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/ray.pipeline.yml
+++ b/.github/workflows/ray.pipeline.yml
@@ -195,3 +195,23 @@ jobs:
       environment: ${{ needs.release-gate.outputs.environment }}
       aws-region: ${{ vars.AWS_REGION }}
     secrets: inherit
+
+  notify-failure:
+    # Notify Slack immediately when an auto-release/dispatch-release run fails.
+    # Guarded on release context so PR runs never notify.
+    if: >-
+      failure() &&
+      github.ref == 'refs/heads/main' &&
+      (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
+      !contains(github.workflow_ref, '.pr') &&
+      inputs.release
+    needs: [ci-config, build, sanity-test, security-test, telemetry-test, ffmpeg-test, serve-test, sagemaker-test, release-gate, release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook-url: ${{ secrets.SLACK_RELEASE_FAILURE_WEBHOOK_URL }}
+          workflow-name: ${{ github.workflow }}
+          config-file: ${{ inputs.config-file }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/sglang.pipeline.yml
+++ b/.github/workflows/sglang.pipeline.yml
@@ -217,3 +217,23 @@ jobs:
       environment: ${{ needs.release-gate.outputs.environment }}
       aws-region: ${{ vars.AWS_REGION }}
     secrets: inherit
+
+  notify-failure:
+    # Notify Slack immediately when an auto-release/dispatch-release run fails.
+    # Guarded on release context so PR runs never notify.
+    if: >-
+      failure() &&
+      github.ref == 'refs/heads/main' &&
+      (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
+      !contains(github.workflow_ref, '.pr') &&
+      inputs.release
+    needs: [ci-config, build, sanity-test, security-test, telemetry-test, upstream-tests, model-tests, sagemaker-tests, efa-test, release-gate, release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook-url: ${{ secrets.SLACK_RELEASE_FAILURE_WEBHOOK_URL }}
+          workflow-name: ${{ github.workflow }}
+          config-file: ${{ inputs.config-file }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/vllm-omni.pipeline.yml
+++ b/.github/workflows/vllm-omni.pipeline.yml
@@ -180,3 +180,23 @@ jobs:
       environment: ${{ needs.release-gate.outputs.environment }}
       aws-region: ${{ vars.AWS_REGION }}
     secrets: inherit
+
+  notify-failure:
+    # Notify Slack immediately when an auto-release/dispatch-release run fails.
+    # Guarded on release context so PR runs never notify.
+    if: >-
+      failure() &&
+      github.ref == 'refs/heads/main' &&
+      (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
+      !contains(github.workflow_ref, '.pr') &&
+      inputs.release
+    needs: [ci-config, build, sanity-test, security-test, telemetry-test, model-tests, sagemaker-tests, release-gate, release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook-url: ${{ secrets.SLACK_RELEASE_FAILURE_WEBHOOK_URL }}
+          workflow-name: ${{ github.workflow }}
+          config-file: ${{ inputs.config-file }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/vllm.pipeline.yml
+++ b/.github/workflows/vllm.pipeline.yml
@@ -216,3 +216,23 @@ jobs:
       environment: ${{ needs.release-gate.outputs.environment }}
       aws-region: ${{ vars.AWS_REGION }}
     secrets: inherit
+
+  notify-failure:
+    # Notify Slack immediately when an auto-release/dispatch-release run fails.
+    # Guarded on release context so PR runs never notify.
+    if: >-
+      failure() &&
+      github.ref == 'refs/heads/main' &&
+      (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
+      !contains(github.workflow_ref, '.pr') &&
+      inputs.release
+    needs: [ci-config, build, sanity-test, security-test, telemetry-test, upstream-tests, model-tests, sagemaker-tests, efa-test, release-gate, release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook-url: ${{ secrets.SLACK_RELEASE_FAILURE_WEBHOOK_URL }}
+          workflow-name: ${{ github.workflow }}
+          config-file: ${{ inputs.config-file }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/xgboost.pipeline.yml
+++ b/.github/workflows/xgboost.pipeline.yml
@@ -182,3 +182,23 @@ jobs:
       environment: ${{ needs.release-gate.outputs.environment }}
       aws-region: ${{ vars.AWS_REGION }}
     secrets: inherit
+
+  notify-failure:
+    # Notify Slack immediately when an auto-release/dispatch-release run fails.
+    # Guarded on release context so PR runs never notify.
+    if: >-
+      failure() &&
+      github.ref == 'refs/heads/main' &&
+      (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
+      !contains(github.workflow_ref, '.pr') &&
+      inputs.release
+    needs: [build, sanity-test, security-test, unit-test, integ-test, integ-test-full, release-gate, release]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/notify-slack-failure
+        with:
+          webhook-url: ${{ secrets.SLACK_RELEASE_FAILURE_WEBHOOK_URL }}
+          workflow-name: ${{ github.workflow }}
+          config-file: ${{ inputs.config-file }}
+          run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
## Context

This is the **embedded** alternative to the scheduled failure digest in #6337, per the design discussion (G's proposal). Both target the same problem — auto-release workflows fail silently — and use the same `SLACK_RELEASE_FAILURE_WEBHOOK_URL` secret, so the team can compare and pick one.

## What this does

Shared logic lives in a composite action, **`.github/actions/notify-slack-failure`**. Each of the 10 `*.pipeline.yml` orchestrators adds a thin `notify-failure` job that `needs` every job in the pipeline, runs on `if: failure() && <release context>`, and calls the action — so **any failed job posts to Slack immediately**.

Per-pipeline addition is ~20 lines (job wiring only); the curl/jq logic is defined once in the action.

Guard (same release context as `release-gate`):
```yaml
if: >-
  failure() &&
  github.ref == 'refs/heads/main' &&
  (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
  !contains(github.workflow_ref, '.pr') &&
  inputs.release
```
→ fires only for autorelease / dispatch-release runs on `main`; **PR runs never notify**.

## Why embedded (vs. the #6337 cron digest)

| | #6337 cron digest | This (embedded) |
|---|---|---|
| Latency | up to ~17h (fixed sweep times) | **immediate** |
| Scan timing risk | yes (best-effort cron) | **none** |
| Dedup logic | window-based, fragile | **none** — 1 failed run = 1 message |
| Reruns reported | maybe double / missed | **each rerun re-posts** |
| Can desync from release | possible | **impossible** (part of the run) |
| Files touched | 1 | 1 action + 10 thin job wirings |

Trade-off: emits one message per failed config (no batching), so a bad night is noisier than a digest. Given failures are ~0–2/day this is acceptable; if noise becomes real we can add a Slack-side throttle.

## Payload / message

The action posts the workflow label + run URL (no `count` — one run per message):

```json
{ "workflow": "PyTorch 2.12 EC2 (2.12-ec2-cuda.yml)", "url": "https://github.com/aws/deep-learning-containers/actions/runs/111" }
```

The label strips the `Auto Release - ` prefix and adds the config basename (one workflow releases several configs via matrix). Rendered with a Slack template of `🚨 {{workflow}} → {{url}}`:
> 🚨 PyTorch 2.12 EC2 (2.12-ec2-cuda.yml) → https://github.com/aws/deep-learning-containers/actions/runs/111

## Configuration

`webhook-url` is a **required** action input, wired to the `SLACK_RELEASE_FAILURE_WEBHOOK_URL` secret. If the secret is unset the notify job fails loudly (`::error::` + non-zero exit) rather than silently skipping, so a misconfiguration is visible instead of dropping alerts.

## Testing

- Action + all 10 pipeline YAMLs validated.
- Payload logic simulated locally (prefix strip + config basename + jq payload).
