### PR TITLE
[DJL] Add available_images data for LMI 28.0.0

### DIFF
--- a/docs/src/data/djl-inference/0.36-lmi28.0.0-gpu.yml
+++ b/docs/src/data/djl-inference/0.36-lmi28.0.0-gpu.yml
@@ -1,0 +1,9 @@
+framework: DJLServing
+version: "0.36"
+accelerator: gpu
+cuda: cu130
+engine: "LMI 28.0.0, vLLM 0.26.0"
+platform: sagemaker
+
+tags:
+  - "0.36.0-lmi28.0.0-cu130"


### PR DESCRIPTION
Adds `docs/src/data/djl-inference/0.36-lmi28.0.0-gpu.yml` for the DJL 0.36.0 / LMI 28.0.0 release (engine "LMI 28.0.0, vLLM 0.26.0", tag `0.36.0-lmi28.0.0-cu130`).

`available_images.md` is auto-generated from these `docs/src/data/` YAML files — do not hand-edit the markdown.

Part of the LMI 28.0.0 release. Do not merge until the 910 release pipeline publishes the image to public ECR.