### PR TITLE
feat(ray-serve): bump Ray to 2.56.1, DLC v1.3

### DIFF
--- a/.github/config/image/ray/ec2-cpu.yml
+++ b/.github/config/image/ray/ec2-cpu.yml
@@ -4,7 +4,7 @@ image:
 
 metadata:
   framework: "ray"
-  framework_version: "2.55.1"
+  framework_version: "2.56.1"
   os_version: "amzn2023"
   customer_type: "ec2"
   arch_type: "x86"
@@ -18,7 +18,7 @@ build:
   target: "ray-ec2-cpu"
   python_version: "3.13.12"
   dlc_major_version: "1"
-  dlc_minor_version: "2"
+  dlc_minor_version: "3"
 
 release:
   release: true

--- a/.github/config/image/ray/ec2-gpu.yml
+++ b/.github/config/image/ray/ec2-gpu.yml
@@ -4,7 +4,7 @@ image:
 
 metadata:
   framework: "ray"
-  framework_version: "2.55.1"
+  framework_version: "2.56.1"
   os_version: "amzn2023"
   customer_type: "ec2"
   arch_type: "x86"
@@ -19,7 +19,7 @@ build:
   python_version: "3.13.12"
   cuda_version: "12.9.1"
   dlc_major_version: "1"
-  dlc_minor_version: "2"
+  dlc_minor_version: "3"
 
 release:
   release: true

--- a/.github/config/image/ray/sagemaker-cpu.yml
+++ b/.github/config/image/ray/sagemaker-cpu.yml
@@ -4,7 +4,7 @@ image:
 
 metadata:
   framework: "ray"
-  framework_version: "2.55.1"
+  framework_version: "2.56.1"
   os_version: "amzn2023"
   customer_type: "sagemaker"
   platform: "sagemaker"
@@ -19,7 +19,7 @@ build:
   target: "ray-sagemaker-cpu"
   python_version: "3.13.12"
   dlc_major_version: "1"
-  dlc_minor_version: "2"
+  dlc_minor_version: "3"
 
 release:
   release: true

--- a/.github/config/image/ray/sagemaker-gpu.yml
+++ b/.github/config/image/ray/sagemaker-gpu.yml
@@ -4,7 +4,7 @@ image:
 
 metadata:
   framework: "ray"
-  framework_version: "2.55.1"
+  framework_version: "2.56.1"
   os_version: "amzn2023"
   customer_type: "sagemaker"
   platform: "sagemaker"
@@ -20,7 +20,7 @@ build:
   python_version: "3.13.12"
   cuda_version: "12.9.1"
   dlc_major_version: "1"
-  dlc_minor_version: "2"
+  dlc_minor_version: "3"
 
 release:
   release: true

--- a/docker/ray/Dockerfile.cpu
+++ b/docker/ray/Dockerfile.cpu
@@ -41,7 +41,7 @@ COPY ./scripts/docker/common/install_python.sh /tmp/install_python.sh
 RUN bash /tmp/install_python.sh ${PYTHON_VERSION} && rm /tmp/install_python.sh
 
 # Install pinned dependencies
-COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.1 /uv /usr/local/bin/uv
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 COPY ./docker/ray/pyproject.toml ./docker/ray/uv.lock /tmp/deps/
 RUN --mount=type=cache,target=/root/.cache/uv cd /tmp/deps \
@@ -58,7 +58,7 @@ ARG CACHE_REFRESH=0
 RUN dnf upgrade -y --security --releasever latest && dnf clean all && rm -rf /var/cache/dnf
 
 ARG DLC_MAJOR_VERSION=1
-ARG DLC_MINOR_VERSION=2
+ARG DLC_MINOR_VERSION=3
 LABEL maintainer="Amazon AI"
 LABEL dlc_major_version="${DLC_MAJOR_VERSION}"
 LABEL dlc_minor_version="${DLC_MINOR_VERSION}"
@@ -66,7 +66,7 @@ LABEL dlc_minor_version="${DLC_MINOR_VERSION}"
 ARG PYTHON_VERSION=3.13.12
 ARG PYTHON_SHORT_VERSION=3.13
 ARG FRAMEWORK="ray"
-ARG FRAMEWORK_VERSION="2.55.1"
+ARG FRAMEWORK_VERSION="2.56.1"
 ARG CONTAINER_TYPE="inference"
 
 # Copy Python and packages from builder

--- a/docker/ray/Dockerfile.cuda
+++ b/docker/ray/Dockerfile.cuda
@@ -70,7 +70,7 @@ COPY ./scripts/docker/common/install_python.sh /tmp/install_python.sh
 RUN bash /tmp/install_python.sh ${PYTHON_VERSION} && rm /tmp/install_python.sh
 
 # Install pinned dependencies
-COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /usr/local/bin/uv
+COPY --from=ghcr.io/astral-sh/uv:0.12.1 /uv /usr/local/bin/uv
 ENV UV_PROJECT_ENVIRONMENT=/usr/local
 COPY ./docker/ray/pyproject.toml ./docker/ray/uv.lock /tmp/deps/
 RUN --mount=type=cache,target=/root/.cache/uv cd /tmp/deps \
@@ -87,7 +87,7 @@ ARG CACHE_REFRESH=0
 RUN dnf upgrade -y --security --releasever latest && dnf clean all && rm -rf /var/cache/dnf
 
 ARG DLC_MAJOR_VERSION=1
-ARG DLC_MINOR_VERSION=2
+ARG DLC_MINOR_VERSION=3
 LABEL maintainer="Amazon AI"
 LABEL dlc_major_version="${DLC_MAJOR_VERSION}"
 LABEL dlc_minor_version="${DLC_MINOR_VERSION}"
@@ -95,7 +95,7 @@ LABEL dlc_minor_version="${DLC_MINOR_VERSION}"
 ARG PYTHON_VERSION=3.13.12
 ARG PYTHON_SHORT_VERSION=3.13
 ARG FRAMEWORK="ray"
-ARG FRAMEWORK_VERSION="2.55.1"
+ARG FRAMEWORK_VERSION="2.56.1"
 ARG CONTAINER_TYPE="inference"
 
 # Enable video capability to mount NVENC/NVDEC driver libraries

--- a/docker/ray/pyproject.toml
+++ b/docker/ray/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "pillow==12.3.0",
     "pyyaml==6.0.3",
     "msgpack>=1.2.1",
-    "ray[serve]==2.55.1",
+    "ray[serve]==2.56.1",
     "scikit-learn==1.8.0",
     "soundfile==0.13.1",
     "torch==2.10.0",

--- a/docker/ray/uv.lock
+++ b/docker/ray/uv.lock
@@ -296,7 +296,7 @@ name = "cuda-bindings"
 version = "12.9.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cuda-pathfinder" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/63/56/e465c31dc9111be3441a9ba7df1941fe98f4aa6e71e8788a3fb4534ce24d/cuda_bindings-12.9.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:32bdc5a76906be4c61eb98f546a6786c5773a881f3b166486449b5d141e4a39f", size = 11906628, upload-time = "2025-10-21T14:51:49.905Z" },
@@ -360,7 +360,7 @@ requires-dist = [
     { name = "pillow", specifier = "==12.3.0" },
     { name = "pip", specifier = "==26.0.1" },
     { name = "pyyaml", specifier = "==6.0.3" },
-    { name = "ray", extras = ["serve"], specifier = "==2.55.1" },
+    { name = "ray", extras = ["serve"], specifier = "==2.56.1" },
     { name = "scikit-learn", specifier = "==1.8.0" },
     { name = "soundfile", specifier = "==0.13.1" },
     { name = "torch", specifier = "==2.10.0" },
@@ -743,6 +743,35 @@ wheels = [
 ]
 
 [[package]]
+name = "mmh3"
+version = "5.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/1a/edb23803a168f070ded7a3014c6d706f63b90c84ccc024f89d794a3b7a6d/mmh3-5.2.1.tar.gz", hash = "sha256:bbea5b775f0ac84945191fb83f845a6fd9a21a03ea7f2e187defac7e401616ad", size = 33775, upload-time = "2026-03-05T15:55:57.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/a5/9daa0508a1569a54130f6198d5462a92deda870043624aa3ea72721aa765/mmh3-5.2.1-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:723b2681ed4cc07d3401bbea9c201ad4f2a4ca6ba8cddaff6789f715dd2b391e", size = 40832, upload-time = "2026-03-05T15:54:43.212Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/6b/3230c6d80c1f4b766dedf280a92c2241e99f87c1504ff74205ec8cebe451/mmh3-5.2.1-cp313-cp313-android_21_x86_64.whl", hash = "sha256:3619473a0e0d329fd4aec8075628f8f616be2da41605300696206d6f36920c3d", size = 41964, upload-time = "2026-03-05T15:54:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/62/fb/648bfddb74a872004b6ee751551bfdda783fe6d70d2e9723bad84dbe5311/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:e48d4dbe0f88e53081da605ae68644e5182752803bbc2beb228cca7f1c4454d6", size = 39114, upload-time = "2026-03-05T15:54:45.205Z" },
+    { url = "https://files.pythonhosted.org/packages/95/c2/ab7901f87af438468b496728d11264cb397b3574d41506e71b92128e0373/mmh3-5.2.1-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:a482ac121de6973897c92c2f31defc6bafb11c83825109275cffce54bb64933f", size = 39819, upload-time = "2026-03-05T15:54:46.509Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/ed/6f88dda0df67de1612f2e130ffea34cf84aaee5bff5b0aff4dbff2babe34/mmh3-5.2.1-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:17fbb47f0885ace8327ce1235d0416dc86a211dcd8cc1e703f41523be32cfec8", size = 40330, upload-time = "2026-03-05T15:54:47.864Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/66/7516d23f53cdf90f43fce24ab80c28f45e6851d78b46bef8c02084edf583/mmh3-5.2.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d51fde50a77f81330523562e3c2734ffdca9c4c9e9d355478117905e1cfe16c6", size = 56078, upload-time = "2026-03-05T15:54:48.9Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/34/4d152fdf4a91a132cb226b671f11c6b796eada9ab78080fb5ce1e95adaab/mmh3-5.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:19bbd3b841174ae6ed588536ab5e1b1fe83d046e668602c20266547298d939a9", size = 40498, upload-time = "2026-03-05T15:54:49.942Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/4c/8e3af1b6d85a299767ec97bd923f12b06267089c1472c27c1696870d1175/mmh3-5.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be77c402d5e882b6fbacfd90823f13da8e0a69658405a39a569c6b58fdb17b03", size = 40033, upload-time = "2026-03-05T15:54:50.994Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/f2/966ea560e32578d453c9e9db53d602cbb1d0da27317e232afa7c38ceba11/mmh3-5.2.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:fd96476f04db5ceba1cfa0f21228f67c1f7402296f0e73fee3513aa680ad237b", size = 97320, upload-time = "2026-03-05T15:54:52.072Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/0d/2c5f9893b38aeb6b034d1a44ecd55a010148054f6a516abe53b5e4057297/mmh3-5.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:707151644085dd0f20fe4f4b573d28e5130c4aaa5f587e95b60989c5926653b5", size = 103299, upload-time = "2026-03-05T15:54:53.569Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/fc/2ebaef4a4d4376f89761274dc274035ffd96006ab496b4ee5af9b08f21a9/mmh3-5.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3737303ca9ea0f7cb83028781148fcda4f1dac7821db0c47672971dabcf63593", size = 106222, upload-time = "2026-03-05T15:54:55.092Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/ea7ffe126d0ba0406622602a2d05e1e1a6841cc92fc322eb576c95b27fad/mmh3-5.2.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2778fed822d7db23ac5008b181441af0c869455b2e7d001f4019636ac31b6fe4", size = 113048, upload-time = "2026-03-05T15:54:56.305Z" },
+    { url = "https://files.pythonhosted.org/packages/85/57/9447032edf93a64aa9bef4d9aa596400b1756f40411890f77a284f6293ca/mmh3-5.2.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d57dea657357230cc780e13920d7fa7db059d58fe721c80020f94476da4ca0a1", size = 120742, upload-time = "2026-03-05T15:54:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/53/82/a86cc87cc88c92e9e1a598fee509f0409435b57879a6129bf3b3e40513c7/mmh3-5.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:169e0d178cb59314456ab30772429a802b25d13227088085b0d49b9fe1533104", size = 99132, upload-time = "2026-03-05T15:54:58.583Z" },
+    { url = "https://files.pythonhosted.org/packages/54/f7/6b16eb1b40ee89bb740698735574536bc20d6cdafc65ae702ea235578e05/mmh3-5.2.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7e4e1f580033335c6f76d1e0d6b56baf009d1a64d6a4816347e4271ba951f46d", size = 98686, upload-time = "2026-03-05T15:55:00.078Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/88/a601e9f32ad1410f438a6d0544298ea621f989bd34a0731a7190f7dec799/mmh3-5.2.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:2bd9f19f7f1fcebd74e830f4af0f28adad4975d40d80620be19ffb2b2af56c9f", size = 106479, upload-time = "2026-03-05T15:55:01.532Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/5c/ce29ae3dfc4feec4007a437a1b7435fb9507532a25147602cd5b52be86db/mmh3-5.2.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:c88653877aeb514c089d1b3d473451677b8b9a6d1497dbddf1ae7934518b06d2", size = 110030, upload-time = "2026-03-05T15:55:02.934Z" },
+    { url = "https://files.pythonhosted.org/packages/13/30/ae444ef2ff87c805d525da4fa63d27cda4fe8a48e77003a036b8461cfd5c/mmh3-5.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fceef7fe67c81e1585198215e42ad3fdba3a25644beda8fbdaf85f4d7b93175a", size = 97536, upload-time = "2026-03-05T15:55:04.135Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f9/dc3787ee5c813cc27fe79f45ad4500d9b5437f23a7402435cc34e07c7718/mmh3-5.2.1-cp313-cp313-win32.whl", hash = "sha256:54b64fb2433bc71488e7a449603bf8bd31fbcf9cb56fbe1eb6d459e90b86c37b", size = 40769, upload-time = "2026-03-05T15:55:05.277Z" },
+    { url = "https://files.pythonhosted.org/packages/43/67/850e0b5a1e97799822ebfc4ca0e8c6ece3ed8baf7dcdf64de817dfdda2ca/mmh3-5.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:cae6383181f1e345317742d2ddd88f9e7d2682fa4c9432e3a74e47d92dce0229", size = 41563, upload-time = "2026-03-05T15:55:06.283Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/cc/98c90b28e1da5458e19fbfaf4adb5289208d3bfccd45dd14eab216a2f0bb/mmh3-5.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:022aa1a528604e6c83d0a7705fdef0b5355d897a9e0fa3a8d26709ceaa06965d", size = 39310, upload-time = "2026-03-05T15:55:07.323Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -890,7 +919,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -901,7 +930,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -928,9 +957,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cusparse-cu12" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -941,7 +970,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -1393,7 +1422,7 @@ wheels = [
 
 [[package]]
 name = "ray"
-version = "2.55.1"
+version = "2.56.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -1406,9 +1435,9 @@ dependencies = [
     { name = "requests" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/95/898699cc1a6a5f304ea95376d079843b5c05f4c8c1ec7e55a5cc7ffcea50/ray-2.55.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:f9844a9272ef2e6eb5771025866072cf4234cf4c7cc1a31e235b7de7111864be", size = 65766823, upload-time = "2026-04-22T20:10:20.786Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/13/87deecc090c672e45a0cf6f5eef511de448b93f37ef18fd10eb8e8557a0d/ray-2.55.1-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:b415d590e062f248907e0fe42994943f11726b7178fcf4b1cf5546721fb1a5f8", size = 72818676, upload-time = "2026-04-22T20:10:26.705Z" },
-    { url = "https://files.pythonhosted.org/packages/71/d7/fc95d3b8824c62105c64aa1b59c59600b581f608d78a2af753e010936dc9/ray-2.55.1-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:1380e043eb57cde69b7e9199c6f2558ceeb8f0fc41c97d1d5e50ea042115f302", size = 73678908, upload-time = "2026-04-22T20:10:32.795Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/58/fab4cf69ec9be22210a6634f9310acf0b40c1c5a0f65d380f8cd11aa661e/ray-2.56.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:93dedab658334af81877b6ed840c4e5f85e2e0b1b3641b20eaaee37cad835cc6", size = 66291122, upload-time = "2026-07-17T21:28:59.906Z" },
+    { url = "https://files.pythonhosted.org/packages/68/9b/622d4f77fc65e9e2ee1a9d2480a1bde4b244edf65eda1f0c488dc8818e57/ray-2.56.1-cp313-cp313-manylinux2014_aarch64.whl", hash = "sha256:7fdc47de4e230f0db7c6c668a9e161f864dac548bd32230986e0b0c36e386eb5", size = 73253432, upload-time = "2026-07-17T21:29:05.445Z" },
+    { url = "https://files.pythonhosted.org/packages/43/ab/649395a3b286c4be86cfe4e8072a746f4d6b6dc68d78396f462d8b94795e/ray-2.56.1-cp313-cp313-manylinux2014_x86_64.whl", hash = "sha256:81f2db202cc31bc3f5c4acf9ef154d10f1f39ece602d9d2d3108875c49bf01c3", size = 74131273, upload-time = "2026-07-17T21:29:10.547Z" },
 ]
 
 [package.optional-dependencies]
@@ -1418,6 +1447,7 @@ serve = [
     { name = "colorful" },
     { name = "fastapi" },
     { name = "grpcio" },
+    { name = "mmh3" },
     { name = "opencensus" },
     { name = "opentelemetry-exporter-prometheus" },
     { name = "opentelemetry-proto" },

--- a/docs/ray/changelog/index.md
+++ b/docs/ray/changelog/index.md
@@ -4,6 +4,16 @@ Changelog for the Ray Serve DLC images.
 
 * * *
 
+## v1.3.0 — 2026-08-05
+
+**Tags:** `serve-ml-cuda-v1.3` · `serve-ml-cpu-v1.3` · `serve-ml-sagemaker-cuda-v1.3` · `serve-ml-sagemaker-cpu-v1.3`
+
+### Changes
+
+- Upgraded Ray from 2.55.1 to 2.56.1
+
+* * *
+
 ## v1.2.0 — 2026-06-02
 
 **Tags:** `serve-ml-cuda-v1.2` · `serve-ml-cpu-v1.2` · `serve-ml-sagemaker-cuda-v1.2` · `serve-ml-sagemaker-cpu-v1.2`

--- a/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
@@ -20,16 +20,6 @@
         "review_by": "2026-08-24"
     },
     {
-        "vulnerability_id": "CVE-2026-47265",
-        "reason": "aiohttp 3.13.5 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, cannot patch without upstream ray release",
-        "review_by": "2026-08-24"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34993",
-        "reason": "aiohttp 3.13.5 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, cannot patch without upstream ray release",
-        "review_by": "2026-08-24"
-    },
-    {
         "vulnerability_id": "CVE-2026-54513",
         "reason": "jackson-databind 2.18.6 bundled in ray_dist.jar, cannot patch without upstream ray rebuild",
         "review_by": "2026-09-29"
@@ -40,58 +30,13 @@
         "review_by": "2026-09-29"
     },
     {
-        "vulnerability_id": "CVE-2026-50269",
-        "reason": "aiohttp 3.13.5 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, cannot patch without upstream ray release",
-        "review_by": "2026-09-29"
-    },
-    {
-        "vulnerability_id": "CVE-2026-54273",
-        "reason": "aiohttp 3.13.5 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, cannot patch without upstream ray release",
-        "review_by": "2026-09-29"
-    },
-    {
-        "vulnerability_id": "CVE-2026-54274",
-        "reason": "aiohttp 3.13.5 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, cannot patch without upstream ray release",
-        "review_by": "2026-09-29"
-    },
-    {
-        "vulnerability_id": "CVE-2026-54278",
-        "reason": "aiohttp 3.13.5 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, cannot patch without upstream ray release",
-        "review_by": "2026-09-29"
-    },
-    {
-        "vulnerability_id": "CVE-2026-54279",
-        "reason": "aiohttp 3.13.5 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, cannot patch without upstream ray release",
-        "review_by": "2026-09-29"
-    },
-    {
-        "vulnerability_id": "CVE-2026-54280",
-        "reason": "aiohttp 3.13.5 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, cannot patch without upstream ray release",
-        "review_by": "2026-09-29"
-    },
-    {
-        "vulnerability_id": "CVE-2026-54275",
-        "reason": "aiohttp 3.13.5 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, cannot patch without upstream ray release",
-        "review_by": "2026-09-29"
-    },
-    {
-        "vulnerability_id": "CVE-2026-54277",
-        "reason": "aiohttp 3.13.5 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, cannot patch without upstream ray release",
-        "review_by": "2026-09-29"
-    },
-    {
-        "vulnerability_id": "CVE-2026-57516",
-        "reason": "ray 2.55.1 WebDataset reader unsafe deserialization, fix requires ray>=2.56.0 which is not yet released for our pinned version",
-        "review_by": "2026-09-10"
-    },
-    {
         "vulnerability_id": "GHSA-r7wm-3cxj-wff9",
         "reason": "jackson-core 2.18.6 bundled in ray_dist.jar, cannot patch without upstream ray rebuild",
         "review_by": "2026-10-20"
     },
     {
         "vulnerability_id": "CVE-2026-69244",
-        "reason": "aiohttp 3.13.5 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, cannot patch without upstream ray release",
+        "reason": "aiohttp 3.14.1 bundled inside ray/_private/runtime_env/agent/thirdparty_files/, fix requires aiohttp>=3.14.3 which is not yet vendored by any released ray",
         "review_by": "2026-10-03"
     }
 ]


### PR DESCRIPTION
Bumps the Ray Serve DLC from Ray 2.55.1 to 2.56.1 and rolls the image version to v1.3.

Also bumps uv 0.11.32 → 0.12.1 for the build stage, and prunes 11 allowlist entries the upgrade resolves:

- 10 aiohttp CVEs — Ray 2.56.1 vendors aiohttp 3.14.1 instead of 3.13.5, and each of these is first patched in 3.14.0 or 3.14.1
- CVE-2026-57516 — fixed in Ray 2.56.0

CVE-2026-69244 stays allowlisted (needs aiohttp >= 3.14.3), with its reason corrected to cite 3.14.1. The log4j and jackson entries stay — `ray_dist.jar` in 2.56.1 still carries log4j-core 2.25.3 and jackson 2.18.6.

torch, transformers, and fastapi are unchanged; Ray does not constrain them.
