### PR TITLE
docs: add TensorFlow 2.21 SageMaker training to README release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ ______________________________________________________________________
 
 ### 🚀 Release Highlights
 
+- **[2026/07/10]** [TensorFlow v2.21.0 (SageMaker training)](https://gallery.ecr.aws/deep-learning-containers/tensorflow-training) — SageMaker CPU: `2.21.0-cpu-py312-amzn2023-sagemaker` · SageMaker GPU: `2.21.0-gpu-py312-cu129-amzn2023-sagemaker` · Amazon Linux 2023 with Python 3.12; GPU images ship CUDA 12.9.1.
 - **[2026/07/06]** [SGLang Server v1.2 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `server-cuda-v1.2` · SageMaker: `server-sagemaker-cuda-v1.2` · SGLang `0.5.14`; adds support for the NVIDIA LocateAnything-3B vision-grounding model and upgrades sgl-kernel 0.4.4, FlashInfer 0.6.12, Mooncake 0.3.11.post1, NCCL 2.30.4, and EFA 1.49.0.
 - **[2026/07/02]** [vLLM Server v2.1 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `server-cuda-v2.1` · SageMaker: `server-sagemaker-cuda-v2.1` · vLLM `0.24.0`; adds JetBrains Mellum2-12B-A2.5B-Thinking (`MellumForCausalLM`); FlashInfer 0.6.12; drops the `transformers<5.10` pin (now requires transformers ≥ 5.5.3).
 - **[2026/07/02]** [vLLM-Omni v1.4 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `omni-cuda-v1.4` · SageMaker: `omni-sagemaker-cuda-v1.4` · SageMaker `/v1/videos` and `/v1/videos/sync` accept `application/json` again (JSON→multipart conversion restored); no framework bump (vLLM-Omni 0.21.0rc1).
@@ -35,7 +36,6 @@ ______________________________________________________________________
 - **[2026/07/01]** [vLLM v0.24.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.24.0-gpu-py312-ec2` · SageMaker: `0.24.0-gpu-py312` · MiniMax-M3, DiffusionGemma (+CPU), Hierarchical Reasoning Model, OpenMOSS; streaming parser engine (Qwen3, MiniMax-M2, GLM-4.7/5.1/5.2, Nemotron V3); DeepSeek-V4 fixes.
 - **[2026/06/29]** [SGLang Server v1.1 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `server-cuda-v1.1` · SageMaker: `server-sagemaker-cuda-v1.1` · SGLang `0.5.13`; adds NIXL KV connector for prefill/decode disaggregation and `runai-model-streamer[s3,gcs,azure]` for fast weight streaming from object storage; starlette CVE patch.
 - **[2026/06/29]** [SGLang v0.5.14](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.14-gpu-py312-ec2` · SageMaker: `0.5.14-gpu-py312` · GLM 5.2, LiquidAI LFM2.5, Kimi-K2.7-Code, DeepSeek V4 on GB300.
-- **[2026/06/14]** [vLLM v0.23.0](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.23.0-gpu-py312-ec2` · SageMaker: `0.23.0-gpu-py312` · Step-3.7-Flash, Cosmos3 Reasoner, Gemma 4 Unified (encoder-free), Granite Speech Plus, Cohere Mini Code; Anthropic Messages API structured output.
 
 ### 📢 Support Updates
 


### PR DESCRIPTION
Adds a TF 2.21 SageMaker training entry to the README release notes section, following the shape of recent DLC release entries.

## Context

TF 2.21 SM training landed in prod on 2026-07-10 via autorelease of PR #6375. Public gallery + private prod ECR both have the images. This PR fills the docs-user-facing gap.
