### PR TITLE
sklearn 1.9: enable gamma release

### DIFF
--- a/.github/config/image/sklearn/sagemaker-1.9-0.yml
+++ b/.github/config/image/sklearn/sagemaker-1.9-0.yml
@@ -21,7 +21,7 @@ build:
   sklearn_container_branch: "master"
 
 release:
-  release: false
+  release: true
   force_release: false
   public_registry: false
   private_registry: true


### PR DESCRIPTION
Flip `release: true` on `sagemaker-1.9-0.yml` so dispatch-release actually pushes to gamma. Prod flip in a follow-up.