### PR TITLE
Bump nvidia-cudnn-cu12 to 9.24.0.43 for TF 2.21 GPU image

### DIFF
--- a/docker/tensorflow/2.21/cuda/pyproject.toml
+++ b/docker/tensorflow/2.21/cuda/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     # ships forward-ABI-compatible SONAMEs so TF 2.21's 9.3-linked binary loads
     # against 9.5 without rebuild. Dockerfile.cuda copies the .so files out into
     # /usr/local/cuda/lib64.
-    "nvidia-cudnn-cu12==9.5.1.17",
+    "nvidia-cudnn-cu12==9.24.0.43",
     "nvidia-nccl-cu12==2.30.7",
     "mpi4py",
     "boto3",

--- a/docker/tensorflow/2.21/cuda/uv.lock
+++ b/docker/tensorflow/2.21/cuda/uv.lock
@@ -2057,13 +2057,13 @@ wheels = [
 
 [[package]]
 name = "nvidia-cudnn-cu12"
-version = "9.5.1.17"
+version = "9.24.0.43"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/78/4535c9c7f859a64781e43c969a3a7e84c54634e319a996d43ef32ce46f83/nvidia_cudnn_cu12-9.5.1.17-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:30ac3869f6db17d170e0e556dd6cc5eee02647abc31ca856634d5a40f82c15b2", size = 570988386, upload-time = "2024-10-25T19:54:26.39Z" },
+    { url = "https://files.pythonhosted.org/packages/10/13/b8887c869cf2471339a24b60d3c28e761facbb534935f572b61423371abb/nvidia_cudnn_cu12-9.24.0.43-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:f424192dd85e7d29f44be18df2dae4c80d32c67a29c0d42f5c283c40cfdf871c", size = 799083985, upload-time = "2026-07-02T16:25:37.467Z" },
 ]
 
 [[package]]
@@ -3614,7 +3614,7 @@ requires-dist = [
     { name = "mpi4py" },
     { name = "numba", marker = "extra == 'sagemaker'" },
     { name = "numpy", specifier = ">=2.1,<2.5" },
-    { name = "nvidia-cudnn-cu12", specifier = "==9.5.1.17" },
+    { name = "nvidia-cudnn-cu12", specifier = "==9.24.0.43" },
     { name = "nvidia-nccl-cu12", specifier = "==2.30.7" },
     { name = "opencv-python", marker = "extra == 'sagemaker'" },
     { name = "packaging" },


### PR DESCRIPTION
## Problem
TF 2.21 GPU training jobs on any CUDA GPU fail with:

```
Autotuner could not find any supported configs for HLO:
  %cudnn-conv-bias-activation.7 = ...
  custom_call_target="__cudnn$convBiasActivationForward"
  backend_config={..., "device_type":"DEVICE_TYPE_INVALID"}
```

This affects any workload using `Conv2D` layers with `model.fit()` — a
common CNN training pattern. Reproduced on:
- Tesla T4 (compute capability 7.5)
- NVIDIA A10G (compute capability 8.6)
- NVIDIA L4 (compute capability 8.9)

## Root cause
XLA in the tensorflow 2.21.0 wheel emits an HLO with
`backend_config.device_type: DEVICE_TYPE_INVALID` for the fused
`cudnn-conv-bias-activation` custom-call. cuDNN 9.5.1 cannot service
this call pattern and returns no supported configs, causing the
autotuner to fail before training starts.

## Fix
Bump the pinned cuDNN wheel from 9.5.1.17 to 9.24.0.43 in the TF 2.21
CUDA pyproject.toml, and regenerate uv.lock so `uv sync --frozen`
picks up the new wheel.

## Verification
End-to-end verification on an NVIDIA A10G devbox:
- Built the TF 2.21 CUDA image with the pin change.
- Confirmed `nvidia-cudnn-cu12 9.24.0.43` present in the built image.
- Ran the MNIST Conv2D `model.fit()` smoke test that fails on the
  released image.
- Result: MNIST training completes cleanly, test accuracy 0.857,
  no `DEVICE_TYPE_INVALID` or `CUDNN_STATUS_NOT_SUPPORTED` errors.

## Test plan
- [ ] CI single-gpu-test passes
- [ ] CI sagemaker-test passes
- [ ] Post-release: deep canary for tensorflow-training on x86 clears
      once the rebuilt image ships