### PR TITLE
tensorflow: flip 2.21 configs to production release

### DIFF
--- a/.github/config/image/tensorflow/2.21-sagemaker-cpu.yml
+++ b/.github/config/image/tensorflow/2.21-sagemaker-cpu.yml
@@ -24,7 +24,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
+  public_registry: true
   private_registry: true
-  enable_soci: false
-  environment: "gamma"
+  enable_soci: true
+  environment: "production"

--- a/.github/config/image/tensorflow/2.21-sagemaker-cuda.yml
+++ b/.github/config/image/tensorflow/2.21-sagemaker-cuda.yml
@@ -26,7 +26,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
+  public_registry: true
   private_registry: true
-  enable_soci: false
-  environment: "gamma"
+  enable_soci: true
+  environment: "production"

--- a/docker/tensorflow/2.21/cpu/pyproject.toml
+++ b/docker/tensorflow/2.21/cpu/pyproject.toml
@@ -19,10 +19,13 @@ dependencies = [
     # cryptography>=48.0.1 — GHSA-537c-gmf6-5ccf (HIGH)
     # starlette>=1.3.1 — GHSA-82w8-qh3p-5jfq + GHSA-wqp7-x3pw-xc5r (HIGH)
     # tornado>=6.5.6   — GHSA-3x9g-8vmp-wqvf + GHSA-mgf9-4vpg-hj56 (HIGH)
+    # soupsieve>=2.8.4 — GHSA-2wc2-fm75-p42x (HIGH, DoS) +
+    #                    GHSA-836r-79rf-4m37 (HIGH, ReDoS)
     "PyJWT>=2.13.0",
     "cryptography>=48.0.1",
     "starlette>=1.3.1",
     "tornado>=6.5.6",
+    "soupsieve>=2.8.4",
     # TF compat pins
     "numpy>=2.1,<2.5",
     "requests",

--- a/docker/tensorflow/2.21/cpu/uv.lock
+++ b/docker/tensorflow/2.21/cpu/uv.lock
@@ -3118,11 +3118,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -3328,6 +3328,7 @@ dependencies = [
     { name = "python-dateutil", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "scipy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "soupsieve", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "tensorflow-cpu", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "tornado", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -3402,6 +3403,7 @@ requires-dist = [
     { name = "seaborn", marker = "extra == 'sagemaker'" },
     { name = "shap", marker = "extra == 'sagemaker'" },
     { name = "smclarify", marker = "extra == 'sagemaker'" },
+    { name = "soupsieve", specifier = ">=2.8.4" },
     { name = "sparkmagic", marker = "extra == 'sagemaker'", specifier = "==0.22.0" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "tensorflow-cpu", specifier = "==2.21.0" },

--- a/docker/tensorflow/2.21/cuda/pyproject.toml
+++ b/docker/tensorflow/2.21/cuda/pyproject.toml
@@ -24,10 +24,13 @@ dependencies = [
     # cryptography>=48.0.1 — GHSA-537c-gmf6-5ccf (HIGH)
     # starlette>=1.3.1 — GHSA-82w8-qh3p-5jfq + GHSA-wqp7-x3pw-xc5r (HIGH)
     # tornado>=6.5.6   — GHSA-3x9g-8vmp-wqvf + GHSA-mgf9-4vpg-hj56 (HIGH)
+    # soupsieve>=2.8.4 — GHSA-2wc2-fm75-p42x (HIGH, DoS) +
+    #                    GHSA-836r-79rf-4m37 (HIGH, ReDoS)
     "PyJWT>=2.13.0",
     "cryptography>=48.0.1",
     "starlette>=1.3.1",
     "tornado>=6.5.6",
+    "soupsieve>=2.8.4",
     # TF compat pins
     "numpy>=2.1,<2.5",
     "requests",

--- a/docker/tensorflow/2.21/cuda/uv.lock
+++ b/docker/tensorflow/2.21/cuda/uv.lock
@@ -3352,11 +3352,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -3563,6 +3563,7 @@ dependencies = [
     { name = "python-dateutil", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "scipy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "soupsieve", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "tensorflow", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "tornado", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -3637,6 +3638,7 @@ requires-dist = [
     { name = "seaborn", marker = "extra == 'sagemaker'" },
     { name = "shap", marker = "extra == 'sagemaker'" },
     { name = "smclarify", marker = "extra == 'sagemaker'" },
+    { name = "soupsieve", specifier = ">=2.8.4" },
     { name = "sparkmagic", marker = "extra == 'sagemaker'", specifier = "==0.22.0" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "tensorflow", specifier = "==2.21.0" },


### PR DESCRIPTION
## Effect on the next autorelease

After merge, the next `tensorflow.autorelease-2.21-sagemaker.yml` cron fire (Tue/Thu 17:30 UTC / 10:30 AM PDT) will:

1. Build both CPU + CUDA images.
2. Run full test matrix (build, sanity, security, telemetry, unit, single-gpu, sagemaker, efa).
3. Push to prod ECR `061416347176.dkr.ecr.<region>.amazonaws.com/tensorflow-training` (private) AND `public.ecr.aws/deep-learning-containers/tensorflow-training` (public).
4. SOCI indexing enabled for faster SageMaker pull.

## Expected prod tags (per legacy shape)

cuda config:
- `2.21.0-gpu-py312-cu129-amzn2023-sagemaker`
- `2.21.0-gpu-py312-cu129-amzn2023-sagemaker-v1.0.0`
- `2.21.0-gpu-py312-cu129-amzn2023-sagemaker-v1.0.0-YYYY-MM-DD-HH-MM-SS`
- `2.21-gpu-py312-cu129-amzn2023-sagemaker`
- `2.21-gpu-py312-cu129-amzn2023-sagemaker-v1`
- `2.21-gpu-py312`
- `2.21.0-gpu-py312`

cpu config: same shape with `-cpu-` in place of `-gpu-py312-cu129-`.

Also SOCI-indexed variants (7 more tags with `-soci` suffix).
