### PR TITLE
change: vllm 0.25.1 vbump to fix image crash

### DIFF
--- a/.github/config/image/huggingface-vllm/sagemaker.yml
+++ b/.github/config/image/huggingface-vllm/sagemaker.yml
@@ -4,7 +4,7 @@ image:
 
 metadata:
   framework: "huggingface-vllm"
-  framework_version: "0.25.0"
+  framework_version: "0.25.1"
   os_version: "ubuntu22.04"
   customer_type: "sagemaker"
   platform: "sagemaker"
@@ -17,7 +17,7 @@ metadata:
 build:
   dockerfile: "docker/huggingface/vllm/Dockerfile"
   target: "huggingface-vllm-sagemaker"
-  base_image: "public.ecr.aws/deep-learning-containers/vllm:0.25.0-gpu-py312-cu130-ubuntu22.04-sagemaker-v1.0"
+  base_image: "public.ecr.aws/deep-learning-containers/vllm:0.25.1-gpu-py312-cu130-ubuntu22.04-sagemaker-v1.0"
   python_version: "3.12"
   cuda_version: "13.0.2"
   transformers_version: "5.10.2"

--- a/docker/huggingface/vllm/Dockerfile
+++ b/docker/huggingface/vllm/Dockerfile
@@ -1,9 +1,9 @@
-ARG BASE_IMAGE=public.ecr.aws/deep-learning-containers/vllm:0.25.0-gpu-py312-cu130-ubuntu22.04-sagemaker-v1.0
+ARG BASE_IMAGE=public.ecr.aws/deep-learning-containers/vllm:0.25.1-gpu-py312-cu130-ubuntu22.04-sagemaker-v1.0
 
 FROM ${BASE_IMAGE} AS base
 
 ARG FRAMEWORK=huggingface-vllm
-ARG FRAMEWORK_VERSION=0.25.0
+ARG FRAMEWORK_VERSION=0.25.1
 ARG CONTAINER_TYPE=general
 ARG DLC_MAJOR_VERSION=1
 
@@ -90,6 +90,7 @@ RUN dpkg -l | grep -E "cuda|nvidia|libnv" | awk '{print $2}' | xargs apt-mark ho
     --disable-debug \
     --disable-doc \
     --enable-gpl \
+    --enable-shared \
     --enable-libmp3lame \
     --enable-libopus \
     --enable-libvorbis \
@@ -98,6 +99,8 @@ RUN dpkg -l | grep -E "cuda|nvidia|libnv" | awk '{print $2}' | xargs apt-mark ho
     --enable-libx265 \
   && make -j"$(nproc)" \
   && make install \
+  && echo /usr/local/lib >/etc/ld.so.conf.d/ffmpeg-local.conf \
+  && ldconfig \
   && which ffmpeg \
   && ffmpeg -version \
   && ffprobe -version \

--- a/docs/src/data/huggingface-vllm/0.25.1-gpu-sagemaker.yml
+++ b/docs/src/data/huggingface-vllm/0.25.1-gpu-sagemaker.yml
@@ -1,5 +1,5 @@
 framework: vLLM
-version: "0.25.0"
+version: "0.25.1"
 accelerator: gpu
 python: py312
 cuda: cu130
@@ -8,4 +8,4 @@ os: ubuntu22.04
 platform: sagemaker
 
 tags:
-  - "0.25.0-transformers5.10.2-gpu-py312-cu130-ubuntu22.04"
+  - "0.25.1-transformers5.10.2-gpu-py312-cu130-ubuntu22.04"

--- a/test/sanity/scripts/test_sanity_vllm_sglang.py
+++ b/test/sanity/scripts/test_sanity_vllm_sglang.py
@@ -283,6 +283,59 @@ class TestPackageVersionConsistency(unittest.TestCase):
             f"Framework version {actual} doesn't match expected {expected_mm}",
         )
 
+    def test_server_entrypoint_imports(self):
+        """vLLM server entrypoint module must import cleanly.
+
+        Startup guard: the vLLM process imports this module under supervisord,
+        so anything that throws here crash-loops the container and fails the
+        /ping health check. vLLM 0.25.1 defers the torchcodec import to runtime
+        (PR vllm-project/vllm#47888), so this no longer catches a missing FFmpeg
+        runtime by itself — test_torchcodec_video_backend_loads covers that. It
+        still catches any import-time regression (e.g. a future re-eager import).
+        """
+        try:
+            import vllm  # noqa: F401
+        except ImportError:
+            self.skipTest("vllm not installed (sglang image)")
+        result = subprocess.run(
+            [sys.executable, "-c", "import vllm.entrypoints.openai.api_server"],
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"Importing vLLM server entrypoint failed:\n{result.stderr}",
+        )
+
+    def test_torchcodec_video_backend_loads(self):
+        """torchcodec's video backend must load its FFmpeg-backed native lib.
+
+        Reproduces the report's failing chain: `from torchcodec.decoders import
+        VideoDecoder` dlopen's libtorchcodec_core*.so, which links
+        libavutil.so.* (and siblings). The huggingface-vllm image builds FFmpeg
+        from source; if it isn't built with --enable-shared / registered with
+        ldconfig, the shared libs are absent and this raises. vLLM 0.25.1 makes
+        the import lazy, so the failure moves from container start to the first
+        actual video decode — this guards that runtime path directly.
+        """
+        try:
+            import torchcodec  # noqa: F401
+        except ImportError:
+            self.skipTest("torchcodec not installed")
+        result = subprocess.run(
+            [sys.executable, "-c", "from torchcodec.decoders import VideoDecoder"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"torchcodec failed to load its FFmpeg runtime:\n{result.stderr}",
+        )
+
     def test_python_version(self):
         """Python major.minor should match the declared version."""
         expected = os.environ.get("EXPECTED_PYTHON_VERSION", "")

--- a/test/sanity/scripts/test_sanity_vllm_sglang.py
+++ b/test/sanity/scripts/test_sanity_vllm_sglang.py
@@ -314,12 +314,18 @@ class TestPackageVersionConsistency(unittest.TestCase):
 
         Reproduces the report's failing chain: `from torchcodec.decoders import
         VideoDecoder` dlopen's libtorchcodec_core*.so, which links
-        libavutil.so.* (and siblings). The huggingface-vllm image builds FFmpeg
-        from source; if it isn't built with --enable-shared / registered with
-        ldconfig, the shared libs are absent and this raises. vLLM 0.25.1 makes
-        the import lazy, so the failure moves from container start to the first
-        actual video decode — this guards that runtime path directly.
+        libavutil.so.* (and siblings). Only images that ship an FFmpeg runtime
+        are expected to satisfy this — the huggingface-vllm image builds FFmpeg
+        from source; base vLLM / SGLang images bundle torchcodec without FFmpeg
+        and are skipped. If ffmpeg is present but not built with --enable-shared
+        / registered via ldconfig, the shared libs are absent and this raises.
+        vLLM 0.25.1 makes the import lazy, so the failure moves from container
+        start to the first actual video decode — this guards that runtime path.
         """
+        import shutil
+
+        if not shutil.which("ffmpeg"):
+            self.skipTest("image ships no ffmpeg runtime (video backend N/A)")
         try:
             import torchcodec  # noqa: F401
         except ImportError:

--- a/test/security/data/ecr_scan_allowlist/huggingface-vllm/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/huggingface-vllm/framework_allowlist.json
@@ -108,5 +108,10 @@
         "vulnerability_id": "CVE-2026-24747",
         "reason": "false positive: torch 2.9.1 is referenced only in a stray text file (dist-packages/benchmarks/requirements.txt) shipped by the upstream vllm-openai base, not an installed package; the image's installed torch is 2.11.0, which already contains the 2.10.0 weights_only unpickler fix",
         "review_by": "2026-09-25"
+    },
+    {
+        "vulnerability_id": "GHSA-hrxh-6v49-42gf",
+        "reason": "google.golang.org/grpc v1.79.3 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-08-30"
     }
 ]


### PR DESCRIPTION
## Purpose
The `huggingface-vllm` SageMaker DLC crash-loops at container start and fails the`/ping` health check. vLLM ≥ 0.25 imports `torchcodec` on the server import path, which `dlopen`s `libavutil.so.*`. The image builds FFmpeg `n8.1` from source, but  FFmpeg's `./configure` defaults to `--disable-shared`, so only static `.a` archives were installed -> the `libavutil.so.60` shared objects torchcodec needs were never produced. `import vllm` therefore throws.

 ### Fix
 `docker/huggingface/vllm/Dockerfile`, FFmpeg-from-source step:
   - add `--enable-shared` -> installs `libavutil.so.60` and siblings
   - register `/usr/local/lib` (`ld.so.conf.d` entry) and run `ldconfig` -> puts them on
     the loader path

 vLLM 0.25.1 (PR vllm-project/vllm#47888) makes the torchcodec import lazy, which stops the startup crash (this was true for versions < 0.25) but a missing FFmpeg runtime would still break the moment a multimodal model decodes video, so the image-side fix is required regardless.

## PR Checklist

- [x] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).