### PR TITLE
docs: add tensorflow framework documentation for 2.21 release

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -8,6 +8,7 @@ nav:
     - TEI: tei
     - Ray: ray
     - PyTorch: pytorch
+    - TensorFlow: tensorflow
     - Base: base
   - Blog Posts: tutorials
   - Resources:

--- a/docs/index.md
+++ b/docs/index.md
@@ -76,6 +76,14 @@ LLM serving is just one example. DLCs cover a range of AI/ML workloads — explo
 
     [PyTorch Guide](pytorch/index.md)
 
+-   **Train Models with TensorFlow**
+
+    ---
+
+    Run TensorFlow training on Amazon SageMaker AI with EFA-capable multi-node support on Amazon Linux 2023.
+
+    [TensorFlow Guide](tensorflow/index.md)
+
 -   **Build Your Own Image**
 
     ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -72,17 +72,9 @@ LLM serving is just one example. DLCs cover a range of AI/ML workloads — explo
 
     ---
 
-    Run distributed training with PyTorch on GPU or CPU, with EFA, NCCL, flash-attn, and DeepSpeed pre-installed.
+    Run distributed training with PyTorch or TensorFlow on GPU or CPU, with EFA and NCCL pre-installed for multi-node workloads.
 
-    [PyTorch Guide](pytorch/index.md)
-
--   **Train Models with TensorFlow**
-
-    ---
-
-    Run TensorFlow training on Amazon SageMaker AI with EFA-capable multi-node support on Amazon Linux 2023.
-
-    [TensorFlow Guide](tensorflow/index.md)
+    [PyTorch Guide](pytorch/index.md) · [TensorFlow Guide](tensorflow/index.md)
 
 -   **Build Your Own Image**
 

--- a/docs/tensorflow/.nav.yml
+++ b/docs/tensorflow/.nav.yml
@@ -1,0 +1,5 @@
+nav:
+  - Overview: index.md
+  - Deployment:
+    - Amazon SageMaker AI: deployment/sagemaker.md
+  - Changelog: changelog/index.md

--- a/docs/tensorflow/changelog/index.md
+++ b/docs/tensorflow/changelog/index.md
@@ -3,7 +3,7 @@
 Changelog for the Amazon Linux 2023-based TensorFlow SageMaker training images (`2.21-gpu-py312-cu129-amzn2023-sagemaker` and
 `2.21-cpu-py312-amzn2023-sagemaker`).
 
----
+* * *
 
 ## TensorFlow 2.21 — 2026-07-10
 

--- a/docs/tensorflow/changelog/index.md
+++ b/docs/tensorflow/changelog/index.md
@@ -1,0 +1,22 @@
+# Changelog
+
+Changelog for the Amazon Linux 2023-based TensorFlow SageMaker training images (`2.21-gpu-py312-cu129-amzn2023-sagemaker` and
+`2.21-cpu-py312-amzn2023-sagemaker`).
+
+---
+
+## TensorFlow 2.21 — 2026-07-10
+
+**Tags:** `2.21-gpu-py312-cu129-amzn2023-sagemaker` · `2.21-cpu-py312-amzn2023-sagemaker` · `2.21.0-gpu-py312-cu129-amzn2023-sagemaker` ·
+`2.21.0-cpu-py312-amzn2023-sagemaker`
+
+**Bundled versions:** TensorFlow 2.21.0 · Python 3.12 · CUDA 12.9.1 · cuDNN 9.5.1.17 · NCCL 2.30.7 · EFA 1.49.0 · OpenMPI 4.1.8
+
+### Highlights
+
+- Initial release of the TensorFlow DLC on Amazon Linux 2023 and Python 3.12
+- TensorFlow 2.21.0 for SageMaker AI training (CPU and GPU variants)
+- CUDA 12.9.1 with cuDNN 9.5.1.17 and NCCL 2.30.7 on the GPU variant
+- EFA 1.49.0 with OpenMPI 4.1.8 for multi-node training on EFA-capable instances
+- SageMaker toolkits pre-installed: `sagemaker-tensorflow-training`, `sagemaker-training`
+- MLflow 3.9+, `smclarify`, `sagemaker>=3.4.0`, and SageMaker Studio integrations bundled

--- a/docs/tensorflow/deployment/sagemaker.md
+++ b/docs/tensorflow/deployment/sagemaker.md
@@ -1,8 +1,7 @@
 # Amazon SageMaker AI Deployment
 
 Use the TensorFlow DLC for training jobs launched via the SageMaker Python SDK or `boto3`. The images bundle the `sagemaker-tensorflow-training`
-toolkit, OpenMPI for multi-node coordination, and SageMaker-specific Python libraries (`mlflow`, `smclarify`, `pandas`, `seaborn`, `s3fs`,
-etc.).
+toolkit, OpenMPI for multi-node coordination, and SageMaker-specific Python libraries (`mlflow`, `smclarify`, `pandas`, `seaborn`, `s3fs`, etc.).
 
 The TensorFlow 2.21 DLC is a **SageMaker-only** release — there is no EC2 or EKS variant of this image. Point your estimators, processors, and
 training jobs at the SageMaker image URIs shown below.
@@ -108,23 +107,22 @@ processor = FrameworkProcessor(
 SageMaker provisions EFA on the instance types that support it (e.g., `ml.p5.48xlarge`, `ml.p4d.24xlarge`). The GPU image ships with EFA 1.49.0 and
 OpenMPI 4.1.8 pre-installed — no extra plumbing in your training script.
 
-Multi-node peer discovery is handled by the `sagemaker_tensorflow_container` training toolkit, which parses
-`/opt/ml/input/config/resourceconfig.json` at container start to enumerate hosts, current host rank, and network interface. Peers are addressed
-by the SageMaker-assigned hostnames (e.g., `algo-1`, `algo-2`) that resolve inside the training cluster — your script does not need to know about
-this.
+Multi-node peer discovery is handled by the `sagemaker_tensorflow_container` training toolkit, which parses `/opt/ml/input/config/resourceconfig.json`
+at container start to enumerate hosts, current host rank, and network interface. Peers are addressed by the SageMaker-assigned hostnames (e.g.,
+`algo-1`, `algo-2`) that resolve inside the training cluster — your script does not need to know about this.
 
 ## Container Layout
 
-| Path                                 | Purpose                                                                                        |
-| ------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| `/opt/ml/input/data/<channel_name>/` | Training data SageMaker mounts from S3 (one subdir per channel)                                |
-| `/opt/ml/model/`                     | Write your final model artifacts here — SageMaker uploads to `OutputDataConfig.s3_output_path` |
-| `/opt/ml/output/`                    | Auxiliary outputs (logs, checkpoints)                                                          |
-| `/opt/ml/code/`                      | Your training source dir (populated from the SDK's `source_dir`)                               |
-| `/opt/venv/`                         | Python venv with TensorFlow + DLC libraries                                                    |
+| Path | Purpose |
+| --- | --- |
+| `/opt/ml/input/data/<channel_name>/` | Training data SageMaker mounts from S3 (one subdir per channel) |
+| `/opt/ml/model/` | Write your final model artifacts here — SageMaker uploads to `OutputDataConfig.s3_output_path` |
+| `/opt/ml/output/` | Auxiliary outputs (logs, checkpoints) |
+| `/opt/ml/code/` | Your training source dir (populated from the SDK's `source_dir`) |
+| `/opt/venv/` | Python venv with TensorFlow + DLC libraries |
 
 ## Notes
 
-- The image sets `SAGEMAKER_TRAINING_MODULE=sagemaker_tensorflow_container.training:main` — this is the entry-point the SageMaker
-  training toolkit invokes at container start, which in turn launches your `entry_point` script.
+- The image sets `SAGEMAKER_TRAINING_MODULE=sagemaker_tensorflow_container.training:main` — this is the entry-point the SageMaker training toolkit
+  invokes at container start, which in turn launches your `entry_point` script.
 - For a baseline driver/AMI compatible with these CUDA 12.9 images, request the latest SageMaker training AMI when launching jobs.

--- a/docs/tensorflow/deployment/sagemaker.md
+++ b/docs/tensorflow/deployment/sagemaker.md
@@ -1,0 +1,132 @@
+# Amazon SageMaker AI Deployment
+
+Use the TensorFlow DLC for training jobs launched via the SageMaker Python SDK or `boto3`. The images bundle the `sagemaker-tensorflow-training`
+toolkit, OpenMPI for multi-node coordination, and SageMaker-specific Python libraries (`mlflow`, `smclarify`, `pandas`, `seaborn`, `s3fs`,
+etc.).
+
+The TensorFlow 2.21 DLC is a **SageMaker-only** release — there is no EC2 or EKS variant of this image. Point your estimators, processors, and
+training jobs at the SageMaker image URIs shown below.
+
+## SageMaker Python SDK v2
+
+Pass the DLC image URI via `image_uri=` rather than `framework_version=`:
+
+```python
+from sagemaker.tensorflow import TensorFlow
+
+estimator = TensorFlow(
+    image_uri="public.ecr.aws/deep-learning-containers/tensorflow-training:2.21-gpu-py312-cu129-amzn2023-sagemaker",
+    role="arn:aws:iam::<account_id>:role/<role_name>",
+    entry_point="train.py",
+    source_dir="src",
+    instance_type="ml.p5.48xlarge",
+    instance_count=2,
+    distribution={"mpi": {"enabled": True, "processes_per_host": 8}},
+)
+
+estimator.fit({"training": "s3://<bucket>/datasets/train/"})
+```
+
+The toolkit invokes your `entry_point` script over MPI when `mpi.enabled` is set and as a single-process launcher otherwise.
+
+## SageMaker Python SDK v3
+
+```python
+from sagemaker.core.resources import TrainingJob
+from sagemaker.core.shapes import (
+    AlgorithmSpecification,
+    Channel,
+    DataSource,
+    InputDataConfig,
+    OutputDataConfig,
+    ResourceConfig,
+    S3DataSource,
+    StoppingCondition,
+)
+
+job = TrainingJob.create(
+    training_job_name="tensorflow-train",
+    role_arn="arn:aws:iam::<account_id>:role/<role_name>",
+    algorithm_specification=AlgorithmSpecification(
+        training_image="public.ecr.aws/deep-learning-containers/tensorflow-training:2.21-gpu-py312-cu129-amzn2023-sagemaker",
+        training_input_mode="File",
+    ),
+    resource_config=ResourceConfig(
+        instance_type="ml.p5.48xlarge",
+        instance_count=2,
+        volume_size_in_gb=200,
+    ),
+    input_data_config=[
+        InputDataConfig(
+            channel_name="training",
+            data_source=DataSource(
+                s3_data_source=S3DataSource(
+                    s3_data_type="S3Prefix",
+                    s3_uri="s3://<bucket>/datasets/train/",
+                ),
+            ),
+        ),
+    ],
+    output_data_config=OutputDataConfig(s3_output_path="s3://<bucket>/output/"),
+    stopping_condition=StoppingCondition(max_runtime_in_seconds=3600),
+)
+job.wait_for_status("Completed")
+```
+
+## Processing Jobs
+
+### `TensorFlowProcessor` (SDK v2)
+
+```python
+from sagemaker.tensorflow.processing import TensorFlowProcessor
+
+processor = TensorFlowProcessor(
+    image_uri="public.ecr.aws/deep-learning-containers/tensorflow-training:2.21-cpu-py312-amzn2023-sagemaker",
+    framework_version="2.21",  # workaround: value ignored when image_uri is set
+    role="arn:aws:iam::<account_id>:role/<role_name>",
+    instance_type="ml.m5.xlarge",
+    instance_count=1,
+)
+```
+
+### `FrameworkProcessor` (SDK v3)
+
+```python
+from sagemaker.workflow.steps import ProcessingStep
+from sagemaker.processing import FrameworkProcessor
+
+processor = FrameworkProcessor(
+    image_uri="public.ecr.aws/deep-learning-containers/tensorflow-training:2.21-cpu-py312-amzn2023-sagemaker",
+    role="arn:aws:iam::<account_id>:role/<role_name>",
+    instance_type="ml.m5.xlarge",
+    instance_count=1,
+)
+```
+
+## Multi-Node Training over EFA
+
+SageMaker provisions EFA on the instance types that support it (e.g., `ml.p5.48xlarge`, `ml.p4d.24xlarge`). The GPU image ships with EFA 1.49.0 and
+OpenMPI 4.1.8 pre-installed — no extra plumbing in your training script.
+
+Multi-node peer discovery is handled by the `sagemaker_tensorflow_container` training toolkit, which parses
+`/opt/ml/input/config/resourceconfig.json` at container start to enumerate hosts, current host rank, and network interface. Peers are addressed
+by the SageMaker-assigned hostnames (e.g., `algo-1`, `algo-2`) that resolve inside the training cluster — your script does not need to know about
+this.
+
+## Container Layout
+
+| Path                                 | Purpose                                                                                        |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `/opt/ml/input/data/<channel_name>/` | Training data SageMaker mounts from S3 (one subdir per channel)                                |
+| `/opt/ml/model/`                     | Write your final model artifacts here — SageMaker uploads to `OutputDataConfig.s3_output_path` |
+| `/opt/ml/output/`                    | Auxiliary outputs (logs, checkpoints)                                                          |
+| `/opt/ml/code/`                      | Your training source dir (populated from the SDK's `source_dir`)                               |
+| `/opt/venv/`                         | Python venv with TensorFlow + DLC libraries                                                    |
+
+## Notes
+
+- The image sets `SAGEMAKER_TRAINING_MODULE=sagemaker_tensorflow_container.training:main` — this is the entry-point the SageMaker
+  training toolkit invokes at container start, which in turn launches your `entry_point` script.
+- For a baseline driver/AMI compatible with these CUDA 12.9 images, request the latest SageMaker training AMI when launching jobs.
+- For inference workloads, use the [vLLM](../../vllm/index.md), [vLLM-Omni](../../vllm-omni/index.md), or [Ray](../../ray/index.md) DLCs — this image
+  is not configured for serving.

--- a/docs/tensorflow/deployment/sagemaker.md
+++ b/docs/tensorflow/deployment/sagemaker.md
@@ -128,5 +128,3 @@ this.
 - The image sets `SAGEMAKER_TRAINING_MODULE=sagemaker_tensorflow_container.training:main` — this is the entry-point the SageMaker
   training toolkit invokes at container start, which in turn launches your `entry_point` script.
 - For a baseline driver/AMI compatible with these CUDA 12.9 images, request the latest SageMaker training AMI when launching jobs.
-- For inference workloads, use the [vLLM](../../vllm/index.md), [vLLM-Omni](../../vllm-omni/index.md), or [Ray](../../ray/index.md) DLCs — this image
-  is not configured for serving.

--- a/docs/tensorflow/index.md
+++ b/docs/tensorflow/index.md
@@ -1,0 +1,56 @@
+# ML Training using TensorFlow DLC
+
+Production-ready Docker images for TensorFlow training workloads on {{ aws }}. Available in CPU and GPU variants, built on Amazon Linux 2023 with
+ongoing security patching.
+
+These images bundle TensorFlow with the libraries needed for **distributed training on {{ sagemaker }}** — EFA for low-latency networking on
+EFA-capable instances, OpenMPI for multi-node coordination, and the SageMaker training toolkits for entry-point invocation and channel wiring.
+
+## Images
+
+| Platform        | Variant | Image                                                                                                 |
+| --------------- | ------- | ----------------------------------------------------------------------------------------------------- |
+| {{ sagemaker }} | GPU     | `public.ecr.aws/deep-learning-containers/tensorflow-training:2.21-gpu-py312-cu129-amzn2023-sagemaker` |
+| {{ sagemaker }} | CPU     | `public.ecr.aws/deep-learning-containers/tensorflow-training:2.21-cpu-py312-amzn2023-sagemaker`       |
+
+All images are also available on the [ECR Public Gallery](https://gallery.ecr.aws/deep-learning-containers/tensorflow-training). For private ECR URIs,
+see [Image Access](../get_started/index.md).
+
+The `2.21.0-*` fully-qualified tags (e.g. `2.21.0-gpu-py312-cu129-amzn2023-sagemaker`) are also published and pin to the same image digest.
+
+## What's Included
+
+The TensorFlow DLC is a focused SageMaker training image. It ships TensorFlow with the CUDA runtime and the SageMaker toolkits, without the extended
+kernel stack (flash-attn, Transformer Engine, DeepSpeed, GDRCopy) that ships with the PyTorch DLC — TensorFlow does not consume those libraries.
+
+The GPU image includes:
+
+- **TensorFlow 2.21.0** (`tensorflow==2.21.0`)
+- **CUDA 12.9.1** with **cuDNN 9.5.1.17** (`nvidia-cudnn-cu12`) and **NCCL 2.30.7** (`nvidia-nccl-cu12`) for multi-GPU collectives
+- **[EFA](https://aws.amazon.com/hpc/efa/) 1.49.0** with **OpenMPI 4.1.8** for low-latency multi-node communication on EFA-capable instances
+- **[MPI for Python](https://mpi4py.readthedocs.io/) (`mpi4py`)** for multi-process Python coordination
+- **[SageMaker training toolkits](https://github.com/aws/sagemaker-tensorflow-training-toolkit)** — `sagemaker-tensorflow-training`, `sagemaker-training`
+- **[MLflow](https://mlflow.org/) 3.9+**, **`sagemaker>=3.4.0`**, **`smclarify`**, and **`sagemaker-experiments` 0.1.45**
+- **Data & ML tooling** — `tensorflow-io` 0.37, `tensorflow-datasets`, `pandas`, `scikit-learn`, `scipy`, `numpy` (2.1+), `Pillow`, `h5py`,
+  `opencv-python`, `numba`, `plotly`, `seaborn`, `shap`, `bokeh`, `imageio`, `cloudpickle`
+- **AWS tooling** — `boto3`, `botocore`, `awscli` (<2), `s3fs`
+- **SageMaker Studio integration** — `sagemaker-studio-analytics-extension`, `sparkmagic` 0.22.0, `sagemaker-studio-sparkmagic-lib`
+- **Python 3.12** in a venv at `/opt/venv` (`PATH` already set)
+
+The CPU variant includes the same TensorFlow ecosystem and SageMaker toolkits. EFA, CUDA, cuDNN, and NCCL are not present in the CPU image.
+
+## CUDA Forward Compatibility
+
+The GPU image entrypoint detects host NVIDIA driver versions older than the bundled `cuda-compat` layer and automatically prepends
+`/usr/local/cuda/compat` to `LD_LIBRARY_PATH`. No flag or env var needed — the check runs on every container start.
+
+## How We Build
+
+These images are curated builds tracking the [TensorFlow](https://www.tensorflow.org/) project:
+
+- **Built from upstream TensorFlow wheels** published to PyPI
+- **Reproducible** — pinned via `pyproject.toml` + `uv.lock` for every image variant
+- **Security-patched** — continuously maintained with security patches from {{ aws }} on an Amazon Linux 2023 base
+
+TensorFlow 2.21 is the first TensorFlow DLC on Amazon Linux 2023 and Python 3.12. Prior TensorFlow DLCs shipped on Ubuntu with earlier Python versions;
+this release moves the base OS and interpreter forward alongside the framework bump.

--- a/docs/tensorflow/index.md
+++ b/docs/tensorflow/index.md
@@ -8,10 +8,10 @@ EFA-capable instances, OpenMPI for multi-node coordination, and the SageMaker tr
 
 ## Images
 
-| Platform        | Variant | Image                                                                                                 |
-| --------------- | ------- | ----------------------------------------------------------------------------------------------------- |
-| {{ sagemaker }} | GPU     | `public.ecr.aws/deep-learning-containers/tensorflow-training:2.21-gpu-py312-cu129-amzn2023-sagemaker` |
-| {{ sagemaker }} | CPU     | `public.ecr.aws/deep-learning-containers/tensorflow-training:2.21-cpu-py312-amzn2023-sagemaker`       |
+| Platform | Variant | Image |
+| --- | --- | --- |
+| {{ sagemaker }} | GPU | `public.ecr.aws/deep-learning-containers/tensorflow-training:2.21-gpu-py312-cu129-amzn2023-sagemaker` |
+| {{ sagemaker }} | CPU | `public.ecr.aws/deep-learning-containers/tensorflow-training:2.21-cpu-py312-amzn2023-sagemaker` |
 
 All images are also available on the [ECR Public Gallery](https://gallery.ecr.aws/deep-learning-containers/tensorflow-training). For private ECR URIs,
 see [Image Access](../get_started/index.md).
@@ -26,7 +26,8 @@ The GPU image includes:
 - **CUDA 12.9.1** with **cuDNN 9.5.1.17** (`nvidia-cudnn-cu12`) and **NCCL 2.30.7** (`nvidia-nccl-cu12`) for multi-GPU collectives
 - **[EFA](https://aws.amazon.com/hpc/efa/) 1.49.0** with **OpenMPI 4.1.8** for low-latency multi-node communication on EFA-capable instances
 - **[MPI for Python](https://mpi4py.readthedocs.io/) (`mpi4py`)** for multi-process Python coordination
-- **[SageMaker training toolkits](https://github.com/aws/sagemaker-tensorflow-training-toolkit)** — `sagemaker-tensorflow-training`, `sagemaker-training`
+- **[SageMaker training toolkits](https://github.com/aws/sagemaker-tensorflow-training-toolkit)** — `sagemaker-tensorflow-training`,
+  `sagemaker-training`
 - **[MLflow](https://mlflow.org/) 3.9+**, **`sagemaker>=3.4.0`**, **`smclarify`**, and **`sagemaker-experiments` 0.1.45**
 - **Data & ML tooling** — `tensorflow-io` 0.37, `tensorflow-datasets`, `pandas`, `scikit-learn`, `scipy`, `numpy` (2.1+), `Pillow`, `h5py`,
   `opencv-python`, `numba`, `plotly`, `seaborn`, `shap`, `bokeh`, `imageio`, `cloudpickle`
@@ -49,5 +50,5 @@ These images are curated builds tracking the [TensorFlow](https://www.tensorflow
 - **Reproducible** — pinned via `pyproject.toml` + `uv.lock` for every image variant
 - **Security-patched** — continuously maintained with security patches from {{ aws }} on an Amazon Linux 2023 base
 
-TensorFlow 2.21 is the first TensorFlow DLC on Amazon Linux 2023 and Python 3.12. Prior TensorFlow DLCs shipped on Ubuntu with earlier Python versions;
-this release moves the base OS and interpreter forward alongside the framework bump.
+TensorFlow 2.21 is the first TensorFlow DLC on Amazon Linux 2023 and Python 3.12. Prior TensorFlow DLCs shipped on Ubuntu with earlier Python
+versions; this release moves the base OS and interpreter forward alongside the framework bump.

--- a/docs/tensorflow/index.md
+++ b/docs/tensorflow/index.md
@@ -20,9 +20,6 @@ The `2.21.0-*` fully-qualified tags (e.g. `2.21.0-gpu-py312-cu129-amzn2023-sagem
 
 ## What's Included
 
-The TensorFlow DLC is a focused SageMaker training image. It ships TensorFlow with the CUDA runtime and the SageMaker toolkits, without the extended
-kernel stack (flash-attn, Transformer Engine, DeepSpeed, GDRCopy) that ships with the PyTorch DLC — TensorFlow does not consume those libraries.
-
 The GPU image includes:
 
 - **TensorFlow 2.21.0** (`tensorflow==2.21.0`)


### PR DESCRIPTION
Add `docs/tensorflow/` to the documentation page.