### PR TITLE
remove pytorch 2.8 images

### DIFF
--- a/release_images_patches.yml
+++ b/release_images_patches.yml
@@ -2,7 +2,7 @@
 # DLC images to patch - force_release is not allowed in this file
 release_images:
   # PyTorch 2.9 Images
-  3:
+  1:
     framework: "pytorch"
     version: "2.9.0"
     customer_type: "ec2"
@@ -17,7 +17,7 @@ release_images:
       force_release: False
       public_registry: True
       enable_soci: True
-  4:
+  2:
     framework: "pytorch"
     version: "2.9.0"
     customer_type: "sagemaker"
@@ -34,7 +34,7 @@ release_images:
       enable_soci: True
 
   # PyTorch 2.10 Images
-  5:
+  3:
     framework: "pytorch"
     version: "2.10.0"
     customer_type: "ec2"
@@ -49,7 +49,7 @@ release_images:
       force_release: False
       public_registry: True
       enable_soci: True
-  6:
+  4:
     framework: "pytorch"
     version: "2.10.0"
     customer_type: "sagemaker"

--- a/release_images_patches.yml
+++ b/release_images_patches.yml
@@ -1,38 +1,6 @@
 ---
 # DLC images to patch - force_release is not allowed in this file
 release_images:
-  # PyTorch 2.8 Images
-  1:
-    framework: "pytorch"
-    version: "2.8.0"
-    customer_type: "ec2"
-    arch_type: "x86"
-    training:
-      device_types: ["cpu", "gpu"]
-      python_versions: [ "py312" ]
-      os_version: "ubuntu22.04"
-      cuda_version: "cu129"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-      public_registry: True
-      enable_soci: True
-  2:
-    framework: "pytorch"
-    version: "2.8.0"
-    customer_type: "sagemaker"
-    arch_type: "x86"
-    training:
-      device_types: ["cpu", "gpu"]
-      python_versions: [ "py312" ]
-      os_version: "ubuntu22.04"
-      cuda_version: "cu129"
-      example: False
-      disable_sm_tag: False
-      force_release: False
-      public_registry: True
-      enable_soci: True
-
   # PyTorch 2.9 Images
   3:
     framework: "pytorch"


### PR DESCRIPTION
PyTorch 2.8 training images have reached end-of-patch per the AWS DLC support policy (https://aws.github.io/deep-learning-containers/reference/support_policy/). Removing the PyTorch 2.8 entries from `release_images_patches.yml` as part of the deprecation.