### PR TITLE
vllm: bump AL2023 images to upstream commit d223c90

### DIFF
--- a/.github/config/image/vllm/ec2-amzn2023.yml
+++ b/.github/config/image/vllm/ec2-amzn2023.yml
@@ -19,7 +19,7 @@ build:
   cuda_version: "13.0.2"
   vllm_ref: "d223c900d85224c02f2162ee2c757a769e99f519"
   flashinfer_version: "0.6.15.post1"
-  deepep_commit_hash: "73b6ea4"
+  deepep_commit_hash: "d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb"
   dlc_major_version: "2"
   dlc_minor_version: "2"
   use_sccache: "true"

--- a/.github/config/image/vllm/ec2-amzn2023.yml
+++ b/.github/config/image/vllm/ec2-amzn2023.yml
@@ -18,7 +18,7 @@ build:
   python_version: "3.12"
   cuda_version: "13.0.2"
   vllm_ref: "d223c900d85224c02f2162ee2c757a769e99f519"
-  flashinfer_version: "0.6.12"
+  flashinfer_version: "0.6.15.post1"
   deepep_commit_hash: "73b6ea4"
   dlc_major_version: "2"
   dlc_minor_version: "2"

--- a/.github/config/image/vllm/ec2-amzn2023.yml
+++ b/.github/config/image/vllm/ec2-amzn2023.yml
@@ -4,7 +4,7 @@ image:
 
 metadata:
   framework: "vllm_server"
-  framework_version: "0.24.0"
+  framework_version: "0.26.0"
   os_version: "amzn2023"
   customer_type: "ec2"
   arch_type: "x86"

--- a/.github/config/image/vllm/ec2-amzn2023.yml
+++ b/.github/config/image/vllm/ec2-amzn2023.yml
@@ -17,11 +17,11 @@ build:
   target: "vllm-ec2-amzn2023"
   python_version: "3.12"
   cuda_version: "13.0.2"
-  vllm_ref: "7b3d595eb197d714052ce296cc8b124f0dc8af31"
+  vllm_ref: "d223c900d85224c02f2162ee2c757a769e99f519"
   flashinfer_version: "0.6.12"
   deepep_commit_hash: "73b6ea4"
   dlc_major_version: "2"
-  dlc_minor_version: "1"
+  dlc_minor_version: "2"
   use_sccache: "true"
 
 release:

--- a/.github/config/image/vllm/sagemaker-amzn2023.yml
+++ b/.github/config/image/vllm/sagemaker-amzn2023.yml
@@ -18,11 +18,11 @@ build:
   target: "vllm-sagemaker-amzn2023"
   python_version: "3.12"
   cuda_version: "13.0.2"
-  vllm_ref: "7b3d595eb197d714052ce296cc8b124f0dc8af31"
+  vllm_ref: "d223c900d85224c02f2162ee2c757a769e99f519"
   flashinfer_version: "0.6.12"
   deepep_commit_hash: "73b6ea4"
   dlc_major_version: "2"
-  dlc_minor_version: "1"
+  dlc_minor_version: "2"
   use_sccache: "true"
 
 release:

--- a/.github/config/image/vllm/sagemaker-amzn2023.yml
+++ b/.github/config/image/vllm/sagemaker-amzn2023.yml
@@ -20,7 +20,7 @@ build:
   cuda_version: "13.0.2"
   vllm_ref: "d223c900d85224c02f2162ee2c757a769e99f519"
   flashinfer_version: "0.6.15.post1"
-  deepep_commit_hash: "73b6ea4"
+  deepep_commit_hash: "d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb"
   dlc_major_version: "2"
   dlc_minor_version: "2"
   use_sccache: "true"

--- a/.github/config/image/vllm/sagemaker-amzn2023.yml
+++ b/.github/config/image/vllm/sagemaker-amzn2023.yml
@@ -4,7 +4,7 @@ image:
 
 metadata:
   framework: "vllm_server"
-  framework_version: "0.24.0"
+  framework_version: "0.26.0"
   os_version: "amzn2023"
   customer_type: "sagemaker"
   platform: "sagemaker"

--- a/.github/config/image/vllm/sagemaker-amzn2023.yml
+++ b/.github/config/image/vllm/sagemaker-amzn2023.yml
@@ -19,7 +19,7 @@ build:
   python_version: "3.12"
   cuda_version: "13.0.2"
   vllm_ref: "d223c900d85224c02f2162ee2c757a769e99f519"
-  flashinfer_version: "0.6.12"
+  flashinfer_version: "0.6.15.post1"
   deepep_commit_hash: "73b6ea4"
   dlc_major_version: "2"
   dlc_minor_version: "2"

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -134,7 +134,7 @@ ARG NVSHMEM_VER
 ARG NCCL_VERSION
 RUN --mount=type=cache,target=/root/.cache/uv mkdir -p /tmp/ep_kernels_workspace/dist \
   && CUDA_MAJOR=$(echo $CUDA_VERSION | cut -d. -f1) \
-  && echo "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" > /tmp/nccl-override.txt \
+  && echo "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" >/tmp/nccl-override.txt \
   && export UV_OVERRIDE=/tmp/nccl-override.txt \
   && export LIBRARY_PATH="/opt/venv/lib/python${PYTHON_VERSION}/site-packages/nvidia/nccl/lib:${LIBRARY_PATH}" \
   && export TORCH_CUDA_ARCH_LIST='9.0a 10.0a' \
@@ -187,7 +187,7 @@ ENV UV_LINK_MODE=copy
 # Match runtime venv NCCL to the DeepEP wheel's compile-time NCCL (see build stage).
 ARG NCCL_VERSION
 RUN CUDA_MAJOR=$(echo $CUDA_VERSION | cut -d. -f1) \
-  && echo "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" > /etc/uv-overrides.txt
+  && echo "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" >/etc/uv-overrides.txt
 ENV UV_OVERRIDE=/etc/uv-overrides.txt
 
 # Install PyTorch

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -3,6 +3,10 @@ ARG PYTHON_VERSION=3.12
 ARG FRAMEWORK_VERSION=0.24.0
 ARG FLASHINFER_VERSION=0.6.12
 ARG DEEPEP_COMMIT_HASH=73b6ea4
+# DeepEPv2 GIN backend requires NCCL >= 2.30.4. torch pins an older NCCL as a
+# transitive dep, so we override it via UV_OVERRIDE at both build and runtime.
+# Only applied on CUDA 13+; CUDA 12 falls back to torch's default NCCL.
+ARG NCCL_VERSION=2.30.7
 
 # =============================================================================
 # STAGE 0: source — clone vLLM and apply patches
@@ -129,7 +133,13 @@ RUN --mount=type=cache,target=/root/.cache/ccache --mount=type=cache,target=/roo
 # Build DeepEP wheels
 ARG DEEPEP_COMMIT_HASH
 ARG NVSHMEM_VER
+ARG NCCL_VERSION
 RUN --mount=type=cache,target=/root/.cache/uv mkdir -p /tmp/ep_kernels_workspace/dist \
+  && CUDA_MAJOR=$(echo $CUDA_VERSION | cut -d. -f1) \
+  && if [ "$CUDA_MAJOR" -ge 13 ] && [ -n "$NCCL_VERSION" ]; then \
+       echo "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" > /tmp/nccl-override.txt \
+       && export UV_OVERRIDE=/tmp/nccl-override.txt; \
+     fi \
   && export TORCH_CUDA_ARCH_LIST='9.0a 10.0a' \
   && tools/ep_kernels/install_python_libraries.sh \
     --workspace /tmp/ep_kernels_workspace \
@@ -176,6 +186,19 @@ ENV PATH="/root/.local/bin:${PATH}"
 ENV UV_HTTP_TIMEOUT=500
 ENV UV_INDEX_STRATEGY="unsafe-best-match"
 ENV UV_LINK_MODE=copy
+
+# DeepEPv2 GIN requires NCCL >= 2.30.4 at both compile and runtime. torch pins
+# an older version as a transitive dep; this override forces uv to use our
+# pinned version whenever nvidia-nccl-cu* is resolved, so the runtime venv
+# matches the NCCL the DeepEP wheel was compiled against. Empty on CUDA 12.
+ARG NCCL_VERSION
+RUN CUDA_MAJOR=$(echo $CUDA_VERSION | cut -d. -f1) \
+  && if [ "$CUDA_MAJOR" -ge 13 ] && [ -n "$NCCL_VERSION" ]; then \
+       echo "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" > /etc/uv-overrides.txt; \
+     else \
+       touch /etc/uv-overrides.txt; \
+     fi
+ENV UV_OVERRIDE=/etc/uv-overrides.txt
 
 # Install PyTorch
 COPY --from=build /workspace/vllm/requirements/common.txt /tmp/common.txt

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -3,9 +3,7 @@ ARG PYTHON_VERSION=3.12
 ARG FRAMEWORK_VERSION=0.24.0
 ARG FLASHINFER_VERSION=0.6.12
 ARG DEEPEP_COMMIT_HASH=73b6ea4
-# DeepEPv2 GIN backend requires NCCL >= 2.30.4. torch pins an older NCCL as a
-# transitive dep, so we override it via UV_OVERRIDE at both build and runtime.
-# Only applied on CUDA 13+; CUDA 12 falls back to torch's default NCCL.
+# DeepEPv2 GIN needs NCCL >= 2.30.4; override torch's older transitive pin (CUDA 13+ only).
 ARG NCCL_VERSION=2.30.7
 
 # =============================================================================
@@ -187,10 +185,7 @@ ENV UV_HTTP_TIMEOUT=500
 ENV UV_INDEX_STRATEGY="unsafe-best-match"
 ENV UV_LINK_MODE=copy
 
-# DeepEPv2 GIN requires NCCL >= 2.30.4 at both compile and runtime. torch pins
-# an older version as a transitive dep; this override forces uv to use our
-# pinned version whenever nvidia-nccl-cu* is resolved, so the runtime venv
-# matches the NCCL the DeepEP wheel was compiled against. Empty on CUDA 12.
+# Match runtime venv NCCL to the DeepEP wheel's compile-time NCCL (see build stage).
 ARG NCCL_VERSION
 RUN CUDA_MAJOR=$(echo $CUDA_VERSION | cut -d. -f1) \
   && if [ "$CUDA_MAJOR" -ge 13 ] && [ -n "$NCCL_VERSION" ]; then \

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -3,7 +3,7 @@ ARG PYTHON_VERSION=3.12
 ARG FRAMEWORK_VERSION=0.24.0
 ARG FLASHINFER_VERSION=0.6.12
 ARG DEEPEP_COMMIT_HASH=73b6ea4
-# DeepEPv2 GIN needs NCCL >= 2.30.4; override torch's older transitive pin (CUDA 13+ only).
+# DeepEPv2 GIN needs NCCL >= 2.30.4; override torch's older transitive pin.
 ARG NCCL_VERSION=2.30.7
 
 # =============================================================================
@@ -128,16 +128,15 @@ RUN --mount=type=cache,target=/root/.cache/ccache --mount=type=cache,target=/roo
       && python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38; \
     fi
 
-# Build DeepEP wheels
+# Build DeepEP wheels. On CUDA 13, NCCL is a separate wheel (not in torch/lib); LIBRARY_PATH puts it on the link search path.
 ARG DEEPEP_COMMIT_HASH
 ARG NVSHMEM_VER
 ARG NCCL_VERSION
 RUN --mount=type=cache,target=/root/.cache/uv mkdir -p /tmp/ep_kernels_workspace/dist \
   && CUDA_MAJOR=$(echo $CUDA_VERSION | cut -d. -f1) \
-  && if [ "$CUDA_MAJOR" -ge 13 ] && [ -n "$NCCL_VERSION" ]; then \
-       echo "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" > /tmp/nccl-override.txt \
-       && export UV_OVERRIDE=/tmp/nccl-override.txt; \
-     fi \
+  && echo "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" > /tmp/nccl-override.txt \
+  && export UV_OVERRIDE=/tmp/nccl-override.txt \
+  && export LIBRARY_PATH="/opt/venv/lib/python${PYTHON_VERSION}/site-packages/nvidia/nccl/lib:${LIBRARY_PATH}" \
   && export TORCH_CUDA_ARCH_LIST='9.0a 10.0a' \
   && tools/ep_kernels/install_python_libraries.sh \
     --workspace /tmp/ep_kernels_workspace \
@@ -188,11 +187,7 @@ ENV UV_LINK_MODE=copy
 # Match runtime venv NCCL to the DeepEP wheel's compile-time NCCL (see build stage).
 ARG NCCL_VERSION
 RUN CUDA_MAJOR=$(echo $CUDA_VERSION | cut -d. -f1) \
-  && if [ "$CUDA_MAJOR" -ge 13 ] && [ -n "$NCCL_VERSION" ]; then \
-       echo "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" > /etc/uv-overrides.txt; \
-     else \
-       touch /etc/uv-overrides.txt; \
-     fi
+  && echo "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" > /etc/uv-overrides.txt
 ENV UV_OVERRIDE=/etc/uv-overrides.txt
 
 # Install PyTorch

--- a/test/security/data/ecr_scan_allowlist/vllm_server/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/vllm_server/framework_allowlist.json
@@ -103,5 +103,30 @@
         "vulnerability_id": "CVE-2026-27145",
         "reason": "go/stdlib 1.24.11 embedded in mooncake libetcd_wrapper.so, x509 VerifyHostname CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
         "review_by": "2026-09-10"
+    },
+    {
+        "vulnerability_id": "CVE-2026-39822",
+        "reason": "go/stdlib 1.25.10 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of a mooncake-transfer-engine rebuild",
+        "review_by": "2026-09-25"
+    },
+    {
+        "vulnerability_id": "CVE-2026-56852",
+        "reason": "golang.org/x/text v0.37.0 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of a mooncake-transfer-engine rebuild",
+        "review_by": "2026-10-25"
+    },
+    {
+        "vulnerability_id": "CVE-2026-46600",
+        "reason": "golang.org/x/net v0.55.0 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of a mooncake-transfer-engine rebuild",
+        "review_by": "2026-10-25"
+    },
+    {
+        "vulnerability_id": "GHSA-hrxh-6v49-42gf",
+        "reason": "google.golang.org/grpc v1.79.3 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of a mooncake-transfer-engine rebuild",
+        "review_by": "2026-10-25"
+    },
+    {
+        "vulnerability_id": "CVE-2026-24747",
+        "reason": "torch 2.9.1 is only a version pin in the upstream vllm base image's benchmarks/requirements.txt (benchmark metadata), not the installed package. weights_only unpickler RCE requires loading a malicious checkpoint; the benchmark requirements file is inert. Not exploitable in the runtime.",
+        "review_by": "2026-09-25"
     }
 ]


### PR DESCRIPTION
## Summary
Bumps the AL2023 vLLM images (EC2 + SageMaker) to build from upstream vLLM commit
[`d223c90`](https://github.com/vllm-project/vllm/commit/d223c900d85224c02f2162ee2c757a769e99f519)
(vllm-project/vllm#50060, "[Bugfix] Only pad transformers backend `value` when it is narrower").

## Changes

### Config (both `ec2-amzn2023.yml` and `sagemaker-amzn2023.yml`)
```
vllm_ref:           7b3d595… -> d223c900d85224c02f2162ee2c757a769e99f519
flashinfer_version: 0.6.12   -> 0.6.15.post1
deepep_commit_hash: 73b6ea4  -> d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb
dlc_minor_version:  1        -> 2
```
FlashInfer and DeepEP track what vLLM pins/expects at `d223c90`.

### Dockerfile (`docker/vllm/Dockerfile.amzn2023`) — NCCL override
DeepEP `d4f41e4e93` (required because `d223c90` patches DeepEP's `symmetric.hpp`) contains the EPv2/GIN
backend. Its `nccl.cu` uses `ncclDevCommRequirements::ginTrafficClass` / `ncclGinRequest_t`, which require
**NCCL >= 2.30.4**. `torch==2.13.0` transitively pins `nvidia-nccl-cu13==2.29.7`, so an initial build failed:

```
nccl.cu(99): error: class "ncclDevCommRequirements" has no member "ginTrafficClass"
```

Mirrors upstream vLLM's `docker/Dockerfile` fix: adds `ARG NCCL_VERSION=2.30.7` and sets `UV_OVERRIDE`
(`nvidia-nccl-cu13==2.30.7`) in both the build stage (before `install_python_libraries.sh`, which
reinstalls torch and thus resolves the overridden NCCL) and the deps stage (so the runtime venv matches the
NCCL the DeepEP wheel was compiled against).

A second, distinct failure surfaced once the version bump was in place — the DeepEP link step failed with:

```
/usr/bin/ld: cannot find -l:libnccl.so.2: No such file or directory
```

On CUDA 13 NCCL is a separate wheel and is no longer bundled in `torch/lib`, so DeepEP's setup passed
`nvidia/nccl/lib` only as `-Wl,-rpath` (runtime), never as `-L` (link-time). The build stage now exports
`LIBRARY_PATH` pointing at that dir so the linker can resolve `libnccl.so.2`. Verified end-to-end on a devbox:
`install_python_libraries.sh --mode wheel` builds the DeepEP wheel with exit 0 and no link error.

The earlier `CUDA_MAJOR >= 13` guards around the override were dropped — this Dockerfile's only CUDA 12
consumer (hyperpod) is filtered out of PR builds and not released, so the guard was dead scaffolding.

## Note
`d223c90` is ~1294 commits ahead of the previously pinned ref but is not a strict fast-forward — it does not
contain 7 commits that were on the prior ref (Minimax-M3, GLM5 Router GEMM, OpenMOSS support, DSv3.2 topK
perf, and two FlashInfer MoE kernels). Confirmed acceptable for the target day-0 model.
