### PR TITLE
Fix TensorBoard profiler log path in tensorflow + tensorboard smoke tests

### DIFF
--- a/test/dlc_tests/container_tests/bin/testTensorBoard
+++ b/test/dlc_tests/container_tests/bin/testTensorBoard
@@ -4,13 +4,14 @@ set -e
 
 HOME_DIR=/test
 BIN_DIR=${HOME_DIR}/bin
+LOG_DIR=${HOME_DIR}/logs
 
-# Use this to conditionally check TF version
-LOG_DIR='*/plugins/profile/*'
+# TensorBoard profile log path pattern (nested under $LOG_DIR)
+PROFILE_LOG_DIR='*/plugins/profile/*'
 
-if [ -d "/logs" ]; then
-    echo "Cleaning existing logs" 
-    find /logs -path "$LOG_DIR" -type f -delete 
+if [ -d "$LOG_DIR" ]; then
+    echo "Cleaning existing logs"
+    find "$LOG_DIR" -path "$PROFILE_LOG_DIR" -type f -delete
 fi
 
 python ${BIN_DIR}/testTensorBoard.py || exit 1
@@ -22,7 +23,7 @@ else
     LOG_FILE="*.pb"
 fi
 
-LOG_RESULT=$(find /logs -path "$LOG_DIR" -name $LOG_FILE)
+LOG_RESULT=$(find "$LOG_DIR" -path "$PROFILE_LOG_DIR" -name $LOG_FILE)
 
 echo "Checking the logs result: $LOG_RESULT"
 

--- a/test/dlc_tests/container_tests/bin/testTensorBoard.py
+++ b/test/dlc_tests/container_tests/bin/testTensorBoard.py
@@ -20,7 +20,7 @@ def train():
         metrics=["accuracy"],
     )
 
-    callbacks = [tf.keras.callbacks.TensorBoard(log_dir="logs", profile_batch=1)]
+    callbacks = [tf.keras.callbacks.TensorBoard(log_dir="/test/logs", profile_batch=1)]
     X_train = np.random.rand(1, 28, 28)
     Y_train = np.random.rand(
         1,

--- a/test/dlc_tests/container_tests/bin/testTensorFlow
+++ b/test/dlc_tests/container_tests/bin/testTensorFlow
@@ -35,9 +35,9 @@ TRAINING_LOG=${LOG_DIR}/${KERAS_BACKEND}_train_mnist.log
 echo "Training mnist using $KERAS_BACKEND... This may take a few minutes. You can follow progress on the log file : $TRAINING_LOG"
 set +e
 
-if [ -d "/logs" ]; then
+if [ -d "$LOG_DIR" ]; then
     echo "Cleanning existing logs"
-    find /logs -path "$PROFILE_LOG_DIR" -type f -delete 
+    find "$LOG_DIR" -path "$PROFILE_LOG_DIR" -type f -delete
 fi
 
 python ${BIN_DIR}/testTensorflow.py >$TRAINING_LOG 2>&1
@@ -53,7 +53,7 @@ else
     LOG_FILE="*.pb"
 fi
 
-LOG_RESULT=$(find /logs -path "$PROFILE_LOG_DIR" -name $LOG_FILE)
+LOG_RESULT=$(find "$LOG_DIR" -path "$PROFILE_LOG_DIR" -name $LOG_FILE)
 
 echo "Checking the logs result: $LOG_RESULT"
 

--- a/test/dlc_tests/container_tests/bin/testTensorflow.py
+++ b/test/dlc_tests/container_tests/bin/testTensorflow.py
@@ -60,7 +60,7 @@ model.compile(
     metrics=["accuracy"],
 )
 
-callbacks = [tf.keras.callbacks.TensorBoard(log_dir="logs", profile_batch=1)]
+callbacks = [tf.keras.callbacks.TensorBoard(log_dir="/test/logs", profile_batch=1)]
 
 model.fit(
     x_train,


### PR DESCRIPTION
## Problem
The deep canary `tensorflow-training` smoke test currently fails on newer TF images with:

    find: '/logs': No such file or directory

## Root cause
`test/dlc_tests/container_tests/bin/testTensorFlow` reads TensorBoard profiler
output from the absolute path `/logs`, while
`test/dlc_tests/container_tests/bin/testTensorflow.py` writes it via
`TensorBoard(log_dir="logs", ...)` -- a relative path that resolves against
the container's working directory. Older images happened to have a WORKDIR
that made these two paths line up; newer images built from a different
Dockerfile template do not, and the mismatch surfaces the latent bug.

## Fix
- Pin both sides of the mnist smoke test to an explicit absolute path
  (`LOG_DIR=/test/logs` on the bash side, `log_dir="/test/logs"` on the
  Python side) so the test no longer depends on the container's working
  directory.
- Apply the same fix to the sibling `testTensorBoard` / `testTensorBoard.py`
  pair, which is used by the `test_tensorflow_tensorboard_{gpu,cpu}`
  integration tests and carries the identical relative-vs-absolute path bug.
  `testTensorBoard` previously did not define a directory `LOG_DIR` (the
  name was shadowed by a glob pattern); rename the glob to `PROFILE_LOG_DIR`
  and introduce `LOG_DIR=\${HOME_DIR}/logs` to match the convention already
  used in `testTensorFlow`.

## Test plan
- Static-checked: `bash -n testTensorFlow`, `bash -n testTensorBoard`,
  `python -m py_compile testTensorflow.py`,
  `python -m py_compile testTensorBoard.py` -- all pass.
- Behavioral: next deep-canary run against a TF image that previously
  failed should now succeed, and the regional canary alarm should
  transition to OK within two 6h build cycles. The same fix also
  removes the latent bug from the TensorBoard integration tests.