### PR TITLE
Align tensorflow smoke tests with upstream TF 2.21 tensorboard removal

### DIFF
--- a/test/dlc_tests/container_tests/bin/testTensorFlow
+++ b/test/dlc_tests/container_tests/bin/testTensorFlow
@@ -8,12 +8,6 @@ if [[ ! -d $LOG_DIR ]]; then
     mkdir -p $LOG_DIR
 fi
 
-# based on keras version bundled with tf, profiler directory is different,
-# for version bundled with keras=3.8.0 is /logs/train/plugins/profile/timestamp/*.pb
-# rebuilt TF2.16 will use keras=3.8.0 too
-# so use regex to match pattern 
-PROFILE_LOG_DIR='*/plugins/profile/*'
-
 set -e
 
 export KERAS_BACKEND="tensorflow"
@@ -35,30 +29,18 @@ TRAINING_LOG=${LOG_DIR}/${KERAS_BACKEND}_train_mnist.log
 echo "Training mnist using $KERAS_BACKEND... This may take a few minutes. You can follow progress on the log file : $TRAINING_LOG"
 set +e
 
-if [ -d "$LOG_DIR" ]; then
-    echo "Cleanning existing logs"
-    find "$LOG_DIR" -path "$PROFILE_LOG_DIR" -type f -delete
-fi
-
 python ${BIN_DIR}/testTensorflow.py >$TRAINING_LOG 2>&1
 RETURN_VAL=`echo $?`
 set -e
 
-echo "Verify tensorflow profiler can generate logs."
-
-# profiler: tf > 2.* and < 2.2 generates local.trace where as tf > 2.2 generates *.pb
-if [[ $(python -c "import tensorflow as tf; from packaging.version import Version; is_less_than_tf22 = Version(tf.__version__) < Version('2.2'); print(is_less_than_tf22)") == 'True' ]]; then
-    LOG_FILE="local.trace"
-else
-    LOG_FILE="*.pb"
-fi
-
-LOG_RESULT=$(find "$LOG_DIR" -path "$PROFILE_LOG_DIR" -name $LOG_FILE)
-
-echo "Checking the logs result: $LOG_RESULT"
-
-[ -z "$LOG_RESULT" ] && echo "Cannot find Profiler logs!" && exit 1
-
+# NOTE: We previously verified TensorBoard profiler `*.pb` output here to
+# gate the smoke test. That check has been removed because TensorFlow 2.21
+# dropped the `tensorboard` package from its Requires list (documented
+# upstream breaking change), so `tf.keras.callbacks.TensorBoard` is no
+# longer usable in DLC TF 2.21+ images without an explicit
+# `pip install tensorboard`. MNIST training completion is now the smoke
+# signal — it exercises the full training path end-to-end and is
+# tensorboard-independent.
 if [ ${RETURN_VAL} -eq 0 ]; then
     echo "Training mnist Complete using $KERAS_BACKEND."
     cat $TRAINING_LOG

--- a/test/dlc_tests/container_tests/bin/testTensorflow.py
+++ b/test/dlc_tests/container_tests/bin/testTensorflow.py
@@ -60,8 +60,13 @@ model.compile(
     metrics=["accuracy"],
 )
 
-callbacks = [tf.keras.callbacks.TensorBoard(log_dir="/test/logs", profile_batch=1)]
-
+# NOTE: TensorFlow 2.21 removed `tensorboard` from its Requires list as a
+# documented breaking change (see the TF 2.21 release notes). Downstream
+# images that depend on TF 2.21+ therefore ship without the tensorboard
+# package by default, and `tf.keras.callbacks.TensorBoard` raises
+# TBNotInstalledError at the first `tf.summary.scalar` call. This smoke
+# test intentionally does not attach a TensorBoard callback: MNIST
+# training completion is the smoke signal.
 model.fit(
     x_train,
     y_train,
@@ -69,7 +74,6 @@ model.fit(
     epochs=epochs,
     verbose=1,
     validation_data=(x_test, y_test),
-    callbacks=callbacks,
 )
 
 score = model.evaluate(x_test, y_test, verbose=0)

--- a/test/dlc_tests/ec2/tensorflow/training/test_tensorflow_training.py
+++ b/test/dlc_tests/ec2/tensorflow/training/test_tensorflow_training.py
@@ -385,6 +385,21 @@ def test_tensorflow_keras_horovod_fp32(
 
 
 # Testing Tensorboard with profiling
+#
+# Skipped: TensorFlow 2.21 removed the `tensorboard` package from its
+# Requires list as a documented upstream breaking change (see the TF 2.21
+# release notes). DLC TF 2.21+ images therefore ship without tensorboard,
+# and `tf.keras.callbacks.TensorBoard` raises TBNotInstalledError at the
+# first `tf.summary.scalar` call. Re-enable once tensorboard is available
+# in the image (either via an explicit dep in the pyproject or via user
+# `pip install tensorboard` in the training script).
+@pytest.mark.skip(
+    reason=(
+        "TensorBoard package no longer bundled with TensorFlow 2.21+ per "
+        "upstream breaking change. See "
+        "https://github.com/tensorflow/tensorflow/blob/r2.21/RELEASE.md"
+    )
+)
 @pytest.mark.integration("tensorboard, keras")
 @pytest.mark.model("sequential")
 @pytest.mark.team("frameworks")
@@ -400,6 +415,16 @@ def test_tensorflow_tensorboard_gpu(
 
 
 # Testing Tensorboard with profiling
+#
+# Skipped: see rationale on test_tensorflow_tensorboard_gpu above — TF 2.21
+# upstream dropped tensorboard from Requires.
+@pytest.mark.skip(
+    reason=(
+        "TensorBoard package no longer bundled with TensorFlow 2.21+ per "
+        "upstream breaking change. See "
+        "https://github.com/tensorflow/tensorflow/blob/r2.21/RELEASE.md"
+    )
+)
 @pytest.mark.integration("tensorboard, keras")
 @pytest.mark.model("sequential")
 @pytest.mark.team("frameworks")


### PR DESCRIPTION
## Problem
The deep-canary tensorflow smoke test fails on TF 2.21 SageMaker images with:

    tensorflow.python.summary.tb_summary.TBNotInstalledError:
      TensorBoard is not installed, missing implementation for tf.summary.scalar

## Root cause
TensorFlow 2.21 [removed the tensorboard package from its Requires list](https://github.com/tensorflow/tensorflow/blob/r2.21/RELEASE.md) as a documented breaking change ("The TensorBoard (TB) dependency has been removed starting with TF 2.21."). Downstream images that depend on TF 2.21+ therefore ship without the tensorboard package by default, and `tf.keras.callbacks.TensorBoard` crashes at the first `tf.summary.scalar` call inside `model.fit`.

## Approach
Mirror upstream's policy rather than maintain a permanent override of an upstream dep decision. Users who need TensorBoard on TF 2.21+ should `pip install tensorboard` explicitly in their training script or extend the image, matching the guidance customers already see from TensorFlow itself.

## Changes
- `test/dlc_tests/container_tests/bin/testTensorflow.py`: drop the `tf.keras.callbacks.TensorBoard(...)` callback and the `callbacks=` argument from `model.fit`. MNIST training completion is the smoke signal, which exercises the full training path end-to-end and is tensorboard-independent.
- `test/dlc_tests/container_tests/bin/testTensorFlow`: drop the profiler-verify block (`Verify tensorflow profiler can generate logs.` / `find ... *.pb` / `Cannot find Profiler logs!`). Wrapper exit code is now determined solely by `python testTensorflow.py`'s return code.
- `test/dlc_tests/ec2/tensorflow/training/test_tensorflow_training.py`: mark `test_tensorflow_tensorboard_gpu` and `test_tensorflow_tensorboard_cpu` as `@pytest.mark.skip(...)` with a reason that points at the upstream release note. Left in place (not deleted) so they can be re-enabled if tensorboard is ever added back explicitly.

`testTensorBoard` and `testTensorBoard.py` under `container_tests/bin/` are unchanged: the pytest tests are skipped, not deleted.

## Test plan
- Static checks: `bash -n testTensorFlow`, `python -m py_compile testTensorflow.py`, `ast.parse(test_tensorflow_training.py)` — all pass.
- End-to-end run of the edited `/test/bin/testTensorFlow` inside a `tensorflow-training:2.21-cpu-py312-amzn2023-sagemaker` container **without** tensorboard installed (`python -c "import tensorboard"` returns `ModuleNotFoundError`): full 12-epoch MNIST run completes, wrapper prints `Training mnist Complete using tensorflow.`, exit 0.
- After merge, the deep-canary CodeBuild picks up the change on the next 6h cycle; regional canary alarm transitions OK after 2 consecutive success builds (~12h).