### PR TITLE
[auto-cve-patch] [ray] bump uv + pyasn1, allowlist jackson-core GHSA

### DIFF
--- a/docker/ray/Dockerfile.cpu
+++ b/docker/ray/Dockerfile.cpu
@@ -38,7 +38,7 @@ COPY ./scripts/docker/common/install_python.sh /tmp/install_python.sh
 RUN bash /tmp/install_python.sh ${PYTHON_VERSION} && rm /tmp/install_python.sh
 
 # Install pinned dependencies
-COPY --from=ghcr.io/astral-sh/uv:0.11.10 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.31 /uv /usr/local/bin/uv
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 COPY ./docker/ray/pyproject.toml ./docker/ray/uv.lock /tmp/deps/
 RUN --mount=type=cache,target=/root/.cache/uv cd /tmp/deps \

--- a/docker/ray/Dockerfile.cuda
+++ b/docker/ray/Dockerfile.cuda
@@ -67,7 +67,7 @@ COPY ./scripts/docker/common/install_python.sh /tmp/install_python.sh
 RUN bash /tmp/install_python.sh ${PYTHON_VERSION} && rm /tmp/install_python.sh
 
 # Install pinned dependencies
-COPY --from=ghcr.io/astral-sh/uv:0.11.10 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.31 /uv /usr/local/bin/uv
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 COPY ./docker/ray/pyproject.toml ./docker/ray/uv.lock /tmp/deps/
 RUN --mount=type=cache,target=/root/.cache/uv cd /tmp/deps \

--- a/docker/ray/uv.lock
+++ b/docker/ray/uv.lock
@@ -1261,11 +1261,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]

--- a/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
@@ -30,16 +30,6 @@
         "review_by": "2026-08-24"
     },
     {
-        "vulnerability_id": "RUSTSEC-2026-0195",
-        "reason": "quick-xml 0.39.2 is bundled inside the uv binary at /usr/local/bin/uv (uv is statically compiled Rust). Advisory is a denial-of-service in NsReader's namespace resolution during Start/Empty XML event handling; the vulnerable code path is only reachable when uv parses attacker-controlled XML (e.g. a hostile PyPI mirror index). uv is retained in the image for customer-side venv management; the standard PyPI flow uses JSON/HTML endpoints and never exercises the XML path. No uv release containing the patched quick-xml>=0.41.0 has been published upstream yet; will swap to a pinned fixed version and drop this entry when upstream ships.",
-        "review_by": "2026-10-25"
-    },
-    {
-        "vulnerability_id": "RUSTSEC-2026-0185",
-        "reason": "quinn-proto in uv binary, upstream uv has not released a fix yet",
-        "review_by": "2026-09-29"
-    },
-    {
         "vulnerability_id": "CVE-2026-54513",
         "reason": "jackson-databind 2.18.6 bundled in ray_dist.jar, cannot patch without upstream ray rebuild",
         "review_by": "2026-09-29"
@@ -93,5 +83,10 @@
         "vulnerability_id": "CVE-2026-57516",
         "reason": "ray 2.55.1 WebDataset reader unsafe deserialization, fix requires ray>=2.56.0 which is not yet released for our pinned version",
         "review_by": "2026-09-10"
+    },
+    {
+        "vulnerability_id": "GHSA-r7wm-3cxj-wff9",
+        "reason": "jackson-core 2.18.6 bundled in ray_dist.jar, cannot patch without upstream ray rebuild",
+        "review_by": "2026-10-20"
     }
 ]


### PR DESCRIPTION
## Purpose

Patch CVEs across Ray DLC images.

## Images affected

`ray:serve-ml-cpu-v1`, `ray:serve-ml-cuda-v1`, `ray:serve-ml-sagemaker-cpu-v1`, `ray:serve-ml-sagemaker-cuda-v1`

## CVEs handled

| CVE | Package | Severity | Affected images | Action | Notes |
|---|---|---|---|---|---|
| CVE-2026-59885 | pyasn1 | HIGH | cpu, cuda, sagemaker-cpu, sagemaker-cuda | bump 0.6.3 -> 0.6.4 | via `uv lock --upgrade-package pyasn1` |
| CVE-2026-59886 | pyasn1 | HIGH | cpu, cuda, sagemaker-cpu, sagemaker-cuda | bump 0.6.3 -> 0.6.4 | via `uv lock --upgrade-package pyasn1` |
| RUSTSEC-2026-0195 | quick-xml (vendored in uv) | HIGH | cpu, cuda, sagemaker-cpu, sagemaker-cuda | bump uv 0.11.10 -> 0.11.31 | uv 0.11.31 ships quick-xml 0.41.0; drops existing allowlist entry |
| RUSTSEC-2026-0185 | quinn-proto (vendored in uv) | HIGH | cpu, cuda, sagemaker-cpu, sagemaker-cuda | bump uv 0.11.10 -> 0.11.31 | uv 0.11.31 ships quinn-proto 0.11.15; drops existing allowlist entry |
| GHSA-r7wm-3cxj-wff9 | jackson-core (in ray_dist.jar) | HIGH | cpu, cuda, sagemaker-cpu, sagemaker-cuda | allowlist | bundled in ray_dist.jar; needs upstream ray rebuild |

**Prunes**: Dropped 2 existing allowlist entries (RUSTSEC-2026-0195, RUSTSEC-2026-0185) — the uv bump ships fixes for both vendored Rust crates.

## Test plan

- [x] CI security tests pass for cpu and cuda
- [x] CI sanity tests pass for cpu and cuda
- [x] CI Ray-specific tests pass

---
Generated by [Claude Code](https://claude.com/claude-code).
