### PR TITLE
Patch mesa and emacs CVEs in PyTorch training 2.10

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-ec2.yml"
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-sm.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = ""
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-ec2.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-sm.yml"
+dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/pytorch/training/buildspec-2-10-ec2.yml
+++ b/pytorch/training/buildspec-2-10-ec2.yml
@@ -50,7 +50,7 @@ images:
     tag_python_version: &TAG_PYTHON_VERSION py313
     os_version: &OS_VERSION ubuntu22.04
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
-    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
+    # latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-ec2" ]
     # skip_build: "False"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
     target: ec2
@@ -66,7 +66,7 @@ images:
     cuda_version: &CUDA_VERSION cu130
     os_version: &OS_VERSION ubuntu22.04
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
-    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
+    # latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-ec2" ]
     # skip_build: "False"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
                          *DEVICE_TYPE ]

--- a/pytorch/training/buildspec-2-10-sm.yml
+++ b/pytorch/training/buildspec-2-10-sm.yml
@@ -50,7 +50,7 @@ images:
     tag_python_version: &TAG_PYTHON_VERSION py313
     os_version: &OS_VERSION ubuntu22.04
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
+    # latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *OS_VERSION, "-sagemaker" ]
     # skip_build: "False"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /Dockerfile., *DEVICE_TYPE ]
     target: sagemaker
@@ -66,7 +66,7 @@ images:
     cuda_version: &CUDA_VERSION cu130
     os_version: &OS_VERSION ubuntu22.04
     tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
-    latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
+    # latest_release_tag: !join [ *VERSION, "-", *DEVICE_TYPE, "-", *TAG_PYTHON_VERSION, "-", *CUDA_VERSION, "-", *OS_VERSION, "-sagemaker" ]
     # skip_build: "False"
     docker_file: !join [ docker/, *SHORT_VERSION, /, *DOCKER_PYTHON_VERSION, /, *CUDA_VERSION, /Dockerfile.,
                          *DEVICE_TYPE ]

--- a/pytorch/training/docker/2.10/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/2.10/py3/Dockerfile.cpu
@@ -39,7 +39,7 @@ RUN apt-get update \
 FROM base_image AS common
 
 LABEL maintainer="Amazon AI"
-LABEL dlc_major_version="1"
+LABEL dlc_major_version="2"
 
 ARG PYTHON
 ARG PYTHON_VERSION
@@ -74,12 +74,11 @@ RUN apt-get update \
     ca-certificates \
     cmake \
     curl \
-    emacs \
     git \
     jq \
     libcurl4-openssl-dev \
     libglib2.0-0 \
-    libgl1-mesa-glx \
+    libgl1 \
     libsm6 \
     libssl-dev \
     libxext6 \
@@ -284,7 +283,7 @@ FROM common AS sagemaker
 ARG PYTHON
 
 LABEL maintainer="Amazon AI"
-LABEL dlc_major_version="1"
+LABEL dlc_major_version="2"
 
 ENV SAGEMAKER_TRAINING_MODULE=sagemaker_pytorch_container.training:main
 

--- a/pytorch/training/docker/2.10/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.10/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
@@ -1,31 +1,4 @@
 {
-    "mesa": [
-        {
-            "description": "In Mesa before 25.3.6 and 26 before 26.0.1, out-of-bounds memory access can occur in WebGPU because the amount of to-be-allocated data depends on an untrusted party, and is then used for alloca.",
-            "vulnerability_id": "CVE-2026-40393",
-            "name": "CVE-2026-40393",
-            "package_name": "mesa",
-            "package_details": {
-                "file_path": null,
-                "name": "mesa",
-                "package_manager": "OS",
-                "version": "23.0.4",
-                "release": "0ubuntu1~22.04.1"
-            },
-            "remediation": {"recommendation": {"text": "None Provided"}},
-            "cvss_v3_score": 9.8,
-            "cvss_v30_score": 0.0,
-            "cvss_v31_score": 9.8,
-            "cvss_v2_score": 0.0,
-            "cvss_v3_severity": "CRITICAL",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2026/CVE-2026-40393.html",
-            "source": "UBUNTU_CVE",
-            "severity": "CRITICAL",
-            "status": "ACTIVE",
-            "title": "CVE-2026-40393 - mesa",
-            "reason_to_ignore": "Training containers do not expose a WebGPU/rendering surface to untrusted content; mesa is transitive via libgl1-mesa-glx. Awaiting patched mesa in Ubuntu 22.04 (upstream fix in mesa 25.3.6/26.0.1)."
-        }
-    ],
     "onnx": [
         {
             "description": "### Summary\n\nA security control bypass exists in onnx.hub.load() due to improper logic in the repository trust verification mechanism. While the function is designed to warn users when loading models from non-official sources, the use of the silent=True parameter completely suppresses all security warnings and confirmation prompts. ### The Technical Flaw The vulnerability is located in onnx/hub.py. The security gate uses a short-circuit evaluation that prioritizes the \"silent\" preference over the trust requirement: ```Python if not _verify_repo_ref(repo) and not silent: # This block (Warning + User Input) is SKIPPED if silent=True print(\"The model repo... is not trusted\") if input().lower() != \"y\": return None ``` **Key Points of Failure**: Complete Suppression: If a developer or a third-party library sets silent=True, the application will download and execute models from any attacker-controlled GitHub repository without notifying the user. **Integrity Verification Bypass**: The SHA256 integrity check validat",

--- a/pytorch/training/docker/2.10/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.10/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
@@ -1,31 +1,4 @@
 {
-    "mesa": [
-        {
-            "description": "In Mesa before 25.3.6 and 26 before 26.0.1, out-of-bounds memory access can occur in WebGPU because the amount of to-be-allocated data depends on an untrusted party, and is then used for alloca.",
-            "vulnerability_id": "CVE-2026-40393",
-            "name": "CVE-2026-40393",
-            "package_name": "mesa",
-            "package_details": {
-                "file_path": null,
-                "name": "mesa",
-                "package_manager": "OS",
-                "version": "23.0.4",
-                "release": "0ubuntu1~22.04.1"
-            },
-            "remediation": {"recommendation": {"text": "None Provided"}},
-            "cvss_v3_score": 9.8,
-            "cvss_v30_score": 0.0,
-            "cvss_v31_score": 9.8,
-            "cvss_v2_score": 0.0,
-            "cvss_v3_severity": "CRITICAL",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2026/CVE-2026-40393.html",
-            "source": "UBUNTU_CVE",
-            "severity": "CRITICAL",
-            "status": "ACTIVE",
-            "title": "CVE-2026-40393 - mesa",
-            "reason_to_ignore": "DLC training containers do not expose a WebGPU/rendering surface to untrusted content; mesa is pulled in transitively via libgl1-mesa-glx for OpenCV/visualization deps."
-        }
-    ],
     "onnx": [
         {
             "description": "### Summary\n\nA security control bypass exists in onnx.hub.load() due to improper logic in the repository trust verification mechanism. While the function is designed to warn users when loading models from non-official sources, the use of the silent=True parameter completely suppresses all security warnings and confirmation prompts. ### The Technical Flaw The vulnerability is located in onnx/hub.py. The security gate uses a short-circuit evaluation that prioritizes the \"silent\" preference over the trust requirement: ```Python if not _verify_repo_ref(repo) and not silent: # This block (Warning + User Input) is SKIPPED if silent=True print(\"The model repo... is not trusted\") if input().lower() != \"y\": return None ``` **Key Points of Failure**: Complete Suppression: If a developer or a third-party library sets silent=True, the application will download and execute models from any attacker-controlled GitHub repository without notifying the user. **Integrity Verification Bypass**: The SHA256 integrity check validat",

--- a/pytorch/training/docker/2.10/py3/cu130/Dockerfile.ec2.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.10/py3/cu130/Dockerfile.ec2.gpu.os_scan_allowlist.json
@@ -1,31 +1,4 @@
 {
-    "mesa": [
-        {
-            "description": "In Mesa before 25.3.6 and 26 before 26.0.1, out-of-bounds memory access can occur in WebGPU because the amount of to-be-allocated data depends on an untrusted party, and is then used for alloca.",
-            "vulnerability_id": "CVE-2026-40393",
-            "name": "CVE-2026-40393",
-            "package_name": "mesa",
-            "package_details": {
-                "file_path": null,
-                "name": "mesa",
-                "package_manager": "OS",
-                "version": "23.0.4",
-                "release": "0ubuntu1~22.04.1"
-            },
-            "remediation": {"recommendation": {"text": "None Provided"}},
-            "cvss_v3_score": 9.8,
-            "cvss_v30_score": 0.0,
-            "cvss_v31_score": 9.8,
-            "cvss_v2_score": 0.0,
-            "cvss_v3_severity": "CRITICAL",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2026/CVE-2026-40393.html",
-            "source": "UBUNTU_CVE",
-            "severity": "CRITICAL",
-            "status": "ACTIVE",
-            "title": "CVE-2026-40393 - mesa",
-            "reason_to_ignore": "Training containers do not expose a WebGPU/rendering surface to untrusted content; mesa is transitive via libgl1-mesa-glx. Awaiting patched mesa in Ubuntu 22.04 (upstream fix in mesa 25.3.6/26.0.1)."
-        }
-    ],
     "onnx": [
         {
             "description": "### Summary\n\nA security control bypass exists in onnx.hub.load() due to improper logic in the repository trust verification mechanism. While the function is designed to warn users when loading models from non-official sources, the use of the silent=True parameter completely suppresses all security warnings and confirmation prompts. ### The Technical Flaw The vulnerability is located in onnx/hub.py. The security gate uses a short-circuit evaluation that prioritizes the \"silent\" preference over the trust requirement: ```Python if not _verify_repo_ref(repo) and not silent: # This block (Warning + User Input) is SKIPPED if silent=True print(\"The model repo... is not trusted\") if input().lower() != \"y\": return None ``` **Key Points of Failure**: Complete Suppression: If a developer or a third-party library sets silent=True, the application will download and execute models from any attacker-controlled GitHub repository without notifying the user. **Integrity Verification Bypass**: The SHA256 integrity check validat",

--- a/pytorch/training/docker/2.10/py3/cu130/Dockerfile.gpu
+++ b/pytorch/training/docker/2.10/py3/cu130/Dockerfile.gpu
@@ -29,7 +29,7 @@ FROM public.ecr.aws/deep-learning-containers/base:13.0.2-gpu-py313-cu130-ubuntu2
 # base has EFA, PYTHON and CUDA 13.0
 
 LABEL maintainer="Amazon AI"
-LABEL dlc_major_version="1"
+LABEL dlc_major_version="2"
 
 ARG PYTHON
 ARG PYTORCH_VERSION
@@ -62,7 +62,7 @@ WORKDIR /
 RUN apt-get update \
  && apt-get -y upgrade --only-upgrade systemd \
  && apt-get install -y --allow-change-held-packages --no-install-recommends \
-    libgl1-mesa-glx \
+    libgl1 \
     build-essential \
     ca-certificates \
     zlib1g-dev \
@@ -179,7 +179,6 @@ RUN apt-get update \
     wget \
     git \
     jq \
-    emacs \
     vim \
     unzip \
  && rm -rf /var/lib/apt/lists/* \
@@ -245,7 +244,7 @@ CMD ["/bin/bash"]
 FROM common AS sagemaker
 
 LABEL maintainer="Amazon AI"
-LABEL dlc_major_version="1"
+LABEL dlc_major_version="2"
 
 ENV SAGEMAKER_TRAINING_MODULE=sagemaker_pytorch_container.training:main
 

--- a/pytorch/training/docker/2.10/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.10/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
@@ -1,31 +1,4 @@
 {
-    "mesa": [
-        {
-            "description": "In Mesa before 25.3.6 and 26 before 26.0.1, out-of-bounds memory access can occur in WebGPU because the amount of to-be-allocated data depends on an untrusted party, and is then used for alloca.",
-            "vulnerability_id": "CVE-2026-40393",
-            "name": "CVE-2026-40393",
-            "package_name": "mesa",
-            "package_details": {
-                "file_path": null,
-                "name": "mesa",
-                "package_manager": "OS",
-                "version": "23.0.4",
-                "release": "0ubuntu1~22.04.1"
-            },
-            "remediation": {"recommendation": {"text": "None Provided"}},
-            "cvss_v3_score": 9.8,
-            "cvss_v30_score": 0.0,
-            "cvss_v31_score": 9.8,
-            "cvss_v2_score": 0.0,
-            "cvss_v3_severity": "CRITICAL",
-            "source_url": "https://people.canonical.com/~ubuntu-security/cve/2026/CVE-2026-40393.html",
-            "source": "UBUNTU_CVE",
-            "severity": "CRITICAL",
-            "status": "ACTIVE",
-            "title": "CVE-2026-40393 - mesa",
-            "reason_to_ignore": "DLC training containers do not expose a WebGPU/rendering surface to untrusted content; mesa is pulled in transitively via libgl1-mesa-glx for OpenCV/visualization deps."
-        }
-    ],
     "onnx": [
         {
             "description": "### Summary\n\nA security control bypass exists in onnx.hub.load() due to improper logic in the repository trust verification mechanism. While the function is designed to warn users when loading models from non-official sources, the use of the silent=True parameter completely suppresses all security warnings and confirmation prompts. ### The Technical Flaw The vulnerability is located in onnx/hub.py. The security gate uses a short-circuit evaluation that prioritizes the \"silent\" preference over the trust requirement: ```Python if not _verify_repo_ref(repo) and not silent: # This block (Warning + User Input) is SKIPPED if silent=True print(\"The model repo... is not trusted\") if input().lower() != \"y\": return None ``` **Key Points of Failure**: Complete Suppression: If a developer or a third-party library sets silent=True, the application will download and execute models from any attacker-controlled GitHub repository without notifying the user. **Integrity Verification Bypass**: The SHA256 integrity check validat",

--- a/test/dlc_tests/sanity/test_dlc_labels.py
+++ b/test/dlc_tests/sanity/test_dlc_labels.py
@@ -264,9 +264,12 @@ def test_dlc_major_version_dockerfiles(image):
             f"in one of the Dockerfiles. Please inspect {versions}"
         )
 
-    # PyTorch training 2.9 supersedes v1 in place rather than adding a v2 variant
+    # PyTorch training 2.9/2.10 supersede v1 in place rather than adding a v2 variant
     # beside it, so only assert the current major version is present.
-    if (framework, fw_version_major_minor, job_type) == ("pytorch", "2.9", "training"):
+    if (framework, fw_version_major_minor, job_type) in (
+        ("pytorch", "2.9", "training"),
+        ("pytorch", "2.10", "training"),
+    ):
         expected_versions = [PYTORCH_TRAINING_CURRENT_MAJOR_VERSION]
 
     # Note: If, for example, we find 3 dockerfiles with the same framework major/minor version, same processor,


### PR DESCRIPTION
## Description

Patches three CVEs in **PyTorch training 2.10**. Split out of #6461 so each framework version gets its own CI run (the PR build handles one version at a time).

| CVE | Package | Severity | Fix |
|---|---|---|---|
| CVE-2026-40393 | mesa | CRITICAL | `libgl1-mesa-glx` → `libgl1` |
| CVE-2025-1244 | emacs | HIGH | drop `emacs` from apt install list |
| CVE-2024-53920 | emacs | HIGH | same removal |

None is fixable by upgrading — in each case the flagged package is dead weight, so the fix is to replace or remove it.

### CVE-2026-40393 (mesa)

The scan flags `libgl1-mesa-glx 23.0.4-0ubuntu1~22.04.1`, an **empty transitional package** shipping zero `.so` files. The patched mesa source (`23.2.1-1ubuntu3.1~22.04.4`, USN-8427-1) no longer builds that binary, so there is no upgrade target and `apt-get upgrade` cannot clear the finding:

```
$ apt-get install -y --only-upgrade 'mesa*'
0 upgraded, 0 newly installed, 0 to remove

$ apt-cache madison libgl1-mesa-glx
libgl1-mesa-glx | 23.0.4-0ubuntu1~22.04.1 | jammy-updates/universe
libgl1-mesa-glx | 22.0.1-1ubuntu2         | jammy/universe
```

`libGL.so.1` is owned by `libgl1`. The real mesa libraries (`libgl1-mesa-dri`, `libglapi-mesa`, `libglx-mesa0`) are already at the patched version — all three share the source name `mesa`, which is why the scanner reports the stale stub.

### CVE-2025-1244 / CVE-2024-53920 (emacs)

Upstream fixes are emacs 29.4 and 30.1, but Ubuntu jammy ships the `1:27.1` line and will not rebase. Jammy's backport is `1:27.1+1-3ubuntu5.2+esm1` — **Ubuntu Pro / ESM Apps only** — while public repos cap at the unfixed `1:27.1+1-3ubuntu5.2`. Neither path is reachable in a DLC build, and emacs is not needed for training. emacs is not needed for training.

## Versioning

`dlc_major_version` bumped `1` → `2` in both Dockerfiles (ec2 and sagemaker stages). Removing emacs is backward-incompatible, so the patched images publish under a new major rather than mutating v1. `DLContainersReleaseLogic` reads this label off the image manifest to build the `-v{major}.{minor}` release tag, so the label is the only change required.

The mesa swap on its own is **not** backward-incompatible: `libgl1-mesa-glx` is an empty transitional package that depends on `libgl1`, so `libgl1` was already installed. The swap drops an empty dpkg alias and leaves the same `libGL.so.1` in place.

## latest_release_tag commented out

`latest_release_tag` is commented out in both 2.10 buildspecs, matching 2.7 / 2.8 / 2.9. This makes `test_package_version_regression_in_image` skip via `test_pre_release.py:1319-1325`.

The released 2.10 images predate the `fastcore<2` pin from #6419 and carry a `fastcore 2.x` that crashes fastai in `vision_learner` (`AttributeError: 'list' object has no attribute 'starmap'`), so they are not a useful regression baseline. The pin itself is unchanged — still in the `common` stage exactly as on master.

## Test change

`test_dlc_major_version_dockerfiles` asserts the DLC major versions across matching Dockerfiles form a contiguous sequence starting at 1. PyTorch training 2.10 supersedes v1 in place rather than adding a v2 variant beside it, so the expectation becomes the current major version only. Scoped to `("pytorch", "2.10", "training")` — `huggingface_pytorch` and every other framework keep the `1..N` rule.

## Verification

From the combined #6461 run on these exact images:

- `test_ecr_enhanced_scan` passed — **no mesa CVE in the scan results at all**, confirming the swap eliminates the finding rather than suppressing it
- `test_oss_compliance`, `test_pip_check`, `test_license_file`, `test_boottime_container_security` passed

Standalone build of the edited install block: stub absent and **not re-pulled transitively**, emacs absent, `libGL.so.1` present, `opencv-python==4.11.0.86` imports. No test references `emacs`, `mesa`, or `libgl1`.

## Note

`dlc_developer_config.toml` is scoped for CI and **must be reverted before merge** or quick-checks will fail.

## Tests run

- [x] Local container verification
- [ ] PR CI (2.10 ec2)
