### PR TITLE
tensorflow: 2.21 legacy tags + gamma flip

### DIFF
--- a/.github/config/image/tensorflow/2.21-sagemaker-cpu.yml
+++ b/.github/config/image/tensorflow/2.21-sagemaker-cpu.yml
@@ -7,11 +7,10 @@ metadata:
   framework_version: "2.21.0"
   os_version: "amzn2023"
   customer_type: "sagemaker"
-  platform: "sagemaker"
   arch_type: "x86"
   device_type: "cpu"
   job_type: "training"
-  prod_image: "tensorflow:2.21-cpu-amzn2023-sagemaker"
+  prod_image: "tensorflow-training:2.21-cpu-py312-amzn2023-sagemaker-v1"
 
 build:
   dockerfile: "docker/tensorflow/2.21/Dockerfile.cpu"

--- a/.github/config/image/tensorflow/2.21-sagemaker-cpu.yml
+++ b/.github/config/image/tensorflow/2.21-sagemaker-cpu.yml
@@ -22,9 +22,9 @@ build:
   dlc_minor_version: "0"
 
 release:
-  release: false
+  release: true
   force_release: false
   public_registry: false
-  private_registry: false
+  private_registry: true
   enable_soci: false
-  environment: "production"
+  environment: "gamma"

--- a/.github/config/image/tensorflow/2.21-sagemaker-cuda.yml
+++ b/.github/config/image/tensorflow/2.21-sagemaker-cuda.yml
@@ -24,9 +24,9 @@ build:
   dlc_minor_version: "0"
 
 release:
-  release: false
+  release: true
   force_release: false
   public_registry: false
-  private_registry: false
+  private_registry: true
   enable_soci: false
-  environment: "production"
+  environment: "gamma"

--- a/.github/config/image/tensorflow/2.21-sagemaker-cuda.yml
+++ b/.github/config/image/tensorflow/2.21-sagemaker-cuda.yml
@@ -7,11 +7,10 @@ metadata:
   framework_version: "2.21.0"
   os_version: "amzn2023"
   customer_type: "sagemaker"
-  platform: "sagemaker"
   arch_type: "x86"
   device_type: "gpu"
   job_type: "training"
-  prod_image: "tensorflow:2.21-cu129-amzn2023-sagemaker"
+  prod_image: "tensorflow-training:2.21-gpu-py312-cu129-amzn2023-sagemaker-v1"
 
 build:
   dockerfile: "docker/tensorflow/2.21/Dockerfile.cuda"


### PR DESCRIPTION
## Changes

Two commits, per-file:

### Commit 1 (`4a274103`) — align configs with legacy tag shape
- Drop `platform: "sagemaker"` metadata field. Legacy templates use `{cx_suffix}` from `customer_type`; `platform` becomes dead metadata.
- Update `prod_image` to match the actual legacy tag that will be pushed:
  - CUDA: `tensorflow-training:2.21-gpu-py312-cu129-amzn2023-sagemaker-v1`
  - CPU:  `tensorflow-training:2.21-cpu-py312-amzn2023-sagemaker-v1`
  Used by `.github/actions/resolve-image-uri` as fallback in test-only runs.

### Commit 2 — flip release configs to gamma
- `release: false → true`
- `private_registry: false → true`
- `environment: "production" → "gamma"`

## Expected gamma tags (per legacy shape)

cuda config produces:
- `2.21.0-gpu-py312-cu129-amzn2023-sagemaker`
- `2.21.0-gpu-py312-cu129-amzn2023-sagemaker-v1.0`
- `2.21.0-gpu-py312-cu129-amzn2023-sagemaker-v1.0-YYYY-MM-DD-HH-MM-SS`
- `2.21-gpu-py312-cu129-amzn2023-sagemaker`
- `2.21-gpu-py312-cu129-amzn2023-sagemaker-v1`
- `2.21-gpu-py312` (sagemaker_short_tag)
- `2.21.0-gpu-py312` (sagemaker_long_tag)

cpu config produces the same shape with `-cpu-` replacing `-gpu-py312-cu129-`.
