### PR TITLE
tei: rename dispatch workflow to match convention

### DIFF
--- a/.github/workflows/tei.dispatch-release.yml
+++ b/.github/workflows/tei.dispatch-release.yml
@@ -1,4 +1,4 @@
-name: "Dispatch Release - TEI"
+name: "Dispatch - TEI Release"
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Renames the TEI dispatch workflow display name to `Dispatch - TEI Release` to match the `Dispatch - <Framework> Release` convention used by `sklearn`, `xgboost`, `huggingface-vllm`, and `partner`. Display-name only, no functional change.