### PR TITLE
docs: add sklearn 1.4-2-py312, note py310 unsupported

### DIFF
--- a/docs/src/data/sagemaker-scikit-learn/1.4-2-py312-cpu-sagemaker.yml
+++ b/docs/src/data/sagemaker-scikit-learn/1.4-2-py312-cpu-sagemaker.yml
@@ -1,0 +1,11 @@
+framework: Scikit-Learn
+version: "1.4-2-py312"
+accelerator: cpu
+platform: sagemaker
+example_ecr_account: "<account-id>"
+
+tags:
+  - "1.4-2-py312"
+
+ga: "2025-10-30"
+eop: "2026-10-30"

--- a/docs/src/global.yml
+++ b/docs/src/global.yml
@@ -68,6 +68,7 @@ display_names:
     # Repositories
     base: "Base"
     ray: "Ray"
+    sagemaker-scikit-learn: "Scikit-Learn"
     sagemaker-xgboost: "XGBoost"
     sglang: "SGLang (Ubuntu)"
     sglang-server: "SGLang"
@@ -220,4 +221,5 @@ table_order:
   - sagemaker-tritonserver
   - stabilityai-pytorch-inference
   - pytorch-trcomp-training
+  - sagemaker-scikit-learn
   - sagemaker-xgboost

--- a/docs/src/tables/sagemaker-scikit-learn.yml
+++ b/docs/src/tables/sagemaker-scikit-learn.yml
@@ -1,0 +1,11 @@
+# Table Configuration - Scikit-Learn
+note: "ECR account IDs for Scikit-Learn vary by region. Refer to [SageMaker AI ECR Paths](https://docs.aws.amazon.com/sagemaker/latest/dg-ecr-paths/sagemaker-algo-docker-registry-paths.html) for your region's account ID."
+columns:
+  - field: framework_version
+    header: "Framework"
+  - field: accelerator
+    header: "Accelerator"
+  - field: platform
+    header: "Platform"
+  - field: example_url
+    header: "Example URL"

--- a/docs/src/templates/reference/support_policy.template.md
+++ b/docs/src/templates/reference/support_policy.template.md
@@ -11,6 +11,7 @@
 
 - We cannot guarantee security patching on Ubuntu-based vLLM and SGLang images due to the lack of Ubuntu Pro licensing. Customers may continue using these images at their own discretion and risk. We recommend migrating to our Amazon Linux-based images.
 - We are extending support for PyTorch 2.6 Inference images until end of June 2026 as these are the last available PyTorch inference images with torchserve support.
+- Scikit-Learn 1.4-2 for Python 3.10 is no longer supported. Please migrate to Scikit-Learn 1.4-2 for Python 3.12 (`sagemaker-scikit-learn:1.4-2-py312`).
 
 ## Supported Frameworks
 


### PR DESCRIPTION
Add sklearn 1.4-2-py312 to available_images + support_policy docs. Add notice bullet for py310 deprecation.