### PR TITLE
base: add CUDA 13.2.1 devel + runtime images

### DIFF
--- a/.github/config/image/base/cu129-devel.yml
+++ b/.github/config/image/base/cu129-devel.yml
@@ -18,7 +18,7 @@ build:
   target: "devel"
   python_version: "3.13.12"
   cuda_version: "12.9.1"
-  uv_version: "0.11.17"
+  uv_version: "0.11.33"
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/base/cu129-runtime.yml
+++ b/.github/config/image/base/cu129-runtime.yml
@@ -18,7 +18,7 @@ build:
   target: "runtime"
   python_version: "3.13.12"
   cuda_version: "12.9.1"
-  uv_version: "0.11.17"
+  uv_version: "0.11.33"
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/base/cu130-devel.yml
+++ b/.github/config/image/base/cu130-devel.yml
@@ -18,7 +18,7 @@ build:
   target: "devel"
   python_version: "3.13.12"
   cuda_version: "13.0.2"
-  uv_version: "0.11.17"
+  uv_version: "0.11.33"
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/base/cu130-runtime.yml
+++ b/.github/config/image/base/cu130-runtime.yml
@@ -18,7 +18,7 @@ build:
   target: "runtime"
   python_version: "3.13.12"
   cuda_version: "13.0.2"
-  uv_version: "0.11.17"
+  uv_version: "0.11.33"
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/base/cu132-devel.yml
+++ b/.github/config/image/base/cu132-devel.yml
@@ -1,0 +1,35 @@
+image:
+  name: "base-cu132-devel"
+  description: "Base devel GPU image with CUDA 13.2.1, Python 3.13, build tools, and the NCCL/EFA stack on AL2023"
+
+metadata:
+  framework: "base_dlc"
+  framework_version: "13.2.1"
+  os_version: "amzn2023"
+  customer_type: "ec2"
+  arch_type: "x86"
+  device_type: "gpu"
+  job_type: "general"
+  container_type: "devel"
+  prod_image: "base:devel-cu132-amzn2023"
+
+build:
+  dockerfile: "docker/base/cu132/Dockerfile"
+  target: "devel"
+  python_version: "3.13.12"
+  cuda_version: "13.2.1"
+  uv_version: "0.11.17"
+  nccl_version: "2.29.7-1"
+  gdrcopy_version: "2.6"
+  # EFA 1.49.0 vends libfabric 2.4.0amzn5.0 and aws-ofi-nccl 1.20.0
+  efa_version: "1.49.0"
+  dlc_major_version: "1"
+  dlc_minor_version: "0"
+
+release:
+  release: true
+  force_release: false
+  public_registry: true
+  private_registry: true
+  enable_soci: true
+  environment: "production"

--- a/.github/config/image/base/cu132-devel.yml
+++ b/.github/config/image/base/cu132-devel.yml
@@ -18,7 +18,7 @@ build:
   target: "devel"
   python_version: "3.13.12"
   cuda_version: "13.2.1"
-  uv_version: "0.11.17"
+  uv_version: "0.11.33"
   nccl_version: "2.29.7-1"
   gdrcopy_version: "2.6"
   # EFA 1.49.0 vends libfabric 2.4.0amzn5.0 and aws-ofi-nccl 1.20.0

--- a/.github/config/image/base/cu132-runtime.yml
+++ b/.github/config/image/base/cu132-runtime.yml
@@ -18,7 +18,7 @@ build:
   target: "runtime"
   python_version: "3.13.12"
   cuda_version: "13.2.1"
-  uv_version: "0.11.17"
+  uv_version: "0.11.33"
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/base/cu132-runtime.yml
+++ b/.github/config/image/base/cu132-runtime.yml
@@ -1,0 +1,31 @@
+image:
+  name: "base-cu132-runtime"
+  description: "Base runtime GPU image with CUDA 13.2.1 and Python 3.13 on AL2023"
+
+metadata:
+  framework: "base_dlc"
+  framework_version: "13.2.1"
+  os_version: "amzn2023"
+  customer_type: "ec2"
+  arch_type: "x86"
+  device_type: "gpu"
+  job_type: "general"
+  container_type: "runtime"
+  prod_image: "base:runtime-cu132-amzn2023"
+
+build:
+  dockerfile: "docker/base/cu132/Dockerfile"
+  target: "runtime"
+  python_version: "3.13.12"
+  cuda_version: "13.2.1"
+  uv_version: "0.11.17"
+  dlc_major_version: "1"
+  dlc_minor_version: "0"
+
+release:
+  release: true
+  force_release: false
+  public_registry: true
+  private_registry: true
+  enable_soci: true
+  environment: "production"

--- a/.github/release-schedule.yml
+++ b/.github/release-schedule.yml
@@ -29,6 +29,10 @@ schedules:
     workflow: vllm.autorelease-ec2-ubuntu.yml
     gpu: heavy
 
+  - cron: "30 20 * * 1,3"
+    workflow: base.autorelease-cu132.yml
+    gpu: minimal
+
   - cron: "00 21 * * 1,3"
     workflow: base.autorelease-cu129.yml
     gpu: minimal

--- a/.github/workflows/_reusable.sanity-tests.yml
+++ b/.github/workflows/_reusable.sanity-tests.yml
@@ -38,6 +38,9 @@ jobs:
       contributor: ${{ steps.parse.outputs.contributor }}
       transformers-version: ${{ steps.parse.outputs.transformers-version }}
       target: ${{ steps.parse.outputs.target }}
+      nccl-version: ${{ steps.parse.outputs.nccl-version }}
+      efa-version: ${{ steps.parse.outputs.efa-version }}
+      gdrcopy-version: ${{ steps.parse.outputs.gdrcopy-version }}
     steps:
       - uses: actions/checkout@v6
 
@@ -75,6 +78,9 @@ jobs:
           echo "contributor=$(yq '.metadata.contributor // ""' "$CONFIG_FILE")" >> $GITHUB_OUTPUT
           echo "transformers-version=$(yq '.build.transformers_version // ""' "$CONFIG_FILE")" >> $GITHUB_OUTPUT
           echo "target=$(yq '.build.target // ""' "$CONFIG_FILE")" >> $GITHUB_OUTPUT
+          echo "nccl-version=$(yq '.build.nccl_version // ""' "$CONFIG_FILE")" >> $GITHUB_OUTPUT
+          echo "efa-version=$(yq '.build.efa_version // ""' "$CONFIG_FILE")" >> $GITHUB_OUTPUT
+          echo "gdrcopy-version=$(yq '.build.gdrcopy_version // ""' "$CONFIG_FILE")" >> $GITHUB_OUTPUT
 
   sanity-test:
     if: ${{ needs.preflight.outputs.image-exists == 'true' }}
@@ -131,6 +137,21 @@ jobs:
           CUDA_SHORT=$(echo '${{ needs.preflight.outputs.cuda-version }}' | cut -d. -f1,2)
           docker exec ${CONTAINER_ID} bash /workdir/test/sanity/scripts/check_base_image.sh \
             "${PYTHON_SHORT}" "${CUDA_SHORT}"
+
+      # Base devel images vend the NCCL/GDRCopy/EFA stack; runtime images do not.
+      # Gated on the version pins being present so a base variant built without
+      # the stack doesn't fail this step.
+      - name: Run NCCL / GDRCopy / EFA install checks
+        if: |
+          needs.preflight.outputs.framework == 'base_dlc' &&
+          needs.preflight.outputs.nccl-version != '' &&
+          needs.preflight.outputs.efa-version != '' &&
+          needs.preflight.outputs.gdrcopy-version != ''
+        run: |
+          docker exec ${CONTAINER_ID} bash /workdir/test/sanity/scripts/check_nccl_efa_gdrcopy.sh \
+            "${{ needs.preflight.outputs.nccl-version }}" \
+            "${{ needs.preflight.outputs.efa-version }}" \
+            "${{ needs.preflight.outputs.gdrcopy-version }}"
 
       - name: Run inference engine checks
         if: |
@@ -263,3 +284,13 @@ jobs:
           CUDA_SHORT=$(echo '${{ needs.preflight.outputs.cuda-version }}' | cut -d. -f1,2)
           docker exec ${CONTAINER_ID} bash /workdir/test/sanity/scripts/cuda_${{ needs.preflight.outputs.target }}_test.sh \
             "${CUDA_SHORT}"
+
+      # Functional NCCL check — compiles against the image's own nccl.h/libnccl
+      # and runs a real all-reduce. devel only (needs nvcc + NCCL headers).
+      # Single-node: EFA/Libfabric transport is covered by test/efa/test_efa.py.
+      - name: Run single-node NCCL test
+        if: |
+          needs.preflight.outputs.target == 'devel' &&
+          needs.preflight.outputs.nccl-version != ''
+        run: |
+          docker exec ${CONTAINER_ID} bash /workdir/test/sanity/scripts/nccl_single_node_test.sh

--- a/.github/workflows/base.autorelease-cu132.yml
+++ b/.github/workflows/base.autorelease-cu132.yml
@@ -4,6 +4,12 @@ on:
   schedule:
     - cron: '30 20 * * 1,3'
   workflow_dispatch:
+    inputs:
+      run-efa-test:
+        description: "Run multi-node EFA/NCCL tests (launches 2x p4d.24xlarge)"
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}
@@ -34,5 +40,8 @@ jobs:
     with:
       config-file: ${{ matrix.config_file }}
       tag-suffix: ${{ github.run_id }}
+      # Off on the cron schedule (inputs is empty there); opt in per-run via
+      # workflow_dispatch. 2x p4d.24xlarge is too costly for every release.
+      run-efa-test: ${{ inputs.run-efa-test == true }}
       release: true
     secrets: inherit

--- a/.github/workflows/base.autorelease-cu132.yml
+++ b/.github/workflows/base.autorelease-cu132.yml
@@ -1,0 +1,38 @@
+name: "Auto Release - Base cu132"
+
+on:
+  schedule:
+    - cron: '30 20 * * 1,3'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      configs: ${{ steps.discover.outputs.configs }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: discover
+        uses: ./.github/actions/discover-configs
+        with:
+          pattern: ".github/config/image/base/cu132-*.yml"
+
+  pipeline:
+    needs: [discover]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.configs) }}
+    uses: ./.github/workflows/base.pipeline.yml
+    with:
+      config-file: ${{ matrix.config_file }}
+      tag-suffix: ${{ github.run_id }}
+      release: true
+    secrets: inherit

--- a/.github/workflows/base.pipeline.yml
+++ b/.github/workflows/base.pipeline.yml
@@ -26,6 +26,16 @@ on:
         required: false
         type: boolean
         default: false
+      run-efa-test:
+        description: "Run multi-node EFA/NCCL tests (launches 2x p4d.24xlarge)"
+        required: false
+        type: boolean
+        default: false
+      efa-instance-type:
+        description: "EFA-enabled instance type for the EFA test"
+        required: false
+        type: string
+        default: "p4d.24xlarge"
       release:
         description: "Run release job after tests pass"
         required: false
@@ -37,6 +47,18 @@ on:
         value: ${{ jobs.build.outputs.image-uri }}
 
 jobs:
+  ci-config:
+    runs-on: ubuntu-latest
+    outputs:
+      device-type: ${{ steps.parse.outputs.device-type }}
+      target: ${{ steps.parse.outputs.target }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: parse
+        run: |
+          echo "device-type=$(yq '.metadata.device_type' '${{ inputs.config-file }}')" >> $GITHUB_OUTPUT
+          echo "target=$(yq '.build.target // ""' '${{ inputs.config-file }}')" >> $GITHUB_OUTPUT
+
   build:
     if: ${{ inputs.build }}
     concurrency:
@@ -81,6 +103,21 @@ jobs:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
+  # Multi-node EFA/NCCL over Libfabric — devel only (runtime has no NCCL/EFA
+  # stack). Opt-in: launches 2x p4d.24xlarge, so it's off by default and enabled
+  # via workflow_dispatch or by a caller passing run-efa-test: true.
+  efa-test:
+    if: ${{ always() && !failure() && !cancelled() && inputs.run-efa-test && needs.ci-config.outputs.target == 'devel' && needs.ci-config.outputs.device-type == 'gpu' }}
+    needs: [build, ci-config]
+    concurrency:
+      group: ${{ github.workflow }}-efa-test-${{ inputs.config-file }}-${{ github.ref }}
+      cancel-in-progress: false
+    uses: ./.github/workflows/_reusable.efa-tests.yml
+    with:
+      config-file: ${{ inputs.config-file }}
+      image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      efa-instance-type: ${{ inputs.efa-instance-type }}
+
   release-gate:
     if: >-
       github.ref == 'refs/heads/main' &&
@@ -89,7 +126,7 @@ jobs:
       inputs.release &&
       !failure() && !cancelled() &&
       needs.build.result == 'success'
-    needs: [build, sanity-test, security-test]
+    needs: [build, sanity-test, security-test, efa-test]
     runs-on: ubuntu-latest
     outputs:
       should-release: ${{ steps.check.outputs.should-release }}
@@ -129,7 +166,7 @@ jobs:
       (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
       !contains(github.workflow_ref, '.pr') &&
       inputs.release
-    needs: [build, sanity-test, security-test, release-gate, release]
+    needs: [build, sanity-test, security-test, efa-test, release-gate, release]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/base.pr-cu132.yml
+++ b/.github/workflows/base.pr-cu132.yml
@@ -73,5 +73,8 @@ jobs:
       build: ${{ needs.check-changes.outputs.build-change == 'true' }}
       run-sanity-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sanity-test-change == 'true' }}
       run-security-test: ${{ needs.check-changes.outputs.build-change == 'true' }}
+      # TEMPORARY: validates the new EFA/NCCL coverage against this PR's image.
+      # Launches 2x p4d.24xlarge per run — remove before merge.
+      run-efa-test: true
       release: false
     secrets: inherit

--- a/.github/workflows/base.pr-cu132.yml
+++ b/.github/workflows/base.pr-cu132.yml
@@ -1,0 +1,77 @@
+name: "PR - Base cu132"
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize]
+    paths:
+      - ".github/config/image/base/cu132-*.yml"
+      - ".github/workflows/base.pipeline.yml"
+      - ".github/workflows/base.pr-cu132.yml"
+      - "docker/base/cu132/**"
+      - "scripts/docker/common/**"
+      - "test/sanity/**"
+      - "test/security/data/ecr_scan_allowlist/base_dlc/**"
+      - "!docs/**"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  gatekeeper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+      - uses: ./.github/actions/pr-permission-gate
+
+  check-changes:
+    needs: [gatekeeper]
+    runs-on: ubuntu-latest
+    outputs:
+      build-change: ${{ steps.changes.outputs.build-change }}
+      sanity-test-change: ${{ steps.changes.outputs.sanity-test-change }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v4
+        id: changes
+        with:
+          filters: |
+            build-change:
+              - ".github/config/image/base/cu132-*.yml"
+              - "docker/base/cu132/**"
+              - "scripts/docker/common/**"
+              - "test/security/data/ecr_scan_allowlist/base_dlc/**"
+            sanity-test-change:
+              - "test/sanity/**"
+
+  discover:
+    needs: [gatekeeper]
+    runs-on: ubuntu-latest
+    outputs:
+      configs: ${{ steps.discover.outputs.configs }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: discover
+        uses: ./.github/actions/discover-configs
+        with:
+          pattern: ".github/config/image/base/cu132-*.yml"
+
+  pipeline:
+    needs: [check-changes, discover]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.configs) }}
+    uses: ./.github/workflows/base.pipeline.yml
+    with:
+      config-file: ${{ matrix.config_file }}
+      tag-suffix: pr-${{ github.event.pull_request.number }}
+      build: ${{ needs.check-changes.outputs.build-change == 'true' }}
+      run-sanity-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sanity-test-change == 'true' }}
+      run-security-test: ${{ needs.check-changes.outputs.build-change == 'true' }}
+      release: false
+    secrets: inherit

--- a/.github/workflows/base.pr-cu132.yml
+++ b/.github/workflows/base.pr-cu132.yml
@@ -73,8 +73,7 @@ jobs:
       build: ${{ needs.check-changes.outputs.build-change == 'true' }}
       run-sanity-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sanity-test-change == 'true' }}
       run-security-test: ${{ needs.check-changes.outputs.build-change == 'true' }}
-      # TEMPORARY: validates the new EFA/NCCL coverage against this PR's image.
-      # Launches 2x p4d.24xlarge per run — remove before merge.
-      run-efa-test: true
+      # Opt-in — flip to true to validate EFA against a PR build (2x p4d.24xlarge per run)
+      run-efa-test: false
       release: false
     secrets: inherit

--- a/docker/base/cu129/Dockerfile
+++ b/docker/base/cu129/Dockerfile
@@ -2,7 +2,7 @@ ARG CUDA_VERSION=12.9.1
 # Short CUDA tag — also the docker/base/<dir> name (cu129, cu130, ...)
 ARG CUDA_VERSION_SHORT=cu129
 # uv release to copy the binary from (pinned via the config build: block)
-ARG UV_VERSION=0.11.17
+ARG UV_VERSION=0.11.33
 
 # ============================================================
 # uv binary source (pinned)

--- a/docker/base/cu130/Dockerfile
+++ b/docker/base/cu130/Dockerfile
@@ -2,7 +2,7 @@ ARG CUDA_VERSION=13.0.2
 # Short CUDA tag — also the docker/base/<dir> name (cu129, cu130, ...)
 ARG CUDA_VERSION_SHORT=cu130
 # uv release to copy the binary from (pinned via the config build: block)
-ARG UV_VERSION=0.11.17
+ARG UV_VERSION=0.11.33
 
 # ============================================================
 # uv binary source (pinned)

--- a/docker/base/cu132/Dockerfile
+++ b/docker/base/cu132/Dockerfile
@@ -1,0 +1,185 @@
+ARG CUDA_VERSION=13.2.1
+# Short CUDA tag — also the docker/base/<dir> name (cu129, cu130, ...)
+ARG CUDA_VERSION_SHORT=cu132
+# uv release to copy the binary from (pinned via the config build: block)
+ARG UV_VERSION=0.11.17
+
+# ============================================================
+# uv binary source (pinned)
+# ============================================================
+FROM ghcr.io/astral-sh/uv:${UV_VERSION} AS uv
+
+# ============================================================
+# Python builder (compile from source on cuda-base)
+# ============================================================
+FROM nvidia/cuda:${CUDA_VERSION}-base-amzn2023 AS python-builder
+
+ARG PYTHON_VERSION="3.13.12"
+ARG PYTHON_SHORT_VERSION="3.13"
+
+RUN dnf install -y --setopt=install_weak_deps=False \
+  gcc gcc-c++ make tar gzip wget \
+  openssl-devel libffi-devel bzip2-devel xz-devel zlib-devel \
+  && dnf clean all && rm -rf /var/cache/dnf
+
+COPY ./scripts/docker/common/install_python.sh install_python.sh
+RUN --mount=type=cache,target=/root/.cache/pip bash install_python.sh ${PYTHON_VERSION} && rm install_python.sh
+
+# ============================================================
+# GDRCopy builder (userspace lib only — independent of Python)
+# ============================================================
+FROM nvidia/cuda:${CUDA_VERSION}-devel-amzn2023 AS gdrcopy-builder
+
+ARG GDRCOPY_VERSION="2.6"
+
+COPY ./scripts/docker/common/install_gdrcopy.sh /tmp/install_gdrcopy.sh
+RUN bash /tmp/install_gdrcopy.sh ${GDRCOPY_VERSION} && rm /tmp/install_gdrcopy.sh
+
+# ============================================================
+# Runtime: CUDA runtime libs + Python
+# ============================================================
+FROM nvidia/cuda:${CUDA_VERSION}-runtime-amzn2023 AS runtime
+
+ARG PYTHON_SHORT_VERSION="3.13"
+ARG CUDA_VERSION_SHORT
+
+LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="1"
+LABEL dlc_minor_version="0"
+
+ENV LANG=C.UTF-8 \
+  LC_ALL=C.UTF-8 \
+  PYTHONDONTWRITEBYTECODE=1 \
+  PYTHONUNBUFFERED=1 \
+  PYTHONIOENCODING=UTF-8 \
+  CUDA_HOME="/usr/local/cuda" \
+  PATH="/usr/local/cuda/bin:${PATH}" \
+  LD_LIBRARY_PATH="/usr/local/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}"
+
+WORKDIR /
+
+COPY --from=python-builder /usr/local/lib/python${PYTHON_SHORT_VERSION} /usr/local/lib/python${PYTHON_SHORT_VERSION}
+COPY --from=python-builder /usr/local/include/python${PYTHON_SHORT_VERSION} /usr/local/include/python${PYTHON_SHORT_VERSION}
+COPY --from=python-builder /usr/local/bin/python${PYTHON_SHORT_VERSION} /usr/local/bin/python${PYTHON_SHORT_VERSION}
+COPY --from=python-builder /usr/local/bin/pip${PYTHON_SHORT_VERSION} /usr/local/bin/pip${PYTHON_SHORT_VERSION}
+COPY --from=python-builder /usr/local/lib/libpython${PYTHON_SHORT_VERSION}* /usr/local/lib/
+RUN echo "/usr/local/lib" >/etc/ld.so.conf.d/python.conf && ldconfig
+RUN ln -sf /usr/local/bin/python${PYTHON_SHORT_VERSION} /usr/local/bin/python3 \
+  && ln -sf /usr/local/bin/python${PYTHON_SHORT_VERSION} /usr/local/bin/python \
+  && ln -sf /usr/local/bin/pip${PYTHON_SHORT_VERSION} /usr/local/bin/pip3 \
+  && ln -sf /usr/local/bin/pip${PYTHON_SHORT_VERSION} /usr/local/bin/pip
+
+RUN dnf install -y --allowerasing --setopt=install_weak_deps=False curl \
+  && dnf upgrade -y --security --releasever latest \
+  # Explicitly upgrade cuda-compat-13-2 to pick up fix for CVE-2025-33219
+  && dnf upgrade -y --releasever latest cuda-compat-13-2 \
+  && dnf clean all && rm -rf /var/cache/dnf
+
+COPY --from=uv /uv /usr/local/bin/uv
+ENV UV_PROJECT_ENVIRONMENT=/usr/local
+COPY ./docker/base/${CUDA_VERSION_SHORT}/pyproject.toml ./docker/base/${CUDA_VERSION_SHORT}/uv.lock /tmp/deps/
+RUN --mount=type=cache,target=/root/.cache/uv cd /tmp/deps \
+  && uv sync --frozen --no-dev --no-install-project \
+  && rm -rf /tmp/deps /tmp/uv-*.lock
+
+COPY ./scripts/docker/common/setup_oss_compliance.sh /tmp/setup_oss_compliance.sh
+
+ARG PYTHON="python3"
+RUN bash /tmp/setup_oss_compliance.sh ${PYTHON} \
+  && rm /tmp/setup_oss_compliance.sh \
+  && rm -rf /root/oss_compliance* \
+  && rm -rf /tmp/tmp* \
+  && rm -rf /root/.cache
+
+CMD ["/bin/bash"]
+
+# ============================================================
+# Devel: CUDA devel libs + Python + build tools + NCCL/EFA stack
+# ============================================================
+FROM nvidia/cuda:${CUDA_VERSION}-devel-amzn2023 AS devel
+
+ARG PYTHON_SHORT_VERSION="3.13"
+ARG CUDA_VERSION
+ARG CUDA_VERSION_SHORT
+# NCCL RPM version as published in the NVIDIA cuda-rhel9 repo. The +cudaX.Y
+# build suffix is derived from CUDA_VERSION below.
+ARG NCCL_VERSION="2.29.7-1"
+# EFA installer 1.49.0 vends libfabric 2.4.0amzn5.0 and aws-ofi-nccl 1.20.0.
+ARG EFA_VERSION="1.49.0"
+
+LABEL maintainer="Amazon AI"
+LABEL dlc_major_version="1"
+LABEL dlc_minor_version="0"
+
+ENV LANG=C.UTF-8 \
+  LC_ALL=C.UTF-8 \
+  PYTHONDONTWRITEBYTECODE=1 \
+  PYTHONUNBUFFERED=1 \
+  PYTHONIOENCODING=UTF-8 \
+  CUDA_HOME="/usr/local/cuda" \
+  PATH="/usr/local/cuda/bin:/opt/amazon/openmpi/bin:/opt/amazon/efa/bin:${PATH}" \
+  LD_LIBRARY_PATH="/usr/local/lib:/usr/local/cuda/lib64:/opt/amazon/ofi-nccl/lib64:/opt/amazon/openmpi/lib:/opt/amazon/openmpi/lib64:/opt/amazon/efa/lib:/opt/amazon/efa/lib64:${LD_LIBRARY_PATH}"
+
+WORKDIR /
+
+COPY --from=python-builder /usr/local/lib/python${PYTHON_SHORT_VERSION} /usr/local/lib/python${PYTHON_SHORT_VERSION}
+COPY --from=python-builder /usr/local/include/python${PYTHON_SHORT_VERSION} /usr/local/include/python${PYTHON_SHORT_VERSION}
+COPY --from=python-builder /usr/local/bin/python${PYTHON_SHORT_VERSION} /usr/local/bin/python${PYTHON_SHORT_VERSION}
+COPY --from=python-builder /usr/local/bin/pip${PYTHON_SHORT_VERSION} /usr/local/bin/pip${PYTHON_SHORT_VERSION}
+COPY --from=python-builder /usr/local/lib/libpython${PYTHON_SHORT_VERSION}* /usr/local/lib/
+RUN echo "/usr/local/lib" >/etc/ld.so.conf.d/python.conf && ldconfig
+RUN ln -sf /usr/local/bin/python${PYTHON_SHORT_VERSION} /usr/local/bin/python3 \
+  && ln -sf /usr/local/bin/python${PYTHON_SHORT_VERSION} /usr/local/bin/python \
+  && ln -sf /usr/local/bin/pip${PYTHON_SHORT_VERSION} /usr/local/bin/pip3 \
+  && ln -sf /usr/local/bin/pip${PYTHON_SHORT_VERSION} /usr/local/bin/pip
+
+RUN dnf install -y --allowerasing --setopt=install_weak_deps=False \
+  curl automake autoconf cmake gcc gcc-c++ git make tar \
+  && dnf clean all && rm -rf /var/cache/dnf
+
+# GDRCopy userspace library (kernel module is provided by the host)
+COPY --from=gdrcopy-builder /usr/local/lib/libgdrapi.so* /usr/local/lib/
+COPY --from=gdrcopy-builder /usr/local/include/gdrapi.h /usr/local/include/gdrconfig.h /usr/local/include/
+RUN ldconfig
+
+# NCCL from the NVIDIA cuda-rhel9 repo. The amzn2023 repo shipped in this base
+# image does not carry libnccl, so the rhel9 repo is added for the NCCL RPMs.
+# Derive the +cudaX.Y build suffix from the image's own CUDA toolkit release.
+RUN CUDA_MAJOR_MINOR=$(echo "${CUDA_VERSION}" | cut -d. -f1,2) \
+  && echo -e '[cuda-rhel9]\nname=cuda-rhel9\nbaseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64\nenabled=1\ngpgcheck=1\ngpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA' >/etc/yum.repos.d/cuda-rhel9.repo \
+  && dnf install -y --setopt=install_weak_deps=False \
+    libnccl-${NCCL_VERSION}+cuda${CUDA_MAJOR_MINOR} \
+    libnccl-devel-${NCCL_VERSION}+cuda${CUDA_MAJOR_MINOR} \
+  && dnf clean all && rm -rf /var/cache/dnf \
+  && ldconfig
+
+# EFA installer — vends libfabric, aws-ofi-nccl (NCCL OFI plugin), OpenMPI, and
+# rdma-core, plus SSH config for multi-node jobs.
+COPY ./scripts/docker/common/install_efa_amzn2023.sh /tmp/install_efa.sh
+RUN bash /tmp/install_efa.sh ${EFA_VERSION} && rm /tmp/install_efa.sh
+
+# Security patch — run after all installers so every OS package is covered
+RUN dnf upgrade -y --security --releasever latest \
+  # Explicitly upgrade cuda-compat-13-2 to pick up fix for CVE-2025-33219
+  && dnf upgrade -y --releasever latest cuda-compat-13-2 \
+  && dnf clean all && rm -rf /var/cache/dnf
+
+COPY --from=uv /uv /usr/local/bin/uv
+ENV UV_PROJECT_ENVIRONMENT=/usr/local
+COPY ./docker/base/${CUDA_VERSION_SHORT}/pyproject.toml ./docker/base/${CUDA_VERSION_SHORT}/uv.lock /tmp/deps/
+RUN --mount=type=cache,target=/root/.cache/uv cd /tmp/deps \
+  && uv sync --frozen --no-dev --no-install-project \
+  && rm -rf /tmp/deps /tmp/uv-*.lock
+
+COPY ./scripts/docker/common/setup_oss_compliance.sh /tmp/setup_oss_compliance.sh
+
+ARG PYTHON="python3"
+RUN bash /tmp/setup_oss_compliance.sh ${PYTHON} \
+  && rm /tmp/setup_oss_compliance.sh \
+  && rm -rf /root/oss_compliance* \
+  && rm -rf /tmp/tmp* \
+  && rm -rf /root/.cache
+
+EXPOSE 22
+
+CMD ["/bin/bash"]

--- a/docker/base/cu132/Dockerfile
+++ b/docker/base/cu132/Dockerfile
@@ -2,7 +2,7 @@ ARG CUDA_VERSION=13.2.1
 # Short CUDA tag — also the docker/base/<dir> name (cu129, cu130, ...)
 ARG CUDA_VERSION_SHORT=cu132
 # uv release to copy the binary from (pinned via the config build: block)
-ARG UV_VERSION=0.11.17
+ARG UV_VERSION=0.11.33
 
 # ============================================================
 # uv binary source (pinned)

--- a/docker/base/cu132/pyproject.toml
+++ b/docker/base/cu132/pyproject.toml
@@ -1,0 +1,8 @@
+[project]
+name = "dlc-base-cu132"
+version = "1.0.0"
+requires-python = "==3.13.*"
+dependencies = [
+    "requests",
+    "urllib3>=2.7.0",
+]

--- a/docker/base/cu132/uv.lock
+++ b/docker/base/cu132/uv.lock
@@ -4,41 +4,38 @@ requires-python = "==3.13.*"
 
 [[package]]
 name = "certifi"
-version = "2026.2.25"
+version = "2026.7.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
 ]
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.7"
+version = "3.4.9"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2a/23f34ec9d04624958e137efdc394888716353190e75f25dd22c7a2c7a8aa/charset_normalizer-3.4.9.tar.gz", hash = "sha256:673611bbd43f0810bec0b0f028ddeaaa501190339cac411f347ac76917c3ae7b", size = 152439, upload-time = "2026-07-07T14:34:58.454Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
-    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
-    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
-    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
-    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
-    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
-    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/06/97ec2aeae780b31d742b6352218b43841a6871e2564578ca522dce4a45c3/charset_normalizer-3.4.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:440eede837960000d74978f0eba527be106b5b9aee0daf779d395276ed0b0614", size = 317688, upload-time = "2026-07-07T14:33:35.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/39/8ff066c672434225f8d25f8b739f992af250944392173dcc88362681c9bf/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:21e764fd1e70b6a3e205a0e46f3051701f98a8cb3fad66eeb80e48bb502f8698", size = 214982, upload-time = "2026-07-07T14:33:36.996Z" },
+    { url = "https://files.pythonhosted.org/packages/92/8f/3a47a3667c83c2df9483d91644c6c107de3bf8874aa1793da9d3012eb986/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e4fd89cc178bced6ad29cb3e6dd4aa63fa5017c3524dbd0b25998fb64a87cc8b", size = 236460, upload-time = "2026-07-07T14:33:38.536Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/60/b22cdbee7e4013dab8b0d7647fc6181120fbbbc8f7025c226d15bd5a47fc/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bd47ba7fc3ca94896759ea0109775132d3e7ab921fbf54038e1bab2e46c313c9", size = 232003, upload-time = "2026-07-07T14:33:40.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f8/72eb13dcabe7257035cea8aefd922caad2f110d252bf9f67c4c2ca763aee/charset_normalizer-3.4.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:84fd18bcc17526fc2b3c1af7d2b9217d32c9c04448c16ec693b9b4f1985c3d33", size = 223149, upload-time = "2026-07-07T14:33:41.631Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3e/faee8f9de92b14ee1198e9163252bb15efee7301b31256a3b6d9ebfdd0dd/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:5b10cd92fc5c498b35a8635df6d5a100207f88b63a4dc1de7ef9a548e1e2cd63", size = 207901, upload-time = "2026-07-07T14:33:43.209Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/25/45f30093ae27dd7b92a793b61882a38685f993700113ca36e0c9c14965e1/charset_normalizer-3.4.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4fbdde9dd4a9ce5fd52c2b3a347bb50cc89483ef783f1cb00d408c13f7a96c0", size = 219176, upload-time = "2026-07-07T14:33:44.725Z" },
+    { url = "https://files.pythonhosted.org/packages/48/18/c8f397329c35e32f6a837e488986f4ae03bd2abebc453b48714991630c2f/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:416c229f77e5ea25b3dfd4b582f8d73d7e43c22320302b9ab128a2d3a0b38efe", size = 217356, upload-time = "2026-07-07T14:33:46.192Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7e/5ce0bba863470fd1902d5e5843968951bddf38abe4742fc97116ef4598b3/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:75286256590a6320cf106a0d28970d3560aad9ee09aa7b34fb40524792436d35", size = 209614, upload-time = "2026-07-07T14:33:47.705Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/ef/2473d3c4d869155be4af1191111d59c4d5c4e0173026f7e85b176e23bf65/charset_normalizer-3.4.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:69b157c5d3292bcd443faca052f3096f637f1e074b98212a933c074ae23dc3b8", size = 224991, upload-time = "2026-07-07T14:33:49.238Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a3/53ddae3db108a088156aa8ddfafd411ebbc1340f48c5573f697b27f69a39/charset_normalizer-3.4.9-cp313-cp313-win32.whl", hash = "sha256:51307f5c71007673a2bf8232ad973483d281e74cb99c8c5a990af1eefa6277d9", size = 150622, upload-time = "2026-07-07T14:33:50.711Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ef/6953a77c7cf2c2ff9998e6f575ab3e380119f100223381565a4f94c1f836/charset_normalizer-3.4.9-cp313-cp313-win_amd64.whl", hash = "sha256:fe2c7201c642b7c308f1675355ad7ff7b66acfe3541625efe5a3ad38f29d6115", size = 161947, upload-time = "2026-07-07T14:33:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fb/d560d1d1555debbfe7849d9cac6145c1b537709d79576bf22557ed803b82/charset_normalizer-3.4.9-cp313-cp313-win_arm64.whl", hash = "sha256:611057cc5d5c0afc743ba8be6bd828c17e0aaa8643f9d0a9b9bb7dea80eb8012", size = 152594, upload-time = "2026-07-07T14:33:53.486Z" },
+    { url = "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl", hash = "sha256:68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5", size = 64538, upload-time = "2026-07-07T14:34:56.993Z" },
 ]
 
 [[package]]
 name = "dlc-base-cu132"
-version = "3.0.0"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "requests" },
@@ -53,16 +50,16 @@ requires-dist = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.18"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
 ]
 
 [[package]]
 name = "requests"
-version = "2.33.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -70,9 +67,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]

--- a/docker/base/cu132/uv.lock
+++ b/docker/base/cu132/uv.lock
@@ -1,0 +1,85 @@
+version = 1
+revision = 3
+requires-python = "==3.13.*"
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "dlc-base-cu132"
+version = "3.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "requests" },
+    { name = "urllib3" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "requests" },
+    { name = "urllib3", specifier = ">=2.7.0" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]

--- a/test/sanity/scripts/check_nccl_efa_gdrcopy.sh
+++ b/test/sanity/scripts/check_nccl_efa_gdrcopy.sh
@@ -1,0 +1,314 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# NCCL / GDRCopy / EFA install checks for base devel images (no GPU required).
+#
+# Verifies the artifacts the Dockerfile installs are present, at the expected
+# version, and dynamically loadable. Functional fabric coverage (EFA provider
+# init, NCCL over Libfabric, GDRDMA) needs EFA hardware and lives in
+# test/efa/test_efa.py, which runs on 2x p4d.24xlarge.
+#
+# Usage: check_nccl_efa_gdrcopy.sh <nccl_version> <efa_version> <gdrcopy_version>
+# Example: check_nccl_efa_gdrcopy.sh 2.29.7-1 1.49.0 2.6
+
+NCCL_VERSION="${1:?Usage: check_nccl_efa_gdrcopy.sh <nccl_version> <efa_version> <gdrcopy_version>}"
+EFA_VERSION="${2:?Usage: check_nccl_efa_gdrcopy.sh <nccl_version> <efa_version> <gdrcopy_version>}"
+GDRCOPY_VERSION="${3:?Usage: check_nccl_efa_gdrcopy.sh <nccl_version> <efa_version> <gdrcopy_version>}"
+FAILED=0
+
+pass() { echo "PASS: $1"; }
+fail() {
+  echo "FAIL: $1"
+  FAILED=1
+}
+
+echo "=============== NCCL ==============="
+
+# --- libnccl runtime is in the linker cache ---
+if ldconfig -p 2>/dev/null | grep -q "libnccl\.so\.2"; then
+  pass "libnccl.so.2 found in ldconfig"
+else
+  fail "libnccl.so.2 not found in ldconfig"
+  ldconfig -p 2>/dev/null | grep -i nccl || echo "  (no libnccl entries at all)"
+fi
+
+# --- libnccl is loadable and reports the expected version ---
+# Strip the RPM release suffix: "2.29.7-1" -> "2.29.7".
+EXPECTED_NCCL="${NCCL_VERSION%%-*}"
+# libnccl needs the NVIDIA driver's libcuda.so.1, which is injected by the
+# container runtime and absent on CPU runners. Only assert the runtime version
+# where the driver is actually present; the header check below covers the
+# no-GPU case.
+if ldconfig -p 2>/dev/null | grep -q "libcuda\.so\.1"; then
+  NCCL_LOAD_ERROR=$(mktemp)
+  NCCL_RUNTIME_VERSION=$(python3 -c "
+import ctypes
+lib = ctypes.CDLL('libnccl.so.2')
+v = ctypes.c_int()
+assert lib.ncclGetVersion(ctypes.byref(v)) == 0
+# NCCL >= 2.9 encodes as major*10000 + minor*100 + patch. Base images ship far
+# newer than that, so the pre-2.9 major*1000 encoding is not handled.
+major, rest = divmod(v.value, 10000)
+minor, patch = divmod(rest, 100)
+print(f'{major}.{minor}.{patch}')
+" 2>"$NCCL_LOAD_ERROR")
+  if [ -z "$NCCL_RUNTIME_VERSION" ]; then
+    fail "could not load libnccl.so.2 / call ncclGetVersion"
+    cat "$NCCL_LOAD_ERROR"
+  elif [ "$NCCL_RUNTIME_VERSION" = "$EXPECTED_NCCL" ]; then
+    pass "ncclGetVersion reports $NCCL_RUNTIME_VERSION"
+  else
+    fail "NCCL version mismatch: runtime $NCCL_RUNTIME_VERSION, expected $EXPECTED_NCCL"
+  fi
+  rm -f "$NCCL_LOAD_ERROR"
+else
+  echo "INFO: libcuda.so.1 not present (no GPU runtime), skipping ncclGetVersion check"
+fi
+
+# --- NCCL development headers (needed to build NCCL-linked code in devel) ---
+NCCL_HEADER=""
+for CANDIDATE in /usr/include/nccl.h /usr/local/cuda/include/nccl.h /usr/local/include/nccl.h; do
+  if [ -f "$CANDIDATE" ]; then
+    NCCL_HEADER="$CANDIDATE"
+    break
+  fi
+done
+if [ -n "$NCCL_HEADER" ]; then
+  pass "nccl.h found at $NCCL_HEADER"
+  HEADER_VERSION=$(awk '
+    /#define NCCL_MAJOR/ {major=$3}
+    /#define NCCL_MINOR/ {minor=$3}
+    /#define NCCL_PATCH/ {patch=$3}
+    END {print major "." minor "." patch}
+  ' "$NCCL_HEADER")
+  if [ "$HEADER_VERSION" = "$EXPECTED_NCCL" ]; then
+    pass "nccl.h reports $HEADER_VERSION"
+  else
+    fail "nccl.h version mismatch: $HEADER_VERSION, expected $EXPECTED_NCCL"
+  fi
+else
+  fail "nccl.h not found (libnccl-devel missing?)"
+fi
+
+# --- The NCCL link-time symlink exists so -lnccl resolves ---
+if ldconfig -p 2>/dev/null | grep -q "libnccl\.so " || \
+  find /usr/lib64 /usr/lib /usr/local/lib /usr/local/cuda/lib64 \
+    -maxdepth 1 -name 'libnccl.so' 2>/dev/null | grep -q .; then
+  pass "libnccl.so link-time symlink present"
+else
+  fail "libnccl.so link-time symlink missing (-lnccl will not resolve)"
+fi
+
+# --- /etc/nccl.conf written by the EFA installer ---
+if [ -f /etc/nccl.conf ]; then
+  NCCL_CONF=$(cat /etc/nccl.conf)
+  for SETTING in "NCCL_DEBUG=INFO" "NCCL_SOCKET_IFNAME"; do
+    if echo "$NCCL_CONF" | grep -q "$SETTING"; then
+      pass "/etc/nccl.conf contains $SETTING"
+    else
+      fail "/etc/nccl.conf missing $SETTING"
+    fi
+  done
+else
+  fail "/etc/nccl.conf not found"
+fi
+
+echo "=============== GDRCopy ==============="
+
+# --- Userspace library. The gdrdrv kernel module comes from the host, so only
+#     the library and its headers can be checked inside a container. ---
+if [ -f /usr/local/lib/libgdrapi.so ]; then
+  pass "/usr/local/lib/libgdrapi.so exists"
+else
+  fail "/usr/local/lib/libgdrapi.so not found"
+  ls -la /usr/local/lib/libgdrapi* 2>/dev/null || echo "  (no libgdrapi* in /usr/local/lib)"
+fi
+
+# --- Versioned soname matches the requested GDRCopy release ---
+if [ -e "/usr/local/lib/libgdrapi.so.${GDRCOPY_VERSION%%.*}" ]; then
+  pass "libgdrapi soname libgdrapi.so.${GDRCOPY_VERSION%%.*} present"
+else
+  fail "libgdrapi.so.${GDRCOPY_VERSION%%.*} not found for GDRCopy ${GDRCOPY_VERSION}"
+fi
+
+# --- Library is in the linker cache and loadable, and exports the API ---
+if ldconfig -p 2>/dev/null | grep -q libgdrapi; then
+  pass "libgdrapi found in ldconfig"
+else
+  fail "libgdrapi not found in ldconfig"
+fi
+
+GDR_MISSING_DEPS=$(ldd /usr/local/lib/libgdrapi.so 2>&1 | grep "not found")
+if [ -n "$GDR_MISSING_DEPS" ]; then
+  fail "libgdrapi has unresolved shared libraries:"
+  echo "$GDR_MISSING_DEPS"
+else
+  GDR_LOAD_ERROR=$(mktemp)
+  if python3 -c "
+import ctypes
+lib = ctypes.CDLL('libgdrapi.so')
+# gdr_open() would need the gdrdrv kernel module the host provides; only
+# resolve the symbols to prove the API surface is there.
+lib.gdr_open
+lib.gdr_pin_buffer
+" 2>"$GDR_LOAD_ERROR"; then
+    pass "libgdrapi loadable and exports gdr_open/gdr_pin_buffer"
+  else
+    fail "libgdrapi not loadable or missing expected symbols"
+    cat "$GDR_LOAD_ERROR"
+  fi
+  rm -f "$GDR_LOAD_ERROR"
+fi
+
+# --- Headers, so customers can build GDRCopy-linked code in the devel image ---
+for HEADER in /usr/local/include/gdrapi.h /usr/local/include/gdrconfig.h; do
+  if [ -f "$HEADER" ]; then
+    pass "$HEADER exists"
+  else
+    fail "$HEADER not found"
+  fi
+done
+
+echo "=============== EFA / libfabric ==============="
+
+# --- EFA binaries on PATH ---
+for BINARY in fi_info ibv_devinfo; do
+  if command -v "$BINARY" &>/dev/null; then
+    pass "$BINARY on PATH ($(command -v "$BINARY"))"
+  else
+    fail "$BINARY not found on PATH"
+  fi
+done
+
+# --- libfabric reports a version. The exact libfabric release is vended by the
+#     EFA installer, so log it rather than pinning it here. ---
+if command -v fi_info &>/dev/null; then
+  FI_VERSION_OUT=$(fi_info --version 2>&1)
+  if echo "$FI_VERSION_OUT" | grep -qi libfabric; then
+    pass "fi_info reports: $(echo "$FI_VERSION_OUT" | tr '\n' ' ')"
+  else
+    fail "fi_info --version did not report a libfabric version"
+    echo "$FI_VERSION_OUT"
+  fi
+
+  # The efa provider must be compiled into libfabric. `fi_info -p efa` needs
+  # real EFA hardware, but `fi_info -l` lists providers built into the library
+  # and works on any host.
+  if fi_info -l 2>/dev/null | grep -q efa; then
+    pass "efa provider built into libfabric"
+  else
+    fail "efa provider not listed by fi_info -l"
+    fi_info -l 2>&1 | head -20
+  fi
+fi
+
+# --- aws-ofi-nccl plugin (the NCCL <-> libfabric bridge). EFA >= 1.44 installs
+#     libnccl-net-ofi.so under lib64; older installers use the arch subdir. ---
+OFI_PLUGIN=""
+for CANDIDATE in /opt/amazon/ofi-nccl/lib64/libnccl-net-ofi.so \
+  "/opt/amazon/ofi-nccl/lib/$(uname -m)-linux-gnu/libnccl-net.so"; do
+  if [ -f "$CANDIDATE" ]; then
+    OFI_PLUGIN="$CANDIDATE"
+    break
+  fi
+done
+if [ -n "$OFI_PLUGIN" ]; then
+  pass "aws-ofi-nccl plugin found at $OFI_PLUGIN"
+  # The plugin dlopen()s libcudart.so and links libfabric — an unresolved
+  # dependency here is exactly the failure that silently drops NCCL to sockets.
+  MISSING=$(ldd "$OFI_PLUGIN" 2>&1 | grep "not found")
+  if [ -z "$MISSING" ]; then
+    pass "aws-ofi-nccl plugin has no unresolved shared libraries"
+  else
+    fail "aws-ofi-nccl plugin has unresolved libraries:"
+    echo "$MISSING"
+  fi
+else
+  fail "aws-ofi-nccl plugin (libnccl-net*.so) not found under /opt/amazon/ofi-nccl"
+  ls -laR /opt/amazon/ofi-nccl 2>/dev/null | head -20
+fi
+
+# --- EFA installer version. The installer records the packages it installed;
+#     treat a missing file as informational since its path is not contractual. ---
+if [ -f /opt/amazon/efa_installed_packages ]; then
+  if grep -q "${EFA_VERSION}" /opt/amazon/efa_installed_packages; then
+    pass "EFA installer ${EFA_VERSION} recorded in /opt/amazon/efa_installed_packages"
+  else
+    fail "EFA ${EFA_VERSION} not recorded in /opt/amazon/efa_installed_packages"
+    cat /opt/amazon/efa_installed_packages
+  fi
+else
+  echo "INFO: /opt/amazon/efa_installed_packages not present, skipping EFA version assertion"
+fi
+
+# --- rdma-core userspace, needed by the efa provider ---
+if ldconfig -p 2>/dev/null | grep -q libibverbs; then
+  pass "libibverbs found in ldconfig"
+else
+  fail "libibverbs not found in ldconfig (rdma-core missing?)"
+fi
+
+echo "=============== OpenMPI ==============="
+
+# --- mpirun wrapper runs as root (the installer wraps it with
+#     --allow-run-as-root; without that every multi-node launch fails). ---
+if command -v mpirun &>/dev/null; then
+  pass "mpirun on PATH ($(command -v mpirun))"
+  if MPI_OUT=$(mpirun -n 1 hostname 2>&1); then
+    pass "mpirun -n 1 hostname succeeded as root"
+  else
+    fail "mpirun -n 1 hostname failed as root"
+    echo "$MPI_OUT"
+  fi
+else
+  fail "mpirun not found on PATH"
+fi
+
+for SETTING in "hwloc_base_binding_policy = none" "rmaps_base_mapping_policy = slot"; do
+  if grep -qF "$SETTING" /opt/amazon/openmpi/etc/openmpi-mca-params.conf 2>/dev/null; then
+    pass "openmpi-mca-params.conf contains '$SETTING'"
+  else
+    fail "openmpi-mca-params.conf missing '$SETTING'"
+  fi
+done
+
+echo "=============== SSH (multi-node launch) ==============="
+
+# --- sshd + keys, used by mpirun to reach worker nodes ---
+if [ -x /usr/sbin/sshd ]; then
+  pass "/usr/sbin/sshd is executable"
+else
+  fail "/usr/sbin/sshd not found or not executable"
+fi
+
+if [ -f /root/.ssh/authorized_keys ]; then
+  pass "/root/.ssh/authorized_keys exists"
+else
+  fail "/root/.ssh/authorized_keys not found"
+fi
+
+if grep -q "StrictHostKeyChecking no" /root/.ssh/config 2>/dev/null; then
+  pass "StrictHostKeyChecking disabled in /root/.ssh/config"
+else
+  fail "StrictHostKeyChecking not disabled in /root/.ssh/config"
+fi
+
+echo "=============== Environment ==============="
+
+# --- PATH / LD_LIBRARY_PATH must expose the EFA + OpenMPI trees, otherwise the
+#     libraries are installed but unreachable at runtime. ---
+for DIRECTORY in /opt/amazon/openmpi/bin /opt/amazon/efa/bin /usr/local/cuda/bin; do
+  case ":${PATH}:" in
+    *":${DIRECTORY}:"*) pass "PATH contains ${DIRECTORY}" ;;
+    *) fail "PATH missing ${DIRECTORY}" ;;
+  esac
+done
+
+for DIRECTORY in /opt/amazon/ofi-nccl/lib64 /opt/amazon/openmpi/lib /opt/amazon/efa/lib /usr/local/lib; do
+  case ":${LD_LIBRARY_PATH:-}:" in
+    *":${DIRECTORY}:"*) pass "LD_LIBRARY_PATH contains ${DIRECTORY}" ;;
+    *) fail "LD_LIBRARY_PATH missing ${DIRECTORY}" ;;
+  esac
+done
+
+exit $FAILED

--- a/test/sanity/scripts/check_nccl_efa_gdrcopy.sh
+++ b/test/sanity/scripts/check_nccl_efa_gdrcopy.sh
@@ -251,13 +251,16 @@ fi
 echo "=============== OpenMPI ==============="
 
 # --- mpirun wrapper runs as root (the installer wraps it with
-#     --allow-run-as-root; without that every multi-node launch fails). ---
+#     --allow-run-as-root; without that every multi-node launch fails).
+#     Launch an absolute path: mpirun treats its first unrecognized token as the
+#     executable, and AL2023 minimal ships no `hostname` binary, so a bare name
+#     would fail on a missing binary rather than on OpenMPI. ---
 if command -v mpirun &>/dev/null; then
   pass "mpirun on PATH ($(command -v mpirun))"
-  if MPI_OUT=$(mpirun -n 1 hostname 2>&1); then
-    pass "mpirun -n 1 hostname succeeded as root"
+  if MPI_OUT=$(mpirun -n 1 /usr/bin/uname -n 2>&1); then
+    pass "mpirun launched a rank as root"
   else
-    fail "mpirun -n 1 hostname failed as root"
+    fail "mpirun could not launch a rank as root (--allow-run-as-root wrapper broken?)"
     echo "$MPI_OUT"
   fi
 else

--- a/test/sanity/scripts/nccl_single_node_test.sh
+++ b/test/sanity/scripts/nccl_single_node_test.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Single-node NCCL functional check for base devel images. Requires GPU(s).
+#
+# Compiles and runs a minimal NCCL all-reduce against the image's own nccl.h /
+# libnccl, which proves three things a file-existence check cannot:
+#   1. nccl.h and libnccl are a matched, linkable pair (-lnccl resolves)
+#   2. NCCL initialises a communicator against the installed CUDA runtime
+#   3. Collective results are numerically correct
+#
+# Works with one GPU (ncclCommInitAll over a single device) and scales to all
+# visible GPUs when the runner has more.
+#
+# Multi-node NCCL over EFA/Libfabric with GDRDMA is not covered here — that
+# needs EFA hardware and lives in test/efa/test_efa.py, whose
+# test/efa/scripts/nccl_allreduce.sh is a superset of this check (it also
+# validates the EFA transport and all_reduce bandwidth). This script is the
+# cheap always-on guard that runs on the existing single-GPU sanity runner.
+#
+# Usage: nccl_single_node_test.sh
+
+FAILED=0
+WORK_DIR=$(mktemp -d)
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+if ! nvidia-smi &>/dev/null; then
+  echo "FAIL: nvidia-smi not found or no GPUs detected"
+  exit 1
+fi
+
+GPU_COUNT=$(nvidia-smi --query-gpu=name --format=csv,noheader | wc -l)
+echo "Detected ${GPU_COUNT} GPU(s)"
+
+# Locate nccl.h — the devel image installs libnccl-devel into /usr/include.
+NCCL_INCLUDE=""
+for CANDIDATE in /usr/include /usr/local/cuda/include /usr/local/include; do
+  if [ -f "${CANDIDATE}/nccl.h" ]; then
+    NCCL_INCLUDE="$CANDIDATE"
+    break
+  fi
+done
+if [ -z "$NCCL_INCLUDE" ]; then
+  echo "FAIL: nccl.h not found; cannot compile the NCCL test"
+  exit 1
+fi
+echo "Using nccl.h from ${NCCL_INCLUDE}"
+
+cat >"${WORK_DIR}/nccl_allreduce.cu" <<'EOF'
+// Minimal single-process, multi-device NCCL all-reduce.
+// Device i contributes (i + 1); every device must end up with the sum.
+#include <cuda_runtime.h>
+#include <nccl.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#define CUDA_CHECK(cmd)                                                       \
+  do {                                                                        \
+    cudaError_t e = (cmd);                                                     \
+    if (e != cudaSuccess) {                                                    \
+      printf("CUDA error %s:%d '%s'\n", __FILE__, __LINE__,                     \
+             cudaGetErrorString(e));                                           \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+#define NCCL_CHECK(cmd)                                                       \
+  do {                                                                        \
+    ncclResult_t r = (cmd);                                                    \
+    if (r != ncclSuccess) {                                                    \
+      printf("NCCL error %s:%d '%s'\n", __FILE__, __LINE__,                     \
+             ncclGetErrorString(r));                                           \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+int main() {
+  int version = 0;
+  NCCL_CHECK(ncclGetVersion(&version));
+  printf("NCCL runtime version code: %d\n", version);
+
+  int num_devices = 0;
+  CUDA_CHECK(cudaGetDeviceCount(&num_devices));
+  if (num_devices < 1) {
+    printf("no CUDA devices visible\n");
+    return 1;
+  }
+  printf("using %d device(s)\n", num_devices);
+
+  const size_t count = 1024 * 1024;  // 4 MiB of floats per device
+  float expected = 0.0f;
+  for (int i = 0; i < num_devices; i++) expected += (float)(i + 1);
+
+  int *devices = (int *)malloc(num_devices * sizeof(int));
+  float **send = (float **)malloc(num_devices * sizeof(float *));
+  float **recv = (float **)malloc(num_devices * sizeof(float *));
+  cudaStream_t *streams =
+      (cudaStream_t *)malloc(num_devices * sizeof(cudaStream_t));
+
+  for (int i = 0; i < num_devices; i++) {
+    devices[i] = i;
+    CUDA_CHECK(cudaSetDevice(i));
+    CUDA_CHECK(cudaMalloc(&send[i], count * sizeof(float)));
+    CUDA_CHECK(cudaMalloc(&recv[i], count * sizeof(float)));
+    CUDA_CHECK(cudaStreamCreate(&streams[i]));
+    // memset can only write byte patterns, so fill from the host instead.
+    float *host = (float *)malloc(count * sizeof(float));
+    for (size_t j = 0; j < count; j++) host[j] = (float)(i + 1);
+    CUDA_CHECK(cudaMemcpy(send[i], host, count * sizeof(float),
+                          cudaMemcpyHostToDevice));
+    free(host);
+  }
+
+  ncclComm_t *comms = (ncclComm_t *)malloc(num_devices * sizeof(ncclComm_t));
+  NCCL_CHECK(ncclCommInitAll(comms, num_devices, devices));
+  printf("ncclCommInitAll succeeded\n");
+
+  NCCL_CHECK(ncclGroupStart());
+  for (int i = 0; i < num_devices; i++) {
+    NCCL_CHECK(ncclAllReduce(send[i], recv[i], count, ncclFloat, ncclSum,
+                             comms[i], streams[i]));
+  }
+  NCCL_CHECK(ncclGroupEnd());
+
+  for (int i = 0; i < num_devices; i++) {
+    CUDA_CHECK(cudaSetDevice(i));
+    CUDA_CHECK(cudaStreamSynchronize(streams[i]));
+  }
+  printf("ncclAllReduce completed\n");
+
+  // Verify every device's full buffer, not just the first element — a partial
+  // or misconfigured collective can leave the tail untouched.
+  int ok = 1;
+  for (int i = 0; i < num_devices && ok; i++) {
+    CUDA_CHECK(cudaSetDevice(i));
+    float *host = (float *)malloc(count * sizeof(float));
+    CUDA_CHECK(
+        cudaMemcpy(host, recv[i], count * sizeof(float), cudaMemcpyDeviceToHost));
+    for (size_t j = 0; j < count; j++) {
+      if (host[j] != expected) {
+        printf("device %d element %zu: got %f, expected %f\n", i, j, host[j],
+               expected);
+        ok = 0;
+        break;
+      }
+    }
+    free(host);
+  }
+
+  for (int i = 0; i < num_devices; i++) {
+    CUDA_CHECK(cudaSetDevice(i));
+    NCCL_CHECK(ncclCommDestroy(comms[i]));
+    CUDA_CHECK(cudaStreamDestroy(streams[i]));
+    CUDA_CHECK(cudaFree(send[i]));
+    CUDA_CHECK(cudaFree(recv[i]));
+  }
+
+  if (!ok) {
+    printf("all_reduce result mismatch\n");
+    return 1;
+  }
+  printf("all_reduce result correct (expected %f on every device)\n", expected);
+  printf("Result = PASS\n");
+  return 0;
+}
+EOF
+
+echo "Compiling NCCL all-reduce test..."
+COMPILE_OUT=$(nvcc -I"${NCCL_INCLUDE}" -o "${WORK_DIR}/nccl_allreduce" \
+  "${WORK_DIR}/nccl_allreduce.cu" -lnccl -lcudart 2>&1)
+COMPILE_RC=$?
+if [ $COMPILE_RC -ne 0 ]; then
+  echo "FAIL: NCCL test failed to compile (nvcc -lnccl)"
+  echo "$COMPILE_OUT"
+  exit 1
+fi
+echo "PASS: compiled against nccl.h + libnccl (-lnccl resolved)"
+
+# NCCL_DEBUG=WARN keeps the output small while still surfacing init problems.
+echo "Running NCCL all-reduce..."
+RUN_OUT=$(NCCL_DEBUG=WARN "${WORK_DIR}/nccl_allreduce" 2>&1)
+RUN_RC=$?
+echo "$RUN_OUT"
+if [ $RUN_RC -eq 0 ] && echo "$RUN_OUT" | grep -q "Result = PASS"; then
+  echo "PASS: NCCL all-reduce across ${GPU_COUNT} GPU(s)"
+else
+  echo "FAIL: NCCL all-reduce did not pass (exit=${RUN_RC})"
+  FAILED=1
+fi
+
+exit $FAILED

--- a/test/security/data/ecr_scan_allowlist/base_dlc/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/base_dlc/framework_allowlist.json
@@ -1,12 +1,1 @@
-[
-    {
-        "vulnerability_id": "RUSTSEC-2026-0195",
-        "reason": "quick-xml 0.39.2 is bundled inside the uv binary at /usr/local/bin/uv (uv is statically compiled Rust). Advisory is a denial-of-service in NsReader's namespace resolution during Start/Empty XML event handling; the vulnerable code path is only reachable when uv parses attacker-controlled XML (e.g. a hostile PyPI mirror index). uv is retained in the image for customer-side venv management; the standard PyPI flow uses JSON/HTML endpoints and never exercises the XML path. No uv release containing the patched quick-xml>=0.41.0 has been published upstream yet; will swap to a pinned fixed version and drop this entry when upstream ships.",
-        "review_by": "2026-10-25"
-    },
-    {
-        "vulnerability_id": "RUSTSEC-2026-0185",
-        "reason": "quinn-proto bundled inside the uv binary (/usr/local/bin/uv). uv is shipped for customer use (e.g. venv management); cannot be patched independently of an upstream uv release.",
-        "review_by": "2026-09-30"
-    }
-]
+[]


### PR DESCRIPTION
Adds a new Base DLC image line for **CUDA 13.2.1** on Amazon Linux 2023 with Python 3.13, replicating the existing cu130 structure (Dockerfile, configs, PR + autorelease workflows). The **devel** stage additionally installs the distributed-training stack (the cu130 devel image does not carry these):

| Component | Version | Source |
|---|---|---|
| NCCL | 2.29.7-1 (`+cuda13.2`) | NVIDIA `cuda-rhel9` repo (gpg-verified) |
| GDRCopy | 2.6 | built from source (dedicated builder stage) |
| libfabric | 2.4.0amzn5.0 | EFA installer 1.49.0 |
| AWS OFI NCCL | 1.20.0 | EFA installer 1.49.0 |
| EFA installer | 1.49.0 | aws-efa-installer |

Tests have been added for these as well. 

- Also upgrading uv to 0.11.33 in cu129 and cu130 since this addresses 2 RUST CVEs
