### PR TITLE
ray-train: drop hardcoded NCCL_SOCKET_IFNAME=eth0 (breaks Slurm/EC2)

### DIFF
--- a/docker/ray-train/Dockerfile.cuda
+++ b/docker/ray-train/Dockerfile.cuda
@@ -134,9 +134,12 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
   DLC_CONTAINER_TYPE=training \
   CUDA_HOME=/usr/local/cuda \
   # EFA/NCCL runtime defaults (NCCL falls back to TCP when EFA is absent).
+  # NCCL_SOCKET_IFNAME is intentionally NOT set here: install_efa writes the
+  # exclusion default NCCL_SOCKET_IFNAME=^docker0,lo to /etc/nccl.conf, which
+  # auto-detects on any host. Hardcoding eth0 broke non-K8s hosts (Slurm/EC2 use
+  # ens6/enp40s0). Per-platform overrides still work (e.g. EKS manifest sets eth0).
   FI_PROVIDER=efa \
   FI_LOG_LEVEL=warn \
-  NCCL_SOCKET_IFNAME=eth0 \
   NCCL_DEBUG=INFO
 
 # cuda-nvcc/cudart-devel for nccl-tests; wget for KubeRay's default health probes.


### PR DESCRIPTION
## Summary
- Removes the hardcoded `NCCL_SOCKET_IFNAME=eth0` ENV from the ray-train Dockerfile
- `eth0` is a K8s/Docker convention; HyperPod-Slurm and EC2 hosts use `ens6`/`enp40s0`, so the hardcoded value caused `NCCL WARN Bootstrap: no socket interface found` -> `ncclInvalidUsage` -> training death on non-K8s platforms
- `install_efa` already writes `NCCL_SOCKET_IFNAME=^docker0,lo` (exclusion-based auto-detect) to `/etc/nccl.conf`, which works on all platforms; the env var was overriding it
- Per-platform overrides still apply (the EKS RayCluster manifest sets `eth0` explicitly on workers)

## Context
Found during HyperPod-Slurm validation. The DLC image runs fine under enroot/pyxis with no slurm-libs/munge/PMIx needed (no `slurm` Dockerfile stage required) — this interface-name bug was the one real image finding.

## Test plan
- [ ] EKS multi-node test still passes (manifest sets eth0)
- [ ] Slurm/EC2 NCCL auto-detects the interface via /etc/nccl.conf