### PR TITLE
sklearn: add dispatch-release workflow for manual pipeline runs

### DIFF
--- a/.github/workflows/sklearn.dispatch-release.yml
+++ b/.github/workflows/sklearn.dispatch-release.yml
@@ -1,0 +1,25 @@
+name: "Dispatch - Scikit-learn Release"
+
+on:
+  workflow_dispatch:
+    inputs:
+      config-file:
+        description: "Path to image config YAML (e.g., .github/config/image/sklearn/sagemaker-py312.yml)"
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  pipeline:
+    uses: ./.github/workflows/sklearn.pipeline.yml
+    with:
+      config-file: ${{ inputs.config-file }}
+      tag-suffix: ${{ github.run_id }}
+      release: true
+    secrets: inherit


### PR DESCRIPTION
## Summary

Adds `sklearn.dispatch-release.yml` — the `workflow_dispatch` entry point for manually invoking the sklearn pipeline with `release: true`. Mirrors `xgboost.dispatch-release.yml`.

Enables branch-testing full E2E flows (currently blocked because `workflow_dispatch`-only workflows aren't visible in the Actions UI until they land on the default branch).

## Test plan

- [x] After merge, "Dispatch - Scikit-learn Release" appears in the Actions UI
- [x] Dispatching against branch `sklearn/e2e-tests` (PR #6359) triggers the full pipeline including the new E2E tests