### PR TITLE
docs(user_guide): add TensorFlow to framework picker

### DIFF
--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -7,4 +7,5 @@ Choose a framework to get started:
 - **[TEI](../tei/index.md)** — serve text embedding, reranker, and classification models with Text Embeddings Inference on {{ sagemaker }}
 - **[Ray](../ray/index.md)** — deploy any ML model with Ray Serve (NLP, vision, audio, tabular)
 - **[PyTorch](../pytorch/index.md)** — distributed training with EFA, NCCL, flash-attn, and DeepSpeed pre-installed
+- **[TensorFlow](../tensorflow/index.md)** — training on {{ sagemaker }} with EFA-capable multi-node support on Amazon Linux 2023
 - **[Base](../base/index.md)** — lightweight CUDA + Python images for building your own AI/ML container


### PR DESCRIPTION
The User Guide landing page (`/user_guide/`) listed vLLM, vLLM-Omni, TEI, Ray, PyTorch, and Base but was missing TensorFlow. This adds the entry so customers landing on the framework picker see all supported frameworks.

## Context

PR #6399 added the full `docs/tensorflow/` tree (index, deployment/sagemaker, changelog) and a Getting Started card, but the `docs/user_guide/index.md` framework picker was hand-maintained and hadn't been updated alongside. This is a small follow-up.

## Change

```diff
+- **[TensorFlow](../tensorflow/index.md)** — training on {{ sagemaker }} with EFA-capable multi-node support on Amazon Linux 2023
```

## Test plan

- Live preview via `mkdocs serve` — verify the bullet renders and the link resolves to `/tensorflow/`.
- CI docs build passes (auto).