### PR TITLE
openfold3 sagemaker test: fall back across 4-GPU instances on ICE, skip if none available

### DIFF
--- a/.github/workflows/openfold3.tests-sagemaker.yml
+++ b/.github/workflows/openfold3.tests-sagemaker.yml
@@ -68,6 +68,8 @@ jobs:
           TEST_IMAGE_URI: ${{ needs.preflight.outputs.image-uri }}
           SM_ROLE_ARN: arn:aws:iam::${{ vars.CI_AWS_ACCOUNT_ID }}:role/SageMakerRole
           AWS_REGION: ${{ vars.AWS_REGION }}
+          # Release runs skip on capacity (ICE); PR runs surface it as a failure.
+          RELEASE_RUN: ${{ contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release') }}
         run: |
           uv venv --python 3.12
           source .venv/bin/activate

--- a/test/openfold3/sagemaker/test_async_endpoint.py
+++ b/test/openfold3/sagemaker/test_async_endpoint.py
@@ -7,7 +7,7 @@ set by the workflow:
   SM_ROLE_ARN     the SageMaker execution role ARN
   AWS_REGION      region (default us-west-2)
 
-One 4-GPU endpoint (ml.g6.12xlarge, falling back to other 4-GPU types on
+One 4-GPU endpoint (ml.g6.12xlarge, falling back to ml.g5.12xlarge on
 capacity errors) serves every case. The handler's GPU pool
 leases one GPU per concurrent request, so "1 GPU" means a single in-flight
 request and "4 GPU" means four concurrent requests fanned across the four GPUs.
@@ -52,10 +52,11 @@ IMAGE_URI = os.environ["TEST_IMAGE_URI"]
 ROLE_ARN = os.environ["SM_ROLE_ARN"]
 REGION = os.environ.get("AWS_REGION", "us-west-2")
 
-# Candidate 4-GPU instances tried in order — SageMaker capacity (ICE) for any
-# single type is intermittent, so we fall back across equivalent 4-GPU types
-# and skip the suite only if none can be provisioned.
-INSTANCE_TYPES = ["ml.g6.12xlarge", "ml.g6e.12xlarge", "ml.g5.12xlarge"]
+# Candidate 4-GPU instances tried in order — g6.12xlarge (4x L4) capacity (ICE)
+# is intermittent, so we fall back to g5.12xlarge (4x A10G, also 4 GPUs / 24 GB)
+# and skip the suite only if none can be provisioned. Both have endpoint quota in
+# the CI account; g6e has 0 quota so it is intentionally not listed.
+INSTANCE_TYPES = ["ml.g6.12xlarge", "ml.g5.12xlarge"]
 MAX_CONCURRENT_INVOCATIONS = 4
 # Generous: warmup compiles CUDA kernels (~6 min) before /ping returns 200.
 STARTUP_HEALTH_CHECK_TIMEOUT = 1200
@@ -156,16 +157,7 @@ def _invoke(endpoint_name: str, query_files: list[str]) -> list[tuple[float, dic
 
 def _is_capacity_error(exc: Exception) -> bool:
     """True if the deploy failed for lack of instance capacity (ICE), not a real defect."""
-    msg = str(exc).lower()
-    return any(
-        s in msg
-        for s in (
-            "insufficientinstancecapacity",
-            "insufficient capacity",
-            "capacityerror",
-            "does not have",
-        )
-    )
+    return "insufficientinstancecapacity" in str(exc).lower()
 
 
 def _deploy(name: str, instance_type: str):

--- a/test/openfold3/sagemaker/test_async_endpoint.py
+++ b/test/openfold3/sagemaker/test_async_endpoint.py
@@ -52,11 +52,11 @@ IMAGE_URI = os.environ["TEST_IMAGE_URI"]
 ROLE_ARN = os.environ["SM_ROLE_ARN"]
 REGION = os.environ.get("AWS_REGION", "us-west-2")
 
-# 4-GPU instance(s) tried in order; if all hit capacity errors (ICE) we skip the
-# suite rather than fail the release. Only g6.12xlarge (4x L4) is currently viable:
-# g6e.12xlarge has 0 endpoint quota, and g5.12xlarge (A10G) is not supported by the
-# CUDA-13 inference AMI this cu130 image needs. Add more here if that changes.
+# Only g6.12xlarge (4x L4) is viable: g6e has 0 endpoint quota, g5 is rejected by the cu13 AMI.
 INSTANCE_TYPES = ["ml.g6.12xlarge"]
+# Retry deploy on capacity errors (ICE) before giving up; skip the suite only if all attempts fail.
+DEPLOY_ATTEMPTS = 3
+DEPLOY_RETRY_WAIT = 300
 MAX_CONCURRENT_INVOCATIONS = 4
 # Generous: warmup compiles CUDA kernels (~6 min) before /ping returns 200.
 STARTUP_HEALTH_CHECK_TIMEOUT = 1200
@@ -69,8 +69,7 @@ OUTPUT_PREFIX = "openfold3/async-output"
 
 SMALL_QUERY = "small.json"  # ubiquitin, 76 residues
 LARGE_QUERY = "large.json"  # synthetic, 622 residues
-# 622-res protein with an inline precomputed MSA (colabfold_main.a3m); exercises
-# the bring-your-own-MSA path. Uploaded by Scripts/upload_openfold3_test_queries.sh.
+# 622-res protein with an inline precomputed MSA; exercises the bring-your-own-MSA path.
 MSA_QUERY = "large_msa.json"
 # Small protein with use_msa_server=true; the handler must reject it under isolation.
 MSA_SERVER_QUERY = "small_msa_server.json"
@@ -216,27 +215,33 @@ def _cleanup(model, endpoint_config, endpoint):
 
 @pytest.fixture(scope="module")
 def endpoint_name():
-    """Deploy one 4-GPU async endpoint, falling back across instance types on capacity errors.
+    """Deploy one 4-GPU async endpoint, retrying instances on capacity errors (ICE).
 
-    If every candidate instance hits a capacity error (ICE), skip the suite rather
-    than fail the release — ICE is an AWS-side capacity issue, not an image defect.
+    ICE is an AWS-side capacity issue, not an image defect: retry each instance
+    a few times (waiting between tries), then skip the suite rather than fail.
     """
     _preflight_s3()
     _sweep_stale()
 
     last_error = None
-    for instance_type in INSTANCE_TYPES:
+    # Each instance gets DEPLOY_ATTEMPTS tries; capacity is intermittent so a wait often clears it.
+    attempts = [(it, n) for it in INSTANCE_TYPES for n in range(DEPLOY_ATTEMPTS)]
+    for i, (instance_type, _) in enumerate(attempts):
         name = random_suffix_name("openfold3-async", 50)
         model = endpoint_config = endpoint = None
         try:
             model, endpoint_config, endpoint = _deploy(name, instance_type)
         except Exception as e:
             _cleanup(model, endpoint_config, endpoint)
-            if _is_capacity_error(e):
-                LOGGER.warning(f"[capacity] {instance_type} unavailable (ICE); trying next. {e}")
-                last_error = e
-                continue
-            raise  # a real deploy failure — surface it
+            if not _is_capacity_error(e):
+                raise  # a real deploy failure — surface it
+            last_error = e
+            if i + 1 < len(attempts):
+                LOGGER.warning(
+                    f"[capacity] {instance_type} ICE; retrying in {DEPLOY_RETRY_WAIT}s. {e}"
+                )
+                time.sleep(DEPLOY_RETRY_WAIT)
+            continue
 
         try:
             LOGGER.info(f"Endpoint InService on {instance_type}; settling {SETTLE_SECONDS}s")
@@ -247,8 +252,7 @@ def endpoint_name():
         return
 
     pytest.skip(
-        f"No SageMaker capacity for any of {INSTANCE_TYPES} (ICE); skipping endpoint tests. "
-        f"Last error: {last_error}"
+        f"No SageMaker capacity after {len(attempts)} attempts (ICE); skipping. Last: {last_error}"
     )
 
 

--- a/test/openfold3/sagemaker/test_async_endpoint.py
+++ b/test/openfold3/sagemaker/test_async_endpoint.py
@@ -7,7 +7,8 @@ set by the workflow:
   SM_ROLE_ARN     the SageMaker execution role ARN
   AWS_REGION      region (default us-west-2)
 
-One 4-GPU endpoint (ml.g6.12xlarge) serves every case. The handler's GPU pool
+One 4-GPU endpoint (ml.g6.12xlarge, falling back to other 4-GPU types on
+capacity errors) serves every case. The handler's GPU pool
 leases one GPU per concurrent request, so "1 GPU" means a single in-flight
 request and "4 GPU" means four concurrent requests fanned across the four GPUs.
 
@@ -51,8 +52,10 @@ IMAGE_URI = os.environ["TEST_IMAGE_URI"]
 ROLE_ARN = os.environ["SM_ROLE_ARN"]
 REGION = os.environ.get("AWS_REGION", "us-west-2")
 
-# One 4-GPU instance hosts every case; 1-GPU cases just send 1 request.
-INSTANCE_TYPE = "ml.g6.12xlarge"
+# Candidate 4-GPU instances tried in order — SageMaker capacity (ICE) for any
+# single type is intermittent, so we fall back across equivalent 4-GPU types
+# and skip the suite only if none can be provisioned.
+INSTANCE_TYPES = ["ml.g6.12xlarge", "ml.g6e.12xlarge", "ml.g5.12xlarge"]
 MAX_CONCURRENT_INVOCATIONS = 4
 # Generous: warmup compiles CUDA kernels (~6 min) before /ping returns 200.
 STARTUP_HEALTH_CHECK_TIMEOUT = 1200
@@ -151,65 +154,110 @@ def _invoke(endpoint_name: str, query_files: list[str]) -> list[tuple[float, dic
     return [_poll_one(out, fail, start) for out, fail in submitted]
 
 
+def _is_capacity_error(exc: Exception) -> bool:
+    """True if the deploy failed for lack of instance capacity (ICE), not a real defect."""
+    msg = str(exc).lower()
+    return any(
+        s in msg
+        for s in (
+            "insufficientinstancecapacity",
+            "insufficient capacity",
+            "capacityerror",
+            "does not have",
+        )
+    )
+
+
+def _deploy(name: str, instance_type: str):
+    """Create model + async endpoint config + endpoint on instance_type; wait for InService.
+
+    Returns (model, endpoint_config, endpoint). Raises on failure (caller handles ICE fallback).
+    """
+    LOGGER.info(f"Creating model: {name}")
+    model = Model.create(
+        model_name=name,
+        primary_container=ContainerDefinition(
+            image=IMAGE_URI,
+            environment={"OPENFOLD_CACHE": "/root/.openfold3"},
+        ),
+        execution_role_arn=ROLE_ARN,
+        # Validate the production no-outbound-network posture (MSA off by default).
+        enable_network_isolation=True,
+    )
+    LOGGER.info(f"Creating async endpoint config: {name} on {instance_type}")
+    endpoint_config = EndpointConfig.create(
+        endpoint_config_name=name,
+        production_variants=[
+            ProductionVariant(
+                variant_name="AllTraffic",
+                model_name=name,
+                initial_instance_count=1,
+                instance_type=instance_type,
+                inference_ami_version=INFERENCE_AMI_VERSION,
+                container_startup_health_check_timeout_in_seconds=STARTUP_HEALTH_CHECK_TIMEOUT,
+            ),
+        ],
+        async_inference_config=AsyncInferenceConfig(
+            output_config=AsyncInferenceOutputConfig(
+                s3_output_path=f"s3://{BUCKET}/{OUTPUT_PREFIX}/",
+            ),
+            client_config=AsyncInferenceClientConfig(
+                max_concurrent_invocations_per_instance=MAX_CONCURRENT_INVOCATIONS,
+            ),
+        ),
+    )
+    LOGGER.info(f"Deploying endpoint {name} on {instance_type} (~10-15 min incl. warmup)...")
+    endpoint = Endpoint.create(endpoint_name=name, endpoint_config_name=name)
+    endpoint.wait_for_status("InService")
+    return model, endpoint_config, endpoint
+
+
+def _cleanup(model, endpoint_config, endpoint):
+    for resource in (endpoint, endpoint_config, model):
+        if resource is None:
+            continue
+        try:
+            resource.delete()
+        except Exception as e:
+            LOGGER.warning(f"Cleanup {type(resource).__name__} failed: {e}")
+
+
 @pytest.fixture(scope="module")
 def endpoint_name():
-    """Deploy one 4-GPU async endpoint for the module; sweep stale first, clean up after."""
+    """Deploy one 4-GPU async endpoint, falling back across instance types on capacity errors.
+
+    If every candidate instance hits a capacity error (ICE), skip the suite rather
+    than fail the release — ICE is an AWS-side capacity issue, not an image defect.
+    """
     _preflight_s3()
     _sweep_stale()
 
-    name = random_suffix_name("openfold3-async", 50)
-    model = endpoint_config = endpoint = None
-    try:
-        LOGGER.info(f"Creating model: {name}")
-        model = Model.create(
-            model_name=name,
-            primary_container=ContainerDefinition(
-                image=IMAGE_URI,
-                environment={"OPENFOLD_CACHE": "/root/.openfold3"},
-            ),
-            execution_role_arn=ROLE_ARN,
-            # Validate the production no-outbound-network posture (MSA off by default).
-            enable_network_isolation=True,
-        )
-
-        LOGGER.info(f"Creating async endpoint config: {name}")
-        endpoint_config = EndpointConfig.create(
-            endpoint_config_name=name,
-            production_variants=[
-                ProductionVariant(
-                    variant_name="AllTraffic",
-                    model_name=name,
-                    initial_instance_count=1,
-                    instance_type=INSTANCE_TYPE,
-                    inference_ami_version=INFERENCE_AMI_VERSION,
-                    container_startup_health_check_timeout_in_seconds=STARTUP_HEALTH_CHECK_TIMEOUT,
-                ),
-            ],
-            async_inference_config=AsyncInferenceConfig(
-                output_config=AsyncInferenceOutputConfig(
-                    s3_output_path=f"s3://{BUCKET}/{OUTPUT_PREFIX}/",
-                ),
-                client_config=AsyncInferenceClientConfig(
-                    max_concurrent_invocations_per_instance=MAX_CONCURRENT_INVOCATIONS,
-                ),
-            ),
-        )
-
-        LOGGER.info(f"Deploying endpoint {name} (~10-15 min incl. warmup)...")
-        endpoint = Endpoint.create(endpoint_name=name, endpoint_config_name=name)
-        endpoint.wait_for_status("InService")
-        LOGGER.info(f"Endpoint InService; settling {SETTLE_SECONDS}s before first invocation")
-        time.sleep(SETTLE_SECONDS)
-
-        yield name
-    finally:
-        for resource in (endpoint, endpoint_config, model):
-            if resource is None:
+    last_error = None
+    for instance_type in INSTANCE_TYPES:
+        name = random_suffix_name("openfold3-async", 50)
+        model = endpoint_config = endpoint = None
+        try:
+            model, endpoint_config, endpoint = _deploy(name, instance_type)
+        except Exception as e:
+            _cleanup(model, endpoint_config, endpoint)
+            if _is_capacity_error(e):
+                LOGGER.warning(f"[capacity] {instance_type} unavailable (ICE); trying next. {e}")
+                last_error = e
                 continue
-            try:
-                resource.delete()
-            except Exception as e:
-                LOGGER.warning(f"Cleanup {type(resource).__name__} failed: {e}")
+            raise  # a real deploy failure — surface it
+
+        try:
+            LOGGER.info(f"Endpoint InService on {instance_type}; settling {SETTLE_SECONDS}s")
+            time.sleep(SETTLE_SECONDS)
+            yield name
+        finally:
+            _cleanup(model, endpoint_config, endpoint)
+        return
+
+    pytest.skip(
+        f"No SageMaker capacity for any of {INSTANCE_TYPES} (ICE); skipping endpoint tests. "
+        f"Last error: {last_error}"
+    )
 
 
 def _sweep_stale():

--- a/test/openfold3/sagemaker/test_async_endpoint.py
+++ b/test/openfold3/sagemaker/test_async_endpoint.py
@@ -54,9 +54,11 @@ REGION = os.environ.get("AWS_REGION", "us-west-2")
 
 # Only g6.12xlarge (4x L4) is viable: g6e has 0 endpoint quota, g5 is rejected by the cu13 AMI.
 INSTANCE_TYPES = ["ml.g6.12xlarge"]
-# Retry deploy on capacity errors (ICE) before giving up; skip the suite only if all attempts fail.
+# Retry deploy on capacity errors (ICE) before giving up.
 DEPLOY_ATTEMPTS = 3
 DEPLOY_RETRY_WAIT = 300
+# On exhausted ICE retries: release runs skip (capacity shouldn't block release); PR runs fail.
+RELEASE_RUN = os.environ.get("RELEASE_RUN", "false").lower() == "true"
 MAX_CONCURRENT_INVOCATIONS = 4
 # Generous: warmup compiles CUDA kernels (~6 min) before /ping returns 200.
 STARTUP_HEALTH_CHECK_TIMEOUT = 1200
@@ -217,8 +219,9 @@ def _cleanup(model, endpoint_config, endpoint):
 def endpoint_name():
     """Deploy one 4-GPU async endpoint, retrying instances on capacity errors (ICE).
 
-    ICE is an AWS-side capacity issue, not an image defect: retry each instance
-    a few times (waiting between tries), then skip the suite rather than fail.
+    ICE is an AWS-side capacity issue, not an image defect: retry each instance a
+    few times (waiting between tries). If all attempts still hit ICE, a release run
+    skips (capacity shouldn't block the release) while a PR run fails (human re-triggers).
     """
     _preflight_s3()
     _sweep_stale()
@@ -251,9 +254,10 @@ def endpoint_name():
             _cleanup(model, endpoint_config, endpoint)
         return
 
-    pytest.skip(
-        f"No SageMaker capacity after {len(attempts)} attempts (ICE); skipping. Last: {last_error}"
-    )
+    msg = f"No SageMaker capacity after {len(attempts)} attempts (ICE). Last: {last_error}"
+    if RELEASE_RUN:
+        pytest.skip(msg)  # don't let AWS capacity block the weekly release
+    raise AssertionError(msg)  # PR runs surface ICE so a human can re-trigger
 
 
 def _sweep_stale():

--- a/test/openfold3/sagemaker/test_async_endpoint.py
+++ b/test/openfold3/sagemaker/test_async_endpoint.py
@@ -7,8 +7,8 @@ set by the workflow:
   SM_ROLE_ARN     the SageMaker execution role ARN
   AWS_REGION      region (default us-west-2)
 
-One 4-GPU endpoint (ml.g6.12xlarge, falling back to ml.g5.12xlarge on
-capacity errors) serves every case. The handler's GPU pool
+One 4-GPU endpoint (ml.g6.12xlarge) serves every case; the suite is skipped
+if SageMaker has no capacity (ICE). The handler's GPU pool
 leases one GPU per concurrent request, so "1 GPU" means a single in-flight
 request and "4 GPU" means four concurrent requests fanned across the four GPUs.
 
@@ -52,11 +52,11 @@ IMAGE_URI = os.environ["TEST_IMAGE_URI"]
 ROLE_ARN = os.environ["SM_ROLE_ARN"]
 REGION = os.environ.get("AWS_REGION", "us-west-2")
 
-# Candidate 4-GPU instances tried in order — g6.12xlarge (4x L4) capacity (ICE)
-# is intermittent, so we fall back to g5.12xlarge (4x A10G, also 4 GPUs / 24 GB)
-# and skip the suite only if none can be provisioned. Both have endpoint quota in
-# the CI account; g6e has 0 quota so it is intentionally not listed.
-INSTANCE_TYPES = ["ml.g6.12xlarge", "ml.g5.12xlarge"]
+# 4-GPU instance(s) tried in order; if all hit capacity errors (ICE) we skip the
+# suite rather than fail the release. Only g6.12xlarge (4x L4) is currently viable:
+# g6e.12xlarge has 0 endpoint quota, and g5.12xlarge (A10G) is not supported by the
+# CUDA-13 inference AMI this cu130 image needs. Add more here if that changes.
+INSTANCE_TYPES = ["ml.g6.12xlarge"]
 MAX_CONCURRENT_INVOCATIONS = 4
 # Generous: warmup compiles CUDA kernels (~6 min) before /ping returns 200.
 STARTUP_HEALTH_CHECK_TIMEOUT = 1200


### PR DESCRIPTION
## Purpose

The weekly OpenFold3 autorelease frequently fails at the SageMaker endpoint deploy step with **InsufficientInstanceCapacity (ICE)** for `ml.g6.12xlarge` (e.g. run 29374054031). ICE is an AWS-side capacity issue, not an image defect, so it shouldn't block the weekly release — but a PR should still surface it so a human notices.

## Change (`test/openfold3/sagemaker/test_async_endpoint.py` + `openfold3.tests-sagemaker.yml`)

**Retry on capacity, then context-aware handling:**
- Deploy retries up to `DEPLOY_ATTEMPTS` (3) times, waiting `DEPLOY_RETRY_WAIT` (300s) between ICE failures — capacity is intermittent, so a wait usually clears it.
- After retries are exhausted **and every attempt was ICE**:
  - **Autorelease / dispatch-release run → `pytest.skip`** (capacity shouldn't block the release).
  - **PR run → fail** (so a human notices and re-triggers).
  - Context is detected via `RELEASE_RUN`, set from `github.workflow_ref` (same signal the release-gate uses).
- **Non-ICE deploy failures always fail** in both contexts (real defects surface). Only `InsufficientInstanceCapacity` triggers the retry/skip path.

**Instance choice:** only `ml.g6.12xlarge` (4× L4) is currently viable — `ml.g6e.12xlarge` has 0 endpoint quota in the CI account, and `ml.g5.12xlarge` (A10G) is rejected by the CUDA-13 inference AMI this cu130 image requires (confirmed in CI: `Invalid combination: instance g5 and InferenceAmiVersion ...gpu-4-1`). The instance list is kept as a list so a viable fallback can be added if quota/AMI support changes.

No behavior change when g6 capacity is available — it deploys and runs all 5 endpoint cases as before.

## Trade-off

A skipped endpoint test on a release run means that week's release ships without re-running the endpoint validation (the image already passed it at PR/merge time). This is intentional: don't hold the release hostage to AWS capacity. PR/merge runs still gate on the full test.

## Test Plan

Pre-commit (ruff format/lint/imports, actionlint) passes. Affects only the deploy-fixture retry/skip behavior; when capacity is available the suite runs unchanged.
