### PR TITLE
[auto-cve-patch] [tensorflow] bump GitPython + pyasn1, prune 2 stale RUSTSEC entries

### DIFF
--- a/docker/tensorflow/2.21/cpu/pyproject.toml
+++ b/docker/tensorflow/2.21/cpu/pyproject.toml
@@ -24,12 +24,19 @@ dependencies = [
     # mistune>=3.3.0   — CVE-2026-59922 + CVE-2026-49851 (HIGH,
     #                    quadratic-work DoS in markdown parser; transitive via
     #                    notebook / sagemaker-studio-analytics-extension)
+    # GitPython>=3.1.52 — GHSA-956x-8gvw-wg5v + GHSA-v396-v7q4-x2qj + GHSA-2f96-g7mh-g2hx
+    #                    (3.1.51) and GHSA-rwj8-pgh3-r573 (3.1.52) — argument-injection
+    #                    and clone-URL command-injection in Git.polish_url path
+    # pyasn1>=0.6.4    — CVE-2026-59885 + CVE-2026-59886 (HIGH, quadratic-time
+    #                    decoding + big-integer exponentiation DoS)
     "PyJWT>=2.13.0",
     "cryptography>=48.0.1",
     "starlette>=1.3.1",
     "tornado>=6.5.6",
     "soupsieve>=2.8.4",
     "mistune>=3.3.0",
+    "GitPython>=3.1.52",
+    "pyasn1>=0.6.4",
     # TF compat pins
     "numpy>=2.1,<2.5",
     "requests",

--- a/docker/tensorflow/2.21/cpu/uv.lock
+++ b/docker/tensorflow/2.21/cpu/uv.lock
@@ -851,14 +851,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", size = 225071, upload-time = "2026-07-23T02:52:43.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", size = 216590, upload-time = "2026-07-23T02:52:41.932Z" },
 ]
 
 [[package]]
@@ -2301,11 +2301,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]
@@ -3315,6 +3315,7 @@ dependencies = [
     { name = "boto3", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "botocore", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "cryptography", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "gitpython", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "h5py", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "mistune", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "mpi4py", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -3323,6 +3324,7 @@ dependencies = [
     { name = "pillow", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "protobuf", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "psutil", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pyasn1", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "pybind11", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "pyjwt", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "python-dateutil", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -3374,6 +3376,7 @@ requires-dist = [
     { name = "botocore" },
     { name = "cloudpickle", marker = "extra == 'sagemaker'" },
     { name = "cryptography", specifier = ">=48.0.1" },
+    { name = "gitpython", specifier = ">=3.1.52" },
     { name = "h5py" },
     { name = "imageio", marker = "extra == 'sagemaker'" },
     { name = "mistune", specifier = ">=3.3.0" },
@@ -3388,6 +3391,7 @@ requires-dist = [
     { name = "plotly", marker = "extra == 'sagemaker'" },
     { name = "protobuf" },
     { name = "psutil" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pybind11" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-dateutil" },

--- a/docker/tensorflow/2.21/cuda/pyproject.toml
+++ b/docker/tensorflow/2.21/cuda/pyproject.toml
@@ -28,12 +28,19 @@ dependencies = [
     # mistune>=3.3.0   — CVE-2026-59922 + CVE-2026-49851 (HIGH,
     #                    quadratic-work DoS in markdown parser; transitive via
     #                    notebook / sagemaker-studio-analytics-extension)
+    # GitPython>=3.1.52 — GHSA-956x-8gvw-wg5v + GHSA-v396-v7q4-x2qj + GHSA-2f96-g7mh-g2hx
+    #                    (3.1.51) and GHSA-rwj8-pgh3-r573 (3.1.52) — argument-injection
+    #                    and clone-URL command-injection in Git.polish_url path
+    # pyasn1>=0.6.4    — CVE-2026-59885 + CVE-2026-59886 (HIGH, quadratic-time
+    #                    decoding + big-integer exponentiation DoS)
     "PyJWT>=2.13.0",
     "cryptography>=48.0.1",
     "starlette>=1.3.1",
     "tornado>=6.5.6",
     "soupsieve>=2.8.4",
     "mistune>=3.3.0",
+    "GitPython>=3.1.52",
+    "pyasn1>=0.6.4",
     # TF compat pins
     "numpy>=2.1,<2.5",
     "requests",

--- a/docker/tensorflow/2.21/cuda/uv.lock
+++ b/docker/tensorflow/2.21/cuda/uv.lock
@@ -913,14 +913,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", size = 225071, upload-time = "2026-07-23T02:52:43.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", size = 216590, upload-time = "2026-07-23T02:52:41.932Z" },
 ]
 
 [[package]]
@@ -2535,11 +2535,11 @@ wheels = [
 
 [[package]]
 name = "pyasn1"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a4/9a/23310166d960def5897e91fe20e5b724601b02a22e84ba1f94232c0b7f67/pyasn1-0.6.4.tar.gz", hash = "sha256:9c447d8431c947fe4c8febc4ed9e760bc29011a5b01e5c74b67025bd9fb8ce81", size = 151262, upload-time = "2026-07-09T01:12:33.988Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/3b/6163796d69c3977d1e4287bea4a6979161cbbdd170ebb430511e8e1999ce/pyasn1-0.6.4-py3-none-any.whl", hash = "sha256:deda9277cfd454080ec40b207fb6df82206a3a2688735233cdcd8d3d565f088b", size = 84410, upload-time = "2026-07-09T01:12:32.92Z" },
 ]
 
 [[package]]
@@ -3549,6 +3549,7 @@ dependencies = [
     { name = "boto3", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "botocore", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "cryptography", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "gitpython", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "h5py", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "mistune", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "mpi4py", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -3558,6 +3559,7 @@ dependencies = [
     { name = "packaging", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "pillow", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "protobuf", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pyasn1", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "pybind11", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "pyjwt", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "python-dateutil", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -3608,6 +3610,7 @@ requires-dist = [
     { name = "botocore" },
     { name = "cloudpickle", marker = "extra == 'sagemaker'" },
     { name = "cryptography", specifier = ">=48.0.1" },
+    { name = "gitpython", specifier = ">=3.1.52" },
     { name = "h5py" },
     { name = "imageio", marker = "extra == 'sagemaker'" },
     { name = "mistune", specifier = ">=3.3.0" },
@@ -3623,6 +3626,7 @@ requires-dist = [
     { name = "pillow", specifier = ">=12.3.0" },
     { name = "plotly", marker = "extra == 'sagemaker'" },
     { name = "protobuf" },
+    { name = "pyasn1", specifier = ">=0.6.4" },
     { name = "pybind11" },
     { name = "pyjwt", specifier = ">=2.13.0" },
     { name = "python-dateutil" },

--- a/test/security/data/ecr_scan_allowlist/tensorflow/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/tensorflow/framework_allowlist.json
@@ -8,15 +8,5 @@
         "vulnerability_id": "CVE-2025-23339",
         "reason": "cuda-toolkit-config-common@12.9.79 ships with the nvidia/cuda:12.9.1-base-amzn2023 base image. Advisory affects an NVML/driver path reachable only by a local privileged caller on the host; not on the in-container training/inference path (nvdisasm and similar privileged binaries are already removed in the Dockerfile). Upstream fix is only available in CUDA 13.0; a 12.9 -> 13.0 bump is out of scope for this PR (TF 2.21 compatibility risk). Will be picked up via the next CUDA base image refresh from NVIDIA.",
         "review_by": "2026-12-08"
-    },
-    {
-        "vulnerability_id": "RUSTSEC-2026-0185",
-        "reason": "quinn-proto 0.11.14 is bundled inside the uv binary at /usr/local/bin/uv (uv is statically compiled Rust). Advisory is a denial-of-service in quinn-proto's QUIC/HTTP-3 stream assembler; the vulnerable code path is only reachable when uv talks to a malicious HTTP/3 server. uv is retained in the image for customer-side venv management; the standard PyPI flow uses HTTPS/1.1+ and never exercises the HTTP/3 path. No uv release containing the patched quinn-proto>=0.11.15 has been published upstream yet (verified through uv 0.11.24, 2026-06-23); will swap to a pinned fixed version and drop this entry when upstream ships.",
-        "review_by": "2026-10-25"
-    },
-    {
-        "vulnerability_id": "RUSTSEC-2026-0195",
-        "reason": "quick-xml 0.39.2 is bundled inside the uv binary at /usr/local/bin/uv (uv is statically compiled Rust). Advisory is a denial-of-service in NsReader's namespace resolution during Start/Empty XML event handling; the vulnerable code path is only reachable when uv parses attacker-controlled XML (e.g. a hostile PyPI mirror index). uv is retained in the image for customer-side venv management; the standard PyPI flow uses JSON/HTML endpoints and never exercises the XML path. No uv release containing the patched quick-xml>=0.41.0 has been published upstream yet; will swap to a pinned fixed version and drop this entry when upstream ships.",
-        "review_by": "2026-10-25"
     }
 ]


### PR DESCRIPTION
## Purpose

Patch CVEs across TensorFlow DLC images for framework_version 2.21.0.

## Images affected

- `tensorflow-training:2.21-cpu-py312-amzn2023-sagemaker-v1`
- `tensorflow-training:2.21-gpu-py312-cu129-amzn2023-sagemaker-v1`

## CVEs handled

| CVE | Package | Severity | Affected images | Action | Notes |
|---|---|---|---|---|---|
| CVE-2026-59885 | pyasn1 | HIGH | both variants | pyproject.toml floor + uv lock | |
| CVE-2026-59886 | pyasn1 | HIGH | both variants | pyproject.toml floor + uv lock | |
| GHSA-956x-8gvw-wg5v | GitPython | HIGH | both variants | pyproject.toml floor + uv lock | |
| GHSA-v396-v7q4-x2qj | GitPython | HIGH | both variants | pyproject.toml floor + uv lock | |
| GHSA-2f96-g7mh-g2hx | GitPython | HIGH | both variants | pyproject.toml floor + uv lock | |
| GHSA-rwj8-pgh3-r573 | GitPython | HIGH | both variants | pyproject.toml floor + uv lock | |

**Prunes:** dropped 2 uv-vendored RUSTSEC entries (RUSTSEC-2026-0185, RUSTSEC-2026-0195) — quinn-proto and quick-xml fixes have shipped in uv and no longer fire on the deployed images.

## Test plan

- [x] CI security tests pass for both variants
- [x] CI sanity tests pass

---
Generated by [Claude Code](https://claude.com/claude-code).
