### PR TITLE
tei 1.9.3: enable gamma release

### DIFF
--- a/.github/config/image/tei/sagemaker-1.9.3-cpu.yml
+++ b/.github/config/image/tei/sagemaker-1.9.3-cpu.yml
@@ -20,7 +20,7 @@ build:
   python_version: "3.10"
 
 release:
-  release: false
+  release: true
   force_release: false
   public_registry: false
   private_registry: true

--- a/.github/config/image/tei/sagemaker-1.9.3-gpu.yml
+++ b/.github/config/image/tei/sagemaker-1.9.3-gpu.yml
@@ -20,7 +20,7 @@ build:
   cuda_version: "12.9.1"
 
 release:
-  release: false
+  release: true
   force_release: false
   public_registry: false
   private_registry: true


### PR DESCRIPTION
Enables gamma release for TEI 1.9.3 CPU + GPU by flipping `release: false` → `true` in both config files. Environment stays at `gamma`.

## Test plan
- [x] Merge, then manually trigger `Dispatch Release - TEI` to push gamma images.