### PR TITLE
[DJL] Add LMI 28.0.0 release image

### DIFF
--- a/release_images_inference.yml
+++ b/release_images_inference.yml
@@ -128,44 +128,6 @@ release_images:
       force_release: False
       public_registry: True
   10:
-    framework: "huggingface_pytorch"
-    version: "2.6.0"
-    arch_type: "x86"
-    hf_transformers: "5.5.3"
-    inference:
-      device_types: [ "cpu", "gpu" ]
-      python_versions: [ "py312" ]
-      os_version: "ubuntu22.04"
-      cuda_version: "cu124"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-  11:
-    framework: "huggingface_pytorch"
-    version: "2.8.0"
-    arch_type: "x86"
-    hf_transformers: "4.55.4"
-    inference:
-      device_types: [ "neuronx" ]
-      python_versions: [ "py310" ]
-      os_version: "ubuntu22.04"
-      neuron_sdk_version: "sdk2.26.0"
-      example: False
-      disable_sm_tag: True
-      force_release: False
-  12:
-    framework: "autogluon"
-    version: "1.5.0"
-    arch_type: "x86"
-    inference:
-      device_types: ["cpu", "gpu"]
-      python_versions: ["py312"]
-      os_version: "ubuntu22.04"
-      cuda_version: "cu124"
-      example: False
-      disable_sm_tag: True
-      force_release: False
-  13:
     framework: "djl"
     version: "0.36.0"
     arch_type: "x86"
@@ -179,3 +141,55 @@ release_images:
       disable_sm_tag: True
       force_release: False
       public_registry: True
+  11:
+    framework: "djl"
+    version: "0.36.0"
+    arch_type: "x86"
+    inference:
+      device_types: [ "gpu" ]
+      python_versions: [ "py312" ]
+      os_version: "ubuntu24.04"
+      lmi_version: "28.0.0"
+      cuda_version: "cu130"
+      example: False
+      disable_sm_tag: True
+      force_release: False
+      public_registry: True
+  12:
+    framework: "huggingface_pytorch"
+    version: "2.6.0"
+    arch_type: "x86"
+    hf_transformers: "5.5.3"
+    inference:
+      device_types: [ "cpu", "gpu" ]
+      python_versions: [ "py312" ]
+      os_version: "ubuntu22.04"
+      cuda_version: "cu124"
+      example: False
+      disable_sm_tag: False
+      force_release: False
+  13:
+    framework: "huggingface_pytorch"
+    version: "2.8.0"
+    arch_type: "x86"
+    hf_transformers: "4.55.4"
+    inference:
+      device_types: [ "neuronx" ]
+      python_versions: [ "py310" ]
+      os_version: "ubuntu22.04"
+      neuron_sdk_version: "sdk2.26.0"
+      example: False
+      disable_sm_tag: True
+      force_release: False
+  14:
+    framework: "autogluon"
+    version: "1.5.0"
+    arch_type: "x86"
+    inference:
+      device_types: ["cpu", "gpu"]
+      python_versions: ["py312"]
+      os_version: "ubuntu22.04"
+      cuda_version: "cu124"
+      example: False
+      disable_sm_tag: True
+      force_release: False


### PR DESCRIPTION
## What

- Add `djl-inference 0.36.0-lmi28.0.0-cu130` to `release_images_inference.yml` (entry 11, `disable_sm_tag: True`, `public_registry: True`), inserted immediately after lmi27 within the DJL cluster.
- Relocate lmi27 from entry 13 (stranded after autogluon) to entry 10, adjacent to lmi26. Carry-over fix from the v27 release, which appended lmi27 at end-of-file instead of end-of-DJL-cluster.
- Renumber huggingface/neuron/autogluon to 12/13/14. Integer keys are ordinal slots only; renumbering does not affect published images.

## Notes

Part of the LMI 28.0.0 release. **Do not merge until LMI 28.0.0 benchmarks pass** (this is a 2-PR validation input for the release pipeline).