### PR TITLE
fix(sglang): use bash for upstream test step — dash rejects pipefail

### DIFF
--- a/.github/workflows/sglang.tests-upstream.yml
+++ b/.github/workflows/sglang.tests-upstream.yml
@@ -108,8 +108,8 @@ jobs:
 
       - name: Run SGLang tests
         run: |
-          docker exec ${CONTAINER_ID} sh -c '
-            set -eux
+          docker exec ${CONTAINER_ID} bash -c '
+            set -euxo pipefail
             nvidia-smi
 
             export PYTHONPATH=/workdir/python:${PYTHONPATH:-}
@@ -128,11 +128,9 @@ jobs:
 
             cd /workdir/test
             export SGLANG_TIMEOUT=600
-            # run_suite.py returns non-zero when a test fails, but pipefail is
-            # required so `tee` does not mask its exit code. It also returns 0
-            # when a suite matches 0 tests (unknown/empty suite), so additionally
-            # fail if nothing ran.
-            set -o pipefail
+            # run_suite.py returns non-zero when a test fails; pipefail (set at
+            # top) ensures `tee` does not mask its exit code. Fail additionally
+            # if nothing ran (unknown/empty suite).
             python3 run_suite.py --hw cuda --suite ${{ inputs.suite }} 2>&1 | tee /tmp/suite.log
             if grep -qE "No tests found|Test Summary: 0/0" /tmp/suite.log; then
               echo "ERROR: suite ${{ inputs.suite }} ran 0 tests — invalid/empty suite for this sglang ref" >&2


### PR DESCRIPTION
## Summary
- The "Run SGLang tests" step in `sglang.tests-upstream.yml` uses `docker exec ... sh -c`, but `/bin/sh` in the Ubuntu container is dash, which doesn't support `set -o pipefail`.
- Every SGLang upstream-test job on main fails deterministically with `sh: 25: set: Illegal option -o pipefail` (exit 2) since #6484 merged.
- Fix: switch to `bash -c` and hoist `pipefail` into the initial `set -euxo pipefail`.

## Test plan
- [ ] Re-run the failing workflow (`main Auto Release - SGLang SageMaker Ubuntu`) and confirm the `srt-backend-test` job passes the "Run SGLang tests" step.