### PR TITLE
[auto-cve-patch] [sglang] bump pillow floor, upgrade cuda-compat, refresh mooncake allowlist

### DIFF
--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -304,6 +304,7 @@ RUN CUDA_SHORT=$(echo ${CUDA_REF} | cut -d. -f1,2 | tr -d '.') \
   && python${PYTHON_VERSION} -m pip install --no-cache-dir --force-reinstall \
      "torch==${TORCH_VERSION}" "torchvision" "torchaudio" \
      --index-url https://download.pytorch.org/whl/cu${CUDA_SHORT} \
+  && python${PYTHON_VERSION} -m pip install --no-cache-dir --force-reinstall "pillow>=12.3.0" \
   && python${PYTHON_VERSION} -m pip install --no-cache-dir --force-reinstall --no-deps \
      sglang-kernel==${SGLANG_KERNEL_VERSION} \
      --index-url https://docs.sglang.ai/whl/cu${CUDA_SHORT}/ \

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -284,7 +284,7 @@ RUN CUDA_MAJOR=$(echo ${CUDA_REF} | cut -d. -f1) \
 # Patch CVEs
 RUN uv pip install --system --no-cache --prerelease=allow \
   "diffusers>=0.38.0" \
-  "pillow>=12.1.1" \
+  "pillow>=12.3.0" \
   "python_multipart>=0.0.22" \
   "xgrammar>=0.1.32" \
   "setuptools>=78.1.1" \
@@ -398,6 +398,7 @@ FROM runtime AS sglang-ec2
 
 ARG CACHE_REFRESH=0
 RUN dnf upgrade -y --security --releasever latest \
+  && dnf upgrade -y --releasever latest cuda-compat-13-0 \
   && dnf clean all && rm -rf /var/cache/dnf /tmp/* \
   && alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
   && ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python
@@ -412,6 +413,7 @@ FROM runtime AS sglang-sagemaker
 
 ARG CACHE_REFRESH=0
 RUN dnf upgrade -y --security --releasever latest \
+  && dnf upgrade -y --releasever latest cuda-compat-13-0 \
   && dnf clean all && rm -rf /var/cache/dnf /tmp/* \
   && alternatives --set python3 /usr/bin/python${PYTHON_VERSION} \
   && ln -sf /usr/bin/python${PYTHON_VERSION} /usr/bin/python

--- a/test/security/data/ecr_scan_allowlist/sglang/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/sglang/framework_allowlist.json
@@ -55,18 +55,8 @@
         "review_by": "2026-09-10"
     },
     {
-        "vulnerability_id": "RUSTSEC-2026-0195",
-        "reason": "quick-xml 0.39.2 is bundled inside the uv binary at /usr/local/bin/uv (uv is statically compiled Rust). Advisory is a denial-of-service in NsReader's namespace resolution during Start/Empty XML event handling; the vulnerable code path is only reachable when uv parses attacker-controlled XML (e.g. a hostile PyPI mirror index). uv is retained in the image for customer-side venv management; the standard PyPI flow uses JSON/HTML endpoints and never exercises the XML path. No uv release containing the patched quick-xml>=0.41.0 has been published upstream yet; will swap to a pinned fixed version and drop this entry when upstream ships.",
-        "review_by": "2026-10-25"
-    },
-    {
         "vulnerability_id": "CVE-2026-27145",
         "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, VerifyHostname CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "RUSTSEC-2026-0185",
-        "reason": "quinn-proto in uv binary, upstream uv has not released a fix yet. QUIC reassembly DoS requires malicious server, low risk for pip installer.",
         "review_by": "2026-09-10"
     },
     {

--- a/test/security/data/ecr_scan_allowlist/sglang_server/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/sglang_server/framework_allowlist.json
@@ -1,37 +1,7 @@
 [
     {
-        "vulnerability_id": "CVE-2026-33186",
-        "reason": "google.golang.org/grpc is a go package statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "CVE-2025-68121",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32283",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32281",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32280",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "CVE-2026-25679",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26+",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "CVE-2026-39820",
-        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
+        "vulnerability_id": "CVE-2026-27145",
+        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, x509 VerifyHostname CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
         "review_by": "2026-09-10"
     },
     {
@@ -45,12 +15,7 @@
         "review_by": "2026-09-10"
     },
     {
-        "vulnerability_id": "CVE-2026-42499",
-        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
-        "review_by": "2026-09-10"
-    },
-    {
-        "vulnerability_id": "CVE-2026-39836",
+        "vulnerability_id": "CVE-2026-39820",
         "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
         "review_by": "2026-09-10"
     },
@@ -60,18 +25,43 @@
         "review_by": "2026-09-10"
     },
     {
+        "vulnerability_id": "CVE-2026-39822",
+        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.5+",
+        "review_by": "2026-09-10"
+    },
+    {
+        "vulnerability_id": "CVE-2026-39836",
+        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
+        "review_by": "2026-09-10"
+    },
+    {
+        "vulnerability_id": "CVE-2026-42499",
+        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild with Go 1.26.3+",
+        "review_by": "2026-09-10"
+    },
+    {
         "vulnerability_id": "CVE-2026-42504",
-        "reason": "go/stdlib 1.24.12 embedded in mooncake libetcd_wrapper.so, MIME header parsing CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
+        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, MIME header parsing CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
         "review_by": "2026-09-10"
     },
     {
-        "vulnerability_id": "RUSTSEC-2026-0185",
-        "reason": "quinn-proto in uv binary, upstream uv has not released a fix yet. QUIC reassembly DoS requires malicious server, low risk for pip installer.",
-        "review_by": "2026-09-10"
+        "vulnerability_id": "CVE-2026-46600",
+        "reason": "golang.org/x/net v0.48.0 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild",
+        "review_by": "2026-10-25"
     },
     {
-        "vulnerability_id": "CVE-2026-27145",
-        "reason": "go/stdlib 1.25.9 embedded in mooncake libetcd_wrapper.so, x509 VerifyHostname CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
-        "review_by": "2026-09-10"
+        "vulnerability_id": "CVE-2026-56852",
+        "reason": "golang.org/x/text v0.32.0 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild",
+        "review_by": "2026-10-25"
+    },
+    {
+        "vulnerability_id": "GHSA-hrxh-6v49-42gf",
+        "reason": "google.golang.org/grpc v1.79.3 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild",
+        "review_by": "2026-10-25"
+    },
+    {
+        "vulnerability_id": "RUSTSEC-2026-0195",
+        "reason": "quick-xml 0.39.2 is bundled inside the uv binary at /root/.local/bin/uv (uv is statically compiled Rust). Advisory is a denial-of-service in NsReader's namespace resolution during Start/Empty XML event handling; the vulnerable code path is only reachable when uv parses attacker-controlled XML (e.g. a hostile PyPI mirror index). uv is retained in the image for customer-side venv management; the standard PyPI flow uses JSON/HTML endpoints and never exercises the XML path. No uv release containing the patched quick-xml>=0.41.0 has been published upstream yet; will swap to a pinned fixed version and drop this entry when upstream ships.",
+        "review_by": "2026-10-25"
     }
 ]


### PR DESCRIPTION
## Purpose

Patch CVEs across sglang DLC images.

## Images affected

- `sglang:server-cuda-v1` (AL2023, EC2)
- `sglang:server-sagemaker-cuda-v1` (AL2023, SageMaker) — sibling
- `sglang:0.5-gpu-py312-ec2` (Ubuntu) — sibling, allowlist-only changes
- `sglang:0.5-gpu-py312` (Ubuntu, SageMaker) — sibling, allowlist-only changes

## CVEs handled

| CVE | Package | Severity | Affected images | Action | Notes |
|---|---|---|---|---|---|
| CVE-2026-54058 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | bump floor to `pillow>=12.3.0` | |
| CVE-2026-54059 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | bump floor to `pillow>=12.3.0` | |
| CVE-2026-54060 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | bump floor to `pillow>=12.3.0` | |
| CVE-2026-55379 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | bump floor to `pillow>=12.3.0` | |
| CVE-2026-55380 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | bump floor to `pillow>=12.3.0` | |
| CVE-2026-59197 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | bump floor to `pillow>=12.3.0` | |
| CVE-2026-59198 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | bump floor to `pillow>=12.3.0` | |
| CVE-2026-59199 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | bump floor to `pillow>=12.3.0` | |
| CVE-2026-59200 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | bump floor to `pillow>=12.3.0` | |
| CVE-2026-59203 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | bump floor to `pillow>=12.3.0` | |
| CVE-2026-59204 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | bump floor to `pillow>=12.3.0` | |
| CVE-2026-59205 | pillow | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | bump floor to `pillow>=12.3.0` | |
| CVE-2026-24193 | cuda-compat-13-0 | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | `dnf upgrade cuda-compat-13-0` in EC2 and SageMaker stages | AL2023 NVIDIA repo pkg |
| CVE-2026-39822 | go/stdlib | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | allowlist | vendored in mooncake libetcd_wrapper.so |
| CVE-2026-46600 | golang.org/x/net | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | allowlist | vendored in mooncake libetcd_wrapper.so |
| CVE-2026-56852 | golang.org/x/text | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | allowlist | vendored in mooncake libetcd_wrapper.so |
| GHSA-hrxh-6v49-42gf | google.golang.org/grpc | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | allowlist | vendored in mooncake libetcd_wrapper.so |
| RUSTSEC-2026-0195 | quick-xml | HIGH | server-cuda-v1, server-sagemaker-cuda-v1 | allowlist | vendored inside uv binary; upstream uv has no release with quick-xml>=0.41.0 yet |

**Prunes:** 9 allowlist entries pruned across both dirs — 7 from `sglang_server/framework_allowlist.json` (older go/stdlib 1.24.12 CVEs on mooncake and `RUSTSEC-2026-0185` no longer firing) and 2 from `sglang/framework_allowlist.json` (`RUSTSEC-2026-0185`, `RUSTSEC-2026-0195` no longer firing on Ubuntu scan).

## Test plan

- [x] CI security tests pass for all affected sglang variants
- [x] CI sanity tests pass
- [x] CI sglang-specific tests pass

---
Generated by CVE patch orchestrator.