### PR TITLE
fix(currency): make all ECR scan failures block merge conditions

### DIFF
--- a/.github/workflows/_prcheck.merge-conditions.yml
+++ b/.github/workflows/_prcheck.merge-conditions.yml
@@ -26,7 +26,6 @@ jobs:
             const self = 'enforce-all-checks';
             const ignoredChecks = new Set([self]);
             const ignoredPatterns = [
-              /ecr-vulnerability-scan$/,
               /efa-test$/,
             ];
             const intervalMs = 30_000;


### PR DESCRIPTION
## What
Remove the `/ecr-vulnerability-scan$/` entry from `ignoredPatterns` in **Merge Conditions**, so any ECR vulnerability scan failure (non-allowlisted CRITICAL/HIGH CVE) blocks merge for **every** framework.

## Why
Commit `66c2d54a` had made all ECR scans non-blocking. Per team discussion, we now want scan failures to gate merge across the board — not just for vLLM/SGLang Ubuntu.

## Effect on the Currency Fix Agent
The Currency Fix Agent (`_prcheck.currency-fix.yml`) triggers when **Merge Conditions** concludes `failure`. With scans blocking again, CVE failures on tracked auto-update PRs (vLLM/SGLang Ubuntu) will once more trigger the agent. Scans on other frameworks now also block merge for regular PRs.

## Relationship to #6494
This supersedes the partial vLLM/SGLang-Ubuntu-only blocking approach in #6494. If this PR is the agreed direction, the merge-conditions change in #6494 should be dropped (its Currency Fix Agent stale-commit + stop-label guard is still worth keeping — those changes are independent).

## Testing
- Validated as parseable YAML.
- One-line diff; no other logic changed.