### PR TITLE
tensorflow: flip 2.21 configs to production release

### DIFF
--- a/.github/config/image/tensorflow/2.21-sagemaker-cpu.yml
+++ b/.github/config/image/tensorflow/2.21-sagemaker-cpu.yml
@@ -23,7 +23,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
+  public_registry: true
   private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"

--- a/.github/config/image/tensorflow/2.21-sagemaker-cuda.yml
+++ b/.github/config/image/tensorflow/2.21-sagemaker-cuda.yml
@@ -25,7 +25,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
+  public_registry: true
   private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"


### PR DESCRIPTION
Promotes TF 2.21 SageMaker CPU + CUDA configs from gamma to production.

## Expected prod tags (2-part legacy shape)

cuda config produces:
- `2.21.0-gpu-py312-cu129-amzn2023-sagemaker`
- `2.21.0-gpu-py312-cu129-amzn2023-sagemaker-v1.0`
- `2.21.0-gpu-py312-cu129-amzn2023-sagemaker-v1.0-YYYY-MM-DD-HH-MM-SS`
- `2.21-gpu-py312-cu129-amzn2023-sagemaker`
- `2.21-gpu-py312-cu129-amzn2023-sagemaker-v1`
- `2.21-gpu-py312`
- `2.21.0-gpu-py312`

cpu config: same shape with `-cpu-` in place of `-gpu-py312-cu129-`.

Plus SOCI-indexed variants (7 more tags with `-soci` suffix).

Aligns TF 2.21 tag shape with the existing prod TF 2.18/2.19 tags in the public gallery.
