### PR TITLE
[auto-cve-patch] [sglang] bump pillow, cuda-compat upgrade, mooncake allowlist refresh

### DIFF
--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -284,7 +284,7 @@ RUN CUDA_MAJOR=$(echo ${CUDA_REF} | cut -d. -f1) \
 # Patch CVEs
 RUN uv pip install --system --no-cache --prerelease=allow \
   "diffusers>=0.38.0" \
-  "pillow>=12.1.1" \
+  "pillow>=12.3.0" \
   "python_multipart>=0.0.22" \
   "xgrammar>=0.1.32" \
   "setuptools>=78.1.1" \
@@ -398,6 +398,9 @@ FROM runtime AS sglang-ec2
 
 ARG CACHE_REFRESH=0
 RUN dnf upgrade -y --security --releasever latest \
+  # Explicitly upgrade cuda-compat-13-0 to pick up fix for CVE-2026-24193
+  # (NVIDIA repo — not flagged in AL2023 security advisories, so --security misses it)
+  && dnf upgrade -y --releasever latest cuda-compat-13-0 \
   && dnf clean all && rm -rf /var/cache/dnf /tmp/* \
   && alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
   && ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python
@@ -412,6 +415,9 @@ FROM runtime AS sglang-sagemaker
 
 ARG CACHE_REFRESH=0
 RUN dnf upgrade -y --security --releasever latest \
+  # Explicitly upgrade cuda-compat-13-0 to pick up fix for CVE-2026-24193
+  # (NVIDIA repo — not flagged in AL2023 security advisories, so --security misses it)
+  && dnf upgrade -y --releasever latest cuda-compat-13-0 \
   && dnf clean all && rm -rf /var/cache/dnf /tmp/* \
   && alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
   && ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python

--- a/test/security/data/ecr_scan_allowlist/sglang_server/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/sglang_server/framework_allowlist.json
@@ -1,57 +1,27 @@
 [
     {
-        "vulnerability_id": "CVE-2026-33186",
-        "reason": "google.golang.org/grpc is a go package statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "CVE-2025-68121",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32283",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32281",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32280",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "CVE-2026-25679",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-09-10"
-    },
-    {
         "vulnerability_id": "CVE-2026-39820",
-        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
+        "reason": "go/stdlib 1.25.10 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
         "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-33811",
-        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
+        "reason": "go/stdlib 1.25.10 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
         "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-33814",
-        "reason": "go/stdlib 1.25.9 and golang.org/x/net v0.48.0 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild",
+        "reason": "go/stdlib 1.25.10 and golang.org/x/net v0.48.0 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild",
         "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-42499",
-        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
+        "reason": "go/stdlib 1.25.10 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
         "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-39836",
-        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
+        "reason": "go/stdlib 1.25.10 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
         "review_by": "2026-09-10"
     },
     {
@@ -61,17 +31,32 @@
     },
     {
         "vulnerability_id": "CVE-2026-42504",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, MIME header parsing CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "RUSTSEC-2026-0185",
-        "reason": "quinn-proto in uv binary, upstream uv has not released a fix yet. QUIC reassembly DoS requires malicious server, low risk for pip installer.",
+        "reason": "go/stdlib 1.25.10 embedded in mooncake libetcd_wrapper.so, MIME header parsing CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
         "review_by": "2026-09-10"
     },
     {
         "vulnerability_id": "CVE-2026-27145",
-        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, x509 VerifyHostname CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
+        "reason": "go/stdlib 1.25.10 embedded in mooncake libetcd_wrapper.so, x509 VerifyHostname CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
+        "review_by": "2026-09-10"
+    },
+    {
+        "vulnerability_id": "CVE-2026-39822",
+        "reason": "go/stdlib 1.25.10 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.5+",
+        "review_by": "2026-09-10"
+    },
+    {
+        "vulnerability_id": "CVE-2026-46600",
+        "reason": "golang.org/x/net v0.48.0 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with x/net 0.56.0+",
+        "review_by": "2026-09-10"
+    },
+    {
+        "vulnerability_id": "CVE-2026-56852",
+        "reason": "golang.org/x/text v0.32.0 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with x/text 0.39.0+",
+        "review_by": "2026-09-10"
+    },
+    {
+        "vulnerability_id": "GHSA-hrxh-6v49-42gf",
+        "reason": "google.golang.org/grpc v1.79.3 embedded in mooncake libetcd_wrapper.so, xDS RBAC + HTTP/2 issues, cannot patch without upstream mooncake rebuild with grpc 1.82.1+",
         "review_by": "2026-09-10"
     }
 ]


### PR DESCRIPTION
## Purpose

Patch CVEs across sglang AL2023 DLC images.

## Images affected

- `sglang:server-cuda-v1` (EC2 AL2023)
- `sglang:server-sagemaker-cuda-v1` (SageMaker AL2023)

## CVEs handled

| CVE | Package | Severity | Affected images | Action | Notes |
|---|---|---|---|---|---|
| CVE-2026-54058 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Bump `pillow>=12.3.0` in Dockerfile.amzn2023 | |
| CVE-2026-54059 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Bump `pillow>=12.3.0` in Dockerfile.amzn2023 | |
| CVE-2026-54060 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Bump `pillow>=12.3.0` in Dockerfile.amzn2023 | |
| CVE-2026-55379 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Bump `pillow>=12.3.0` in Dockerfile.amzn2023 | |
| CVE-2026-55380 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Bump `pillow>=12.3.0` in Dockerfile.amzn2023 | |
| CVE-2026-59197 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Bump `pillow>=12.3.0` in Dockerfile.amzn2023 | |
| CVE-2026-59198 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Bump `pillow>=12.3.0` in Dockerfile.amzn2023 | |
| CVE-2026-59199 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Bump `pillow>=12.3.0` in Dockerfile.amzn2023 | |
| CVE-2026-59200 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Bump `pillow>=12.3.0` in Dockerfile.amzn2023 | |
| CVE-2026-59203 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Bump `pillow>=12.3.0` in Dockerfile.amzn2023 | |
| CVE-2026-59204 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Bump `pillow>=12.3.0` in Dockerfile.amzn2023 | |
| CVE-2026-59205 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Bump `pillow>=12.3.0` in Dockerfile.amzn2023 | |
| CVE-2026-24193 | cuda-compat-13-0 | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Add explicit `dnf upgrade -y --releasever latest cuda-compat-13-0` to EC2 + SageMaker final stages | ALAS2023NVIDIA-2026-313; not caught by `dnf upgrade --security` |
| CVE-2026-39822 | go/stdlib (mooncake) | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Allowlist | Vendored in mooncake `libetcd_wrapper.so`; needs upstream mooncake rebuild with Go 1.26.5+ |
| CVE-2026-46600 | golang.org/x/net (mooncake) | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Allowlist | Vendored in mooncake `libetcd_wrapper.so`; needs upstream mooncake rebuild with x/net 0.56.0+ |
| CVE-2026-56852 | golang.org/x/text (mooncake) | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Allowlist | Vendored in mooncake `libetcd_wrapper.so`; needs upstream mooncake rebuild with x/text 0.39.0+ |
| GHSA-hrxh-6v49-42gf | google.golang.org/grpc (mooncake) | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | Allowlist | Vendored in mooncake `libetcd_wrapper.so`; needs upstream mooncake rebuild with grpc 1.82.1+ |

**Prunes:** removed 7 stale allowlist entries from `sglang_server/framework_allowlist.json` — 6 mooncake Go CVEs that no longer fire on the current image (older Go 1.24.12 references) and 1 uv RUSTSEC entry (RUSTSEC-2026-0185) that no longer fires. Reason: those CVE IDs did not appear in the current prod scan of `sglang:server-cuda-v1`.

**Reason refresh:** updated the "Go 1.25.9" references in existing mooncake allowlist entries to "Go 1.25.10" (latest mooncake v0.3.12.post1 ships Go 1.25.10 via toolchain directive).

## Test plan

- [ ] CI security tests pass for all affected sglang variants
- [ ] CI sanity tests pass
- [ ] CI sglang-specific tests pass

---
🤖 Generated by [Claude Code](https://claude.com/claude-code).
