### PR TITLE
sklearn 1.9: switch release to preprod

### DIFF
--- a/.github/config/image/sklearn/sagemaker-1.9-0.yml
+++ b/.github/config/image/sklearn/sagemaker-1.9-0.yml
@@ -26,4 +26,4 @@ release:
   public_registry: false
   private_registry: true
   enable_soci: false
-  environment: "gamma"
+  environment: "preprod"


### PR DESCRIPTION
Flip `environment: gamma → preprod` on `sagemaker-1.9-0.yml`. Prod flip in a follow-up after preprod soak.