### PR TITLE
add: improved huggingface-vllm tests

### DIFF
--- a/.github/workflows/_reusable.sanity-tests.yml
+++ b/.github/workflows/_reusable.sanity-tests.yml
@@ -136,6 +136,7 @@ jobs:
         if: |
           needs.preflight.outputs.framework == 'vllm' ||
           needs.preflight.outputs.framework == 'vllm_server' ||
+          needs.preflight.outputs.framework == 'huggingface-vllm' ||
           needs.preflight.outputs.framework == 'sglang' ||
           needs.preflight.outputs.framework == 'sglang_server'
         run: |

--- a/.github/workflows/huggingface-vllm.pipeline.yml
+++ b/.github/workflows/huggingface-vllm.pipeline.yml
@@ -80,6 +80,50 @@ jobs:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
+  hf-sanity-test:
+    if: ${{ always() && !failure() && !cancelled() && inputs.run-sanity-test }}
+    needs: [build]
+    concurrency:
+      group: ${{ github.workflow }}-hf-sanity-test-${{ inputs.config-file }}-${{ github.ref }}
+      cancel-in-progress: true
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve image URI
+        id: image
+        uses: ./.github/actions/resolve-image-uri
+        with:
+          image-uri: ${{ needs.build.outputs.image-uri || '' }}
+          ci-aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          prod-aws-account-id: ${{ vars.PROD_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+          config-file: ${{ inputs.config-file }}
+
+      - name: Check image exists
+        id: check
+        uses: ./.github/actions/check-image-exists
+        with:
+          image-uri: ${{ steps.image.outputs.image-uri }}
+
+      - name: ECR login and pull image
+        if: steps.check.outputs.exists == 'true'
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ steps.image.outputs.aws-account-id }}
+          aws-region: ${{ vars.AWS_REGION }}
+          image-uri: ${{ steps.image.outputs.image-uri }}
+
+      - name: Run Hugging Face vLLM sanity tests
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          docker run --rm -v $(pwd):/workdir --workdir /workdir \
+            --entrypoint python3 ${{ steps.image.outputs.image-uri }} \
+            test/sanity/scripts/test_sanity_huggingface_vllm.py
+
   security-test:
     if: ${{ always() && !failure() && !cancelled() && inputs.run-security-test }}
     needs: [build]
@@ -113,6 +157,57 @@ jobs:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
+  hf-endpoint-boot-test:
+    # vllm.tests-sagemaker.yml gates its whole endpoint-test job on the
+    # vllm-sagemaker-endpoint-tests.yml matrix, and every entry there requires
+    # os_version amzn2023 — so for this ubuntu image that job always skips and no
+    # server is ever started on real SageMaker. test_sm_endpoint.py reads no
+    # matrix, so run it directly here: it deploys a text-only model and waits for
+    # InService, which fails when the server crash-loops at startup.
+    if: ${{ always() && !failure() && !cancelled() && inputs.run-sagemaker-test }}
+    needs: [build]
+    concurrency:
+      group: ${{ github.workflow }}-hf-endpoint-boot-test-${{ inputs.config-file }}-${{ github.ref }}
+      cancel-in-progress: false
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve image URI
+        id: image
+        uses: ./.github/actions/resolve-image-uri
+        with:
+          image-uri: ${{ needs.build.outputs.image-uri || '' }}
+          ci-aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          prod-aws-account-id: ${{ vars.PROD_AWS_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}
+          config-file: ${{ inputs.config-file }}
+
+      - name: Check image exists
+        id: check
+        uses: ./.github/actions/check-image-exists
+        with:
+          image-uri: ${{ steps.image.outputs.image-uri }}
+
+      - name: Install test dependencies
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          uv venv --python 3.12
+          source .venv/bin/activate
+          uv pip install -r test/requirements.txt
+          uv pip install -r test/vllm/sagemaker/requirements.txt
+
+      - name: Run SageMaker endpoint boot test
+        if: steps.check.outputs.exists == 'true'
+        run: |
+          source .venv/bin/activate
+          cd test/
+          python3 -m pytest -vs -rA --image-uri ${{ steps.image.outputs.image-uri }} \
+            vllm/sagemaker/test_sm_endpoint.py
+
   release-gate:
     if: >-
       github.ref == 'refs/heads/main' &&
@@ -121,7 +216,8 @@ jobs:
       inputs.release &&
       !failure() && !cancelled() &&
       needs.build.result == 'success'
-    needs: [build, sanity-test, security-test, telemetry-test, sagemaker-tests]
+    needs:
+      [build, sanity-test, hf-sanity-test, security-test, telemetry-test, sagemaker-tests, hf-endpoint-boot-test]
     runs-on: ubuntu-latest
     outputs:
       should-release: ${{ steps.check.outputs.should-release }}
@@ -161,7 +257,18 @@ jobs:
       (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
       !contains(github.workflow_ref, '.pr') &&
       inputs.release
-    needs: [build, sanity-test, security-test, telemetry-test, sagemaker-tests, release-gate, release]
+    needs:
+      [
+        build,
+        sanity-test,
+        hf-sanity-test,
+        security-test,
+        telemetry-test,
+        sagemaker-tests,
+        hf-endpoint-boot-test,
+        release-gate,
+        release,
+      ]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/test/sanity/scripts/test_sanity_huggingface_vllm.py
+++ b/test/sanity/scripts/test_sanity_huggingface_vllm.py
@@ -15,9 +15,11 @@ The image is identified by its HF entrypoint; every test skips cleanly when the
 container is not a Hugging Face vLLM SageMaker image.
 """
 
+import json
 import os
 import signal
 import subprocess
+import tempfile
 import unittest
 
 ENTRYPOINT = "/usr/local/bin/sagemaker_entrypoint.sh"
@@ -47,6 +49,10 @@ class TestServerStartup(unittest.TestCase):
     so those libs did not exist. Text-only serving died at startup even though
     nothing in the request path touched video.
 
+    A second class the same launch produces: an argument mangled in transit, so
+    the server starts, parses its own flags, and dies on malformed input. Those
+    are asserted on the argv the server actually receives.
+
     Failures are asserted by the *absence* of import/link signatures rather than
     the presence of an expected error, so the checks do not rot when upstream
     error messages change. That is also what makes this runnable on the GPU-less
@@ -62,7 +68,9 @@ class TestServerStartup(unittest.TestCase):
         "undefined symbol",
     )
 
+    # Importing torch plus the server graph is slow; capturing argv is not.
     STARTUP_TIMEOUT = 600
+    ARGV_TIMEOUT = 120
 
     def setUp(self):
         if not _is_hf_vllm_image():
@@ -77,29 +85,30 @@ class TestServerStartup(unittest.TestCase):
             f"crash-loop for every model:\n{output[-4000:]}",
         )
 
-    def test_entrypoint_startup_loads_all_code(self):
-        """The real SageMaker entrypoint must not die on unloadable code.
+    def _run_entrypoint(self, env_overrides, stub_interpreter=False):
+        """Run the real entrypoint; return (server argv, combined output).
 
-        Invokes the entrypoint the way SageMaker does. This exercises what a
-        synthetic import cannot: hf_optimizations.sh, the SM_VLLM_* to CLI
-        translation, and the injected --kv-transfer-config and --middleware.
-
-        ``PROCESS_AUTO_RECOVERY=false`` keeps the run bounded. standard-supervisor
-        always launches the server under supervisord — the flag only sets
-        ``autorestart=false`` — so without it a startup failure would be retried
-        PROCESS_MAX_START_RETRIES times before the process gave up.
-
-        Without an accelerator the process is expected to fail in engine/platform
-        init, so the assertion is on *how* it fails, not whether it survives.
+        With stub_interpreter, a fake ``python3`` shadows the real one on PATH and
+        records the argv it was handed, so the launch chain runs end to end without
+        paying for a vLLM import. argv is empty when no stub was installed.
         """
-        model_dir = "/tmp/hf_sanity_startup_model"
-        os.makedirs(model_dir, exist_ok=True)
+        workdir = tempfile.mkdtemp(prefix="hf_sanity_")
+        model_dir = os.path.join(workdir, "model")
+        os.makedirs(model_dir)
         with open(os.path.join(model_dir, "config.json"), "w") as f:
             f.write("{}")
 
         env = {k: v for k, v in os.environ.items() if not k.startswith("SM_VLLM_")}
-        env["PROCESS_AUTO_RECOVERY"] = "false"
         env["SM_VLLM_MODEL"] = model_dir
+        env.update(env_overrides)
+
+        argv_file = os.path.join(workdir, "argv")
+        if stub_interpreter:
+            stub = os.path.join(workdir, "python3")
+            with open(stub, "w") as f:
+                f.write(f'#!/bin/sh\nprintf "%s\\0" "$@" >{argv_file}\n')
+            os.chmod(stub, 0o755)
+            env["PATH"] = workdir + os.pathsep + env.get("PATH", "")
 
         proc = subprocess.Popen(
             [ENTRYPOINT],
@@ -109,20 +118,75 @@ class TestServerStartup(unittest.TestCase):
             text=True,
             start_new_session=True,
         )
+        timeout = self.ARGV_TIMEOUT if stub_interpreter else self.STARTUP_TIMEOUT
         try:
-            output = proc.communicate(timeout=self.STARTUP_TIMEOUT)[0]
+            output = proc.communicate(timeout=timeout)[0]
         except subprocess.TimeoutExpired:
-            # A server that reaches its listening state never exits, and its
-            # children would hold the stdout pipe open — kill the whole group.
+            # A server that reaches its listening state never exits, and supervisord
+            # respawns it — kill the whole group so no child holds the stdout pipe.
             os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
             output = proc.communicate()[0]
 
+        argv = []
+        if os.path.isfile(argv_file):
+            with open(argv_file) as f:
+                argv = f.read().split("\0")[:-1]
+        return argv, output
+
+    def test_entrypoint_startup_loads_all_code(self):
+        """The real SageMaker entrypoint must not die on unloadable code.
+
+        Invokes the entrypoint the way SageMaker does. This exercises what a
+        synthetic import cannot: hf_optimizations.sh, the SM_VLLM_* to CLI
+        translation, and the injected --kv-transfer-config and --middleware.
+
+        ``PROCESS_AUTO_RECOVERY=false`` makes standard-supervisor os.execvp() the
+        server instead of running it under supervisord, so this is one bounded
+        attempt rather than PROCESS_MAX_START_RETRIES of them.
+
+        Without an accelerator the process is expected to fail in engine/platform
+        init, so the assertion is on *how* it fails, not whether it survives.
+        """
+        output = self._run_entrypoint({"PROCESS_AUTO_RECOVERY": "false"})[1]
         self.assertRegex(
             output.lower(),
             r"vllm",
             f"{ENTRYPOINT} produced no server output, so nothing was verified:\n{output[-4000:]}",
         )
         self._assert_loadable(output, f"{ENTRYPOINT} startup")
+
+    def test_server_argv_survives_launch_chain(self):
+        """Arguments must reach the server intact on both launch paths.
+
+        A stub ``python3`` earlier on PATH captures the argv the server would have
+        been exec'd with, so the whole real chain runs — entrypoint,
+        hf_optimizations.sh, standard-supervisor, and in supervisor mode
+        supervisord's command= round-trip — without importing vLLM.
+
+        Guards the failure class where a value is mangled in transit rather than
+        rejected outright: the server starts, parses its own flags, and dies on
+        malformed input. standard-supervisor 0.1.16 switched from " ".join to
+        shlex.join when writing command=, which flipped whether the LMCache
+        --kv-transfer-config JSON had to be pre-quoted; getting it wrong for the
+        installed version crash-loops every model.
+        """
+        for auto_recovery in ("false", "true"):
+            with self.subTest(process_auto_recovery=auto_recovery):
+                argv = self._run_entrypoint(
+                    {"PROCESS_AUTO_RECOVERY": auto_recovery, "PROCESS_MAX_START_RETRIES": "1"},
+                    stub_interpreter=True,
+                )[0]
+                self.assertIn("--port", argv, f"entrypoint never reached the server: argv={argv}")
+                for flag, value in zip(argv, argv[1:]):
+                    if "{" not in value:
+                        continue
+                    try:
+                        json.loads(value)
+                    except ValueError as exc:
+                        self.fail(
+                            f"{flag} reached the server malformed ({exc}); the launch chain "
+                            f"mangled it: {value!r}"
+                        )
 
 
 if __name__ == "__main__":

--- a/test/sanity/scripts/test_sanity_huggingface_vllm.py
+++ b/test/sanity/scripts/test_sanity_huggingface_vllm.py
@@ -18,12 +18,10 @@ container is not a Hugging Face vLLM SageMaker image.
 import os
 import signal
 import subprocess
-import sys
 import unittest
 
 ENTRYPOINT = "/usr/local/bin/sagemaker_entrypoint.sh"
 OPTIMIZATIONS = "/usr/local/bin/hf_optimizations.sh"
-SERVER_MODULE = "vllm.entrypoints.openai.api_server"
 
 
 def _is_hf_vllm_image():
@@ -51,9 +49,10 @@ class TestServerStartup(unittest.TestCase):
 
     Failures are asserted by the *absence* of import/link signatures rather than
     the presence of an expected error, so the checks do not rot when upstream
-    error messages change. No accelerator is required: vLLM resolves to
-    UnspecifiedPlatform when none is visible, so the CLI/config surface still
-    builds and the module graph still loads.
+    error messages change. That is also what makes this runnable on the GPU-less
+    sanity runner: the module graph loads before any device is needed, and the
+    process is then expected to die in engine init (vLLM raises "Failed to infer
+    device type" once it builds a VllmConfig).
     """
 
     FATAL_PATTERNS = (
@@ -78,35 +77,17 @@ class TestServerStartup(unittest.TestCase):
             f"crash-loop for every model:\n{output[-4000:]}",
         )
 
-    def test_server_cli_builds(self):
-        """``python3 -m vllm.entrypoints.openai.api_server --help`` must exit 0.
-
-        Strictly broader than importing the server module: building the parser
-        walks the whole engine/config argument surface, which is where optional
-        features register themselves and drag in their dependencies.
-        """
-        result = subprocess.run(
-            [sys.executable, "-m", SERVER_MODULE, "--help"],
-            capture_output=True,
-            text=True,
-            timeout=self.STARTUP_TIMEOUT,
-        )
-        output = result.stdout + result.stderr
-        self._assert_loadable(output, f"`python3 -m {SERVER_MODULE} --help`")
-        self.assertEqual(
-            result.returncode,
-            0,
-            f"`python3 -m {SERVER_MODULE} --help` exited {result.returncode}:\n{output[-4000:]}",
-        )
-
     def test_entrypoint_startup_loads_all_code(self):
         """The real SageMaker entrypoint must not die on unloadable code.
 
-        Invokes the entrypoint the way SageMaker does, in direct mode
-        (``PROCESS_AUTO_RECOVERY=false``) so standard-supervisor execs the server
-        once instead of respawning it. This exercises what a synthetic import
-        cannot: hf_optimizations.sh, the SM_VLLM_* to CLI translation, and the
-        injected --kv-transfer-config and --middleware.
+        Invokes the entrypoint the way SageMaker does. This exercises what a
+        synthetic import cannot: hf_optimizations.sh, the SM_VLLM_* to CLI
+        translation, and the injected --kv-transfer-config and --middleware.
+
+        ``PROCESS_AUTO_RECOVERY=false`` keeps the run bounded. standard-supervisor
+        always launches the server under supervisord — the flag only sets
+        ``autorestart=false`` — so without it a startup failure would be retried
+        PROCESS_MAX_START_RETRIES times before the process gave up.
 
         Without an accelerator the process is expected to fail in engine/platform
         init, so the assertion is on *how* it fails, not whether it survives.

--- a/test/sanity/scripts/test_sanity_huggingface_vllm.py
+++ b/test/sanity/scripts/test_sanity_huggingface_vllm.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""
+Sanity tests for the Hugging Face-contributed vLLM DLC images.
+
+Scoped to the huggingface-vllm family and invoked only by
+.github/workflows/huggingface-vllm.pipeline.yml — these are not part of the
+shared vLLM/SGLang sanity suite.
+
+Run inside the container:
+    docker run --rm -v $(pwd):/workdir --workdir /workdir \
+        --entrypoint python3 <image> \
+        test/sanity/scripts/test_sanity_huggingface_vllm.py
+
+The image is identified by its HF entrypoint; every test skips cleanly when the
+container is not a Hugging Face vLLM SageMaker image.
+"""
+
+import os
+import signal
+import subprocess
+import sys
+import unittest
+
+ENTRYPOINT = "/usr/local/bin/sagemaker_entrypoint.sh"
+OPTIMIZATIONS = "/usr/local/bin/hf_optimizations.sh"
+SERVER_MODULE = "vllm.entrypoints.openai.api_server"
+
+
+def _is_hf_vllm_image():
+    """True when this container is a Hugging Face vLLM SageMaker image."""
+    if not os.path.isfile(ENTRYPOINT) or not os.path.isfile(OPTIMIZATIONS):
+        return False
+    with open(ENTRYPOINT) as f:
+        return "SM_VLLM_" in f.read()
+
+
+class TestServerStartup(unittest.TestCase):
+    """The server must survive its own startup path.
+
+    Guards the failure class where something in the server's module graph is
+    imported eagerly and cannot load in this image — a package that is absent,
+    or a native extension whose shared libraries this image broke. The server
+    then crash-loops for *every* workload, not only the feature that needs the
+    dependency, and a SageMaker endpoint never reaches InService.
+
+    The motivating regression: vLLM 0.25.0 imported torchcodec at server-module
+    import time; torchcodec dlopen's libtorchcodec_core*.so, which links
+    libavutil.so.*; this image built FFmpeg from source without --enable-shared,
+    so those libs did not exist. Text-only serving died at startup even though
+    nothing in the request path touched video.
+
+    Failures are asserted by the *absence* of import/link signatures rather than
+    the presence of an expected error, so the checks do not rot when upstream
+    error messages change. No accelerator is required: vLLM resolves to
+    UnspecifiedPlatform when none is visible, so the CLI/config surface still
+    builds and the module graph still loads.
+    """
+
+    FATAL_PATTERNS = (
+        "ModuleNotFoundError",
+        "ImportError",
+        "cannot open shared object file",
+        "undefined symbol",
+    )
+
+    STARTUP_TIMEOUT = 600
+
+    def setUp(self):
+        if not _is_hf_vllm_image():
+            self.skipTest("not a Hugging Face vLLM SageMaker image")
+
+    def _assert_loadable(self, output, context):
+        hits = [p for p in self.FATAL_PATTERNS if p in output]
+        self.assertEqual(
+            hits,
+            [],
+            f"{context} hit {hits} — the server cannot load its own code, so it will "
+            f"crash-loop for every model:\n{output[-4000:]}",
+        )
+
+    def test_server_cli_builds(self):
+        """``python3 -m vllm.entrypoints.openai.api_server --help`` must exit 0.
+
+        Strictly broader than importing the server module: building the parser
+        walks the whole engine/config argument surface, which is where optional
+        features register themselves and drag in their dependencies.
+        """
+        result = subprocess.run(
+            [sys.executable, "-m", SERVER_MODULE, "--help"],
+            capture_output=True,
+            text=True,
+            timeout=self.STARTUP_TIMEOUT,
+        )
+        output = result.stdout + result.stderr
+        self._assert_loadable(output, f"`python3 -m {SERVER_MODULE} --help`")
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"`python3 -m {SERVER_MODULE} --help` exited {result.returncode}:\n{output[-4000:]}",
+        )
+
+    def test_entrypoint_startup_loads_all_code(self):
+        """The real SageMaker entrypoint must not die on unloadable code.
+
+        Invokes the entrypoint the way SageMaker does, in direct mode
+        (``PROCESS_AUTO_RECOVERY=false``) so standard-supervisor execs the server
+        once instead of respawning it. This exercises what a synthetic import
+        cannot: hf_optimizations.sh, the SM_VLLM_* to CLI translation, and the
+        injected --kv-transfer-config and --middleware.
+
+        Without an accelerator the process is expected to fail in engine/platform
+        init, so the assertion is on *how* it fails, not whether it survives.
+        """
+        model_dir = "/tmp/hf_sanity_startup_model"
+        os.makedirs(model_dir, exist_ok=True)
+        with open(os.path.join(model_dir, "config.json"), "w") as f:
+            f.write("{}")
+
+        env = {k: v for k, v in os.environ.items() if not k.startswith("SM_VLLM_")}
+        env["PROCESS_AUTO_RECOVERY"] = "false"
+        env["SM_VLLM_MODEL"] = model_dir
+
+        proc = subprocess.Popen(
+            [ENTRYPOINT],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            start_new_session=True,
+        )
+        try:
+            output = proc.communicate(timeout=self.STARTUP_TIMEOUT)[0]
+        except subprocess.TimeoutExpired:
+            # A server that reaches its listening state never exits, and its
+            # children would hold the stdout pipe open — kill the whole group.
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+            output = proc.communicate()[0]
+
+        self.assertRegex(
+            output.lower(),
+            r"vllm",
+            f"{ENTRYPOINT} produced no server output, so nothing was verified:\n{output[-4000:]}",
+        )
+        self._assert_loadable(output, f"{ENTRYPOINT} startup")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/sanity/scripts/test_sanity_vllm_sglang.py
+++ b/test/sanity/scripts/test_sanity_vllm_sglang.py
@@ -141,14 +141,23 @@ class TestEntrypointArgHandling(unittest.TestCase):
         """Run entrypoint in dry-run mode and capture the generated args."""
         with open(self.SAGEMAKER_ENTRYPOINT) as f:
             script = f.read()
+        # \s* matters: an entrypoint may guard the exec inside an if-block (the
+        # huggingface-vllm one prefers standard-supervisor when present), and an
+        # unreplaced exec launches the real server instead of dry-running.
         script = re.sub(
-            r"^exec\s+(standard-supervisor\s+)?python3\s+.*$",
+            r"^\s*exec\s+(standard-supervisor\s+)?python3\s+.*$",
             'echo "__ARGS__${ARGS[@]}__END__"',
             script,
             flags=re.MULTILINE,
         )
-        # Also suppress start_cuda_compat.sh if present
-        script = script.replace("bash /usr/local/bin/start_cuda_compat.sh", "true")
+        # Also suppress start_cuda_compat.sh if present, sourced or executed: it
+        # shells out to nvidia-smi, which is slow on a GPU-less sanity runner.
+        script = re.sub(
+            r"^\s*(bash|source|\.)\s+\S*start_cuda_compat\.sh.*$",
+            "true",
+            script,
+            flags=re.MULTILINE,
+        )
 
         env = {k: v for k, v in os.environ.items()}
         # Clear any existing SM_VLLM_ / SM_SGLANG_ vars


### PR DESCRIPTION
## Purpose

v0.25.0 shipped an image whose server crash-looped for **every** model (fixed in #6440) while CI stayed green. Two reasons, both skip silently:

   1. `huggingface-vllm` is missing from `_reusable.sanity-tests.yml` 
   2. `vllm.tests-sagemaker.yml` gates `endpoint-test` on a matrix whose every entry requires `os_version: amzn2023`. We're `ubuntu22.04` -> empty matrix -> no server ever started on SageMaker.

- [x] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).