### PR TITLE
ci(xgboost): onboard SageMaker XGBoost 3.0.5 + 3.2.0 to autorelease cron

### DIFF
--- a/.github/release-schedule.yml
+++ b/.github/release-schedule.yml
@@ -49,6 +49,10 @@ schedules:
     workflow: pytorch.autorelease-2.12-sagemaker.yml
     gpu: light
 
+  - cron: "00 23 * * 1,3"
+    workflow: xgboost.autorelease-3.0-sagemaker.yml
+    gpu: minimal
+
   # Tuesday / Thursday
   - cron: "00 16 * * 2,4"
     workflow: sglang.autorelease-ec2-amzn2023.yml
@@ -97,6 +101,10 @@ schedules:
   - cron: "00 23 * * 2,4"
     workflow: pytorch.autorelease-2.13-sagemaker.yml
     gpu: light
+
+  - cron: "00 23 * * 2,4"
+    workflow: xgboost.autorelease-3.2-sagemaker.yml
+    gpu: minimal
 
   - cron: "30 23 * * 2,4"
     workflow: ray-train.autorelease-gpu.yml

--- a/.github/workflows/xgboost.autorelease-3.0-sagemaker.yml
+++ b/.github/workflows/xgboost.autorelease-3.0-sagemaker.yml
@@ -1,0 +1,39 @@
+name: "Auto Release - XGBoost 3.0 SageMaker"
+
+on:
+  schedule:
+    - cron: '00 23 * * 1,3'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      configs: ${{ steps.discover.outputs.configs }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: discover
+        uses: ./.github/actions/discover-configs
+        with:
+          pattern: ".github/config/image/xgboost/sagemaker-3.0.yml"
+
+  pipeline:
+    needs: [discover]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.configs) }}
+    uses: ./.github/workflows/xgboost.pipeline.yml
+    with:
+      config-file: ${{ matrix.config_file }}
+      tag-suffix: ${{ github.run_id }}
+      run-telemetry-test: false
+      release: true
+    secrets: inherit

--- a/.github/workflows/xgboost.autorelease-3.2-sagemaker.yml
+++ b/.github/workflows/xgboost.autorelease-3.2-sagemaker.yml
@@ -1,0 +1,39 @@
+name: "Auto Release - XGBoost 3.2 SageMaker"
+
+on:
+  schedule:
+    - cron: '00 23 * * 2,4'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      configs: ${{ steps.discover.outputs.configs }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: discover
+        uses: ./.github/actions/discover-configs
+        with:
+          pattern: ".github/config/image/xgboost/sagemaker.yml"
+
+  pipeline:
+    needs: [discover]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.configs) }}
+    uses: ./.github/workflows/xgboost.pipeline.yml
+    with:
+      config-file: ${{ matrix.config_file }}
+      tag-suffix: ${{ github.run_id }}
+      run-telemetry-test: false
+      release: true
+    secrets: inherit


### PR DESCRIPTION
## What

Onboard the two SageMaker XGBoost images to the scheduled autorelease cron, matching how the other frameworks (vLLM, SGLang, Ray, PyTorch, etc.) release.

Today XGBoost only has PR workflows (`xgboost.pr-3.0.yml`, `xgboost.pr-3.2.yml`) and a manual `xgboost.dispatch-release.yml` — there was no `*.autorelease-*` workflow, so neither image released on a schedule.

## Changes

- **`.github/workflows/xgboost.autorelease-3.0-sagemaker.yml`** — discovers `config/image/xgboost/sagemaker-3.0.yml` (XGBoost 3.0.5, ubuntu20.04) and calls `xgboost.pipeline.yml` with `release: true`.
  - cron: `00 23 * * 1,3` (Mon/Wed)
- **`.github/workflows/xgboost.autorelease-3.2-sagemaker.yml`** — discovers `config/image/xgboost/sagemaker.yml` (XGBoost 3.2.0, amzn2023) and calls `xgboost.pipeline.yml` with `release: true`.
  - cron: `00 23 * * 2,4` (Tue/Thu)
- **`.github/release-schedule.yml`** — registered both workflows so `check_release_schedule.py` (run by `_prcheck.release-schedule.yml`) validates the crons.

Both follow the existing `ray.autorelease-sagemaker.yml` / `pytorch.autorelease-*-sagemaker.yml` pattern: `discover-configs` -> matrix -> `xgboost.pipeline.yml`, `concurrency: cancel-in-progress: false`, `secrets: inherit`. `run-telemetry-test: false` mirrors the existing XGBoost PR/pipeline setup (telemetry tests are commented out for XGBoost pending setup verification).

## Timing rationale

Both XGBoost SageMaker images are **CPU-only** (`device_type: cpu`), so they carry no GPU-fleet contention — the schedule's interleaving exists to avoid GPU resource contention. They occupy the end-of-window `23:00 UTC` (4 PM PST) slot, one image per day-pair, matching the dominant twice-weekly cadence. 3.0 shares the Mon/Wed 23:00 slot with the CPU-light `pytorch-2.12-sagemaker`; 3.2 takes the otherwise-free Tue/Thu 23:00 slot.

## Validation

- `python3 scripts/ci/check_release_schedule.py` -> `OK: All 22 autorelease schedules match release-schedule.yml`
- Both workflow YAMLs parse cleanly.