### PR TITLE
sklearn: promote 1.4-2-py312 release to preprod

### DIFF
--- a/.github/config/image/sklearn/sagemaker-1.4-2-py312.yml
+++ b/.github/config/image/sklearn/sagemaker-1.4-2-py312.yml
@@ -33,4 +33,4 @@ release:
   public_registry: false
   private_registry: true
   enable_soci: false
-  environment: "gamma"
+  environment: "preprod"


### PR DESCRIPTION
## Change

Flip `environment: gamma → preprod` in `.github/config/image/sklearn/sagemaker-1.4-2-py312.yml`. Gamma dispatch (PR #6376) passed all tests + landed cleanly in gamma ECR with tags: `gamma-1.4-2-py312-1.0.1968.0, gamma-1.4-2-py312-cpu-py3, gamma-1.4-2-py312`

## After merge

Manually dispatch `sklearn.dispatch-release.yml` on `main` to push to preprod ECR (25 regions).