### PR TITLE
docs(tensorflow): bump cuDNN reference from 9.5.1.17 to 9.24.0.43

### DIFF
--- a/docs/tensorflow/changelog/index.md
+++ b/docs/tensorflow/changelog/index.md
@@ -10,13 +10,13 @@ Changelog for the Amazon Linux 2023-based TensorFlow SageMaker training images (
 **Tags:** `2.21-gpu-py312-cu129-amzn2023-sagemaker` · `2.21-cpu-py312-amzn2023-sagemaker` · `2.21.0-gpu-py312-cu129-amzn2023-sagemaker` ·
 `2.21.0-cpu-py312-amzn2023-sagemaker`
 
-**Bundled versions:** TensorFlow 2.21.0 · Python 3.12 · CUDA 12.9.1 · cuDNN 9.5.1.17 · NCCL 2.30.7 · EFA 1.49.0 · OpenMPI 4.1.8
+**Bundled versions:** TensorFlow 2.21.0 · Python 3.12 · CUDA 12.9.1 · cuDNN 9.24.0.43 · NCCL 2.30.7 · EFA 1.49.0 · OpenMPI 4.1.8
 
 ### Highlights
 
 - Initial release of the TensorFlow DLC on Amazon Linux 2023 and Python 3.12
 - TensorFlow 2.21.0 for SageMaker AI training (CPU and GPU variants)
-- CUDA 12.9.1 with cuDNN 9.5.1.17 and NCCL 2.30.7 on the GPU variant
+- CUDA 12.9.1 with cuDNN 9.24.0.43 and NCCL 2.30.7 on the GPU variant
 - EFA 1.49.0 with OpenMPI 4.1.8 for multi-node training on EFA-capable instances
 - SageMaker toolkits pre-installed: `sagemaker-tensorflow-training`, `sagemaker-training`
 - MLflow 3.9+, `smclarify`, `sagemaker>=3.4.0`, and SageMaker Studio integrations bundled

--- a/docs/tensorflow/index.md
+++ b/docs/tensorflow/index.md
@@ -23,7 +23,7 @@ The `2.21.0-*` fully-qualified tags (e.g. `2.21.0-gpu-py312-cu129-amzn2023-sagem
 The GPU image includes:
 
 - **TensorFlow 2.21.0** (`tensorflow==2.21.0`)
-- **CUDA 12.9.1** with **cuDNN 9.5.1.17** (`nvidia-cudnn-cu12`) and **NCCL 2.30.7** (`nvidia-nccl-cu12`) for multi-GPU collectives
+- **CUDA 12.9.1** with **cuDNN 9.24.0.43** (`nvidia-cudnn-cu12`) and **NCCL 2.30.7** (`nvidia-nccl-cu12`) for multi-GPU collectives
 - **[EFA](https://aws.amazon.com/hpc/efa/) 1.49.0** with **OpenMPI 4.1.8** for low-latency multi-node communication on EFA-capable instances
 - **[MPI for Python](https://mpi4py.readthedocs.io/) (`mpi4py`)** for multi-process Python coordination
 - **[SageMaker training toolkits](https://github.com/aws/sagemaker-tensorflow-training-toolkit)** — `sagemaker-tensorflow-training`,


### PR DESCRIPTION
Updates the TensorFlow 2.21 docs to reflect the cuDNN version pinned by #6418.

## Context

PR #6418 pinned `nvidia-cudnn-cu12` from `9.5.1.17` to `9.24.0.43` because cuDNN 9.5.x failed XLA autotuning of the fused `conv-bias-activation` kernel. The docs still referenced the pre-bump version.

## Changes

Both files under `docs/tensorflow/`:

```diff
- **CUDA 12.9.1** with **cuDNN 9.5.1.17** (\`nvidia-cudnn-cu12\`) and **NCCL 2.30.7** ...
+ **CUDA 12.9.1** with **cuDNN 9.24.0.43** (\`nvidia-cudnn-cu12\`) and **NCCL 2.30.7** ...
```

- `docs/tensorflow/index.md` — "What's Included" list on the framework landing page.
- `docs/tensorflow/changelog/index.md` — the 2.21 entry's bundled-versions row and highlights bullet.