### PR TITLE
docs(pytorch): register 2.13 images in docs generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <a href="https://aws.github.io/deep-learning-containers/reference/available_images/"><strong>Available Images</strong></a> · <a href="https://aws.github.io/deep-learning-containers/tutorials/"><strong>Tutorials</strong></a></p>
 
 <p align="center">
-  <a href="https://github.com/aws/deep-learning-containers/actions/workflows/pytorch.autorelease-2.12-ec2.yml"><img src="https://github.com/aws/deep-learning-containers/actions/workflows/pytorch.autorelease-2.12-ec2.yml/badge.svg" alt="Auto Release - PyTorch 2.12"></a>
+  <a href="https://github.com/aws/deep-learning-containers/actions/workflows/pytorch.autorelease-2.13-ec2.yml"><img src="https://github.com/aws/deep-learning-containers/actions/workflows/pytorch.autorelease-2.13-ec2.yml/badge.svg" alt="Auto Release - PyTorch 2.13"></a>
   <a href="https://github.com/aws/deep-learning-containers/actions/workflows/tensorflow.autorelease-2.21-sagemaker.yml"><img src="https://github.com/aws/deep-learning-containers/actions/workflows/tensorflow.autorelease-2.21-sagemaker.yml/badge.svg" alt="Auto Release - TensorFlow 2.21"></a>
   <a href="https://github.com/aws/deep-learning-containers/actions/workflows/vllm.autorelease-ec2-amzn2023.yml"><img src="https://github.com/aws/deep-learning-containers/actions/workflows/vllm.autorelease-ec2-amzn2023.yml/badge.svg" alt="Auto Release - vLLM"></a>
   <a href="https://github.com/aws/deep-learning-containers/actions/workflows/vllm-omni.autorelease-ec2.yml"><img src="https://github.com/aws/deep-learning-containers/actions/workflows/vllm-omni.autorelease-ec2.yml/badge.svg" alt="Auto Release - vLLM-Omni"></a>
@@ -29,6 +29,7 @@ ______________________________________________________________________
 
 ### 🚀 Release Highlights
 
+- **[2026/07/20]** [PyTorch v2.13.0](https://gallery.ecr.aws/deep-learning-containers/pytorch) — EC2: `2.13-cu133-amzn2023` · SageMaker: `2.13-cu133-amzn2023-sagemaker` · Amazon Linux 2023 with EFA, flash-attn, and Transformer Engine; PyTorch 2.13.0 with CUDA 13.3.0, NCCL 2.30.7, TE 2.17.0, DeepSpeed 0.19.2.
 - **[2026/07/15]** [vLLM v0.25.1 (Ubuntu)](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.25.1-gpu-py312-ec2` · SageMaker: `0.25.1-gpu-py312` · Patch release: defer TorchCodec FFmpeg import error to runtime (unblocks startup without system FFmpeg); guard mixed-dtype allreduce RMSNorm quant fusions (fixes NVFP4 garbage output).
 - **[2026/07/13]** [vLLM v0.25.0 (Ubuntu)](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.25.0-gpu-py312-ec2` · SageMaker: `0.25.0-gpu-py312` · LLaVA-OneVision-2, Unlimited OCR, MOSS-Transcribe-Diarize, openai/privacy-filter, Hy3.
 - **[2026/07/11]** [SGLang v0.5.15 (Ubuntu)](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.15-gpu-py312-ec2` · SageMaker: `0.5.15-gpu-py312` · GLM 5.2 Tuned, Hy3, HRM-Text, LocateAnything-3B.
@@ -36,7 +37,6 @@ ______________________________________________________________________
 - **[2026/07/06]** [SGLang Server v1.2 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `server-cuda-v1.2` · SageMaker: `server-sagemaker-cuda-v1.2` · SGLang `0.5.14`; adds support for the NVIDIA LocateAnything-3B vision-grounding model and upgrades sgl-kernel 0.4.4, FlashInfer 0.6.12, Mooncake 0.3.11.post1, NCCL 2.30.4, and EFA 1.49.0.
 - **[2026/07/02]** [vLLM Server v2.1 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `server-cuda-v2.1` · SageMaker: `server-sagemaker-cuda-v2.1` · vLLM `0.24.0`; adds JetBrains Mellum2-12B-A2.5B-Thinking (`MellumForCausalLM`); FlashInfer 0.6.12; drops the `transformers<5.10` pin (now requires transformers ≥ 5.5.3).
 - **[2026/07/02]** [vLLM-Omni v1.4 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `omni-cuda-v1.4` · SageMaker: `omni-sagemaker-cuda-v1.4` · SageMaker `/v1/videos` and `/v1/videos/sync` accept `application/json` again (JSON→multipart conversion restored); no framework bump (vLLM-Omni 0.21.0rc1).
-- **[2026/07/02]** [PyTorch v2.12.1](https://gallery.ecr.aws/deep-learning-containers/pytorch) — EC2: `2.12.1-cu130-amzn2023` · SageMaker: `2.12.1-cu130-amzn2023-sagemaker` · Amazon Linux 2023 with EFA, flash-attn, and Transformer Engine; PyTorch 2.12.1 bug-fix release (B200/Triton correctness fixes).
 
 ### 📢 Support Updates
 

--- a/docs/pytorch/changelog/index.md
+++ b/docs/pytorch/changelog/index.md
@@ -8,8 +8,8 @@ Changelog for the Amazon Linux 2023-based PyTorch images (`2.13-cu133-amzn2023`,
 
 **Tags:** `2.13-cu133-amzn2023` · `2.13-cpu-amzn2023` · `2.13-cu133-amzn2023-sagemaker` · `2.13-cpu-amzn2023-sagemaker`
 
-**Bundled versions:** PyTorch 2.13.0 · `torchvision` 0.28.0 · `torchaudio` 2.11.0 · CUDA 13.3.0 · Python 3.12 · NCCL 2.30.7 · EFA 1.49.0 · GDRCopy
-2.6 · flash-attn 2.8.3 · Transformer Engine 2.17.0 · DeepSpeed 0.19.2
+**Bundled versions:** PyTorch 2.13.0 · `torchvision` 0.28.0 · `torchaudio` 2.11.0 · CUDA 13.3.0 · Python 3.12 · NCCL 2.30.7 · EFA 1.49.0 · GDRCopy 2.6
+· flash-attn 2.8.3 · Transformer Engine 2.17.0 · DeepSpeed 0.19.2
 
 ### Highlights
 

--- a/docs/pytorch/changelog/index.md
+++ b/docs/pytorch/changelog/index.md
@@ -1,6 +1,21 @@
 # Changelog
 
-Changelog for the Amazon Linux 2023-based PyTorch images (`2.12-cu130-amzn2023`, `2.12-cpu-amzn2023`, and the corresponding `*-sagemaker` variants).
+Changelog for the Amazon Linux 2023-based PyTorch images (`2.13-cu133-amzn2023`, `2.13-cpu-amzn2023`, and the corresponding `*-sagemaker` variants).
+
+* * *
+
+## PyTorch 2.13 — 2026-07-20
+
+**Tags:** `2.13-cu133-amzn2023` · `2.13-cpu-amzn2023` · `2.13-cu133-amzn2023-sagemaker` · `2.13-cpu-amzn2023-sagemaker`
+
+**Bundled versions:** PyTorch 2.13.0 · `torchvision` 0.28.0 · `torchaudio` 2.11.0 · CUDA 13.3.0 · Python 3.12 · NCCL 2.30.7 · EFA 1.49.0 · GDRCopy
+2.6 · flash-attn 2.8.3 · Transformer Engine 2.17.0 · DeepSpeed 0.19.2
+
+### Highlights
+
+- Bumped PyTorch to 2.13.0, with `torchvision` 0.28.0
+- CUDA upgraded to 13.3.0 (new `cu133` tag); NCCL bumped to 2.30.7 and EFA to 1.49.0 for improved multi-node collective performance
+- Transformer Engine upgraded to 2.17.0 and DeepSpeed to 0.19.2
 
 * * *
 

--- a/docs/pytorch/index.md
+++ b/docs/pytorch/index.md
@@ -10,10 +10,10 @@ collectives, flash-attn and Transformer Engine for fused attention/FP8 kernels, 
 
 | Platform | Variant | Image |
 | --- | --- | --- |
-| {{ ec2_short }} / {{ eks_short }} | GPU | `public.ecr.aws/deep-learning-containers/pytorch:2.12-cu130-amzn2023` |
-| {{ ec2_short }} / {{ eks_short }} | CPU | `public.ecr.aws/deep-learning-containers/pytorch:2.12-cpu-amzn2023` |
-| {{ sagemaker }} | GPU | `public.ecr.aws/deep-learning-containers/pytorch:2.12-cu130-amzn2023-sagemaker` |
-| {{ sagemaker }} | CPU | `public.ecr.aws/deep-learning-containers/pytorch:2.12-cpu-amzn2023-sagemaker` |
+| {{ ec2_short }} / {{ eks_short }} | GPU | `public.ecr.aws/deep-learning-containers/pytorch:2.13-cu133-amzn2023` |
+| {{ ec2_short }} / {{ eks_short }} | CPU | `public.ecr.aws/deep-learning-containers/pytorch:2.13-cpu-amzn2023` |
+| {{ sagemaker }} | GPU | `public.ecr.aws/deep-learning-containers/pytorch:2.13-cu133-amzn2023-sagemaker` |
+| {{ sagemaker }} | CPU | `public.ecr.aws/deep-learning-containers/pytorch:2.13-cpu-amzn2023-sagemaker` |
 
 All images are also available on the [ECR Public Gallery](https://gallery.ecr.aws/deep-learning-containers/pytorch). For private ECR URIs, see
 [Image Access](../get_started/index.md).
@@ -22,15 +22,15 @@ All images are also available on the [ECR Public Gallery](https://gallery.ecr.aw
 
 The GPU images bundle the full distributed-training stack so you can launch multi-GPU and multi-node training without building a custom image:
 
-- **PyTorch 2.12.1** with `torchvision` 0.27.1 and `torchaudio` 2.11.0 (CUDA 13.0 wheels for the GPU variant, CPU wheels for the CPU variant)
-- **CUDA 13.0.2** with cuDNN and **NCCL 2.26.2** for multi-GPU collectives
-- **[EFA](https://aws.amazon.com/hpc/efa/) 1.47.0** with **OpenMPI** and the **AWS NCCL OFI plugin** for low-latency multi-node communication on
+- **PyTorch 2.13.0** with `torchvision` 0.28.0 and `torchaudio` 2.11.0 (CUDA 13.3 wheels for the GPU variant, CPU wheels for the CPU variant)
+- **CUDA 13.3.0** with cuDNN and **NCCL 2.30.7** for multi-GPU collectives
+- **[EFA](https://aws.amazon.com/hpc/efa/) 1.49.0** with **OpenMPI** and the **AWS NCCL OFI plugin** for low-latency multi-node communication on
   EFA-capable instances
-- **[GDRCopy](https://github.com/NVIDIA/gdrcopy) 2.4.4** userspace library for direct GPU-to-NIC memory copies
+- **[GDRCopy](https://github.com/NVIDIA/gdrcopy) 2.6** userspace library for direct GPU-to-NIC memory copies
 - **[flash-attn](https://github.com/Dao-AILab/flash-attention) 2.8.3** — fused attention kernels for transformer training
-- **[Transformer Engine](https://github.com/NVIDIA/TransformerEngine) 2.12.0** — FP8/BF16 mixed-precision primitives optimized for Hopper and newer
+- **[Transformer Engine](https://github.com/NVIDIA/TransformerEngine) 2.17.0** — FP8/BF16 mixed-precision primitives optimized for Hopper and newer
   GPUs
-- **[DeepSpeed](https://www.deepspeed.ai/) 0.18.8** — ZeRO sharding, pipeline parallel, and memory-efficient optimizers
+- **[DeepSpeed](https://www.deepspeed.ai/) 0.19.2** — ZeRO sharding, pipeline parallel, and memory-efficient optimizers
 - **[FastAI](https://www.fast.ai/)**, `boto3`, `botocore`, `requests`, `PyYAML`, `GitPython`, `Mako`
 - **NCCL test utility** — `all_reduce_perf` is pre-installed at `/usr/local/bin/all_reduce_perf` for verifying EFA/NCCL connectivity before training
 - **OpenSSH** server pre-configured (port 22) for inter-node communication in MPI/`torchrun` launches

--- a/docs/src/data/pytorch/2.13-cpu-ec2.yml
+++ b/docs/src/data/pytorch/2.13-cpu-ec2.yml
@@ -1,0 +1,13 @@
+framework: PyTorch
+version: "2.13"
+accelerator: cpu
+python: py312
+os: amzn2023
+platform: ec2
+ga: "2026-07-20"
+eop: "2027-07-20"
+public_registry: true
+
+tags:
+  - "2.13.0-cpu-amzn2023"
+  - "2.13-cpu-amzn2023"

--- a/docs/src/data/pytorch/2.13-cpu-sagemaker.yml
+++ b/docs/src/data/pytorch/2.13-cpu-sagemaker.yml
@@ -1,0 +1,13 @@
+framework: PyTorch
+version: "2.13"
+accelerator: cpu
+python: py312
+os: amzn2023
+platform: sagemaker
+ga: "2026-07-20"
+eop: "2027-07-20"
+public_registry: true
+
+tags:
+  - "2.13.0-cpu-amzn2023-sagemaker"
+  - "2.13-cpu-amzn2023-sagemaker"

--- a/docs/src/data/pytorch/2.13-cuda-ec2.yml
+++ b/docs/src/data/pytorch/2.13-cuda-ec2.yml
@@ -1,0 +1,14 @@
+framework: PyTorch
+version: "2.13"
+accelerator: gpu
+python: py312
+cuda: cu133
+os: amzn2023
+platform: ec2
+ga: "2026-07-20"
+eop: "2027-07-20"
+public_registry: true
+
+tags:
+  - "2.13.0-cu133-amzn2023"
+  - "2.13-cu133-amzn2023"

--- a/docs/src/data/pytorch/2.13-cuda-sagemaker.yml
+++ b/docs/src/data/pytorch/2.13-cuda-sagemaker.yml
@@ -1,0 +1,14 @@
+framework: PyTorch
+version: "2.13"
+accelerator: gpu
+python: py312
+cuda: cu133
+os: amzn2023
+platform: sagemaker
+ga: "2026-07-20"
+eop: "2027-07-20"
+public_registry: true
+
+tags:
+  - "2.13.0-cu133-amzn2023-sagemaker"
+  - "2.13-cu133-amzn2023-sagemaker"


### PR DESCRIPTION
## Summary

Registers the 4 released PyTorch 2.13 image configs in `docs/src/data/pytorch/` so the auto-generated DLC docs pages reflect 2.13 availability.

Follow-up to:
- PR #6365 — PyTorch 2.13 currency scaffold
- PR #6431 — 2.13 promoted from gamma to production

## Registered image tags

| Config | prod_image tag |
|---|---|
| 2.13-ec2-cuda | `pytorch:2.13-cu133-amzn2023` |
| 2.13-ec2-cpu | `pytorch:2.13-cpu-amzn2023` |
| 2.13-sagemaker-cuda | `pytorch:2.13-cu133-amzn2023-sagemaker` |
| 2.13-sagemaker-cpu | `pytorch:2.13-cpu-amzn2023-sagemaker` |

Common: `framework_version` 2.13.0, Python 3.12, OS `amzn2023`, CUDA 13.3.0 (GPU only), GA 2026-07-20, EOP 2027-07-20. Pattern mirrors the 2.12 registration in PR #6339.

## Test plan

- [ ] Docs build passes (`python docs/src/main.py --verbose`)
- [ ] `available_images.md` renders 2.13 rows (cpu/gpu x ec2/sagemaker)
- [ ] `support_policy.md` reflects new 2.13 GA/EOP dates
- [ ] CI green