### PR TITLE
docs: add sklearn 1.9 to available images and support policy

### DIFF
--- a/docs/src/data/sagemaker-scikit-learn/1.9-0-cpu-sagemaker.yml
+++ b/docs/src/data/sagemaker-scikit-learn/1.9-0-cpu-sagemaker.yml
@@ -1,0 +1,11 @@
+framework: Scikit-Learn
+version: "1.9-0"
+accelerator: cpu
+platform: sagemaker
+example_ecr_account: "<account-id>"
+
+tags:
+  - "1.9-0"
+
+ga: "2026-07-16"
+eop: "2027-07-16"


### PR DESCRIPTION
Adds `docs/src/data/sagemaker-scikit-learn/1.9-0-cpu-sagemaker.yml` so that `sagemaker-scikit-learn:1.9-0-cpu-py3` renders as a new row on:

- `docs/reference/available_images.md` (Scikit-Learn table)
- `docs/reference/support_policy.md` (Supported Frameworks table, with GA 2026-07-16 / EOP 2027-07-16)


## Test plan
- [x] Verified locally via `mkdocs serve` that the new row renders on both pages
- [x] Merge after prod release of sklearn 1.9 completes