### PR TITLE
feat(pytorch): promote 2.13 releases from gamma to production

### DIFF
--- a/.github/config/image/pytorch/2.13-ec2-cpu.yml
+++ b/.github/config/image/pytorch/2.13-ec2-cpu.yml
@@ -29,4 +29,4 @@ release:
   public_registry: true
   private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"

--- a/.github/config/image/pytorch/2.13-ec2-cuda.yml
+++ b/.github/config/image/pytorch/2.13-ec2-cuda.yml
@@ -36,4 +36,4 @@ release:
   public_registry: true
   private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"

--- a/.github/config/image/pytorch/2.13-sagemaker-cpu.yml
+++ b/.github/config/image/pytorch/2.13-sagemaker-cpu.yml
@@ -30,4 +30,4 @@ release:
   public_registry: true
   private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"

--- a/.github/config/image/pytorch/2.13-sagemaker-cuda.yml
+++ b/.github/config/image/pytorch/2.13-sagemaker-cuda.yml
@@ -37,4 +37,4 @@ release:
   public_registry: true
   private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"


### PR DESCRIPTION
# Promote PyTorch 2.13 releases from gamma to production

Follow-up to PR #6365 (PyTorch 2.13 currency, already merged).

## What this PR does

Flips `release.environment: "gamma"` -> `"production"` on all four 2.13 image configs so 2.13 autorelease publishes to prod ECR instead of gamma.

## Files changed (4 files, 4 lines)

- `.github/config/image/pytorch/2.13-ec2-cpu.yml`
- `.github/config/image/pytorch/2.13-ec2-cuda.yml`
- `.github/config/image/pytorch/2.13-sagemaker-cpu.yml`
- `.github/config/image/pytorch/2.13-sagemaker-cuda.yml`

## Validation

Gamma release cycle completed successfully. 2.13 gamma images validated end-to-end (build, tests, sagemaker training smoke). Ready for prod promotion.

## Test plan

- [ ] CI passes on this PR
- [ ] After merge: next 2.13 autorelease cron picks up the prod routing and publishes to prod ECR
- [ ] Prod ECR replication accounts receive the images