### PR TITLE
sklearn: promote 1.4-2-py312 release to production

### DIFF
--- a/.github/config/image/sklearn/sagemaker-1.4-2-py312.yml
+++ b/.github/config/image/sklearn/sagemaker-1.4-2-py312.yml
@@ -33,4 +33,4 @@ release:
   public_registry: false
   private_registry: true
   enable_soci: false
-  environment: "preprod"
+  environment: "production"


### PR DESCRIPTION
## Change

Flip `environment: preprod → production` in `.github/config/image/sklearn/sagemaker-1.4-2-py312.yml`. Preprod dispatch landed cleanly across all 25 preprod regions; all tag templates matched unit-test expectations.

## Prior stages (for review context)

- Gamma: #6376
- Preprod: #6380

## After merge

Manually dispatch `sklearn.dispatch-release.yml` on `main` to push to the production ECR (25+ regions).

## What lands

- `1.4-2-py312`
- `1.4-2-py312-cpu-py3`
- `1.4-2-py312-1.0.X.0`

py310 tags (`1.4-2`, `1.4-2-cpu-py3`) are NOT touched