### PR TITLE
tei 1.9.3: switch release to preprod

### DIFF
--- a/.github/config/image/tei/sagemaker-1.9.3-cpu.yml
+++ b/.github/config/image/tei/sagemaker-1.9.3-cpu.yml
@@ -25,4 +25,4 @@ release:
   public_registry: false
   private_registry: true
   enable_soci: false
-  environment: "gamma"
+  environment: "preprod"

--- a/.github/config/image/tei/sagemaker-1.9.3-gpu.yml
+++ b/.github/config/image/tei/sagemaker-1.9.3-gpu.yml
@@ -25,4 +25,4 @@ release:
   public_registry: false
   private_registry: true
   enable_soci: false
-  environment: "gamma"
+  environment: "preprod"


### PR DESCRIPTION
Switches TEI 1.9.3 CPU + GPU release environment from `gamma` to `preprod` in both config files.
Gamma release succeeded: https://github.com/aws/deep-learning-containers/actions/runs/30492090526

## Test plan
- [x] Merge, then manually trigger `Dispatch - TEI Release` to push preprod images.