### PR TITLE
security(huggingface-vllm): allowlist CVE-2026-39822 and CVE-2026-55574

### DIFF
--- a/test/security/data/ecr_scan_allowlist/huggingface-vllm/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/huggingface-vllm/framework_allowlist.json
@@ -93,5 +93,15 @@
         "vulnerability_id": "CVE-2026-27145",
         "reason": "go/stdlib statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
         "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-39822",
+        "reason": "go/stdlib 1.25.9 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-55574",
+        "reason": "vllm 0.22.1; fixed only in 0.24.0, which would require changing the base vLLM DLC version — cannot be bumped independently of the base image",
+        "review_by": "2026-09-25"
     }
 ]


### PR DESCRIPTION
## Purpose

The Hugging Face vLLM SageMaker ECR scan flags two non-allowlisted HIGH CVEs, both unpatchable from the HF layer. Approved to allowlist:

- **CVE-2026-39822** — `go/stdlib 1.25.9` statically linked inside the prebuilt `mooncake/libetcd_wrapper.so`. Cannot be patched without a `mooncake-transfer-engine` rebuild (same class as the other `CVE-2026-3982x` mooncake entries already in this allowlist).
- **CVE-2026-55574** — `vllm 0.22.1`, fixed only in `0.24.0`. The vLLM version is pinned by the base DLC and can't be bumped independently.

Both get a `reason` + `review_by` in `test/security/data/ecr_scan_allowlist/huggingface-vllm/framework_allowlist.json`. This is risk-acceptance, not a code fix — neither CVE is patchable downstream.

## Test Plan

Re-run the Hugging Face vLLM pipeline security scan.

## Test Result

- ✅ JSON validates; `pre-commit` clean.
- ⏳ ECR scan passes on the next pipeline run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)