### PR TITLE
docs: note PyTorch 2.8-2.10 Ubuntu images are not fully patchable

### DIFF
--- a/docs/src/templates/reference/support_policy.template.md
+++ b/docs/src/templates/reference/support_policy.template.md
@@ -10,6 +10,7 @@
 ## Notice
 
 - We cannot guarantee security patching on Ubuntu-based vLLM and SGLang images due to the lack of Ubuntu Pro licensing. Customers may continue using these images at their own discretion and risk. We recommend migrating to our Amazon Linux-based images.
+- We cannot fully patch Ubuntu-based PyTorch 2.8–2.10 images due to the lack of Ubuntu Pro licensing. Customers may continue using these images at their own discretion and risk. We recommend migrating to our Amazon Linux 2023-based PyTorch 2.11 or later images.
 - We are extending support for PyTorch 2.6 Inference images until end of June 2026 as these are the last available PyTorch inference images with torchserve support.
 - Scikit-Learn 1.4-2 for Python 3.10 is no longer supported. Please migrate to Scikit-Learn 1.4-2 for Python 3.12 (`sagemaker-scikit-learn:1.4-2-py312`).
 


### PR DESCRIPTION
## Purpose

Add a notice to the Framework Support Policy page clarifying that Ubuntu-based PyTorch 2.8–2.10 images cannot be fully patched due to the lack of Ubuntu Pro licensing, and advising customers to migrate to the Amazon Linux 2023-based PyTorch 2.11 or later images.

This mirrors the existing notice for Ubuntu-based vLLM and SGLang images, which have the same Ubuntu Pro licensing limitation. The change is a single line added to the `support_policy.template.md` static Notice section (the version tables are unaffected).

## Test Plan

- `mkdocs build --strict` renders the page without errors
- Documentation generation tests: `pytest test/docs/test_generate_support_policy.py`
- `pre-commit` markdown/formatting hooks on the changed file

## Test Result

- `mkdocs build --strict` — passed (exit 0); the new bullet renders in the generated `reference/support_policy.md`
- `pytest docs/test_generate_support_policy.py` — 8 passed
- `pre-commit` `trailing-whitespace`, `mdformat`, `flowmark`, `typos`, `check-merge-conflict` — passed on the changed file (file unmodified). Note: the `gitleaks` hook could not run in my environment due to a network restriction blocking its Go module download; the diff was manually verified to contain no secrets.

______________________________________________________________________

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [x] I ran `pre-commit` on the changed file before creating this PR (all markdown/formatting hooks passed; `gitleaks` could not install in my environment — see Test Result). (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
