### PR TITLE
xgboost: add serving-container longevity/resource-impact test

### DIFF
--- a/.github/workflows/xgboost.pipeline.yml
+++ b/.github/workflows/xgboost.pipeline.yml
@@ -131,6 +131,19 @@ jobs:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
+  # Longevity test — sustained-load resource-impact check on the serving
+  # container. Lightweight; runs on PRs alongside the local integ tests.
+  longevity-test:
+    if: ${{ always() && !failure() && !cancelled() && inputs.run-integ-test }}
+    needs: [build]
+    concurrency:
+      group: ${{ github.workflow }}-longevity-test-${{ inputs.config-file }}-${{ github.ref }}
+      cancel-in-progress: true
+    uses: ./.github/workflows/xgboost.tests-longevity.yml
+    with:
+      config-file: ${{ inputs.config-file }}
+      image-uri: ${{ needs.build.outputs.image-uri || '' }}
+
   # Full integration suite — GPU container tests + SageMaker e2e + benchmarks.
   # Heavy; only runs on the release pipeline, not on PRs.
   integ-test-full:
@@ -152,7 +165,7 @@ jobs:
       inputs.release &&
       !failure() && !cancelled() &&
       needs.build.result == 'success'
-    needs: [build, sanity-test, security-test, unit-test, integ-test, integ-test-full]
+    needs: [build, sanity-test, security-test, unit-test, integ-test, longevity-test, integ-test-full]
     runs-on: ubuntu-latest
     outputs:
       environment: ${{ steps.check.outputs.environment }}

--- a/.github/workflows/xgboost.tests-longevity.yml
+++ b/.github/workflows/xgboost.tests-longevity.yml
@@ -1,0 +1,75 @@
+name: Reusable XGBoost Longevity Test
+
+# Sustained-load resource-impact test for the XGBoost serving container.
+# Lightweight (a few minutes) so it can run on PRs alongside the local
+# integration tests, unlike the full container/e2e suite which is release-only.
+
+on:
+  workflow_call:
+    inputs:
+      config-file:
+        description: "Path to image config YAML"
+        required: true
+        type: string
+      image-uri:
+        description: "Image URI to test. If empty, derives prod URI from config."
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  longevity-test:
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:x86-g6xl-runner
+        buildspec-override:true
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve image URI
+        id: image
+        uses: ./.github/actions/resolve-image-uri
+        with:
+          image-uri: ${{ inputs.image-uri }}
+          ci-aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          prod-aws-account-id: ${{ vars.PROD_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+          config-file: ${{ inputs.config-file }}
+
+      - name: Check image exists
+        id: check
+        uses: ./.github/actions/check-image-exists
+        with:
+          image-uri: ${{ steps.image.outputs.image-uri }}
+
+      - name: ECR login
+        if: steps.check.outputs.exists == 'true'
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ steps.image.outputs.aws-account-id }}
+          aws-region: ${{ vars.AWS_REGION }}
+          image-uri: ${{ steps.image.outputs.image-uri }}
+
+      - name: Install test dependencies
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          uv venv --python 3.12
+          source .venv/bin/activate
+          uv pip install -r test/requirements.txt docker pytest boto3 requests
+
+      - name: Run longevity test
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          source .venv/bin/activate
+          cd test/
+          python3 -m pytest -v --tb=short -rA --log-cli-level=INFO \
+            --image ${{ steps.image.outputs.image-uri }} \
+            xgboost/container/test_longevity.py
+
+      - name: Skip notice
+        if: steps.check.outputs.exists != 'true'
+        run: echo "Image not found in ECR — skipping longevity test (first release scenario)"

--- a/docker/xgboost/Dockerfile
+++ b/docker/xgboost/Dockerfile
@@ -8,6 +8,7 @@
 #
 # ============================================================================
 
+# TEMP: force CI build to validate longevity-test job — revert before merge
 # ── Global ARGs ─────────────────────────────────────────────────────────────
 ARG PYTHON_VERSION=3.12
 

--- a/docker/xgboost/Dockerfile
+++ b/docker/xgboost/Dockerfile
@@ -8,7 +8,6 @@
 #
 # ============================================================================
 
-# TEMP: force CI build to validate longevity-test job — revert before merge
 # ── Global ARGs ─────────────────────────────────────────────────────────────
 ARG PYTHON_VERSION=3.12
 

--- a/test/xgboost/README.md
+++ b/test/xgboost/README.md
@@ -22,10 +22,11 @@ Runs the XGBoost container locally via docker-py. The container is mounted with
 | `test_training.py`        | Algorithm-mode training: libsvm/csv, single/multi-file, weights, HPO metrics, objectives, verbosity, checkpoint/reload, distributed, invalid hyperparameters |
 | `test_scoring.py`         | Inference: csv/libsvm/protobuf payloads, execution parameters, 20 MB payload, content type validation                                                        |
 | `test_batch_transform.py` | Batch transform with `SAGEMAKER_BATCH=True`                                                                                                                  |
+| `test_longevity.py`       | Resource-impact longevity: serving container under sustained `/invocations` load, sampling memory/CPU via `docker stats`; asserts no memory leak, bounded peak usage, and liveness after load |
 
 Supporting files:
 
-- `container_helper.py` — `run_training()` and `ServingContainer` context manager
+- `container_helper.py` — `run_training()` and `ServingContainer` context manager (with `stats()` for resource sampling)
 - `generate_models.py` — generates XGBoost 3.0.5-compatible inference models
 
 ### Tier 2: E2E Tests (`e2e/`)

--- a/test/xgboost/README.md
+++ b/test/xgboost/README.md
@@ -17,11 +17,11 @@ test/xgboost/
 Runs the XGBoost container locally via docker-py. The container is mounted with
 `/opt/ml/` directory structures and exercised directly — no SageMaker jobs are created.
 
-| File                      | What it tests                                                                                                                                                |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `test_training.py`        | Algorithm-mode training: libsvm/csv, single/multi-file, weights, HPO metrics, objectives, verbosity, checkpoint/reload, distributed, invalid hyperparameters |
-| `test_scoring.py`         | Inference: csv/libsvm/protobuf payloads, execution parameters, 20 MB payload, content type validation                                                        |
-| `test_batch_transform.py` | Batch transform with `SAGEMAKER_BATCH=True`                                                                                                                  |
+| File                      | What it tests                                                                                                                                                                                 |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `test_training.py`        | Algorithm-mode training: libsvm/csv, single/multi-file, weights, HPO metrics, objectives, verbosity, checkpoint/reload, distributed, invalid hyperparameters                                  |
+| `test_scoring.py`         | Inference: csv/libsvm/protobuf payloads, execution parameters, 20 MB payload, content type validation                                                                                         |
+| `test_batch_transform.py` | Batch transform with `SAGEMAKER_BATCH=True`                                                                                                                                                   |
 | `test_longevity.py`       | Resource-impact longevity: serving container under sustained `/invocations` load, sampling memory/CPU via `docker stats`; asserts no memory leak, bounded peak usage, and liveness after load |
 
 Supporting files:

--- a/test/xgboost/container/container_helper.py
+++ b/test/xgboost/container/container_helper.py
@@ -313,6 +313,37 @@ class ServingContainer:
     def execution_parameters(self):
         return requests.get(self._url("/execution-parameters"), timeout=5)
 
+    # -- resource sampling ---------------------------------------------------
+
+    def stats(self):
+        """Return a single resource sample: {mem_bytes, mem_mb, cpu_percent}.
+
+        Reads one non-streaming ``docker stats`` snapshot for the container and
+        computes CPU% the same way the docker CLI does (delta of container CPU
+        usage over delta of system CPU usage, scaled by online CPUs).
+        """
+        raw = self._container.stats(stream=False)
+
+        mem_bytes = raw.get("memory_stats", {}).get("usage", 0)
+
+        cpu_percent = 0.0
+        try:
+            cpu = raw["cpu_stats"]
+            precpu = raw["precpu_stats"]
+            cpu_delta = cpu["cpu_usage"]["total_usage"] - precpu["cpu_usage"]["total_usage"]
+            system_delta = cpu["system_cpu_usage"] - precpu["system_cpu_usage"]
+            online_cpus = cpu.get("online_cpus") or len(cpu["cpu_usage"].get("percpu_usage", []))
+            if system_delta > 0 and cpu_delta > 0:
+                cpu_percent = (cpu_delta / system_delta) * online_cpus * 100.0
+        except (KeyError, TypeError, ZeroDivisionError):
+            cpu_percent = 0.0
+
+        return {
+            "mem_bytes": mem_bytes,
+            "mem_mb": mem_bytes / (1024 * 1024),
+            "cpu_percent": cpu_percent,
+        }
+
     def get_logs(self):
         if self._container:
             return self._container.logs().decode("utf-8", errors="replace")

--- a/test/xgboost/container/test_longevity.py
+++ b/test/xgboost/container/test_longevity.py
@@ -1,0 +1,145 @@
+"""Longevity / resource-impact container test.
+
+Exercises the XGBoost serving container under sustained inference load and
+tracks its resource footprint (memory + CPU) over time. The goal is to catch
+container-level regressions that unit / functional tests miss:
+
+- memory leaks — RSS that climbs steadily and never plateaus under repeated
+  ``/invocations`` requests
+- runaway resource use — CPU or memory that blows past a sane bound
+- loss of liveness — the container becoming unresponsive after prolonged load
+
+This is intentionally lightweight (a couple of minutes) so it can run on every
+PR alongside the other local container tests, not just on the release pipeline.
+"""
+
+import logging
+import os
+import time
+
+from .container_helper import ServingContainer
+
+LOGGER = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tunables
+# ---------------------------------------------------------------------------
+
+# Total wall-clock duration to keep hammering the container.
+LOAD_DURATION_SECONDS = int(os.environ.get("XGB_LONGEVITY_DURATION", "150"))
+# How often to sample docker stats (memory / cpu).
+SAMPLE_INTERVAL_SECONDS = 5
+# Warm-up window ignored when computing the memory-growth baseline — lets the
+# process finish lazy allocation / model load before we start trusting numbers.
+WARMUP_SECONDS = 20
+
+# Memory growth from the post-warmup baseline to the end of the run that we
+# consider indicative of a leak. XGBoost inference on a fixed model should be
+# flat; a steadily climbing RSS is the signal we want to catch.
+MEM_GROWTH_LIMIT_MB = 150
+# Absolute ceiling — the small mnist model should never need anywhere near this.
+MEM_ABSOLUTE_LIMIT_MB = 4096
+
+MODEL_NAME = "mnist-xgb-model"
+INPUT_FILE = "mnist-1.csv"
+CONTENT_TYPE = "text/csv"
+
+
+def _model_path(resources, model_name):
+    return os.path.join(resources, "models", model_name)
+
+
+def _input_path(resources, filename):
+    return os.path.join(resources, "input", filename)
+
+
+def test_serving_longevity_no_memory_leak(docker_client, image_uri, inference_resources):
+    """Sustained-load longevity check on the serving container.
+
+    Sends inference requests continuously for ``LOAD_DURATION_SECONDS`` while
+    sampling memory and CPU. Asserts the container stays healthy, every request
+    succeeds, and memory does not grow past the leak threshold.
+    """
+    model_dir = _model_path(inference_resources, MODEL_NAME)
+    with open(_input_path(inference_resources, INPUT_FILE), "rb") as f:
+        payload = f.read()
+
+    request_count = 0
+    failures = 0
+    samples = []  # list of (elapsed_s, mem_mb, cpu_percent)
+
+    with ServingContainer(docker_client, image_uri, model_dir) as ctx:
+        start = time.time()
+        next_sample = 0.0
+
+        while True:
+            elapsed = time.time() - start
+            if elapsed >= LOAD_DURATION_SECONDS:
+                break
+
+            # Drive load.
+            try:
+                resp = ctx.invocations(data=payload, content_type=CONTENT_TYPE)
+                request_count += 1
+                if resp.status_code != 200:
+                    failures += 1
+                    LOGGER.warning("Non-200 response: %s %s", resp.status_code, resp.text[:200])
+            except Exception as exc:  # connection dropped == container in trouble
+                failures += 1
+                LOGGER.warning("Invocation raised: %s", exc)
+
+            # Sample resources on a fixed cadence.
+            if elapsed >= next_sample:
+                sample = ctx.stats()
+                samples.append((elapsed, sample["mem_mb"], sample["cpu_percent"]))
+                LOGGER.info(
+                    "t=%5.1fs reqs=%d mem=%.1fMB cpu=%.1f%%",
+                    elapsed,
+                    request_count,
+                    sample["mem_mb"],
+                    sample["cpu_percent"],
+                )
+                next_sample = elapsed + SAMPLE_INTERVAL_SECONDS
+
+        # Container must still answer a health check after the load.
+        assert ctx.ping().status_code == 200, "container unhealthy after sustained load"
+
+    # -- assertions ----------------------------------------------------------
+
+    assert request_count > 0, "no requests were sent"
+    assert samples, "no resource samples collected"
+    assert failures == 0, f"{failures}/{request_count} invocations failed under sustained load"
+
+    mem_series = [mem for _, mem, _ in samples]
+    peak_mem = max(mem_series)
+    cpu_series = [cpu for _, _, cpu in samples]
+    peak_cpu = max(cpu_series)
+
+    # Baseline = first sample taken after the warm-up window (fall back to the
+    # first sample if the run is shorter than warm-up for any reason).
+    post_warmup = [mem for elapsed, mem, _ in samples if elapsed >= WARMUP_SECONDS]
+    baseline_mem = post_warmup[0] if post_warmup else mem_series[0]
+    final_mem = mem_series[-1]
+    mem_growth = final_mem - baseline_mem
+
+    LOGGER.info(
+        "longevity summary: requests=%d duration=%ds peak_mem=%.1fMB "
+        "baseline_mem=%.1fMB final_mem=%.1fMB growth=%.1fMB peak_cpu=%.1f%%",
+        request_count,
+        LOAD_DURATION_SECONDS,
+        peak_mem,
+        baseline_mem,
+        final_mem,
+        mem_growth,
+        peak_cpu,
+    )
+
+    assert peak_mem < MEM_ABSOLUTE_LIMIT_MB, (
+        f"peak memory {peak_mem:.1f}MB exceeded absolute ceiling {MEM_ABSOLUTE_LIMIT_MB}MB"
+    )
+    assert mem_growth < MEM_GROWTH_LIMIT_MB, (
+        f"memory grew {mem_growth:.1f}MB (baseline {baseline_mem:.1f}MB -> "
+        f"final {final_mem:.1f}MB) over {LOAD_DURATION_SECONDS}s, exceeding leak "
+        f"threshold {MEM_GROWTH_LIMIT_MB}MB"
+    )


### PR DESCRIPTION
### Description

Adds a **longevity / resource-impact test** for the XGBoost serving container, addressing the ORR action item to test the container's impact on resources like CPU and memory.

`test/xgboost/container/test_longevity.py` drives the serving container under sustained `/invocations` load for a fixed duration (default 150s, tunable via `XGB_LONGEVITY_DURATION`) while sampling memory and CPU via `docker stats`. It asserts:

- **No memory leak** — RSS growth from a post-warmup baseline stays under a threshold (150 MB)
- **Bounded peak memory** — peak stays under an absolute ceiling
- **All requests succeed** under sustained load
- **Liveness** — the container still answers `/ping` after the load window

### Changes

- `test/xgboost/container/test_longevity.py` — new sustained-load resource test (reuses the existing `ServingContainer` helper).
- `test/xgboost/container/container_helper.py` — added a `stats()` sampler to `ServingContainer` (memory RSS + CPU%, computed the same way the docker CLI does).
- `.github/workflows/xgboost.tests-longevity.yml` — new reusable workflow; resolves/checks the image URI, ECR login, runs the test on `x86-g6xl-runner`. Skips gracefully when the image isn't in ECR (first-release case), matching the local-integ pattern.
- `.github/workflows/xgboost.pipeline.yml` — new `longevity-test` job gated on `run-integ-test` so it runs on PRs (not just the release-only full suite); added to the `release-gate` `needs`.
- `test/xgboost/README.md` — documented the new container-test tier.

### Validation

✅ **Validated in CI** via commit `494efa2` (temp Dockerfile touch to force build — now reverted).

The longevity test ran against the freshly-built `sagemaker-xgboost:3.2` image on the `x86-g6xl-runner`:
- **34,293 requests** served over 150 seconds, all HTTP 200
- **Memory**: 681.5 MB → 682.0 MB (peak 682.0 MB, growth **0.0 MB** — no leak)
- **CPU**: 19.9% peak (initial burst only)
- **Container healthy** after sustained load (`/ping` 200)
- Total test runtime: **2m 49s**

Job log: https://github.com/aws/deep-learning-containers/actions/runs/29033607372/job/86173464126

The temp build-trigger commit has been reverted (`fd0c62d`). The Dockerfile is unchanged from `main`.

### Testing

- YAML parses; Python compiles; `ruff check` / `ruff format` clean (line-length 100).
- Referenced composite actions (`resolve-image-uri`, `check-image-exists`, `ecr-authenticate`) exist.
- `pytest --collect-only` collects the test cleanly.
- End-to-end validated in CI (see above).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
