### PR TITLE
docs: add missing ap-southeast-6 to region availability table

### DIFF
--- a/docs/reference/region_availability.md
+++ b/docs/reference/region_availability.md
@@ -23,8 +23,8 @@ Private ECR account IDs by region. See [Image Access](../get_started/index.md) f
 | Asia Pacific (Taipei) | ap-east-2 | 975050140332 |
 | Asia Pacific (Thailand) | ap-southeast-7 | 590183813437 |
 | Asia Pacific (Tokyo) | ap-northeast-1 | 763104351884 |
-| Canada (Central) | ca-central-1 | 763104351884 |
 | Canada (Calgary) | ca-west-1 | 204538143572 |
+| Canada (Central) | ca-central-1 | 763104351884 |
 | EU (Frankfurt) | eu-central-1 | 763104351884 |
 | EU (Ireland) | eu-west-1 | 763104351884 |
 | EU (London) | eu-west-2 | 763104351884 |

--- a/docs/reference/region_availability.md
+++ b/docs/reference/region_availability.md
@@ -15,6 +15,7 @@ Private ECR account IDs by region. See [Image Access](../get_started/index.md) f
 | Asia Pacific (Malaysia) | ap-southeast-5 | 550225433462 |
 | Asia Pacific (Melbourne) | ap-southeast-4 | 457447274322 |
 | Asia Pacific (Mumbai) | ap-south-1 | 763104351884 |
+| Asia Pacific (New Zealand) | ap-southeast-6 | 633930458069 |
 | Asia Pacific (Osaka) | ap-northeast-3 | 364406365360 |
 | Asia Pacific (Seoul) | ap-northeast-2 | 763104351884 |
 | Asia Pacific (Singapore) | ap-southeast-1 | 763104351884 |


### PR DESCRIPTION
## Purpose

`ap-southeast-6` (Asia Pacific New Zealand) was missing from the private ECR account table, so readers would fall back to the shared `763104351884` account, which is wrong for that region. Also fixed Canada (Calgary), which was sorted after Canada (Central).

## Test Plan

Diffed the table against the authoritative region-to-account mapping, then built the docs.

## Test Result

`ap-southeast-6` was the only missing region and all 35 existing account IDs were already correct. `mkdocs build` succeeds and `test/docs/` passes 74/74.

Not included: the GA regions in GovCloud/ISO/European Sovereign Cloud partitions are also absent from this table, but that is a separate scope decision.