### PR TITLE
sklearn: pin container branch to release-1.4-2-py312 (was master)

### DIFF
--- a/.github/config/image/sklearn/sagemaker-1.4-2-py312.yml
+++ b/.github/config/image/sklearn/sagemaker-1.4-2-py312.yml
@@ -25,7 +25,7 @@ build:
   # When upstream master moves past 1.4-2, swap to a release branch/tag
   # that preserves 1.4-2 behavior — same pattern xgboost 3.0.5 uses
   # (xgboost_container_branch: "release-3.0.5").
-  sklearn_container_branch: "master"
+  sklearn_container_branch: "release-1.4-2-py312"
 
 release:
   release: true

--- a/.github/config/image/sklearn/sagemaker-1.4-2-py312.yml
+++ b/.github/config/image/sklearn/sagemaker-1.4-2-py312.yml
@@ -21,10 +21,6 @@ build:
   python_version: "3.12"
   pyarrow_version: "17.0.0"
   numpy_version: "2.1.0"
-  # Pinned to upstream master (currently 1.4-2-py312 HEAD).
-  # When upstream master moves past 1.4-2, swap to a release branch/tag
-  # that preserves 1.4-2 behavior — same pattern xgboost 3.0.5 uses
-  # (xgboost_container_branch: "release-3.0.5").
   sklearn_container_branch: "release-1.4-2-py312"
 
 release:


### PR DESCRIPTION
## Change

Pin `sklearn_container_branch` in `sagemaker-1.4-2-py312.yml` from `master` → `release-1.4-2-py312` (new upstream branch cut from current master HEAD).

Zero functional change today — branches are identical. Freezes the 1.4-2-py312 image source so future upstream 1.9+ commits on master don't accidentally pull into 1.4-2-py312 rebuilds.

Mirrors xgboost's `release-3.0.5` pattern (see comment above the pin in the config file).

## Ordering

Should merge BEFORE the prod-flip PR #6383 so that the first prod dispatch uses the frozen branch source.