### PR TITLE
ci(vllm): add nemotron-nano-12b-v2 to sagemaker endpoint tests

### DIFF
--- a/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
+++ b/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
@@ -39,6 +39,37 @@ sagemaker:
             temperature: 0
         validate: "json_field:choices.0.message.content"
 
+  # NVIDIA Nemotron-Nano-12B-v2 — Mamba2-Transformer hybrid (NemotronHForCausalLM),
+  # 12B params bf16 (~24GB weights, ~42GB steady-state including Mamba SSM float32
+  # cache + KV pool). Requires ml.g6e.xlarge (L40S 48GB); ml.g6.xlarge (L4 24GB)
+  # cannot fit the model. --trust-remote-code loads the custom
+  # configuration_nemotron_h.py; --mamba-ssm-cache-dtype=float32 is required by
+  # the model card to preserve accuracy (skipping it silently degrades quality).
+  - name: "nemotron-nano-12b-v2"
+    s3_model: "nemotron-nano-12b-v2.tar.gz"
+    instance_type: "ml.g6e.xlarge"
+    required_image_pattern:
+      os_version: "amzn2023"
+    env:
+      SM_VLLM_MODEL: "/opt/ml/model"
+      SM_VLLM_MAX_MODEL_LEN: "4096"
+      SM_VLLM_DTYPE: "bfloat16"
+      SM_VLLM_TRUST_REMOTE_CODE: "true"
+      SM_VLLM_MAMBA_SSM_CACHE_DTYPE: "float32"
+    test_cases:
+      - name: "chat-completion"
+        route: "/v1/chat/completions"
+        content_type: "application/json"
+        request:
+          body:
+            model: "/opt/ml/model"
+            messages:
+              - role: "user"
+                content: "What is the capital of France?"
+            max_tokens: 256
+            temperature: 0
+        validate: "json_field:choices.0.message.content"
+
   - name: "voxtral-mini-4b"
     s3_model: "voxtral-mini-4b.tar.gz"
     instance_type: "ml.g6.xlarge"


### PR DESCRIPTION
## Summary
Follow-up to #6349 — Nemotron-Nano-12B-v2 was added to the vLLM smoke-test matrix but the corresponding SageMaker endpoint entry was missed. This PR adds it.

## Details
- **Instance:** `ml.g6e.xlarge` (L40S 48GB). The default `ml.g6.xlarge` (L4 24GB) cannot fit the 12B model — steady-state footprint is ~42 GiB (weights + Mamba SSM float32 cache + KV pool), verified end-to-end in #6349.
- **Required env flags** (mirror the smoke-test entry's `extra_args`):
  - `SM_VLLM_TRUST_REMOTE_CODE=true` — loads the custom `configuration_nemotron_h.py`
  - `SM_VLLM_MAMBA_SSM_CACHE_DTYPE=float32` — model card requires this; skipping it silently degrades accuracy
  - `SM_VLLM_MAX_MODEL_LEN=4096`, `SM_VLLM_DTYPE=bfloat16`
- **Test case:** single-turn `/v1/chat/completions` — mirrors `minicpm5-1b`'s shape (`json_field:choices.0.message.content` non-empty check).
- **Filter:** `required_image_pattern: {os_version: amzn2023}` — routed through the preflight parser gate added in #6349, so ubuntu autoreleases are unaffected.

## Test plan
- [ ] Preflight parse step returns `matrix` with the new entry present on amzn2023, absent on ubuntu.
- [ ] endpoint-test provisions `ml.g6e.xlarge`, deploys the model, and receives a non-empty `choices.0.message.content` from `/v1/chat/completions`.
- [ ] Existing 6 sagemaker entries continue to run unchanged.