### PR TITLE
[DJL] Add LMI v27 (0.36.0-lmi27.0.0-cu130) to available images docs

### DIFF
--- a/docs/src/data/djl-inference/0.36-lmi27.0.0-gpu.yml
+++ b/docs/src/data/djl-inference/0.36-lmi27.0.0-gpu.yml
@@ -1,0 +1,9 @@
+framework: DJLServing
+version: "0.36"
+accelerator: gpu
+cuda: cu130
+engine: "LMI 27.0.0, vLLM 0.23.1"
+platform: sagemaker
+
+tags:
+  - "0.36.0-lmi27.0.0-cu130"


### PR DESCRIPTION
## Add LMI v27 to available-images docs

Adds the auto-generated docs data file for LMI v27:
`docs/src/data/djl-inference/0.36-lmi27.0.0-gpu.yml` (LMI 27.0.0, vLLM 0.23.1, cu130, `0.36.0-lmi27.0.0-cu130`).