### PR TITLE
add: pinned hf-vllm 0.25 config for LMCache republish

### DIFF
--- a/.github/config/image/huggingface-vllm/sagemaker-0.25.yml
+++ b/.github/config/image/huggingface-vllm/sagemaker-0.25.yml
@@ -1,0 +1,41 @@
+image:
+  name: "huggingface-vllm-sagemaker-0.25"
+  description: "Hugging Face vLLM 0.25 for SageMaker (layered on the AWS vLLM DLC)"
+
+metadata:
+  framework: "huggingface-vllm"
+  framework_version: "0.25.1"
+  os_version: "ubuntu22.04"
+  customer_type: "sagemaker"
+  platform: "sagemaker"
+  arch_type: "x86"
+  device_type: "gpu"
+  job_type: "general"
+  contributor: "huggingface"
+  prod_image: "huggingface-vllm:0.25-gpu-py312-cu130-ubuntu22.04"
+
+build:
+  dockerfile: "docker/huggingface/vllm/Dockerfile"
+  target: "huggingface-vllm-sagemaker"
+  base_image: "public.ecr.aws/deep-learning-containers/vllm:0.25.1-gpu-py312-cu130-ubuntu22.04-sagemaker-v1.0"
+  python_version: "3.12"
+  cuda_version: "13.0.2"
+  transformers_version: "5.10.2"
+  huggingface_hub_version: "1.17.0"
+  hf_xet_version: "1.5.0"
+  ffmpeg_tag: "n8.1"
+  dlc_major_version: "1"
+  # Second build of 0.25.1: carries the LMCache --kv-transfer-config entrypoint
+  # fix (#6464), which landed after sagemaker.yml had moved to 0.26. Note only
+  # dlc_major_version reaches the image (LABEL dlc_major_version); the minor is
+  # bookkeeping — it is absent from the release spec, so the publish tool, not
+  # this field, decides the final tag.
+  dlc_minor_version: "1"
+
+release:
+  release: true
+  force_release: false
+  public_registry: false
+  private_registry: true
+  enable_soci: false
+  environment: "production"

--- a/.github/config/image/huggingface-vllm/sagemaker-0.25.yml
+++ b/.github/config/image/huggingface-vllm/sagemaker-0.25.yml
@@ -25,12 +25,10 @@ build:
   hf_xet_version: "1.5.0"
   ffmpeg_tag: "n8.1"
   dlc_major_version: "1"
-  # Second build of 0.25.1: carries the LMCache --kv-transfer-config entrypoint
-  # fix (#6464), which landed after sagemaker.yml had moved to 0.26. Note only
-  # dlc_major_version reaches the image (LABEL dlc_major_version); the minor is
-  # bookkeeping — it is absent from the release spec, so the publish tool, not
-  # this field, decides the final tag.
-  dlc_minor_version: "1"
+  # No dlc_minor_version: the release logic auto-versions off the image digest.
+  # This build differs from the released 0.25 image (it carries the LMCache
+  # --kv-transfer-config fix, #6464), so the DLC version bumps -v1.0 -> -v1.1 on
+  # its own. The -v1.x suffix is the DLC image version, not the vLLM version.
 
 release:
   release: true

--- a/docker/huggingface/vllm/Dockerfile
+++ b/docker/huggingface/vllm/Dockerfile
@@ -25,7 +25,7 @@ RUN uv pip install --system \
   "grpcio>=1.79.3" \
   "cryptography>=50.0.0" \
   "starlette>=1.3.1" \
-  "aiohttp>=3.14.1" \
+  "aiohttp>=3.14.3" \
   && uv cache clean \
   && rm -rf /tmp/uv*
 

--- a/docker/huggingface/vllm/Dockerfile
+++ b/docker/huggingface/vllm/Dockerfile
@@ -23,7 +23,7 @@ RUN uv pip install --system \
   "huggingface-hub==${HUGGINGFACE_HUB_VERSION}" \
   "hf-xet==${HF_XET_VERSION}" \
   "grpcio>=1.79.3" \
-  "cryptography>=48.0.1" \
+  "cryptography>=50.0.0" \
   "starlette>=1.3.1" \
   "aiohttp>=3.14.1" \
   && uv cache clean \
@@ -70,6 +70,10 @@ ARG FFMPEG_TAG=n8.1
 # Patch OS CVEs carried by the ubuntu22.04 base (openssl, mesa, ...). Hold
 # cuda/nvidia/libnv packages first so the broad upgrade can't bump the toolkit
 # or driver (same pattern as docker/vllm).
+# ffmpeg is cloned shallow and tag-pinned from the GitHub mirror rather than
+# git.ffmpeg.org: n8.1 is the same commit on both (a65b3bf), the mirror does not
+# 502 mid-clone the way git.ffmpeg.org did on PR #6480, and --depth 1 drops the
+# full history. Same form as docker/ray/Dockerfile.{cpu,cuda}.
 RUN dpkg -l | grep -E "cuda|nvidia|libnv" | awk '{print $2}' | xargs apt-mark hold \
   && apt-get update && apt-get upgrade -y \
   && apt-get install -y --no-install-recommends \
@@ -82,9 +86,8 @@ RUN dpkg -l | grep -E "cuda|nvidia|libnv" | awk '{print $2}' | xargs apt-mark ho
     libvpx-dev \
     libx264-dev \
     libx265-dev \
-  && git clone https://git.ffmpeg.org/ffmpeg.git /tmp/ffmpeg \
+  && git clone --depth 1 --branch "${FFMPEG_TAG}" https://github.com/FFmpeg/FFmpeg.git /tmp/ffmpeg \
   && cd /tmp/ffmpeg \
-  && git checkout "${FFMPEG_TAG}" \
   && ./configure \
     --prefix=/usr/local \
     --disable-debug \


### PR DESCRIPTION
## Purpose
Applying LMCache args patch to v0.25

## PR Checklist

- [x] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

