### PR TITLE
[auto-cve-patch] [xgboost] bump pillow to 12.3.0 (CVE-2026-55379)

### DIFF
--- a/.github/workflows/xgboost.tests-integ-local.yml
+++ b/.github/workflows/xgboost.tests-integ-local.yml
@@ -61,6 +61,30 @@ jobs:
           echo "framework-version=$(yq '.metadata.framework_version' "$CONFIG_FILE")" >> $GITHUB_OUTPUT
           echo "xgboost-branch=$(yq '.build.xgboost_container_branch // "master"' "$CONFIG_FILE")" >> $GITHUB_OUTPUT
           echo "python-version=$(yq '.build.python_version' "$CONFIG_FILE")" >> $GITHUB_OUTPUT
+          echo "dockerfile=$(yq '.build.dockerfile' "$CONFIG_FILE")" >> $GITHUB_OUTPUT
+
+      - name: Verify pinned package versions match declared dependencies
+        if: steps.check.outputs.exists == 'true'
+        env:
+          IMAGE_URI: ${{ steps.image.outputs.image-uri }}
+          DOCKERFILE: ${{ steps.config.outputs.dockerfile }}
+        run: |
+          # 3.2.0+ declares deps in pyproject.toml; 3.0-5 uses requirements.txt.
+          DOCKER_DIR="$(dirname "$DOCKERFILE")"
+          if [[ -f "$DOCKER_DIR/pyproject.toml" ]]; then
+            REQS_FILE="$DOCKER_DIR/pyproject.toml"
+          elif [[ -f "$DOCKER_DIR/requirements.txt" ]]; then
+            REQS_FILE="$DOCKER_DIR/requirements.txt"
+          else
+            echo "No pyproject.toml or requirements.txt at $DOCKER_DIR — skipping version check"
+            exit 0
+          fi
+          docker run --rm \
+            -v "$PWD/$REQS_FILE:/tmp/$(basename "$REQS_FILE"):ro" \
+            -v "$PWD/test/xgboost/scripts/check_versions.py:/tmp/check_versions.py:ro" \
+            --entrypoint python3 \
+            "$IMAGE_URI" \
+            /tmp/check_versions.py "/tmp/$(basename "$REQS_FILE")"
 
       - name: Clone sagemaker-xgboost-container (tests + source)
         if: steps.check.outputs.exists == 'true'
@@ -92,6 +116,7 @@ jobs:
           cd /tmp/xgboost-integ
           pytest test/integration/local \
             --ignore=test/integration/local/test_multiple_model_endpoint.py \
+            --ignore=test/integration/local/test_versions.py \
             --docker-base-name "${CI_IMAGE_URI%:*}" \
             --tag "${CI_IMAGE_URI##*:}" \
             --py-version 3 \

--- a/docker/xgboost/pyproject.toml
+++ b/docker/xgboost/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "numba==0.65.1",
     "numpy==2.1.0",
     "pandas==2.2.3",
-    "Pillow==12.2.0",
+    "Pillow==12.3.0",
     "psutil==7.0.0",
     "pynvml==12.0.0",
     "python-dateutil==2.9.0",
@@ -50,5 +50,5 @@ override-dependencies = [
     "werkzeug==3.1.8",
     "urllib3==2.7.0",
     "certifi==2025.4.26",
-    "pillow==12.2.0",
+    "pillow==12.3.0",
 ]

--- a/docker/xgboost/uv.lock
+++ b/docker/xgboost/uv.lock
@@ -9,7 +9,7 @@ overrides = [
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "markupsafe", specifier = ">=2.1.5" },
-    { name = "pillow", specifier = "==12.2.0" },
+    { name = "pillow", specifier = "==12.3.0" },
     { name = "urllib3", specifier = "==2.7.0" },
     { name = "werkzeug", specifier = "==3.1.8" },
 ]
@@ -786,21 +786,19 @@ wheels = [
 
 [[package]]
 name = "pillow"
-version = "12.2.0"
+version = "12.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8c/21/c2bcdd5906101a30244eaffc1b6e6ce71a31bd0742a01eb89e660ebfac2d/pillow-12.2.0.tar.gz", hash = "sha256:a830b1a40919539d07806aa58e1b114df53ddd43213d9c8b75847eee6c0182b5", size = 46987819, upload-time = "2026-04-01T14:46:17.687Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/3d/bb7fca845737cf9d7dbde16ed1843984665ff2e0a518f5db43e77ec540b9/pillow-12.3.0.tar.gz", hash = "sha256:3b8182a766685eaa002637e28b4ec8d6b18819a0c71f579bf0dbaa5830297cce", size = 47025035, upload-time = "2026-07-01T11:56:38.965Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/58/be/7482c8a5ebebbc6470b3eb791812fff7d5e0216c2be3827b30b8bb6603ed/pillow-12.2.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:2d192a155bbcec180f8564f693e6fd9bccff5a7af9b32e2e4bf8c9c69dbad6b5", size = 5308279, upload-time = "2026-04-01T14:43:13.246Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/95/0a351b9289c2b5cbde0bacd4a83ebc44023e835490a727b2a3bd60ddc0f4/pillow-12.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f3f40b3c5a968281fd507d519e444c35f0ff171237f4fdde090dd60699458421", size = 4695490, upload-time = "2026-04-01T14:43:15.584Z" },
-    { url = "https://files.pythonhosted.org/packages/de/af/4e8e6869cbed569d43c416fad3dc4ecb944cb5d9492defaed89ddd6fe871/pillow-12.2.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:03e7e372d5240cc23e9f07deca4d775c0817bffc641b01e9c3af208dbd300987", size = 6284462, upload-time = "2026-04-01T14:43:18.268Z" },
-    { url = "https://files.pythonhosted.org/packages/e9/9e/c05e19657fd57841e476be1ab46c4d501bffbadbafdc31a6d665f8b737b6/pillow-12.2.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:b86024e52a1b269467a802258c25521e6d742349d760728092e1bc2d135b4d76", size = 8094744, upload-time = "2026-04-01T14:43:20.716Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/54/1789c455ed10176066b6e7e6da1b01e50e36f94ba584dc68d9eebfe9156d/pillow-12.2.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7371b48c4fa448d20d2714c9a1f775a81155050d383333e0a6c15b1123dda005", size = 6398371, upload-time = "2026-04-01T14:43:23.443Z" },
-    { url = "https://files.pythonhosted.org/packages/43/e3/fdc657359e919462369869f1c9f0e973f353f9a9ee295a39b1fea8ee1a77/pillow-12.2.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:62f5409336adb0663b7caa0da5c7d9e7bdbaae9ce761d34669420c2a801b2780", size = 7087215, upload-time = "2026-04-01T14:43:26.758Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/f8/2f6825e441d5b1959d2ca5adec984210f1ec086435b0ed5f52c19b3b8a6e/pillow-12.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:01afa7cf67f74f09523699b4e88c73fb55c13346d212a59a2db1f86b0a63e8c5", size = 6509783, upload-time = "2026-04-01T14:43:29.56Z" },
-    { url = "https://files.pythonhosted.org/packages/67/f9/029a27095ad20f854f9dba026b3ea6428548316e057e6fc3545409e86651/pillow-12.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fc3d34d4a8fbec3e88a79b92e5465e0f9b842b628675850d860b8bd300b159f5", size = 7212112, upload-time = "2026-04-01T14:43:32.091Z" },
-    { url = "https://files.pythonhosted.org/packages/be/42/025cfe05d1be22dbfdb4f264fe9de1ccda83f66e4fc3aac94748e784af04/pillow-12.2.0-cp312-cp312-win32.whl", hash = "sha256:58f62cc0f00fd29e64b29f4fd923ffdb3859c9f9e6105bfc37ba1d08994e8940", size = 6378489, upload-time = "2026-04-01T14:43:34.601Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/7b/25a221d2c761c6a8ae21bfa3874988ff2583e19cf8a27bf2fee358df7942/pillow-12.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:7f84204dee22a783350679a0333981df803dac21a0190d706a50475e361c93f5", size = 7084129, upload-time = "2026-04-01T14:43:37.213Z" },
-    { url = "https://files.pythonhosted.org/packages/10/e1/542a474affab20fd4a0f1836cb234e8493519da6b76899e30bcc5d990b8b/pillow-12.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:af73337013e0b3b46f175e79492d96845b16126ddf79c438d7ea7ff27783a414", size = 2463612, upload-time = "2026-04-01T14:43:39.421Z" },
+    { url = "https://files.pythonhosted.org/packages/37/bf/fb3ebff8ddcb76aac5a01389251bbbb9519922a9b520d8247c1ca864a25d/pillow-12.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ba09209fbe443b4acccebe845d8a138b89a8f4fbaeedd44953490b5315d5e965", size = 5345969, upload-time = "2026-07-01T11:54:06.397Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/66/9a386a92561f402389a4fc70c18838bf6d35eb5eb5c6850b4b2dc64f5048/pillow-12.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ffd0c5368496f41b0944be820fcb7a838aa6e623d250b01acf2643939c3f99d7", size = 4780323, upload-time = "2026-07-01T11:54:09.351Z" },
+    { url = "https://files.pythonhosted.org/packages/25/27/ac8f99618ffd3dde21db0f4d4b1d2ab00c0880595bfd17df103f7f39fd0c/pillow-12.3.0-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d9c7f76c0673154f044e9d78c8655fb4213f6ca31a836df48b40fe5d187717b9", size = 6266838, upload-time = "2026-07-01T11:54:11.71Z" },
+    { url = "https://files.pythonhosted.org/packages/84/21/a35af28dcc61f37ed850a2d64c65c701321dfbf25085e469d5559360cbbf/pillow-12.3.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:78cb2c6865a35ab8ff8b75fd122f6033b92a62c82801110e48ddd6c936a45d91", size = 6940830, upload-time = "2026-07-01T11:54:13.732Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/51/8b08617af3ad95e33ce6d7dd2c99ed6c8298f7fb131636303956be022e25/pillow-12.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e491916b378fba47242221bb9ead245211b70d504f495d105d17b14a24b4907c", size = 6344383, upload-time = "2026-07-01T11:54:15.756Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/72/cf78ac9780bb93c28328f408973845a309d4d145041665f734572ced1b52/pillow-12.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0dd2064cbc55aaec028ef5fbb60fa47bb6c3e7918e07ff17935284b227a9d2df", size = 7052934, upload-time = "2026-07-01T11:54:17.721Z" },
+    { url = "https://files.pythonhosted.org/packages/20/20/25e0f4dc178a6bc0696793720055519a0de89e7661dae886992decbd2f81/pillow-12.3.0-cp312-cp312-win32.whl", hash = "sha256:dbce0b29841537a2fa4a214c2bbf14de3587c9680caa9b4e217568472490b28f", size = 6472684, upload-time = "2026-07-01T11:54:19.839Z" },
+    { url = "https://files.pythonhosted.org/packages/45/89/da2f7971a317f83d807fdd4065c0af40208e59e692cc43d315a71a0e96d1/pillow-12.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:a2b55dd6b2a4c4b7d87ffa56bdb33fdc5fdb9a462173861a7bc097f17d91cb09", size = 7227137, upload-time = "2026-07-01T11:54:22.025Z" },
+    { url = "https://files.pythonhosted.org/packages/de/47/4845a0a6c0dbf1db8456bd9fc791f13c5ced7ced20606d08a0aacfd25b49/pillow-12.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:331b624368d4f1d069149002f25f44bc61c8919ce8ddb3c45bdad8f6e2d89510", size = 2568267, upload-time = "2026-07-01T11:54:24.051Z" },
 ]
 
 [[package]]
@@ -1254,7 +1252,7 @@ requires-dist = [
     { name = "numba", specifier = "==0.65.1" },
     { name = "numpy", specifier = "==2.1.0" },
     { name = "pandas", specifier = "==2.2.3" },
-    { name = "pillow", specifier = "==12.2.0" },
+    { name = "pillow", specifier = "==12.3.0" },
     { name = "protobuf", specifier = ">=3.20.0,<=3.20.3" },
     { name = "psutil", specifier = "==7.0.0" },
     { name = "pyarrow", specifier = "==22.0.0" },

--- a/test/xgboost/scripts/check_versions.py
+++ b/test/xgboost/scripts/check_versions.py
@@ -1,0 +1,126 @@
+"""Verify installed package versions match the versions declared for the image.
+
+Runs inside the built xgboost container. Reads a declared-dependency file
+(copied in by the caller) and asserts the installed version of each package
+satisfies the declared specifier (==, >=, <, ~=, etc.).
+
+Two declaration formats are supported, chosen by file extension:
+  - requirements.txt  — one PEP 508 requirement per line (used by 3.0-5).
+  - pyproject.toml     — reads [project].dependencies (used by 3.2.0+).
+
+Bare entries with no specifier (e.g. `certifi`) can't be verified — logged and
+skipped. Unparsable lines are logged and skipped.
+
+Usage: python3 check_versions.py <requirements.txt | pyproject.toml path>
+
+Exits non-zero on any drift, with a summary of what changed.
+"""
+
+import importlib.metadata
+import sys
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.version import Version
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - fallback for older interpreters
+    tomllib = None
+
+
+def parse_requirements_txt(path):
+    reqs = []
+    unparsable = []
+    with open(path) as f:
+        for raw in f:
+            line = raw.split("#", 1)[0].strip()
+            if not line:
+                continue
+            try:
+                reqs.append((Requirement(line), line))
+            except InvalidRequirement:
+                unparsable.append(line)
+    return reqs, unparsable
+
+
+def parse_pyproject(path):
+    if tomllib is None:
+        print("tomllib unavailable; cannot parse pyproject.toml", file=sys.stderr)
+        sys.exit(1)
+    with open(path, "rb") as f:
+        data = tomllib.load(f)
+    entries = data.get("project", {}).get("dependencies", [])
+    reqs = []
+    unparsable = []
+    for line in entries:
+        try:
+            reqs.append((Requirement(line), line))
+        except InvalidRequirement:
+            unparsable.append(line)
+    return reqs, unparsable
+
+
+def parse_declared(path):
+    if path.endswith(".toml"):
+        return parse_pyproject(path)
+    return parse_requirements_txt(path)
+
+
+def installed_version(name):
+    for candidate in (name, name.replace("-", "_"), name.replace("_", "-")):
+        try:
+            return importlib.metadata.version(candidate)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return None
+
+
+def main(path):
+    reqs, unparsable = parse_declared(path)
+    if not reqs:
+        print(f"No dependencies found in {path}", file=sys.stderr)
+        sys.exit(1)
+
+    drift = []
+    missing = []
+    unconstrained = []
+    checked = 0
+
+    for req, raw in reqs:
+        actual = installed_version(req.name)
+        if actual is None:
+            missing.append(req.name)
+            continue
+        if not req.specifier:
+            unconstrained.append(raw)
+            continue
+        checked += 1
+        if Version(actual) not in req.specifier:
+            drift.append((req.name, str(req.specifier), actual))
+
+    print(f"Checked {checked} constrained packages against declared specifiers.")
+    if unconstrained:
+        print(f"Skipped {len(unconstrained)} unconstrained entries (no version specifier):")
+        for line in unconstrained:
+            print(f"  {line}")
+    if unparsable:
+        print(f"Skipped {len(unparsable)} unparsable lines:", file=sys.stderr)
+        for line in unparsable:
+            print(f"  {line}", file=sys.stderr)
+
+    if not drift and not missing:
+        print(f"All {checked} constrained packages satisfy declared specifiers.")
+        return
+
+    for name, spec, act in drift:
+        print(f"DRIFT: {name} declared{spec} but installed=={act}", file=sys.stderr)
+    for name in missing:
+        print(f"MISSING: {name} declared but not installed", file=sys.stderr)
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: check_versions.py <requirements.txt | pyproject.toml path>", file=sys.stderr)
+        sys.exit(2)
+    main(sys.argv[1])


### PR DESCRIPTION
## Purpose

Patch CVEs across XGBoost DLC images for framework_version 3.2.0, and move the package-version assertion into this repo so version pins are owned here.

## Images affected

`sagemaker-xgboost:3.2-0-cpu-py3`

## CVEs handled

| CVE | Package | Severity | Affected images | Action | Notes |
|---|---|---|---|---|---|
| CVE-2026-55379 | pillow | HIGH | sagemaker-xgboost:3.2-0-cpu-py3 | pyproject.toml bump (12.2.0 → 12.3.0) + uv lock | |

## Additional change: version check moved into DLC repo

The pillow bump surfaced that the local integration suite asserts installed versions against a manifest that lived in the upstream sagemaker-xgboost-container repo, so bumping a package here without a companion upstream change broke the test. This PR moves that check into the DLC repo (mirroring the existing sklearn pattern):

- Adds `test/xgboost/scripts/check_versions.py` — asserts each installed package satisfies the version declared for the image. Reads `pyproject.toml` (3.2.0+) or `requirements.txt` (3.0-5).
- Wires a "Verify pinned package versions" step into `xgboost.tests-integ-local.yml`, run inside the built image.
- Ignores the upstream `test/integration/local/test_versions.py` so the pin is owned here.

## Test plan

- [ ] CI security tests pass for affected xgboost variant
- [ ] CI sanity + local integration tests pass (including the new version check)
- [ ] **Reviewer must manually run the [Release - SageMaker XGBoost workflow](https://github.com/aws/deep-learning-containers/actions/workflows/dispatch-release-sagemaker-xgboost.yml) on this branch before merging.** PR CI does NOT include the upstream-repo integration tests (~2 hr); they only run in the release workflow. Required for any change that touches the Dockerfile or installed packages.

---
🤖 Generated by [Claude Code](https://claude.com/claude-code).
