### PR TITLE
chore - ray: sync dlc_minor_version in configs to match Dockerfile label (0 → 2)

### DIFF
--- a/.github/config/image/ray/ec2-cpu.yml
+++ b/.github/config/image/ray/ec2-cpu.yml
@@ -18,7 +18,7 @@ build:
   target: "ray-ec2-cpu"
   python_version: "3.13.12"
   dlc_major_version: "1"
-  dlc_minor_version: "0"
+  dlc_minor_version: "2"
 
 release:
   release: true

--- a/.github/config/image/ray/ec2-gpu.yml
+++ b/.github/config/image/ray/ec2-gpu.yml
@@ -19,7 +19,7 @@ build:
   python_version: "3.13.12"
   cuda_version: "12.9.1"
   dlc_major_version: "1"
-  dlc_minor_version: "0"
+  dlc_minor_version: "2"
 
 release:
   release: true

--- a/.github/config/image/ray/sagemaker-cpu.yml
+++ b/.github/config/image/ray/sagemaker-cpu.yml
@@ -19,7 +19,7 @@ build:
   target: "ray-sagemaker-cpu"
   python_version: "3.13.12"
   dlc_major_version: "1"
-  dlc_minor_version: "0"
+  dlc_minor_version: "2"
 
 release:
   release: true

--- a/.github/config/image/ray/sagemaker-gpu.yml
+++ b/.github/config/image/ray/sagemaker-gpu.yml
@@ -20,7 +20,7 @@ build:
   python_version: "3.13.12"
   cuda_version: "12.9.1"
   dlc_major_version: "1"
-  dlc_minor_version: "0"
+  dlc_minor_version: "2"
 
 release:
   release: true


### PR DESCRIPTION
Bump `dlc_minor_version: "0" → "2"` in all 4 ray configs (ec2-cpu, ec2-gpu, sagemaker-cpu, sagemaker-gpu) to match `LABEL dlc_minor_version="2"` in the Dockerfiles. 