### PR TITLE
tensorflow: 2.21 gamma retest — 2-part versioning + SOCI + soupsieve CVE

### DIFF
--- a/.github/config/image/tensorflow/2.21-sagemaker-cpu.yml
+++ b/.github/config/image/tensorflow/2.21-sagemaker-cpu.yml
@@ -25,5 +25,5 @@ release:
   force_release: false
   public_registry: false
   private_registry: true
-  enable_soci: false
+  enable_soci: true
   environment: "gamma"

--- a/.github/config/image/tensorflow/2.21-sagemaker-cpu.yml
+++ b/.github/config/image/tensorflow/2.21-sagemaker-cpu.yml
@@ -19,7 +19,6 @@ build:
   tf_version: "2.21.0"
   open_mpi_version: "4.1.8"
   dlc_major_version: "1"
-  dlc_minor_version: "0"
 
 release:
   release: true

--- a/.github/config/image/tensorflow/2.21-sagemaker-cuda.yml
+++ b/.github/config/image/tensorflow/2.21-sagemaker-cuda.yml
@@ -21,7 +21,6 @@ build:
   open_mpi_version: "4.1.8"
   efa_version: "1.49.0"
   dlc_major_version: "1"
-  dlc_minor_version: "0"
 
 release:
   release: true

--- a/.github/config/image/tensorflow/2.21-sagemaker-cuda.yml
+++ b/.github/config/image/tensorflow/2.21-sagemaker-cuda.yml
@@ -27,5 +27,5 @@ release:
   force_release: false
   public_registry: false
   private_registry: true
-  enable_soci: false
+  enable_soci: true
   environment: "gamma"

--- a/docker/tensorflow/2.21/Dockerfile.cpu
+++ b/docker/tensorflow/2.21/Dockerfile.cpu
@@ -6,7 +6,6 @@
 # ============================================================================
 
 ARG DLC_MAJOR_VERSION=1
-ARG DLC_MINOR_VERSION=0
 ARG PYTHON_VERSION=3.12
 ARG TF_VERSION=2.21.0
 ARG OPEN_MPI_VERSION=4.1.8
@@ -49,11 +48,9 @@ ARG PYTHON_VERSION
 ARG TF_VERSION
 ARG OPEN_MPI_VERSION
 ARG DLC_MAJOR_VERSION
-ARG DLC_MINOR_VERSION
 
 LABEL maintainer="Amazon AI"
 LABEL dlc_major_version="${DLC_MAJOR_VERSION}"
-LABEL dlc_minor_version="${DLC_MINOR_VERSION}"
 LABEL framework="tensorflow"
 LABEL framework_version="${TF_VERSION}"
 

--- a/docker/tensorflow/2.21/Dockerfile.cuda
+++ b/docker/tensorflow/2.21/Dockerfile.cuda
@@ -6,7 +6,6 @@
 # ============================================================================
 
 ARG DLC_MAJOR_VERSION=1
-ARG DLC_MINOR_VERSION=0
 ARG CUDA_VERSION=12.9.1
 ARG PYTHON_VERSION=3.12
 ARG TF_VERSION=2.21.0
@@ -53,11 +52,9 @@ ARG TF_VERSION
 ARG OPEN_MPI_VERSION
 ARG EFA_VERSION
 ARG DLC_MAJOR_VERSION
-ARG DLC_MINOR_VERSION
 
 LABEL maintainer="Amazon AI"
 LABEL dlc_major_version="${DLC_MAJOR_VERSION}"
-LABEL dlc_minor_version="${DLC_MINOR_VERSION}"
 LABEL framework="tensorflow"
 LABEL framework_version="${TF_VERSION}"
 

--- a/docker/tensorflow/2.21/cpu/pyproject.toml
+++ b/docker/tensorflow/2.21/cpu/pyproject.toml
@@ -19,10 +19,13 @@ dependencies = [
     # cryptography>=48.0.1 — GHSA-537c-gmf6-5ccf (HIGH)
     # starlette>=1.3.1 — GHSA-82w8-qh3p-5jfq + GHSA-wqp7-x3pw-xc5r (HIGH)
     # tornado>=6.5.6   — GHSA-3x9g-8vmp-wqvf + GHSA-mgf9-4vpg-hj56 (HIGH)
+    # soupsieve>=2.8.4 — GHSA-2wc2-fm75-p42x + GHSA-836r-79rf-4m37 (HIGH,
+    #                    DoS/ReDoS in CSS selector parser; transitive via bs4)
     "PyJWT>=2.13.0",
     "cryptography>=48.0.1",
     "starlette>=1.3.1",
     "tornado>=6.5.6",
+    "soupsieve>=2.8.4",
     # TF compat pins
     "numpy>=2.1,<2.5",
     "requests",

--- a/docker/tensorflow/2.21/cpu/uv.lock
+++ b/docker/tensorflow/2.21/cpu/uv.lock
@@ -3118,11 +3118,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -3328,6 +3328,7 @@ dependencies = [
     { name = "python-dateutil", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "scipy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "soupsieve", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "tensorflow-cpu", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "tornado", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -3402,6 +3403,7 @@ requires-dist = [
     { name = "seaborn", marker = "extra == 'sagemaker'" },
     { name = "shap", marker = "extra == 'sagemaker'" },
     { name = "smclarify", marker = "extra == 'sagemaker'" },
+    { name = "soupsieve", specifier = ">=2.8.4" },
     { name = "sparkmagic", marker = "extra == 'sagemaker'", specifier = "==0.22.0" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "tensorflow-cpu", specifier = "==2.21.0" },

--- a/docker/tensorflow/2.21/cuda/pyproject.toml
+++ b/docker/tensorflow/2.21/cuda/pyproject.toml
@@ -24,10 +24,13 @@ dependencies = [
     # cryptography>=48.0.1 — GHSA-537c-gmf6-5ccf (HIGH)
     # starlette>=1.3.1 — GHSA-82w8-qh3p-5jfq + GHSA-wqp7-x3pw-xc5r (HIGH)
     # tornado>=6.5.6   — GHSA-3x9g-8vmp-wqvf + GHSA-mgf9-4vpg-hj56 (HIGH)
+    # soupsieve>=2.8.4 — GHSA-2wc2-fm75-p42x + GHSA-836r-79rf-4m37 (HIGH,
+    #                    DoS/ReDoS in CSS selector parser; transitive via bs4)
     "PyJWT>=2.13.0",
     "cryptography>=48.0.1",
     "starlette>=1.3.1",
     "tornado>=6.5.6",
+    "soupsieve>=2.8.4",
     # TF compat pins
     "numpy>=2.1,<2.5",
     "requests",

--- a/docker/tensorflow/2.21/cuda/uv.lock
+++ b/docker/tensorflow/2.21/cuda/uv.lock
@@ -3352,11 +3352,11 @@ wheels = [
 
 [[package]]
 name = "soupsieve"
-version = "2.8.3"
+version = "2.8.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/ae/2d9c981590ed9999a0d91755b47fc74f74de286b0f5cee14c9269041e6c4/soupsieve-2.8.3.tar.gz", hash = "sha256:3267f1eeea4251fb42728b6dfb746edc9acaffc4a45b27e19450b676586e8349", size = 118627, upload-time = "2026-01-20T04:27:02.457Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/2c/0a5f6f8ee0d5589e48c7640213ed5175d52cf540a06725b628cc1a45d6ce/soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e", size = 121110, upload-time = "2026-05-24T13:55:57.154Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl", hash = "sha256:ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95", size = 37016, upload-time = "2026-01-20T04:27:01.012Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65", size = 37304, upload-time = "2026-05-24T13:55:55.406Z" },
 ]
 
 [[package]]
@@ -3563,6 +3563,7 @@ dependencies = [
     { name = "python-dateutil", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "scipy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "soupsieve", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "tensorflow", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "tornado", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -3637,6 +3638,7 @@ requires-dist = [
     { name = "seaborn", marker = "extra == 'sagemaker'" },
     { name = "shap", marker = "extra == 'sagemaker'" },
     { name = "smclarify", marker = "extra == 'sagemaker'" },
+    { name = "soupsieve", specifier = ">=2.8.4" },
     { name = "sparkmagic", marker = "extra == 'sagemaker'", specifier = "==0.22.0" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "tensorflow", specifier = "==2.21.0" },


### PR DESCRIPTION
Second gamma cycle for TF 2.21 bundling three changes discovered from the first gamma cycle:

## 1. 2-part DLC versioning

TF 2.21 was shipping 3-part tags (`-v1.0.0`, `-v1.0.1`, ...) because both `DLC_MAJOR_VERSION` and `DLC_MINOR_VERSION` LABELs were emitted from the Dockerfile. This diverges from the historical TF 2.18/2.19 shape in the prod `tensorflow-training` ECR repo (e.g. `2.19.0-cpu-py312-ubuntu22.04-sagemaker-v1.10` — 2-part).

Fix: drop `DLC_MINOR_VERSION` from both Dockerfiles + drop `dlc_minor_version` from both configs. Release-logic will now emit 2-part tags (`-v1.0`, `-v1.1`, ...) auto-incrementing minor.

## 2. Enable SOCI on gamma

First gamma cycle had `enable_soci: false`. Enabling now so SOCI packing/indexing is exercised in gamma before the production flip. SOCI has its own compatibility surface (packed-manifest, index-v2 compat) that's worth catching in gamma.

## 3. soupsieve CVE fix

First gamma cycle scan surfaced 2 HIGH CVEs:
- GHSA-2wc2-fm75-p42x — CSS selector parser DoS (unbounded memory).
- GHSA-836r-79rf-4m37 — CSS selector parser ReDoS (catastrophic backtracking).

Both fixed in `soupsieve>=2.8.4`. Adding an explicit pin in pyproject.toml so uv picks up 2.8.4 (soupsieve is a transitive dep via BeautifulSoup4).

## Expected gamma tags after merge (per 2-part legacy shape)

cuda config produces:
- `2.21.0-gpu-py312-cu129-amzn2023-sagemaker`
- `2.21.0-gpu-py312-cu129-amzn2023-sagemaker-v1.0`  ← 2-part
- `2.21.0-gpu-py312-cu129-amzn2023-sagemaker-v1.0-YYYY-MM-DD-HH-MM-SS`
- `2.21-gpu-py312-cu129-amzn2023-sagemaker`
- `2.21-gpu-py312-cu129-amzn2023-sagemaker-v1`
- `2.21-gpu-py312`
- `2.21.0-gpu-py312`

Plus SOCI-indexed variants (7 more with `-soci` suffix).

cpu config: same shape with `-cpu-` in place of `-gpu-py312-cu129-`.

## Supersedes

- Closed PR #6369 — its prod-flip work moves to a follow-up PR after this gamma cycle validates cleanly.

