### PR TITLE
docs: add tensorflow 2.21 sagemaker training entries

### DIFF
--- a/docs/src/data/tensorflow-training/2.21-cpu-sagemaker.yml
+++ b/docs/src/data/tensorflow-training/2.21-cpu-sagemaker.yml
@@ -1,0 +1,15 @@
+framework: TensorFlow
+version: "2.21"
+accelerator: cpu
+python: py312
+os: amzn2023
+platform: sagemaker
+ga: "2026-07-10"
+eop: "2027-07-10"
+public_registry: true
+
+tags:
+  - "2.21.0-cpu-py312-amzn2023-sagemaker"
+  - "2.21-cpu-py312-amzn2023-sagemaker-v1"
+  - "2.21.0-cpu-py312-sagemaker"
+  - "2.21-cpu-py312-sagemaker"

--- a/docs/src/data/tensorflow-training/2.21-gpu-sagemaker.yml
+++ b/docs/src/data/tensorflow-training/2.21-gpu-sagemaker.yml
@@ -1,0 +1,16 @@
+framework: TensorFlow
+version: "2.21"
+accelerator: gpu
+python: py312
+cuda: cu129
+os: amzn2023
+platform: sagemaker
+ga: "2026-07-10"
+eop: "2027-07-10"
+public_registry: true
+
+tags:
+  - "2.21.0-gpu-py312-cu129-amzn2023-sagemaker"
+  - "2.21-gpu-py312-cu129-amzn2023-sagemaker-v1"
+  - "2.21.0-gpu-py312-sagemaker"
+  - "2.21-gpu-py312-sagemaker"


### PR DESCRIPTION
## What

Adds two docs data YAMLs under `docs/src/data/tensorflow-training/` for the newly released TensorFlow 2.21 SageMaker training images:

- `docs/src/data/tensorflow-training/2.21-cpu-sagemaker.yml` — 2.21.0 CPU py312 amzn2023
- `docs/src/data/tensorflow-training/2.21-gpu-sagemaker.yml` — 2.21.0 GPU py312 cu129 amzn2023

## Shape

Both files mirror the existing `docs/src/data/tensorflow-training/2.19-{cpu,gpu}-sagemaker.yml` shape exactly (same field ordering, same 4-tag format including bare `-sagemaker` tags). Only the OS moves from `ubuntu22.04` (2.19) to `amzn2023` (2.21), matching `.github/config/image/tensorflow/2.21-sagemaker-{cpu,cuda}.yml`.

Fields: `framework`, `version`, `accelerator`, `python`, `cuda` (GPU only), `os`, `platform`, `ga`, `eop`, `public_registry`, `tags`.

Dated immutable tags (e.g. `...-v1.0-YYYY-MM-DD-HH-MM-SS`) are intentionally omitted — the existing 2.19 entries do not include them, so this mirrors precedent. `dlc_major_version` bare tags like `2.21-cpu-py312-sagemaker-v1.0` are also omitted per 2.19 precedent (only the `-v1` short form is listed).
