### PR TITLE
[auto-cve-patch] [ray] bump uv 0.11.31 -> 0.11.32 (RUSTSEC-2026-0195)

### DIFF
--- a/docker/ray/Dockerfile.cpu
+++ b/docker/ray/Dockerfile.cpu
@@ -38,7 +38,7 @@ COPY ./scripts/docker/common/install_python.sh /tmp/install_python.sh
 RUN bash /tmp/install_python.sh ${PYTHON_VERSION} && rm /tmp/install_python.sh
 
 # Install pinned dependencies
-COPY --from=ghcr.io/astral-sh/uv:0.11.31 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /usr/local/bin/uv
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 COPY ./docker/ray/pyproject.toml ./docker/ray/uv.lock /tmp/deps/
 RUN --mount=type=cache,target=/root/.cache/uv cd /tmp/deps \

--- a/docker/ray/Dockerfile.cuda
+++ b/docker/ray/Dockerfile.cuda
@@ -67,7 +67,7 @@ COPY ./scripts/docker/common/install_python.sh /tmp/install_python.sh
 RUN bash /tmp/install_python.sh ${PYTHON_VERSION} && rm /tmp/install_python.sh
 
 # Install pinned dependencies
-COPY --from=ghcr.io/astral-sh/uv:0.11.31 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /usr/local/bin/uv
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 COPY ./docker/ray/pyproject.toml ./docker/ray/uv.lock /tmp/deps/
 RUN --mount=type=cache,target=/root/.cache/uv cd /tmp/deps \


### PR DESCRIPTION
## Purpose

Patch CVEs across Ray DLC images.

## Images affected

`ray:serve-ml-cpu-v1`, `ray:serve-ml-cuda-v1`, `ray:serve-ml-sagemaker-cpu-v1`, `ray:serve-ml-sagemaker-cuda-v1`

## CVEs handled

| CVE | Package | Severity | Affected images | Action | Notes |
|---|---|---|---|---|---|
| RUSTSEC-2026-0195 | quick-xml | HIGH | cuda, sagemaker-cpu | bump uv 0.11.31 -> 0.11.32 | vendored in `/usr/local/bin/uvx`; uv 0.11.32 ships quick-xml 0.41.0 (fixed version) |

## Test plan

- [x] CI security tests pass for cpu and gpu
- [x] CI sanity tests pass for cpu and gpu
- [x] CI Ray-specific tests pass

---
🤖 Generated by [Claude Code](https://claude.com/claude-code).