### PR TITLE
ci: notify Slack only for production release failures

### DIFF
--- a/.github/actions/notify-slack-failure/action.yml
+++ b/.github/actions/notify-slack-failure/action.yml
@@ -1,5 +1,5 @@
 name: 'Notify Slack Failure'
-description: 'Post a failed auto-release run to a Slack Workflow Builder webhook.'
+description: 'Post a failed production auto-release run to a Slack Workflow Builder webhook. Non-production environments are skipped.'
 
 inputs:
   webhook-url:
@@ -29,6 +29,13 @@ runs:
         if [[ -z "${SLACK_WEBHOOK_URL}" ]]; then
           echo "::error::webhook-url is empty — set the SLACK_RELEASE_FAILURE_WEBHOOK_URL secret."
           exit 1
+        fi
+
+        # Production releases only: gamma/preprod runs are often manual tests.
+        environment=$(yq -r '.release.environment // ""' "${CONFIG_FILE}")
+        if [[ "${environment}" != "production" ]]; then
+          echo "Skipping notification: environment is '${environment:-unset}', not production."
+          exit 0
         fi
 
         # Include the config basename: one workflow releases several configs via matrix.


### PR DESCRIPTION
## Problem

The auto-release failure notification currently fires for **every** release environment, including `gamma`. Gamma runs are often someone manually testing, so their failures page the channel with noise that needs no action.

## Change

Gate the notification on `release.environment == "production"`, read from the image config inside the `notify-slack-failure` action. Non-production environments log a skip line and exit 0.

```bash
# Production releases only: gamma/preprod runs are often manual tests.
environment=$(yq -r '.release.environment // ""' "${CONFIG_FILE}")
if [[ "${environment}" != "production" ]]; then
  echo "Skipping notification: environment is '${environment:-unset}', not production."
  exit 0
fi
```

Gating inside the action means one change covers all 11 pipelines that call it — no per-pipeline edits.

## Impact

Configs that will **no longer** notify (currently `gamma`):
- `.github/config/image/ray-train/ec2-gpu.yml`
- `.github/config/image/tei/sagemaker-1.9.3-cpu.yml`
- `.github/config/image/tei/sagemaker-1.9.3-gpu.yml`

All other 39 image configs are `production` and keep notifying.

## Notes

- The gate reads the config directly rather than reusing `release-gate`'s `environment` output, because `notify-failure` must also fire when `build` fails — in that case `release-gate` is skipped and its outputs are empty.
- A missing/unset `release.environment` is treated as non-production (fails closed to silence rather than noise).
- `yq` is preinstalled on `ubuntu-latest`, which is where every `notify-failure` job runs; `release-gate` already depends on the same.

## Testing

- Action YAML validated.
- Gate logic exercised locally against all real configs: the 3 gamma configs skip, production samples (pytorch 2.12, vllm, base cu130) notify, and the missing-key / missing-file edge cases skip cleanly.
