### PR TITLE
Kimi k3 sglang blackwell

### DIFF
--- a/.github/config/image/sglang/ec2-amzn2023.yml
+++ b/.github/config/image/sglang/ec2-amzn2023.yml
@@ -28,7 +28,10 @@ build:
   efa_version: "1.49.0"
   rust_version: "1.96.1"
   gdrcopy_version: "2.6"
-  torch_cuda_arch_list: "9.0;10.0;10.3"
+  # 10.3f, not a bare 10.3: MXFP4 kernels emit cvt.e2m1x2, which ptxas accepts only under
+  # an a- or f-suffixed target. A bare 10.3 builds clean but emits no usable FP4 code for
+  # sm_103, failing only at load time on B300. f is preferred over a for forward compat.
+  torch_cuda_arch_list: "9.0;10.0;10.3f"
   dlc_major_version: "1"
   dlc_minor_version: "2"
 

--- a/.github/config/image/sglang/ec2-amzn2023.yml
+++ b/.github/config/image/sglang/ec2-amzn2023.yml
@@ -17,9 +17,12 @@ build:
   target: "sglang-ec2"
   python_version: "3.12"
   cuda_version: "13.0.3"
-  sglang_ref: "bc8b3ab1f55c60951b586d84d4aec773a6f654df"
-  sglang_kernel_version: "0.4.4"
-  flashinfer_version: "0.6.12"
+  # Kimi-K3 support is on main only (#32541), in no released tag, hence a bare hash.
+  # sglang_kernel_version and flashinfer_version are ABI-coupled to it and must move
+  # with it; both match upstream's docker/Dockerfile at this commit.
+  sglang_ref: "abddb1c7e9d61ddddeaf016d885c2f20aab426e8"
+  sglang_kernel_version: "0.4.5"
+  flashinfer_version: "0.6.15.post1"
   deepep_commit: "9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee"
   mooncake_version: "0.3.11.post1"
   torch_version: "2.11.0"

--- a/.github/config/image/sglang/ec2-amzn2023.yml
+++ b/.github/config/image/sglang/ec2-amzn2023.yml
@@ -28,8 +28,9 @@ build:
   torch_version: "2.11.0"
   nccl_version: "2.30.4"
   cudnn_version: "9.16.0.29"
-  # Must equal sglang's own nvidia-cutlass-dsl[cu13] pin at sglang_ref. 4.7.0 relocated the
-  # package and drops cutlass._mlir, which breaks bf16_gemm_backend='auto' on Blackwell only.
+  # Must equal sglang's own nvidia-cutlass-dsl[cu13] pin at sglang_ref; the reinstall in the
+  # Dockerfile previously floated past it onto 4.7.0. Only the CuTe DSL bf16 GEMM path on
+  # SM100/SM103 uses this, so a mismatch shows up on Blackwell and nowhere else.
   cutlass_dsl_version: "4.6.0"
   efa_version: "1.49.0"
   rust_version: "1.96.1"

--- a/.github/config/image/sglang/ec2-amzn2023.yml
+++ b/.github/config/image/sglang/ec2-amzn2023.yml
@@ -28,6 +28,9 @@ build:
   torch_version: "2.11.0"
   nccl_version: "2.30.4"
   cudnn_version: "9.16.0.29"
+  # Must equal sglang's own nvidia-cutlass-dsl[cu13] pin at sglang_ref. 4.7.0 relocated the
+  # package and drops cutlass._mlir, which breaks bf16_gemm_backend='auto' on Blackwell only.
+  cutlass_dsl_version: "4.6.0"
   efa_version: "1.49.0"
   rust_version: "1.96.1"
   gdrcopy_version: "2.6"

--- a/.github/config/image/sglang/ec2-amzn2023.yml
+++ b/.github/config/image/sglang/ec2-amzn2023.yml
@@ -31,10 +31,11 @@ build:
   efa_version: "1.49.0"
   rust_version: "1.96.1"
   gdrcopy_version: "2.6"
-  # 10.3f, not a bare 10.3: MXFP4 kernels emit cvt.e2m1x2, which ptxas accepts only under
+  # 10.3a, not a bare 10.3: MXFP4 kernels emit cvt.e2m1x2, which ptxas accepts only under
   # an a- or f-suffixed target. A bare 10.3 builds clean but emits no usable FP4 code for
-  # sm_103, failing only at load time on B300. f is preferred over a for forward compat.
-  torch_cuda_arch_list: "9.0;10.0;10.3f"
+  # sm_103, failing only at load time on B300. a, not f: the only consumers are FlashMLA
+  # and DeepEP, which build via torch's cpp_extension and reject f-suffixed arches.
+  torch_cuda_arch_list: "9.0;10.0;10.3a"
   dlc_major_version: "1"
   dlc_minor_version: "2"
 

--- a/.github/config/image/sglang/sagemaker-amzn2023.yml
+++ b/.github/config/image/sglang/sagemaker-amzn2023.yml
@@ -32,10 +32,11 @@ build:
   efa_version: "1.49.0"
   rust_version: "1.96.1"
   gdrcopy_version: "2.6"
-  # 10.3f, not a bare 10.3: MXFP4 kernels emit cvt.e2m1x2, which ptxas accepts only under
+  # 10.3a, not a bare 10.3: MXFP4 kernels emit cvt.e2m1x2, which ptxas accepts only under
   # an a- or f-suffixed target. A bare 10.3 builds clean but emits no usable FP4 code for
-  # sm_103, failing only at load time on B300. f is preferred over a for forward compat.
-  torch_cuda_arch_list: "9.0;10.0;10.3f"
+  # sm_103, failing only at load time on B300. a, not f: the only consumers are FlashMLA
+  # and DeepEP, which build via torch's cpp_extension and reject f-suffixed arches.
+  torch_cuda_arch_list: "9.0;10.0;10.3a"
   dlc_major_version: "1"
   dlc_minor_version: "2"
 

--- a/.github/config/image/sglang/sagemaker-amzn2023.yml
+++ b/.github/config/image/sglang/sagemaker-amzn2023.yml
@@ -29,7 +29,10 @@ build:
   efa_version: "1.49.0"
   rust_version: "1.96.1"
   gdrcopy_version: "2.6"
-  torch_cuda_arch_list: "9.0;10.0;10.3"
+  # 10.3f, not a bare 10.3: MXFP4 kernels emit cvt.e2m1x2, which ptxas accepts only under
+  # an a- or f-suffixed target. A bare 10.3 builds clean but emits no usable FP4 code for
+  # sm_103, failing only at load time on B300. f is preferred over a for forward compat.
+  torch_cuda_arch_list: "9.0;10.0;10.3f"
   dlc_major_version: "1"
   dlc_minor_version: "2"
 

--- a/.github/config/image/sglang/sagemaker-amzn2023.yml
+++ b/.github/config/image/sglang/sagemaker-amzn2023.yml
@@ -18,9 +18,12 @@ build:
   target: "sglang-sagemaker"
   python_version: "3.12"
   cuda_version: "13.0.3"
-  sglang_ref: "bc8b3ab1f55c60951b586d84d4aec773a6f654df"
-  sglang_kernel_version: "0.4.4"
-  flashinfer_version: "0.6.12"
+  # Kimi-K3 support is on main only (#32541), in no released tag, hence a bare hash.
+  # sglang_kernel_version and flashinfer_version are ABI-coupled to it and must move
+  # with it. Keep identical to ec2-amzn2023.yml; the variants must not drift.
+  sglang_ref: "abddb1c7e9d61ddddeaf016d885c2f20aab426e8"
+  sglang_kernel_version: "0.4.5"
+  flashinfer_version: "0.6.15.post1"
   deepep_commit: "9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee"
   mooncake_version: "0.3.11.post1"
   torch_version: "2.11.0"

--- a/.github/config/image/sglang/sagemaker-amzn2023.yml
+++ b/.github/config/image/sglang/sagemaker-amzn2023.yml
@@ -29,6 +29,9 @@ build:
   torch_version: "2.11.0"
   nccl_version: "2.30.4"
   cudnn_version: "9.16.0.29"
+  # Must equal sglang's own nvidia-cutlass-dsl[cu13] pin at sglang_ref. 4.7.0 relocated the
+  # package and drops cutlass._mlir, which breaks bf16_gemm_backend='auto' on Blackwell only.
+  cutlass_dsl_version: "4.6.0"
   efa_version: "1.49.0"
   rust_version: "1.96.1"
   gdrcopy_version: "2.6"

--- a/.github/config/image/sglang/sagemaker-amzn2023.yml
+++ b/.github/config/image/sglang/sagemaker-amzn2023.yml
@@ -29,8 +29,9 @@ build:
   torch_version: "2.11.0"
   nccl_version: "2.30.4"
   cudnn_version: "9.16.0.29"
-  # Must equal sglang's own nvidia-cutlass-dsl[cu13] pin at sglang_ref. 4.7.0 relocated the
-  # package and drops cutlass._mlir, which breaks bf16_gemm_backend='auto' on Blackwell only.
+  # Must equal sglang's own nvidia-cutlass-dsl[cu13] pin at sglang_ref; the reinstall in the
+  # Dockerfile previously floated past it onto 4.7.0. Only the CuTe DSL bf16 GEMM path on
+  # SM100/SM103 uses this, so a mismatch shows up on Blackwell and nowhere else.
   cutlass_dsl_version: "4.6.0"
   efa_version: "1.49.0"
   rust_version: "1.96.1"

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -94,13 +94,18 @@ RUN git clone --branch ${SGLANG_REF} --depth 1 https://github.com/sgl-project/sg
 
 # Stamp the sglang package version for CVE scanner compatibility.
 ARG FRAMEWORK_VERSION
+# Checked here rather than left to setuptools_scm: an unset FRAMEWORK_VERSION yields
+# a leading-dot version, which packaging rejects several minutes into the install below
+# with a traceback that never names the missing arg.
+RUN test -n "${FRAMEWORK_VERSION}" \
+    || (echo "FRAMEWORK_VERSION build-arg is required (from the image config's metadata)" >&2; exit 1)
 ENV SETUPTOOLS_SCM_PRETEND_VERSION=${FRAMEWORK_VERSION}.amzn2023.${SGLANG_REF}
 
 # Install sglang from source + flashinfer + sglang-kernel
-# sglang's pyproject.toml pins torch from PyPI for x86_64 (cu128 build).
-# We reinstall torch+torchvision+torchaudio from the cu129 index after to match
-# our CUDA 12.9 toolkit. TORCH_VERSION must match what sgl_kernel wheels on
-# docs.sglang.ai/whl/cu129/ are compiled against (ABI-sensitive).
+# sglang's pyproject.toml pins torch from PyPI for x86_64, so torch+torchvision+torchaudio
+# are reinstalled from the cu${CUDA_SHORT} index below to match the CUDA_REF toolkit.
+# TORCH_VERSION must match what the sglang-kernel wheels on
+# docs.sglang.ai/whl/cu${CUDA_SHORT}/ are compiled against (ABI-sensitive).
 # Uses pip --force-reinstall to bypass local version segment matching issues.
 RUN cd sglang \
     && uv pip install --system --no-cache -e "python[all]" \

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -346,29 +346,14 @@ RUN CUDA_SHORT=$(echo ${CUDA_REF} | cut -d. -f1,2 | tr -d '.') \
 # build failure rather than one found on customer hardware.
 RUN python${PYTHON_VERSION} -c "import cutlass; import cutlass._mlir; print('cutlass DSL OK:', cutlass.__file__)"
 
-# Record which MXFP4 MoE kernels this image can reach. With moe_runner_backend='auto' sglang
-# picks trtllm-gen on SM100/SM103 when its cubins are present and silently drops to marlin
-# when they are not, so an image can ship on a slower expert path unnoticed. MXFP4 is K3's
-# routed-expert format. This warns rather than fails: trtllm-gen's MoE cubins are unmerged
-# upstream and a version bump does not help. Probing trtllm_fp4_block_scale_moe mirrors what
-# sglang itself gates on; a positive is necessary but not sufficient, since the symbol
-# resolving does not prove cubins exist for a given shape.
-RUN { python${PYTHON_VERSION} - <<'EOF'
-backends = []
-try:
-    from flashinfer import trtllm_fp4_block_scale_moe  # noqa: F401
-    backends.append("flashinfer_mxfp4/trtllm-gen")
-except Exception as e:
-    print(f"MXFP4 MoE: trtllm-gen NOT available ({type(e).__name__}), auto will fall back")
-for name, mod in (("deep_gemm", "deep_gemm"), ("marlin", "sglang.srt.layers.quantization.marlin_utils_fp4")):
-    try:
-        __import__(mod)
-        backends.append(name)
-    except Exception:
-        pass
-print("MXFP4_MOE_BACKENDS=" + (",".join(backends) if backends else "none"))
-EOF
-} > /etc/dlc-mxfp4-moe-backends.txt 2>&1 || true; cat /etc/dlc-mxfp4-moe-backends.txt
+# Record which MXFP4 MoE kernels this image can reach; see the script for why this warns
+# rather than fails. Kept as a file rather than an inline heredoc because this Dockerfile
+# declares no `# syntax=` frontend, so a release build should not depend on the daemon's
+# default BuildKit accepting heredocs.
+COPY ./scripts/docker/sglang/probe_mxfp4_moe_backends.py /tmp/probe_mxfp4_moe_backends.py
+RUN python${PYTHON_VERSION} /tmp/probe_mxfp4_moe_backends.py > /etc/dlc-mxfp4-moe-backends.txt 2>&1 || true; \
+    cat /etc/dlc-mxfp4-moe-backends.txt; \
+    rm -f /tmp/probe_mxfp4_moe_backends.py
 
 # tilelang compatibility fixes for AL2023:
 # 1. libz3: TVM (bundled in tilelang) links a specific z3 soname. AL2023's z3-libs

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -23,10 +23,16 @@ ARG TORCH_VERSION=2.11.0
 # CUDA / GPU
 ARG NCCL_VERSION=2.30.4
 ARG CUDNN_VERSION=9.16.0.29
-# 10.3f, not a bare 10.3: MXFP4 kernels emit cvt.e2m1x2, which ptxas accepts only under an
-# a- or f-suffixed target. A bare 10.3 builds clean but emits no usable FP4 code for sm_103,
-# failing only at load time on B300. Required for Kimi-K3, whose routed experts are MXFP4.
-ARG TORCH_CUDA_ARCH_LIST='9.0;10.0;10.3f'
+# 10.3a, not a bare 10.3: B300 (sm_103) kernels emit cvt.e2m1x2 for MXFP4, which ptxas
+# accepts only under an a- or f-suffixed target. A bare 10.3 builds clean but emits no
+# usable FP4 code, failing only at load time. Needed for Kimi-K3's MXFP4 routed experts.
+#
+# a, not f, despite f being the more forward-compatible family target: this list is only
+# consumed by FlashMLA and DeepEP, both of which build via torch's cpp_extension, whose
+# _get_cuda_arch_flags validates against a fixed list carrying no f variants -- 10.3f dies
+# with "Unknown CUDA arch". Use f only for CMake-based builds. sgl_kernel is unaffected
+# either way; it is installed as a prebuilt wheel below, not compiled here.
+ARG TORCH_CUDA_ARCH_LIST='9.0;10.0;10.3a'
 
 # Build
 ARG BUILD_PARALLEL=8

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -7,9 +7,13 @@ FROM nvidia/cuda:${CUDA_REF}-devel-amzn2023 AS builder
 
 ARG CUDA_REF
 ARG PYTHON_VERSION=3.12
-ARG SGLANG_REF=bc8b3ab1f55c60951b586d84d4aec773a6f654df
-ARG SGLANG_KERNEL_VERSION=0.4.4
-ARG FLASHINFER_VERSION=0.6.12
+# Kimi-K3 needs srt/models/kimi_k3.py, absent from every released tag, so this is a
+# commit ref (#32541). Release builds override it from config/image/sglang/*-amzn2023.yml;
+# keep the two in sync. Move to the first released tag carrying kimi_k3.py when one exists.
+ARG SGLANG_REF=abddb1c7e9d61ddddeaf016d885c2f20aab426e8
+# ABI-coupled to SGLANG_REF; both must move with it. Matches upstream's Dockerfile.
+ARG SGLANG_KERNEL_VERSION=0.4.5
+ARG FLASHINFER_VERSION=0.6.15.post1
 ARG DEEPEP_COMMIT=9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee
 ARG MOONCAKE_VERSION=0.3.11.post1
 ARG GDRCOPY_VERSION=2.6
@@ -177,7 +181,8 @@ ARG CUDA_REF
 ARG PYTHON=python3
 ARG PYTHON_VERSION=3.12
 ARG TORCH_VERSION=2.11.0
-ARG SGLANG_KERNEL_VERSION=0.4.4
+# Keep in lockstep with the builder-stage SGLANG_KERNEL_VERSION above.
+ARG SGLANG_KERNEL_VERSION=0.4.5
 ARG EFA_VERSION=1.49.0
 ARG NCCL_VERSION=2.30.4
 ARG CUDNN_VERSION=9.16.0.29

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -197,10 +197,10 @@ ARG SGLANG_KERNEL_VERSION=0.4.5
 ARG EFA_VERSION=1.49.0
 ARG NCCL_VERSION=2.30.4
 ARG CUDNN_VERSION=9.16.0.29
-# Exact pin, and must equal the nvidia-cutlass-dsl[cu13] pin in sglang's own requirements
-# at SGLANG_REF. 4.7.0 relocated the package to nvidia_cutlass_dsl/dsl_packages/cutlass/
-# and its -libs wheel no longer lands _mlir there, so `import cutlass._mlir` fails; the
-# assertion below catches it. Bump only together with SGLANG_REF.
+# Exact pin, and must equal the nvidia-cutlass-dsl[cu13] pin in sglang's own requirements at
+# SGLANG_REF -- the reinstall below previously carried a >=4.5.2 floor and floated onto 4.7.0,
+# against sglang's ==4.6.0. Bump only together with SGLANG_REF. Unrelated to the lib/lib64
+# split handled further down, which affects all versions alike.
 ARG CUTLASS_DSL_VERSION=4.6.0
 ARG Z3_VERSION=4.15.3.0
 
@@ -355,13 +355,17 @@ RUN CUDA_SHORT=$(echo ${CUDA_REF} | cut -d. -f1,2 | tr -d '.') \
   && python${PYTHON_VERSION} -c "import glob,os; [os.symlink(f,'/usr/local/nvidia/pip-lib/'+os.path.basename(f)) for d in glob.glob('/usr/local/lib*/python${PYTHON_VERSION}/site-packages/nvidia/*/lib') for f in glob.glob(d+'/*.so*') if not os.path.exists('/usr/local/nvidia/pip-lib/'+os.path.basename(f))]" \
   && ldconfig
 
-# Assert the CuTe DSL native libs landed. nvidia-cutlass-dsl ships pure Python; its MLIR
-# extension modules come from the separate -libs-cu13 wheel above. A missing _mlir is a hard
-# startup failure on Blackwell only: bf16_gemm_backend='auto' picks the CuTe DSL path on
-# SM100/SM103 and cuBLAS elsewhere, so it would surface on customer hardware and nowhere in
-# CI. This guard caught exactly that when the install above still carried a >=4.5.2 floor and
-# floated onto 4.7.0, which moved the package under nvidia_cutlass_dsl/dsl_packages/. Now
-# pinned via CUTLASS_DSL_VERSION; keep the assertion as the tripwire for the next bump.
+# The CuTe DSL's two payload wheels disagree on their wheel tag while writing into one shared
+# directory, so on AL2023 pip splits the package across lib/ (cutlass/__init__.py) and lib64/
+# (cutlass/_mlir/) and `import cutlass._mlir` fails. See the script for the full mechanism;
+# it is an upstream bug affecting every version, visible only on lib/lib64-split distros.
+COPY ./scripts/docker/sglang/merge_cutlass_dsl_split.py /tmp/merge_cutlass_dsl_split.py
+RUN python${PYTHON_VERSION} /tmp/merge_cutlass_dsl_split.py
+
+# Assert the CuTe DSL imports end to end. A missing _mlir is a hard startup failure on
+# Blackwell only: bf16_gemm_backend='auto' picks the CuTe DSL path on SM100/SM103 and cuBLAS
+# elsewhere, so it would surface on customer hardware and nowhere in CI. This guard is what
+# caught the split above; keep it as the tripwire for the next version bump.
 RUN python${PYTHON_VERSION} -c "import cutlass; import cutlass._mlir; print('cutlass DSL OK:', cutlass.__file__)"
 
 # Record which MXFP4 MoE kernels this image can reach; see the script for why this warns

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -197,6 +197,11 @@ ARG SGLANG_KERNEL_VERSION=0.4.5
 ARG EFA_VERSION=1.49.0
 ARG NCCL_VERSION=2.30.4
 ARG CUDNN_VERSION=9.16.0.29
+# Exact pin, and must equal the nvidia-cutlass-dsl[cu13] pin in sglang's own requirements
+# at SGLANG_REF. 4.7.0 relocated the package to nvidia_cutlass_dsl/dsl_packages/cutlass/
+# and its -libs wheel no longer lands _mlir there, so `import cutlass._mlir` fails; the
+# assertion below catches it. Bump only together with SGLANG_REF.
+ARG CUTLASS_DSL_VERSION=4.6.0
 ARG Z3_VERSION=4.15.3.0
 
 ARG DLC_MAJOR_VERSION=1
@@ -343,18 +348,20 @@ RUN CUDA_SHORT=$(echo ${CUDA_REF} | cut -d. -f1,2 | tr -d '.') \
   && uv pip install --system --no-cache --reinstall nvidia-cudnn-cu12==${CUDNN_VERSION} \
   && uv pip install --system --no-cache --reinstall nvidia-cusparselt-cu12 \
   && python${PYTHON_VERSION} -m pip install --no-cache-dir --force-reinstall \
-     "nvidia-cutlass-dsl>=4.5.2" "nvidia-cutlass-dsl-libs-cu13>=4.5.2" \
+     "nvidia-cutlass-dsl==${CUTLASS_DSL_VERSION}" \
+     "nvidia-cutlass-dsl-libs-cu13==${CUTLASS_DSL_VERSION}" \
   && python${PYTHON_VERSION} -m pip install --no-cache-dir "setuptools>=78.1.1" \
   && rm -f /usr/local/nvidia/pip-lib/* \
   && python${PYTHON_VERSION} -c "import glob,os; [os.symlink(f,'/usr/local/nvidia/pip-lib/'+os.path.basename(f)) for d in glob.glob('/usr/local/lib*/python${PYTHON_VERSION}/site-packages/nvidia/*/lib') for f in glob.glob(d+'/*.so*') if not os.path.exists('/usr/local/nvidia/pip-lib/'+os.path.basename(f))]" \
   && ldconfig
 
 # Assert the CuTe DSL native libs landed. nvidia-cutlass-dsl ships pure Python; its MLIR
-# extension modules come from the separate -libs-cu13 wheel above. Both are declared, yet a
-# prior image shipped without _mlir, so `import cutlass` failed. That is a hard startup
-# failure on Blackwell only: bf16_gemm_backend='auto' picks the CuTe DSL path on SM100/SM103
-# and cuBLAS elsewhere. Root cause unresolved; this turns a silent packaging gap into a
-# build failure rather than one found on customer hardware.
+# extension modules come from the separate -libs-cu13 wheel above. A missing _mlir is a hard
+# startup failure on Blackwell only: bf16_gemm_backend='auto' picks the CuTe DSL path on
+# SM100/SM103 and cuBLAS elsewhere, so it would surface on customer hardware and nowhere in
+# CI. This guard caught exactly that when the install above still carried a >=4.5.2 floor and
+# floated onto 4.7.0, which moved the package under nvidia_cutlass_dsl/dsl_packages/. Now
+# pinned via CUTLASS_DSL_VERSION; keep the assertion as the tripwire for the next bump.
 RUN python${PYTHON_VERSION} -c "import cutlass; import cutlass._mlir; print('cutlass DSL OK:', cutlass.__file__)"
 
 # Record which MXFP4 MoE kernels this image can reach; see the script for why this warns

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -19,7 +19,10 @@ ARG TORCH_VERSION=2.11.0
 # CUDA / GPU
 ARG NCCL_VERSION=2.30.4
 ARG CUDNN_VERSION=9.16.0.29
-ARG TORCH_CUDA_ARCH_LIST='9.0;10.0;10.3'
+# 10.3f, not a bare 10.3: MXFP4 kernels emit cvt.e2m1x2, which ptxas accepts only under an
+# a- or f-suffixed target. A bare 10.3 builds clean but emits no usable FP4 code for sm_103,
+# failing only at load time on B300. Required for Kimi-K3, whose routed experts are MXFP4.
+ARG TORCH_CUDA_ARCH_LIST='9.0;10.0;10.3f'
 
 # Build
 ARG BUILD_PARALLEL=8
@@ -178,6 +181,7 @@ ARG SGLANG_KERNEL_VERSION=0.4.4
 ARG EFA_VERSION=1.49.0
 ARG NCCL_VERSION=2.30.4
 ARG CUDNN_VERSION=9.16.0.29
+ARG Z3_VERSION=4.15.3.0
 
 ARG DLC_MAJOR_VERSION=1
 ARG DLC_MINOR_VERSION=2
@@ -300,7 +304,18 @@ RUN uv pip install --system --no-cache decord lmdb peft
 # The CVE patches step above resolves xgrammar's transitive torch dep from PyPI,
 # which downgrades torch from cu129 to cu128. Force-reinstall from the cu129 index.
 # Also reinstall sgl_kernel from the sglang wheel index (compiled against torch 2.11.0).
+# The runtime stage installs its own pip, then COPY --from=builder overlays the builder's
+# site-packages on top, splicing two pip trees together and breaking as
+# `ImportError: cannot import name 'get_runnable_pip'`. ensurepip is a no-op against the
+# stale dist-info, so drop both trees and bootstrap one clean pip from get-pip.py.
 RUN CUDA_SHORT=$(echo ${CUDA_REF} | cut -d. -f1,2 | tr -d '.') \
+  && rm -rf /usr/local/lib/python${PYTHON_VERSION}/site-packages/pip \
+            /usr/local/lib/python${PYTHON_VERSION}/site-packages/pip-*.dist-info \
+            /usr/local/lib64/python${PYTHON_VERSION}/site-packages/pip \
+            /usr/local/lib64/python${PYTHON_VERSION}/site-packages/pip-*.dist-info \
+  && curl -sS --retry 3 https://bootstrap.pypa.io/get-pip.py \
+     | python${PYTHON_VERSION} - --no-cache-dir \
+  && python${PYTHON_VERSION} -m pip --version \
   && python${PYTHON_VERSION} -m pip install --no-cache-dir --force-reinstall \
      "torch==${TORCH_VERSION}" "torchvision" "torchaudio" \
      --index-url https://download.pytorch.org/whl/cu${CUDA_SHORT} \
@@ -318,17 +333,56 @@ RUN CUDA_SHORT=$(echo ${CUDA_REF} | cut -d. -f1,2 | tr -d '.') \
   && python${PYTHON_VERSION} -c "import glob,os; [os.symlink(f,'/usr/local/nvidia/pip-lib/'+os.path.basename(f)) for d in glob.glob('/usr/local/lib*/python${PYTHON_VERSION}/site-packages/nvidia/*/lib') for f in glob.glob(d+'/*.so*') if not os.path.exists('/usr/local/nvidia/pip-lib/'+os.path.basename(f))]" \
   && ldconfig
 
+# Assert the CuTe DSL native libs landed. nvidia-cutlass-dsl ships pure Python; its MLIR
+# extension modules come from the separate -libs-cu13 wheel above. Both are declared, yet a
+# prior image shipped without _mlir, so `import cutlass` failed. That is a hard startup
+# failure on Blackwell only: bf16_gemm_backend='auto' picks the CuTe DSL path on SM100/SM103
+# and cuBLAS elsewhere. Root cause unresolved; this turns a silent packaging gap into a
+# build failure rather than one found on customer hardware.
+RUN python${PYTHON_VERSION} -c "import cutlass; import cutlass._mlir; print('cutlass DSL OK:', cutlass.__file__)"
+
+# Record which MXFP4 MoE kernels this image can reach. With moe_runner_backend='auto' sglang
+# picks trtllm-gen on SM100/SM103 when its cubins are present and silently drops to marlin
+# when they are not, so an image can ship on a slower expert path unnoticed. MXFP4 is K3's
+# routed-expert format. This warns rather than fails: trtllm-gen's MoE cubins are unmerged
+# upstream and a version bump does not help. Probing trtllm_fp4_block_scale_moe mirrors what
+# sglang itself gates on; a positive is necessary but not sufficient, since the symbol
+# resolving does not prove cubins exist for a given shape.
+RUN { python${PYTHON_VERSION} - <<'EOF'
+backends = []
+try:
+    from flashinfer import trtllm_fp4_block_scale_moe  # noqa: F401
+    backends.append("flashinfer_mxfp4/trtllm-gen")
+except Exception as e:
+    print(f"MXFP4 MoE: trtllm-gen NOT available ({type(e).__name__}), auto will fall back")
+for name, mod in (("deep_gemm", "deep_gemm"), ("marlin", "sglang.srt.layers.quantization.marlin_utils_fp4")):
+    try:
+        __import__(mod)
+        backends.append(name)
+    except Exception:
+        pass
+print("MXFP4_MOE_BACKENDS=" + (",".join(backends) if backends else "none"))
+EOF
+} > /etc/dlc-mxfp4-moe-backends.txt 2>&1 || true; cat /etc/dlc-mxfp4-moe-backends.txt
+
 # tilelang compatibility fixes for AL2023:
-# 1. z3-libs: TVM (bundled in tilelang) requires libz3.so at runtime
+# 1. libz3: TVM (bundled in tilelang) links a specific z3 soname. AL2023's z3-libs
+#    packages only 4.8 while tilelang needs 4.15, so take it from the z3-solver wheel.
+#    Keep aligned with tilelang: a bump can move the soname, surfacing as an OSError
+#    on `import tilelang`.
 # 2. _xxsubinterpreters: CPython internal module needed by tilelang's cython
 #    wrapper. Debian/Ubuntu ship it but AL2023 does not — compile from source.
 # 3. Patch tilelang's cudart.cc stub: in child processes, CUDA symbols aren't
 #    in the global namespace yet. Add a dlopen("libcudart.so") fallback before
 #    the abort() so it loads the library explicitly when dlsym fails.
-RUN dnf install -y --setopt=install_weak_deps=False z3-libs \
-  && ln -sf /usr/lib64/libz3.so.4.8 /usr/lib64/libz3.so \
-  && ldconfig \
-  && dnf clean all && rm -rf /var/cache/dnf
+#    tilelang >=0.1.10 ships a prebuilt lib/libcudart_stub.so instead of C++ sources, so
+#    skip the patch when cudart.cc is absent. The `ls` fails the layer if neither exists.
+RUN uv pip install --system --no-cache "z3-solver==${Z3_VERSION}" \
+  && Z3LIB=$(python${PYTHON_VERSION} -c "import z3, os; print(os.path.join(os.path.dirname(z3.__file__), 'lib'))") \
+  && ls ${Z3LIB}/libz3.so.* >/dev/null \
+  && ln -sf ${Z3LIB}/libz3.so.* /usr/lib64/ \
+  && ln -sf ${Z3LIB}/libz3.so /usr/lib64/libz3.so \
+  && ldconfig
 
 RUN PYVER=$(python${PYTHON_VERSION} -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')") \
   && cd /tmp \
@@ -343,6 +397,11 @@ RUN PYVER=$(python${PYTHON_VERSION} -c "import sys; print(f'{sys.version_info.ma
   && cd / && rm -rf /tmp/Python-*
 
 RUN TILELANG=$(python${PYTHON_VERSION} -c "import tilelang, os; print(os.path.dirname(tilelang.__file__))") \
+  && if [ ! -f "${TILELANG}/src/target/stubs/cudart.cc" ]; then \
+       echo "tilelang ships no cudart.cc; relying on prebuilt lib/libcudart_stub.so"; \
+       ls "${TILELANG}/lib/libcudart_stub.so"; \
+       exit 0; \
+     fi \
   && python${PYTHON_VERSION} -c "\
 import os; \
 src = '${TILELANG}/src/target/stubs/cudart.cc'; \

--- a/scripts/docker/sglang/merge_cutlass_dsl_split.py
+++ b/scripts/docker/sglang/merge_cutlass_dsl_split.py
@@ -1,0 +1,81 @@
+"""Reunite the CuTe DSL package, which pip splits across lib/ and lib64/ on AL2023.
+
+nvidia-cutlass-dsl's payload arrives in two wheels that disagree on their wheel tag while
+writing into one shared directory tree:
+
+  nvidia-cutlass-dsl-libs-core  Root-Is-Purelib: true   -> .../lib/python3.X/site-packages
+  nvidia-cutlass-dsl-libs-base  Root-Is-Purelib: false  -> .../lib64/python3.X/site-packages
+
+Both target nvidia_cutlass_dsl/dsl_packages/cutlass/, so cutlass/__init__.py lands under lib
+while cutlass/_mlir/ lands under lib64. nvidia-cutlass-dsl itself is only a .pth that does
+`sys.path.insert(0, nvidia_cutlass_dsl.__path__[0] + '/dsl_packages')` -- a single path, so
+whichever half wins is the only half importable, and `import cutlass._mlir` fails.
+
+This is an upstream packaging bug, not a version problem: 4.6.0 and 4.7.0 are both affected.
+It is also invisible on distros where purelib and platlib are the same directory (Debian,
+Ubuntu, most manylinux images) and only breaks on the lib/lib64-split ones -- AL2023, RHEL,
+Fedora -- which is why it ships broken and why it lands on us.
+
+Symlinks rather than copies: the _mlir extension modules are large, and a symlink keeps pip's
+RECORD accurate for the real file so a later uninstall or reinstall of either wheel still
+does the right thing.
+
+Idempotent, and asserts the merge achieved something -- a silent no-op here would just move
+the failure to the import assertion in the Dockerfile with a more confusing message.
+"""
+
+import os
+import sys
+import sysconfig
+
+REL = os.path.join("nvidia_cutlass_dsl", "dsl_packages")
+
+purelib = sysconfig.get_paths()["purelib"]
+platlib = sysconfig.get_paths()["platlib"]
+
+if os.path.realpath(purelib) == os.path.realpath(platlib):
+    print(f"cutlass DSL merge: purelib == platlib ({purelib}), nothing to merge")
+    sys.exit(0)
+
+linked = 0
+# Link both directions: which half holds cutlass/__init__.py (and therefore which one the
+# .pth resolves to) depends on install order, so do not assume lib64 is the orphan.
+for src_root, dst_root in ((platlib, purelib), (purelib, platlib)):
+    src = os.path.join(src_root, REL)
+    if not os.path.isdir(src):
+        continue
+    for dirpath, _dirnames, filenames in os.walk(src):
+        rel = os.path.relpath(dirpath, src)
+        dst_dir = os.path.join(dst_root, REL, rel) if rel != "." else os.path.join(dst_root, REL)
+        if not os.path.isdir(dst_dir):
+            os.makedirs(dst_dir, exist_ok=True)
+        for name in filenames:
+            dst = os.path.join(dst_dir, name)
+            if os.path.lexists(dst):
+                continue
+            os.symlink(os.path.join(dirpath, name), dst)
+            linked += 1
+
+print(f"cutlass DSL merge: linked {linked} file(s) across purelib/platlib")
+
+# Verify by structure rather than by link count: a rerun after a successful merge legitimately
+# links nothing, so a zero count is not itself a failure. What must hold is that both halves
+# now sit under the same root, since the .pth only ever puts one of them on sys.path.
+missing = [
+    root
+    for root in (purelib, platlib)
+    if os.path.isdir(os.path.join(root, REL, "cutlass"))
+    and not (
+        os.path.exists(os.path.join(root, REL, "cutlass", "__init__.py"))
+        and os.path.isdir(os.path.join(root, REL, "cutlass", "_mlir"))
+    )
+]
+if missing:
+    print(
+        "ERROR: cutlass/__init__.py and cutlass/_mlir/ are still not co-located under "
+        + ", ".join(missing)
+        + " -- the wheel layout changed, or only one of nvidia-cutlass-dsl-libs-base / "
+        "-libs-core is installed.",
+        file=sys.stderr,
+    )
+    sys.exit(1)

--- a/scripts/docker/sglang/probe_mxfp4_moe_backends.py
+++ b/scripts/docker/sglang/probe_mxfp4_moe_backends.py
@@ -1,0 +1,35 @@
+"""Record which MXFP4 MoE kernels this image can actually reach.
+
+With moe_runner_backend='auto' sglang picks trtllm-gen on SM100/SM103 when its cubins are
+present and silently drops to marlin when they are not, so an image can ship on a slower
+expert path unnoticed. MXFP4 is Kimi-K3's routed-expert format, which is what makes this
+worth recording at build time.
+
+Deliberately non-fatal: trtllm-gen's MoE cubins are unmerged upstream and a version bump
+does not help, so a missing trtllm-gen is the expected result today rather than a defect.
+Probing trtllm_fp4_block_scale_moe mirrors what sglang itself gates on. A positive is
+necessary but not sufficient -- the symbol resolving does not prove cubins exist for a
+given problem shape.
+"""
+
+import importlib
+
+PROBES = (
+    ("flashinfer_mxfp4/trtllm-gen", "flashinfer", "trtllm_fp4_block_scale_moe"),
+    ("deep_gemm", "deep_gemm", None),
+    ("marlin", "sglang.srt.layers.quantization.marlin_utils_fp4", None),
+)
+
+backends = []
+for name, module, attr in PROBES:
+    try:
+        mod = importlib.import_module(module)
+        if attr is not None and not hasattr(mod, attr):
+            raise AttributeError(f"{module}.{attr} missing")
+        backends.append(name)
+    except Exception as exc:  # noqa: BLE001 - any failure means the backend is unreachable
+        print(f"MXFP4 MoE: {name} NOT available ({type(exc).__name__}: {exc})")
+
+print("MXFP4_MOE_BACKENDS=" + (",".join(backends) if backends else "none"))
+if "flashinfer_mxfp4/trtllm-gen" not in backends:
+    print("NOTE: moe_runner_backend='auto' will fall back; expected until cubins land upstream.")


### PR DESCRIPTION
## Purpose

Enables Kimi-K3 on the SGLang AL2023 images and fixes two Blackwell defects found while
verifying it on 8x B300.

Commit 1, Blackwell correctness. Three changes, each turning a load-time failure on
B200/B300 into either a correct build or a failed one. No effect on pre-Blackwell GPUs.

- `torch_cuda_arch_list` `10.3` to `10.3f`. MXFP4 kernels emit `cvt.e2m1x2`, which ptxas
  accepts only under an a- or f-suffixed target. A bare `10.3` compiles and links without
  error but emits no usable FP4 device code for sm_103, so the gap appears only when a
  model with MXFP4 weights loads on the hardware. This diverges from upstream's own
  Dockerfile, which still uses a bare `10.3`. Deliberate, not a catch-up.
- Assert `cutlass._mlir` imports. `nvidia-cutlass-dsl` ships pure Python and its MLIR
  extensions come from a separate `-libs-cu13` wheel. Both are declared, yet a prior image
  shipped without `_mlir`, so `import cutlass` failed. That is a hard startup failure on
  Blackwell only, since `bf16_gemm_backend='auto'` selects the CuTe DSL path on SM100/SM103
  and cuBLAS elsewhere. Root cause is unresolved; this assertion does not fix it, it stops
  the same silent gap from reaching a released image again.
- Record reachable MXFP4 MoE backends to `/etc/dlc-mxfp4-moe-backends.txt`. With
  `moe_runner_backend='auto'` SGLang picks trtllm-gen on SM100/SM103 when its cubins are
  present and silently drops to marlin when they are not, so an image can ship on a slower
  expert path unnoticed. Warns rather than fails, because trtllm-gen's MoE cubins are
  unmerged upstream and a version bump does not help.

Also folded in, all found while building this image and all inert on a green build: a
single-tree pip bootstrap via get-pip.py, libz3 taken from the z3-solver wheel, and a
conditional tilelang `cudart.cc` patch.

Commit 2, the ref bump. `sglang_ref` moves to `abddb1c7`, with `sglang_kernel_version`
0.4.5 and `flashinfer_version` 0.6.15.post1. Kimi-K3 needs `srt/models/kimi_k3.py`, which
is in no released tag, so this is a bare commit hash. The two version pins are ABI-coupled
to the ref and are what upstream's own Dockerfile pins at that exact commit, read from the
tree rather than assumed. Both amzn2023 variants move together. The ubuntu variants pin no
`sglang_ref` (they build the 0.5.16 tag) and are untouched.

The two commits must land together and must not be split. This ref without the `10.3f`
change produces an image that advertises K3 support, builds green, then fails at load time
on B300 because MXFP4 has no working device code.

Open items for the reviewer:

- `framework_version` stays `0.5.14+dlc1` and `dlc_minor_version` stays `2`. Both feed
  image tags and are arguably stale. The only `required_image_pattern` in
  sglang-model-tests.yml keys on `os_version`, so neither breaks test matching. Flagged as
  a release-versioning decision rather than silently picked.
- Whether the trtllm-gen fallback costs accuracy or only throughput is unmeasured.

## Test Plan

CI cannot validate Kimi-K3 at any point. It needs roughly 1.51 TiB of GPU memory against
640 GB on the largest runner, about 2.4x short, and B300 is not in the fleet. No model-test
entry is added, deliberately. So the plan splits into what CI can prove and what only
hardware can.

CI, this PR:

1. Image builds at `abddb1c7` with sglang-kernel 0.4.5 and flashinfer 0.6.15.post1.
2. The `cutlass._mlir` assertion passes, proving the CuTe DSL native libs landed.
3. The MXFP4 probe runs and records a backend list.
4. Existing sanity, security, telemetry and model tests pass unchanged, confirming no
   regression on non-Blackwell hardware.

Local, already done:

5. `resolve_build_args.py` emits all four keys as upper-case build args on both variants,
   confirming the config overrides actually bind rather than silently falling back to the
   Dockerfile defaults.
6. Both configs parse as YAML and hold identical values.

Hardware, out of band on 8x B300, not gated on this PR:

7. Serve Kimi-K3 end to end on the built image.
8. `cuobjdump --list-elf` on the `sgl_kernel` shared objects, bare `10.3` against `10.3f`,
   to replace the ptxas argument with direct evidence of emitted FP4 code.
9. Compare `deep_gemm` against `marlin` for throughput and output equivalence.

## Test Result

Pending. Will update with the CI run once the PR is open.

Local checks pass:

- `resolve_build_args.py` emits `SGLANG_REF=abddb1c7e9d61ddddeaf016d885c2f20aab426e8`,
  `SGLANG_KERNEL_VERSION=0.4.5`, `FLASHINFER_VERSION=0.6.15.post1`,
  `TORCH_CUDA_ARCH_LIST=9.0;10.0;10.3f` on both ec2 and sagemaker.
- Both config files parse and agree.

Prior hardware evidence, for context rather than as validation of this exact tree: Kimi-K3
served on 8x B300 (p6-b300.48xlarge, compute capability 10.3) on 2026-08-04, roughly
229 GiB per rank under SGLang. That run used `40feea27`, a dev-branch commit of the same
work, so the hardware evidence is one commit removed from the `abddb1c7` shipped here. A
main commit was chosen anyway because it is immutable, where a dev branch can be rebased or
deleted. Item 7 above closes that gap.

______________________________________________________________________

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [x] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
