### PR TITLE
fix(currency): unblock CVE fixes + guard agent-fix against stale commits

### DIFF
--- a/.github/workflows/_prcheck.currency-fix.yml
+++ b/.github/workflows/_prcheck.currency-fix.yml
@@ -12,6 +12,7 @@ on:
 permissions:
   contents: read
   actions: read
+  pull-requests: read
 
 concurrency:
   group: currency-fix-${{ github.event.workflow_run.head_branch }}
@@ -51,13 +52,45 @@ jobs:
           fi
           gh --version
 
+      # Skip if the branch moved past the failed run's commit (stale trigger) or
+      # the PR carries the stop-agent-fix label (manual override).
+      - name: Guard — stale commit or stop label
+        id: guard
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          SHA=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}" --jq '.head_sha')
+          echo "HEAD_SHA=$SHA" >> $GITHUB_ENV
+
+          TIP=$(gh api "/repos/${{ github.repository }}/git/refs/heads/$HEAD_BRANCH" --jq '.object.sha' 2>/dev/null || true)
+          if [ -z "$TIP" ]; then
+            echo "::notice::Branch '$HEAD_BRANCH' no longer exists. Skipping."
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if [ "$TIP" != "$SHA" ]; then
+            echo "::notice::Failed run commit ($SHA) is stale; branch tip is $TIP. A newer run will handle it. Skipping."
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          HAS_STOP=$(gh pr list --head "$HEAD_BRANCH" --json labels \
+            --jq '[.[0].labels[].name | select(. == "stop-agent-fix")] | length')
+          if [ "${HAS_STOP:-0}" -gt 0 ]; then
+            echo "::notice::PR has 'stop-agent-fix' label. Skipping."
+            echo "should_run=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          echo "should_run=true" >> $GITHUB_OUTPUT
+
       - name: Wait for tracked workflows to complete
+        if: steps.guard.outputs.should_run == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           TRACKED="PR - vLLM Ubuntu|PR - SGLang Ubuntu"
-          SHA=$(gh api "/repos/${{ github.repository }}/actions/runs/${RUN_ID}" --jq '.head_sha')
-          echo "HEAD_SHA=$SHA" >> $GITHUB_ENV
+          SHA="${HEAD_SHA}"
           TIMEOUT=1800
           ELAPSED=0
           while [ $ELAPSED -lt $TIMEOUT ]; do
@@ -76,6 +109,7 @@ jobs:
           fi
 
       - name: Find failed tracked workflows
+        if: steps.guard.outputs.should_run == 'true'
         id: failures
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/_prcheck.merge-conditions.yml
+++ b/.github/workflows/_prcheck.merge-conditions.yml
@@ -26,16 +26,24 @@ jobs:
             const self = 'enforce-all-checks';
             const ignoredChecks = new Set([self]);
             const ignoredPatterns = [
-              /ecr-vulnerability-scan$/,
               /efa-test$/,
             ];
+            // ECR scans are non-blocking except vLLM/SGLang Ubuntu, which block merge so the Currency Fix Agent triggers on CVE failures.
+            const scanPattern = /ecr-vulnerability-scan$/;
+            const blockingScanPattern = /config\/image\/(vllm|sglang)\/[^,]*-ubuntu\.yml[^)]*\).*ecr-vulnerability-scan$/;
+            const isIgnored = (name) => {
+              if (ignoredChecks.has(name)) return true;
+              if (ignoredPatterns.some(p => p.test(name))) return true;
+              if (scanPattern.test(name) && !blockingScanPattern.test(name)) return true;
+              return false;
+            };
             const intervalMs = 30_000;
             const timeoutMs = 7_200_000;
             const deadline = Date.now() + timeoutMs;
 
             while (Date.now() < deadline) {
               const { data } = await github.rest.checks.listForRef({ owner, repo, ref: sha, per_page: 100 });
-              const runs = data.check_runs.filter(r => !ignoredChecks.has(r.name) && !ignoredPatterns.some(p => p.test(r.name)));
+              const runs = data.check_runs.filter(r => !isIgnored(r.name));
 
               const failed = runs.filter(r => r.status === 'completed' && r.conclusion !== 'success' && r.conclusion !== 'skipped' && r.conclusion !== 'neutral');
               if (failed.length > 0) {


### PR DESCRIPTION
## Problem

The Day0 currency **Currency Fix Agent** (`_prcheck.currency-fix.yml`) stopped fixing CVEs, and could push fixes on top of stale commits.

### 1. CVEs no longer get fixed
Commit `66c2d54a` added `/ecr-vulnerability-scan$/` to `ignoredPatterns` in **Merge Conditions**, making *every* ECR scan non-blocking. The Currency Fix Agent only triggers when **Merge Conditions** concludes `failure`, so:

> CVE scan fails → Merge Conditions ignores it → concludes `success` → agent never runs → CVEs never fixed.

### 2. Agent acts on stale commits
`workflow_run` can fire for an *older* Merge Conditions run. The agent checks out the branch tip but reasons off the old run's logs, then pushes an `[agent-fix]` commit on top of whatever was pushed since — e.g. a manual human fix.

## Changes

**`_prcheck.merge-conditions.yml`** — ECR scans stay non-blocking **except** `vllm/*-ubuntu` and `sglang/*-ubuntu` configs, which now block merge (exactly what the agent already tracks: `PR - vLLM Ubuntu | PR - SGLang Ubuntu`). The `blockingScanPattern` regex was validated against real check-run names — it blocks the three Ubuntu scans and still ignores amzn2023 / vllm-omni / huggingface-vllm / pytorch scans.

**`_prcheck.currency-fix.yml`** — Added a **Guard** step (runs before checkout, via GitHub API) that skips the job when:
- **Stale trigger**: the failed run's `head_sha` no longer matches the branch tip — a newer run will handle the latest commit.
- **Branch gone**: the ref no longer exists.
- **Manual override**: the PR carries a `stop-agent-fix` label.

The `Wait` and `Find failed workflows` steps are gated on the guard; all downstream steps already key off `has_failures`, which stays empty when the guard skips, so the chain cascades off cleanly. Added `pull-requests: read` permission for the label lookup.

## Manual override
Add the **`stop-agent-fix`** label to any auto-update PR to stop the agent from pushing commits to it. (Label created in the repo.)

## Testing
- Both workflow files validated as parseable YAML.
- `blockingScanPattern` verified against real check-run names from a merged currency PR (#6446).