### PR TITLE
tei 1.9.3: switch release to production

### DIFF
--- a/.github/config/image/tei/sagemaker-1.9.3-cpu.yml
+++ b/.github/config/image/tei/sagemaker-1.9.3-cpu.yml
@@ -25,4 +25,4 @@ release:
   public_registry: false
   private_registry: true
   enable_soci: false
-  environment: "preprod"
+  environment: "production"

--- a/.github/config/image/tei/sagemaker-1.9.3-gpu.yml
+++ b/.github/config/image/tei/sagemaker-1.9.3-gpu.yml
@@ -25,4 +25,4 @@ release:
   public_registry: false
   private_registry: true
   enable_soci: false
-  environment: "preprod"
+  environment: "production"


### PR DESCRIPTION
Switches TEI 1.9.3 CPU + GPU release environment from `preprod` to `production` in both config files.
Preprod release succeeded and images verified.

## Test plan
- [x] Merge, then manually trigger `Dispatch - TEI Release` to push production images.