### PR TITLE
sklearn 1.9: switch release to production

### DIFF
--- a/.github/config/image/sklearn/sagemaker-1.9-0.yml
+++ b/.github/config/image/sklearn/sagemaker-1.9-0.yml
@@ -26,4 +26,4 @@ release:
   public_registry: false
   private_registry: true
   enable_soci: false
-  environment: "preprod"
+  environment: "production"


### PR DESCRIPTION
Flip `environment: preprod` → `environment: production` for `sagemaker-scikit-learn-1.9.0` now that preprod validation is complete.

preprod release: https://github.com/aws/deep-learning-containers/actions/runs/29453155390