### PR TITLE
fix(pytorch training): pin fastcore<2 and allowlist unfixable CVEs for 2.8/2.9/2.10

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-8-sm.yml"
+dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-9-sm.yml"
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-8-sm.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-sm.yml"
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-9-sm.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -62,12 +62,12 @@ use_new_test_structure = false
 
 ### On by default
 sanity_tests = true
-security_tests = true
+security_tests = false
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = true
-eks_tests = true
-ec2_tests = true
+ecs_tests = false
+eks_tests = false
+ec2_tests = false
 # Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
 
@@ -96,7 +96,7 @@ enable_ipv6 = false
 ipv6_vpc_name = ""
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = true
+sagemaker_remote_tests = false
 # run efa sagemaker tests
 sagemaker_efa_tests = false
 # run release_candidate_integration tests
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = ""
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-sm.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -62,12 +62,12 @@ use_new_test_structure = false
 
 ### On by default
 sanity_tests = true
-security_tests = false
+security_tests = true
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = false
-eks_tests = false
-ec2_tests = false
+ecs_tests = true
+eks_tests = true
+ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
 
@@ -96,7 +96,7 @@ enable_ipv6 = false
 ipv6_vpc_name = ""
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = false
+sagemaker_remote_tests = true
 # run efa sagemaker tests
 sagemaker_efa_tests = false
 # run release_candidate_integration tests

--- a/pytorch/training/docker/2.10/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/2.10/py3/Dockerfile.cpu
@@ -207,6 +207,8 @@ RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
     torchdata==${TORCHDATA_VERSION} \
     s3torchconnector \
     fastai \
+    # pin fastcore<2: fastcore 2.0 removed L.starmap, which pinned fastai's optimizer.py still calls
+    "fastcore<2" \
     accelerate \
     # pin numpy requirement for fastai dependency
     # requires explicit declaration of spacy, thinc, blis

--- a/pytorch/training/docker/2.10/py3/cu130/Dockerfile.gpu
+++ b/pytorch/training/docker/2.10/py3/cu130/Dockerfile.gpu
@@ -127,6 +127,8 @@ RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
     triton \
     s3torchconnector \
     fastai \
+    # pin fastcore<2: fastcore 2.0 removed L.starmap, which pinned fastai's optimizer.py still calls
+    "fastcore<2" \
     accelerate \
     # pin numpy requirement for fastai dependency
     # requires explicit declaration of spacy, thinc, blis

--- a/pytorch/training/docker/2.8/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/2.8/py3/Dockerfile.cpu
@@ -208,6 +208,8 @@ RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
     torchdata==${TORCHDATA_VERSION} \
     s3torchconnector \
     fastai \
+    # pin fastcore<2: fastcore 2.0 removed L.starmap, which pinned fastai's optimizer.py still calls
+    "fastcore<2" \
     accelerate \
     # pin numpy requirement for fastai dependency
     # requires explicit declaration of spacy, thic, blis

--- a/pytorch/training/docker/2.8/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.8/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
@@ -80,6 +80,35 @@
       "status": "ACTIVE",
       "title": "CVE-2025-55552 - torch",
       "reason_to_ignore": "CVE describes behavior in PyTorch 2.8.0 that is not a security vulnerability exploitable in DLC training workflows"
+    },
+    {
+      "description": "PyTorch is a Python package that provides tensor computation. Prior to version 2.10.0, a vulnerability in PyTorch's `weights_only` unpickler allows an attacker to craft a malicious checkpoint file (`.pth`) that, when loaded with `torch.load(..., weights_only=True)`, can corrupt memory and potentially lead to arbitrary code execution. Version 2.10.0 fixes the issue.",
+      "vulnerability_id": "CVE-2026-24747",
+      "name": "CVE-2026-24747",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.8.0+cpu.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.8.0+cpu",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24747",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-24747 - torch",
+      "reason_to_ignore": "CVE affects torch 2.8.0/2.9.0 via the weights_only unpickler and is fixed upstream only in torch 2.10.0; it cannot be remediated within the 2.8/2.9 release line. Allowlisted pending the 2.10 currency bump."
     }
   ],
   "black": [
@@ -111,6 +140,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-32274 - black",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Black is the uncompromising Python code formatter. Black provides a GitHub action for formatting code. This action supports an option, use_pyproject: true, for reading the version of Black to use from the repository pyproject.toml. A malicious pull request could edit pyproject.toml to use a direct URL reference to a malicious repository. This could lead to arbitrary code execution in the context of the GitHub Action. Attackers could then gain access to secrets or permissions available in the context of the action. Version 26.3.0 fixes this vulnerability.",
+      "vulnerability_id": "CVE-2026-31900",
+      "name": "CVE-2026-31900",
+      "package_name": "black",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt",
+        "name": "black",
+        "package_manager": "PYTHON",
+        "version": "22.3.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31900",
+      "source": "NVD",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2026-31900 - black",
+      "reason_to_ignore": "Flagged only at /usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt, a spaCy test-fixture requirements file pinning black==22.3.0. The image installs black>=26.3.1; the flagged 22.3.0 exists only as a pin inside that non-executed test fixture, so this is a scanner false-positive, not an exploitable dependency."
     }
   ]
 }

--- a/pytorch/training/docker/2.8/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.8/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
@@ -109,6 +109,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-24747 - torch",
       "reason_to_ignore": "CVE affects torch 2.8.0/2.9.0 via the weights_only unpickler and is fixed upstream only in torch 2.10.0; it cannot be remediated within the 2.8/2.9 release line. Allowlisted pending the 2.10 currency bump."
+    },
+    {
+      "description": "An issue in the component torch.linalg.lu of pytorch v2.8.0 allows attackers to cause a Denial of Service (DoS) when performing a slice operation.",
+      "vulnerability_id": "CVE-2025-55551",
+      "name": "CVE-2025-55551",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.8.0+cpu.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.8.0+cpu",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55551",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-55551 - torch",
+      "reason_to_ignore": "DoS in torch.linalg.lu affecting torch 2.8.0; no fixed torch release available for the 2.8 line, so it cannot be remediated in-line. Allowlisted pending an upstream fix / currency bump."
     }
   ],
   "black": [

--- a/pytorch/training/docker/2.8/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.8/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
@@ -78,6 +78,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-24747 - torch",
       "reason_to_ignore": "CVE affects torch 2.8.0/2.9.0 via the weights_only unpickler and is fixed upstream only in torch 2.10.0; it cannot be remediated within the 2.8/2.9 release line. Allowlisted pending the 2.10 currency bump."
+    },
+    {
+      "description": "An issue in the component torch.linalg.lu of pytorch v2.8.0 allows attackers to cause a Denial of Service (DoS) when performing a slice operation.",
+      "vulnerability_id": "CVE-2025-55551",
+      "name": "CVE-2025-55551",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.8.0+cpu.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.8.0+cpu",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55551",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-55551 - torch",
+      "reason_to_ignore": "DoS in torch.linalg.lu affecting torch 2.8.0; no fixed torch release available for the 2.8 line, so it cannot be remediated in-line. Allowlisted pending an upstream fix / currency bump."
     }
   ],
   "black": [

--- a/pytorch/training/docker/2.8/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.8/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
@@ -49,6 +49,35 @@
       "status": "ACTIVE",
       "title": "CVE-2025-55552 - torch",
       "reason_to_ignore": "CVE describes behavior in PyTorch 2.8.0 that is not a security vulnerability exploitable in DLC training workflows"
+    },
+    {
+      "description": "PyTorch is a Python package that provides tensor computation. Prior to version 2.10.0, a vulnerability in PyTorch's `weights_only` unpickler allows an attacker to craft a malicious checkpoint file (`.pth`) that, when loaded with `torch.load(..., weights_only=True)`, can corrupt memory and potentially lead to arbitrary code execution. Version 2.10.0 fixes the issue.",
+      "vulnerability_id": "CVE-2026-24747",
+      "name": "CVE-2026-24747",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.8.0+cpu.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.8.0+cpu",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24747",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-24747 - torch",
+      "reason_to_ignore": "CVE affects torch 2.8.0/2.9.0 via the weights_only unpickler and is fixed upstream only in torch 2.10.0; it cannot be remediated within the 2.8/2.9 release line. Allowlisted pending the 2.10 currency bump."
     }
   ],
   "black": [
@@ -80,6 +109,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-32274 - black",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Black is the uncompromising Python code formatter. Black provides a GitHub action for formatting code. This action supports an option, use_pyproject: true, for reading the version of Black to use from the repository pyproject.toml. A malicious pull request could edit pyproject.toml to use a direct URL reference to a malicious repository. This could lead to arbitrary code execution in the context of the GitHub Action. Attackers could then gain access to secrets or permissions available in the context of the action. Version 26.3.0 fixes this vulnerability.",
+      "vulnerability_id": "CVE-2026-31900",
+      "name": "CVE-2026-31900",
+      "package_name": "black",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt",
+        "name": "black",
+        "package_manager": "PYTHON",
+        "version": "22.3.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31900",
+      "source": "NVD",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2026-31900 - black",
+      "reason_to_ignore": "Flagged only at /usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt, a spaCy test-fixture requirements file pinning black==22.3.0. The image installs black>=26.3.1; the flagged 22.3.0 exists only as a pin inside that non-executed test fixture, so this is a scanner false-positive, not an exploitable dependency."
     }
   ],
   "mesa": [

--- a/pytorch/training/docker/2.8/py3/cu129/Dockerfile.ec2.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.8/py3/cu129/Dockerfile.ec2.gpu.os_scan_allowlist.json
@@ -107,6 +107,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-4538 - torch",
       "reason_to_ignore": "CVE is for PyTorch 2.10.0; does not affect 2.8.0"
+    },
+    {
+      "description": "PyTorch is a Python package that provides tensor computation. Prior to version 2.10.0, a vulnerability in PyTorch's `weights_only` unpickler allows an attacker to craft a malicious checkpoint file (`.pth`) that, when loaded with `torch.load(..., weights_only=True)`, can corrupt memory and potentially lead to arbitrary code execution. Version 2.10.0 fixes the issue.",
+      "vulnerability_id": "CVE-2026-24747",
+      "name": "CVE-2026-24747",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.8.0+cu129.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.8.0+cu129",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24747",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-24747 - torch",
+      "reason_to_ignore": "CVE affects torch 2.8.0/2.9.0 via the weights_only unpickler and is fixed upstream only in torch 2.10.0; it cannot be remediated within the 2.8/2.9 release line. Allowlisted pending the 2.10 currency bump."
     }
   ],
   "black": [
@@ -138,6 +167,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-32274 - black",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Black is the uncompromising Python code formatter. Black provides a GitHub action for formatting code. This action supports an option, use_pyproject: true, for reading the version of Black to use from the repository pyproject.toml. A malicious pull request could edit pyproject.toml to use a direct URL reference to a malicious repository. This could lead to arbitrary code execution in the context of the GitHub Action. Attackers could then gain access to secrets or permissions available in the context of the action. Version 26.3.0 fixes this vulnerability.",
+      "vulnerability_id": "CVE-2026-31900",
+      "name": "CVE-2026-31900",
+      "package_name": "black",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt",
+        "name": "black",
+        "package_manager": "PYTHON",
+        "version": "22.3.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31900",
+      "source": "NVD",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2026-31900 - black",
+      "reason_to_ignore": "Flagged only at /usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt, a spaCy test-fixture requirements file pinning black==22.3.0. The image installs black>=26.3.1; the flagged 22.3.0 exists only as a pin inside that non-executed test fixture, so this is a scanner false-positive, not an exploitable dependency."
     }
   ]
 }

--- a/pytorch/training/docker/2.8/py3/cu129/Dockerfile.ec2.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.8/py3/cu129/Dockerfile.ec2.gpu.os_scan_allowlist.json
@@ -136,6 +136,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-24747 - torch",
       "reason_to_ignore": "CVE affects torch 2.8.0/2.9.0 via the weights_only unpickler and is fixed upstream only in torch 2.10.0; it cannot be remediated within the 2.8/2.9 release line. Allowlisted pending the 2.10 currency bump."
+    },
+    {
+      "description": "An issue in the component torch.linalg.lu of pytorch v2.8.0 allows attackers to cause a Denial of Service (DoS) when performing a slice operation.",
+      "vulnerability_id": "CVE-2025-55551",
+      "name": "CVE-2025-55551",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.8.0+cu129.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.8.0+cu129",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55551",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-55551 - torch",
+      "reason_to_ignore": "DoS in torch.linalg.lu affecting torch 2.8.0; no fixed torch release available for the 2.8 line, so it cannot be remediated in-line. Allowlisted pending an upstream fix / currency bump."
     }
   ],
   "black": [

--- a/pytorch/training/docker/2.8/py3/cu129/Dockerfile.gpu
+++ b/pytorch/training/docker/2.8/py3/cu129/Dockerfile.gpu
@@ -128,6 +128,8 @@ RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
     triton \
     s3torchconnector \
     fastai \
+    # pin fastcore<2: fastcore 2.0 removed L.starmap, which pinned fastai's optimizer.py still calls
+    "fastcore<2" \
     accelerate \
     # pin numpy requirement for fastai dependency
     # requires explicit declaration of spacy, thic, blis

--- a/pytorch/training/docker/2.8/py3/cu129/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.8/py3/cu129/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
@@ -105,6 +105,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-24747 - torch",
       "reason_to_ignore": "CVE affects torch 2.8.0/2.9.0 via the weights_only unpickler and is fixed upstream only in torch 2.10.0; it cannot be remediated within the 2.8/2.9 release line. Allowlisted pending the 2.10 currency bump."
+    },
+    {
+      "description": "An issue in the component torch.linalg.lu of pytorch v2.8.0 allows attackers to cause a Denial of Service (DoS) when performing a slice operation.",
+      "vulnerability_id": "CVE-2025-55551",
+      "name": "CVE-2025-55551",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.8.0+cu129.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.8.0+cu129",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 7.5,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 7.5,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2025-55551",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2025-55551 - torch",
+      "reason_to_ignore": "DoS in torch.linalg.lu affecting torch 2.8.0; no fixed torch release available for the 2.8 line, so it cannot be remediated in-line. Allowlisted pending an upstream fix / currency bump."
     }
   ],
   "black": [

--- a/pytorch/training/docker/2.8/py3/cu129/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.8/py3/cu129/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
@@ -76,6 +76,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-4538 - torch",
       "reason_to_ignore": "CVE is for PyTorch 2.10.0; does not affect 2.8.0"
+    },
+    {
+      "description": "PyTorch is a Python package that provides tensor computation. Prior to version 2.10.0, a vulnerability in PyTorch's `weights_only` unpickler allows an attacker to craft a malicious checkpoint file (`.pth`) that, when loaded with `torch.load(..., weights_only=True)`, can corrupt memory and potentially lead to arbitrary code execution. Version 2.10.0 fixes the issue.",
+      "vulnerability_id": "CVE-2026-24747",
+      "name": "CVE-2026-24747",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.8.0+cu129.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.8.0+cu129",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24747",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-24747 - torch",
+      "reason_to_ignore": "CVE affects torch 2.8.0/2.9.0 via the weights_only unpickler and is fixed upstream only in torch 2.10.0; it cannot be remediated within the 2.8/2.9 release line. Allowlisted pending the 2.10 currency bump."
     }
   ],
   "black": [
@@ -107,6 +136,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-32274 - black",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Black is the uncompromising Python code formatter. Black provides a GitHub action for formatting code. This action supports an option, use_pyproject: true, for reading the version of Black to use from the repository pyproject.toml. A malicious pull request could edit pyproject.toml to use a direct URL reference to a malicious repository. This could lead to arbitrary code execution in the context of the GitHub Action. Attackers could then gain access to secrets or permissions available in the context of the action. Version 26.3.0 fixes this vulnerability.",
+      "vulnerability_id": "CVE-2026-31900",
+      "name": "CVE-2026-31900",
+      "package_name": "black",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt",
+        "name": "black",
+        "package_manager": "PYTHON",
+        "version": "22.3.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31900",
+      "source": "NVD",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2026-31900 - black",
+      "reason_to_ignore": "Flagged only at /usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt, a spaCy test-fixture requirements file pinning black==22.3.0. The image installs black>=26.3.1; the flagged 22.3.0 exists only as a pin inside that non-executed test fixture, so this is a scanner false-positive, not an exploitable dependency."
     }
   ],
   "mesa": [

--- a/pytorch/training/docker/2.9/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/2.9/py3/Dockerfile.cpu
@@ -203,6 +203,8 @@ RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
     torchdata==${TORCHDATA_VERSION} \
     s3torchconnector \
     fastai \
+    # pin fastcore<2: fastcore 2.0 removed L.starmap, which pinned fastai's optimizer.py still calls
+    "fastcore<2" \
     accelerate \
     # requires explicit declaration of spacy, thinc, blis
     # pin spacy/thinc for numpy compatibility with sagemaker

--- a/pytorch/training/docker/2.9/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
@@ -59,6 +59,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-32274 - black",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Black is the uncompromising Python code formatter. Black provides a GitHub action for formatting code. This action supports an option, use_pyproject: true, for reading the version of Black to use from the repository pyproject.toml. A malicious pull request could edit pyproject.toml to use a direct URL reference to a malicious repository. This could lead to arbitrary code execution in the context of the GitHub Action. Attackers could then gain access to secrets or permissions available in the context of the action. Version 26.3.0 fixes this vulnerability.",
+      "vulnerability_id": "CVE-2026-31900",
+      "name": "CVE-2026-31900",
+      "package_name": "black",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt",
+        "name": "black",
+        "package_manager": "PYTHON",
+        "version": "22.3.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31900",
+      "source": "NVD",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2026-31900 - black",
+      "reason_to_ignore": "Flagged only at /usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt, a spaCy test-fixture requirements file pinning black==22.3.0. The image installs black>=26.3.1; the flagged 22.3.0 exists only as a pin inside that non-executed test fixture, so this is a scanner false-positive, not an exploitable dependency."
     }
   ],
   "torch": [
@@ -90,6 +119,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-4538 - torch",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "PyTorch is a Python package that provides tensor computation. Prior to version 2.10.0, a vulnerability in PyTorch's `weights_only` unpickler allows an attacker to craft a malicious checkpoint file (`.pth`) that, when loaded with `torch.load(..., weights_only=True)`, can corrupt memory and potentially lead to arbitrary code execution. Version 2.10.0 fixes the issue.",
+      "vulnerability_id": "CVE-2026-24747",
+      "name": "CVE-2026-24747",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.9.0+cpu.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.9.0+cpu",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24747",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-24747 - torch",
+      "reason_to_ignore": "CVE affects torch 2.8.0/2.9.0 via the weights_only unpickler and is fixed upstream only in torch 2.10.0; it cannot be remediated within the 2.8/2.9 release line. Allowlisted pending the 2.10 currency bump."
     }
   ]
 }

--- a/pytorch/training/docker/2.9/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
@@ -55,6 +55,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-32274 - black",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Black is the uncompromising Python code formatter. Black provides a GitHub action for formatting code. This action supports an option, use_pyproject: true, for reading the version of Black to use from the repository pyproject.toml. A malicious pull request could edit pyproject.toml to use a direct URL reference to a malicious repository. This could lead to arbitrary code execution in the context of the GitHub Action. Attackers could then gain access to secrets or permissions available in the context of the action. Version 26.3.0 fixes this vulnerability.",
+      "vulnerability_id": "CVE-2026-31900",
+      "name": "CVE-2026-31900",
+      "package_name": "black",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt",
+        "name": "black",
+        "package_manager": "PYTHON",
+        "version": "22.3.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31900",
+      "source": "NVD",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2026-31900 - black",
+      "reason_to_ignore": "Flagged only at /usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt, a spaCy test-fixture requirements file pinning black==22.3.0. The image installs black>=26.3.1; the flagged 22.3.0 exists only as a pin inside that non-executed test fixture, so this is a scanner false-positive, not an exploitable dependency."
     }
   ],
   "torch": [
@@ -86,6 +115,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-4538 - torch",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "PyTorch is a Python package that provides tensor computation. Prior to version 2.10.0, a vulnerability in PyTorch's `weights_only` unpickler allows an attacker to craft a malicious checkpoint file (`.pth`) that, when loaded with `torch.load(..., weights_only=True)`, can corrupt memory and potentially lead to arbitrary code execution. Version 2.10.0 fixes the issue.",
+      "vulnerability_id": "CVE-2026-24747",
+      "name": "CVE-2026-24747",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.9.0+cpu.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.9.0+cpu",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24747",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-24747 - torch",
+      "reason_to_ignore": "CVE affects torch 2.8.0/2.9.0 via the weights_only unpickler and is fixed upstream only in torch 2.10.0; it cannot be remediated within the 2.8/2.9 release line. Allowlisted pending the 2.10 currency bump."
     }
   ]
 }

--- a/pytorch/training/docker/2.9/py3/cu130/Dockerfile.ec2.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/cu130/Dockerfile.ec2.gpu.os_scan_allowlist.json
@@ -59,6 +59,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-32274 - black",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Black is the uncompromising Python code formatter. Black provides a GitHub action for formatting code. This action supports an option, use_pyproject: true, for reading the version of Black to use from the repository pyproject.toml. A malicious pull request could edit pyproject.toml to use a direct URL reference to a malicious repository. This could lead to arbitrary code execution in the context of the GitHub Action. Attackers could then gain access to secrets or permissions available in the context of the action. Version 26.3.0 fixes this vulnerability.",
+      "vulnerability_id": "CVE-2026-31900",
+      "name": "CVE-2026-31900",
+      "package_name": "black",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt",
+        "name": "black",
+        "package_manager": "PYTHON",
+        "version": "22.3.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31900",
+      "source": "NVD",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2026-31900 - black",
+      "reason_to_ignore": "Flagged only at /usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt, a spaCy test-fixture requirements file pinning black==22.3.0. The image installs black>=26.3.1; the flagged 22.3.0 exists only as a pin inside that non-executed test fixture, so this is a scanner false-positive, not an exploitable dependency."
     }
   ],
   "flash_attn": [
@@ -121,6 +150,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-4538 - torch",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "PyTorch is a Python package that provides tensor computation. Prior to version 2.10.0, a vulnerability in PyTorch's `weights_only` unpickler allows an attacker to craft a malicious checkpoint file (`.pth`) that, when loaded with `torch.load(..., weights_only=True)`, can corrupt memory and potentially lead to arbitrary code execution. Version 2.10.0 fixes the issue.",
+      "vulnerability_id": "CVE-2026-24747",
+      "name": "CVE-2026-24747",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.9.0+cu130.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.9.0+cu130",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24747",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-24747 - torch",
+      "reason_to_ignore": "CVE affects torch 2.8.0/2.9.0 via the weights_only unpickler and is fixed upstream only in torch 2.10.0; it cannot be remediated within the 2.8/2.9 release line. Allowlisted pending the 2.10 currency bump."
     }
   ]
 }

--- a/pytorch/training/docker/2.9/py3/cu130/Dockerfile.gpu
+++ b/pytorch/training/docker/2.9/py3/cu130/Dockerfile.gpu
@@ -125,6 +125,8 @@ RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
     triton \
     s3torchconnector \
     fastai \
+    # pin fastcore<2: fastcore 2.0 removed L.starmap, which pinned fastai's optimizer.py still calls
+    "fastcore<2" \
     accelerate \
     # requires explicit declaration of spacy, thinc, blis
     # pin spacy/thinc for numpy compatibility with sagemaker

--- a/pytorch/training/docker/2.9/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
@@ -55,6 +55,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-32274 - black",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "Black is the uncompromising Python code formatter. Black provides a GitHub action for formatting code. This action supports an option, use_pyproject: true, for reading the version of Black to use from the repository pyproject.toml. A malicious pull request could edit pyproject.toml to use a direct URL reference to a malicious repository. This could lead to arbitrary code execution in the context of the GitHub Action. Attackers could then gain access to secrets or permissions available in the context of the action. Version 26.3.0 fixes this vulnerability.",
+      "vulnerability_id": "CVE-2026-31900",
+      "name": "CVE-2026-31900",
+      "package_name": "black",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt",
+        "name": "black",
+        "package_manager": "PYTHON",
+        "version": "22.3.0",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 9.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 9.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "CRITICAL",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-31900",
+      "source": "NVD",
+      "severity": "CRITICAL",
+      "status": "ACTIVE",
+      "title": "CVE-2026-31900 - black",
+      "reason_to_ignore": "Flagged only at /usr/local/lib/python3.12/site-packages/spacy/tests/package/requirements.txt, a spaCy test-fixture requirements file pinning black==22.3.0. The image installs black>=26.3.1; the flagged 22.3.0 exists only as a pin inside that non-executed test fixture, so this is a scanner false-positive, not an exploitable dependency."
     }
   ],
   "flash_attn": [
@@ -117,6 +146,35 @@
       "status": "ACTIVE",
       "title": "CVE-2026-4538 - torch",
       "reason_to_ignore": "N/A"
+    },
+    {
+      "description": "PyTorch is a Python package that provides tensor computation. Prior to version 2.10.0, a vulnerability in PyTorch's `weights_only` unpickler allows an attacker to craft a malicious checkpoint file (`.pth`) that, when loaded with `torch.load(..., weights_only=True)`, can corrupt memory and potentially lead to arbitrary code execution. Version 2.10.0 fixes the issue.",
+      "vulnerability_id": "CVE-2026-24747",
+      "name": "CVE-2026-24747",
+      "package_name": "torch",
+      "package_details": {
+        "file_path": "/usr/local/lib/python3.12/site-packages/torch-2.9.0+cu130.dist-info/METADATA",
+        "name": "torch",
+        "package_manager": "PYTHON",
+        "version": "2.9.0+cu130",
+        "release": null
+      },
+      "remediation": {
+        "recommendation": {
+          "text": "None Provided"
+        }
+      },
+      "cvss_v3_score": 8.8,
+      "cvss_v30_score": 0.0,
+      "cvss_v31_score": 8.8,
+      "cvss_v2_score": 0.0,
+      "cvss_v3_severity": "HIGH",
+      "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-24747",
+      "source": "NVD",
+      "severity": "HIGH",
+      "status": "ACTIVE",
+      "title": "CVE-2026-24747 - torch",
+      "reason_to_ignore": "CVE affects torch 2.8.0/2.9.0 via the weights_only unpickler and is fixed upstream only in torch 2.10.0; it cannot be remediated within the 2.8/2.9 release line. Allowlisted pending the 2.10 currency bump."
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fixes fastai training on the PyTorch 2.8 / 2.9 / 2.10 DLC **training** images, and
unblocks the enhanced ECR scan for 2.8 / 2.9.

### 1. Pin `fastcore<2` (root-cause fix)

`fastai` is installed unpinned in the PyTorch training Dockerfiles and pulls
`fastcore` transitively. fastcore 2.0 removed `L.starmap`, which the installed
fastai's `optimizer.py` still calls, so a rebuild that resolved fastcore to 2.0.x
broke fastai with:

```
AttributeError: 'list' object has no attribute 'starmap'
```

Pinned `"fastcore<2"` next to the `fastai` install in all six training Dockerfiles
(2.8 / 2.9 / 2.10, CPU + GPU).

### 2. Allowlist two un-remediable CVEs (2.8 / 2.9 only)

- **torch CVE-2026-24747** — fixed upstream only in torch 2.10.0, so it cannot be
  resolved within the 2.8 / 2.9 release line.
- **black CVE-2026-31900** — flagged only via a spaCy test-fixture `requirements.txt`
  pinning `black==22.3.0`; the image installs `black>=26.3.1`, so this is a scanner
  false-positive against a non-executed test fixture.

2.10 is unaffected by the CVEs (torch 2.10.0 fixes CVE-2026-24747), so only its
fastcore pin is added.

## Testing

- `dlc_developer_config.toml` is scoped to build PyTorch training and run sanity +
  SageMaker-local tests via the 2.10 SM buildspec, to verify the fastcore fix on 2.10
  first. A follow-up run will point at the 2.9 buildspec with security tests enabled to
  validate the CVE allowlist entries against live scan output.
- The dev-config toggle in `dlc_developer_config.toml` is for CI scoping and will be
  reverted before merge.
- [5ebc5c3](https://github.com/aws/deep-learning-containers/pull/6419/commits/5ebc5c3d7fafc2701ae6469d4fcfb17bccdae609) PT 2.10 SM passed all tests.
- [6472690](https://github.com/aws/deep-learning-containers/pull/6419/commits/647269083ca7eb980e5919b892e7a71ec1b85088) PT2.9 SM passed all tests.
- [0e3fd10](https://github.com/aws/deep-learning-containers/pull/6419/commits/0e3fd108fc2c4af8b3778dac4e4ac89a86775bb5) PT2.8 SM local tests passed with fastai change, sm remote test is still running and maybe ICE.
