### PR TITLE
sglang Kimi-k3 verification

### DIFF
--- a/.github/config/image/sglang/ec2-amzn2023.yml
+++ b/.github/config/image/sglang/ec2-amzn2023.yml
@@ -30,7 +30,7 @@ build:
   gdrcopy_version: "2.6"
   torch_cuda_arch_list: "9.0;10.0;10.3"
   dlc_major_version: "1"
-  dlc_minor_version: "4"
+  dlc_minor_version: "3"
 
 release:
   release: true

--- a/.github/config/image/sglang/ec2-amzn2023.yml
+++ b/.github/config/image/sglang/ec2-amzn2023.yml
@@ -17,7 +17,7 @@ build:
   target: "sglang-ec2"
   python_version: "3.12"
   cuda_version: "13.0.3"
-  sglang_ref: "b6a09f38fcc5e96574324b4acc19d421c539cfc6"
+  sglang_ref: "29481685462732237d80d86076d6563e1f658102"
   sglang_kernel_version: "0.4.5"
   flashinfer_version: "0.6.15.post1"
   deepep_commit: "9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee"

--- a/.github/config/image/sglang/ec2-amzn2023.yml
+++ b/.github/config/image/sglang/ec2-amzn2023.yml
@@ -30,7 +30,7 @@ build:
   gdrcopy_version: "2.6"
   torch_cuda_arch_list: "9.0;10.0;10.3"
   dlc_major_version: "1"
-  dlc_minor_version: "3"
+  dlc_minor_version: "4"
 
 release:
   release: true

--- a/.github/config/image/sglang/ec2-amzn2023.yml
+++ b/.github/config/image/sglang/ec2-amzn2023.yml
@@ -4,7 +4,7 @@ image:
 
 metadata:
   framework: "sglang_server"
-  framework_version: "0.5.14+dlc1"
+  framework_version: "0.5.17+dlc1"
   os_version: "amzn2023"
   customer_type: "ec2"
   arch_type: "x86"
@@ -17,11 +17,11 @@ build:
   target: "sglang-ec2"
   python_version: "3.12"
   cuda_version: "13.0.3"
-  sglang_ref: "bc8b3ab1f55c60951b586d84d4aec773a6f654df"
-  sglang_kernel_version: "0.4.4"
-  flashinfer_version: "0.6.12"
+  sglang_ref: "b6a09f38fcc5e96574324b4acc19d421c539cfc6"
+  sglang_kernel_version: "0.4.5"
+  flashinfer_version: "0.6.15.post1"
   deepep_commit: "9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee"
-  mooncake_version: "0.3.11.post1"
+  mooncake_version: "0.3.12.post1"
   torch_version: "2.11.0"
   nccl_version: "2.30.4"
   cudnn_version: "9.16.0.29"
@@ -30,7 +30,7 @@ build:
   gdrcopy_version: "2.6"
   torch_cuda_arch_list: "9.0;10.0;10.3"
   dlc_major_version: "1"
-  dlc_minor_version: "2"
+  dlc_minor_version: "3"
 
 release:
   release: true

--- a/.github/config/image/sglang/sagemaker-amzn2023.yml
+++ b/.github/config/image/sglang/sagemaker-amzn2023.yml
@@ -31,7 +31,7 @@ build:
   gdrcopy_version: "2.6"
   torch_cuda_arch_list: "9.0;10.0;10.3"
   dlc_major_version: "1"
-  dlc_minor_version: "3"
+  dlc_minor_version: "4"
 
 release:
   release: true

--- a/.github/config/image/sglang/sagemaker-amzn2023.yml
+++ b/.github/config/image/sglang/sagemaker-amzn2023.yml
@@ -4,7 +4,7 @@ image:
 
 metadata:
   framework: "sglang_server"
-  framework_version: "0.5.14+dlc1"
+  framework_version: "0.5.17+dlc1"
   os_version: "amzn2023"
   customer_type: "sagemaker"
   platform: "sagemaker"
@@ -18,9 +18,9 @@ build:
   target: "sglang-sagemaker"
   python_version: "3.12"
   cuda_version: "13.0.3"
-  sglang_ref: "bc8b3ab1f55c60951b586d84d4aec773a6f654df"
-  sglang_kernel_version: "0.4.4"
-  flashinfer_version: "0.6.12"
+  sglang_ref: "b6a09f38fcc5e96574324b4acc19d421c539cfc6"
+  sglang_kernel_version: "0.4.5"
+  flashinfer_version: "0.6.15.post1"
   deepep_commit: "9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee"
   mooncake_version: "0.3.12.post1"
   torch_version: "2.11.0"
@@ -31,7 +31,7 @@ build:
   gdrcopy_version: "2.6"
   torch_cuda_arch_list: "9.0;10.0;10.3"
   dlc_major_version: "1"
-  dlc_minor_version: "2"
+  dlc_minor_version: "3"
 
 release:
   release: true

--- a/.github/config/image/sglang/sagemaker-amzn2023.yml
+++ b/.github/config/image/sglang/sagemaker-amzn2023.yml
@@ -22,7 +22,7 @@ build:
   sglang_kernel_version: "0.4.4"
   flashinfer_version: "0.6.12"
   deepep_commit: "9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee"
-  mooncake_version: "0.3.11.post1"
+  mooncake_version: "0.3.12.post1"
   torch_version: "2.11.0"
   nccl_version: "2.30.4"
   cudnn_version: "9.16.0.29"

--- a/.github/config/image/sglang/sagemaker-amzn2023.yml
+++ b/.github/config/image/sglang/sagemaker-amzn2023.yml
@@ -18,7 +18,7 @@ build:
   target: "sglang-sagemaker"
   python_version: "3.12"
   cuda_version: "13.0.3"
-  sglang_ref: "b6a09f38fcc5e96574324b4acc19d421c539cfc6"
+  sglang_ref: "29481685462732237d80d86076d6563e1f658102"
   sglang_kernel_version: "0.4.5"
   flashinfer_version: "0.6.15.post1"
   deepep_commit: "9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee"

--- a/.github/config/image/sglang/sagemaker-amzn2023.yml
+++ b/.github/config/image/sglang/sagemaker-amzn2023.yml
@@ -31,7 +31,7 @@ build:
   gdrcopy_version: "2.6"
   torch_cuda_arch_list: "9.0;10.0;10.3"
   dlc_major_version: "1"
-  dlc_minor_version: "4"
+  dlc_minor_version: "3"
 
 release:
   release: true

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -209,7 +209,7 @@ RUN CUDA_DASH=$(echo ${CUDA_REF} | cut -d. -f1,2 | tr '.' '-') \
   && sed -i '/^\[cuda\]/a priority=50' /etc/yum.repos.d/cuda.repo \
   && dnf install -y --allowerasing --setopt=install_weak_deps=False \
     python${PYTHON_VERSION} python${PYTHON_VERSION}-devel \
-    ca-certificates wget curl git tar gzip \
+    ca-certificates wget curl git tar gzip unzip patch \
     openmpi numactl \
     rdma-core libibverbs librdmacm \
     libnl3 infiniband-diags \
@@ -219,6 +219,9 @@ RUN CUDA_DASH=$(echo ${CUDA_REF} | cut -d. -f1,2 | tr '.' '-') \
     cuda-nvcc-${CUDA_DASH} \
     cuda-cuobjdump-${CUDA_DASH} \
     cuda-cudart-devel-${CUDA_DASH} \
+    # Kimi-K3 JIT-compiles MoE kernels against nvrtc at runtime; without the
+    # devel package there is no <nvrtc.h> and no libnvrtc.so for -lnvrtc.
+    cuda-nvrtc-devel-${CUDA_DASH} \
     libcurand-devel-${CUDA_DASH} \
     libcublas-devel-${CUDA_DASH} \
     gcc gcc-c++ make which hostname findutils \
@@ -322,8 +325,8 @@ RUN CUDA_SHORT=$(echo ${CUDA_REF} | cut -d. -f1,2 | tr -d '.') \
   && uv pip install --system --no-cache --reinstall nvidia-cudnn-cu12==${CUDNN_VERSION} \
   && uv pip install --system --no-cache --reinstall nvidia-cusparselt-cu12 \
   && python${PYTHON_VERSION} -m pip install --no-cache-dir --force-reinstall \
-     "nvidia-cutlass-dsl>=4.5.2" "nvidia-cutlass-dsl-libs-cu13>=4.5.2" \
-  && python${PYTHON_VERSION} -m pip install --no-cache-dir "setuptools>=78.1.1" \
+     "nvidia-cutlass-dsl[cu13]==4.6.0" \
+  && python${PYTHON_VERSION} -m pip install --no-cache-dir "setuptools>=78.1.1,<82" "numpy<2.5" \
   && rm -f /usr/local/nvidia/pip-lib/* \
   && python${PYTHON_VERSION} -c "import glob,os; [os.symlink(f,'/usr/local/nvidia/pip-lib/'+os.path.basename(f)) for d in glob.glob('/usr/local/lib*/python${PYTHON_VERSION}/site-packages/nvidia/*/lib') for f in glob.glob(d+'/*.so*') if not os.path.exists('/usr/local/nvidia/pip-lib/'+os.path.basename(f))]" \
   && ldconfig
@@ -354,6 +357,86 @@ RUN python${PYTHON_VERSION} -c "import importlib.util, os; print(os.path.join(os
       > /etc/ld.so.conf.d/z3-solver.conf \
   && ldconfig \
   && python${PYTHON_VERSION} -c "import tilelang; print('tilelang', tilelang.__version__)"
+
+# ---------------------------------------------------------------------------
+# Kimi-K3 support (MXFP4 MoE + CuTeDSL MLA decode with DCP)
+# ---------------------------------------------------------------------------
+
+# nvidia-cutlass-dsl splits across purelib and platlib on AL2023: the DSL wheel
+# is pure-Python (-> lib/) while its -libs-cu13 companion is a platform wheel
+# (-> lib64/). Debian/Ubuntu collapse both to one dir, so upstream never sees
+# this. The two trees are complementary, not competing: lib/ has the pure
+# `cutlass` package, lib64/ has the native _mlir extensions it imports. The
+# package's own .pth takes __path__[0] (the payload-free lib entry), and .pth
+# files run in sorted filename order, so no sys.path reordering can fix it —
+# the trees have to be merged. The import below is the check.
+RUN PURE=/usr/local/lib/python${PYTHON_VERSION}/site-packages/nvidia_cutlass_dsl \
+  && PLAT=/usr/local/lib64/python${PYTHON_VERSION}/site-packages/nvidia_cutlass_dsl \
+  && for d in cu12 cu13; do \
+       if [ -e "${PLAT}/${d}" ]; then ln -sfn "${PLAT}/${d}" "${PURE}/${d}"; fi; \
+     done \
+  && mkdir -p "${PURE}/dsl_packages/cutlass" \
+  && for f in "${PLAT}"/dsl_packages/cutlass/*; do \
+       if [ -e "$f" ]; then ln -sfn "$f" "${PURE}/dsl_packages/cutlass/$(basename "$f")"; fi; \
+     done \
+  && python${PYTHON_VERSION} -c "import cutlass, cutlass.cute; print('cutlass-dsl ok')"
+
+# Assert the two nvrtc build-time artifacts exist: the <nvrtc.h> header and the
+# unversioned libnvrtc.so that `ld -lnvrtc` resolves. cuda-nvrtc-devel above
+# supplies both; without them K3's runtime MoE JIT dies in FlashInfer autotune
+# with "ninja: build stopped". The fallback symlinks cover the case where the
+# devel package's layout shifts — the header then comes from the cu13 pip wheel
+# (named explicitly, since a cu12 wheel is installed too) and the library from
+# the versioned soname already in-tree (not the .alt variant, a separate build).
+RUN CUDA_TGT=/usr/local/cuda-$(echo ${CUDA_REF} | cut -d. -f1,2)/targets/x86_64-linux \
+  && [ -e ${CUDA_TGT}/include/nvrtc.h ] \
+     || ln -sf /usr/local/lib/python${PYTHON_VERSION}/site-packages/nvidia/cu13/include/nvrtc.h \
+               ${CUDA_TGT}/include/nvrtc.h \
+  && [ -e ${CUDA_TGT}/lib/libnvrtc.so ] \
+     || ln -sf ${CUDA_TGT}/lib/libnvrtc.so.$(echo ${CUDA_REF} | cut -d. -f1) \
+               ${CUDA_TGT}/lib/libnvrtc.so \
+  && ldconfig \
+  && test -e ${CUDA_TGT}/include/nvrtc.h \
+  && test -e ${CUDA_TGT}/lib/libnvrtc.so \
+  && echo '#include <nvrtc.h>' > /tmp/nvrtc_probe.c \
+  && echo 'int main(){nvrtcVersion(0,0);return 0;}' >> /tmp/nvrtc_probe.c \
+  && gcc /tmp/nvrtc_probe.c -I${CUDA_TGT}/include -L${CUDA_TGT}/lib -lnvrtc -o /tmp/nvrtc_probe \
+  && rm -f /tmp/nvrtc_probe /tmp/nvrtc_probe.c
+
+# Kimi-K3 selects its MoE kernels from a prebuilt trtllm-gen cubin pool, and JIT
+# compiles the accompanying overlay/ sources against it at first use. Absent the
+# pool, MXFP4 MoE has no kernels to dispatch to.
+ARG TRTLLM_GEN_MOE_CUBIN_POOL_VERSION=trtllm_gen_moe_cubin_pool_20260617_v0613rc1
+ARG TRTLLM_GEN_MOE_CUBIN_POOL_TAG=trtllm_gen_moe_cubin_20260617
+ARG TRTLLM_GEN_MOE_CUBIN_POOL_SHA256=4900501cbe782a76b08a5858f9f07152287b97cb68114466dac286366b66c192
+ENV SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL=/opt/trtllm_gen_moe_cubin_pool
+RUN cd /tmp \
+  && curl --retry 3 -sSLo pool.zip \
+     https://github.com/sgl-project/whl/releases/download/${TRTLLM_GEN_MOE_CUBIN_POOL_TAG}/${TRTLLM_GEN_MOE_CUBIN_POOL_VERSION}.zip \
+  && echo "${TRTLLM_GEN_MOE_CUBIN_POOL_SHA256}  pool.zip" | sha256sum -c - \
+  && unzip -q pool.zip \
+  && mv ${TRTLLM_GEN_MOE_CUBIN_POOL_VERSION} ${SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL} \
+  && rm -f pool.zip \
+  && CUBINS=$(find ${SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL} -name '*.cubin' | wc -l) \
+  && echo "trtllm-gen cubins: ${CUBINS}" \
+  && test "${CUBINS}" -eq 1696
+
+# K3 decodes with the CuTeDSL MLA backend, which needs decode context parallel
+# (enable_dcp) plumbed through flashinfer. The patch ships in the sglang source
+# tree but upstream only applies it in their own K3 image. tests/ diffs are
+# stripped (no test tree in site-packages); --dry-run first so a patch that has
+# gone stale against a flashinfer bump fails the build loudly instead of
+# half-applying. The signature check is the assertion that it took.
+RUN FLASHINFER_DCP_PATCH=/sgl-workspace/sglang/docker/kimi_k3/flashinfer-perkz-dcp-0.6.15.txt \
+  && FLASHINFER_SITE_PACKAGES="$(python${PYTHON_VERSION} -c 'from pathlib import Path; import flashinfer; print(Path(flashinfer.__file__).resolve().parent.parent)')" \
+  && sed '/^diff --git a\/tests\//,$d' "${FLASHINFER_DCP_PATCH}" \
+     | patch --dry-run --batch --forward --strip=1 --directory="${FLASHINFER_SITE_PACKAGES}" \
+  && sed '/^diff --git a\/tests\//,$d' "${FLASHINFER_DCP_PATCH}" \
+     | patch --batch --forward --strip=1 --directory="${FLASHINFER_SITE_PACKAGES}" \
+  && python${PYTHON_VERSION} -c "import inspect, flashinfer.decode as d; \
+     assert 'enable_dcp' in inspect.signature(d.trtllm_batch_decode_with_kv_cache_mla).parameters, \
+     'flashinfer DCP patch did not apply'; print('flashinfer DCP ok')" \
+  && rm -rf /root/.cache/flashinfer /root/.cache/pip
 
 
 # Telemetry, common scripts, and OSS compliance

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -320,17 +320,13 @@ RUN CUDA_SHORT=$(echo ${CUDA_REF} | cut -d. -f1,2 | tr -d '.') \
   && ldconfig
 
 # tilelang compatibility fixes for AL2023:
-# 1. z3-libs: TVM (bundled in tilelang) requires libz3.so at runtime
-# 2. _xxsubinterpreters: CPython internal module needed by tilelang's cython
+# 1. _xxsubinterpreters: CPython internal module needed by tilelang's cython
 #    wrapper. Debian/Ubuntu ship it but AL2023 does not — compile from source.
-# 3. Patch tilelang's cudart.cc stub: in child processes, CUDA symbols aren't
-#    in the global namespace yet. Add a dlopen("libcudart.so") fallback before
-#    the abort() so it loads the library explicitly when dlsym fails.
-RUN dnf install -y --setopt=install_weak_deps=False z3-libs \
-  && ln -sf /usr/lib64/libz3.so.4.8 /usr/lib64/libz3.so \
-  && ldconfig \
-  && dnf clean all && rm -rf /var/cache/dnf
-
+# 2. libz3: tilelang's bundled TVM has a DT_NEEDED on the versioned soname
+#    libz3.so.4.15. AL2023's z3-libs package is 4.8 and the loader matches the
+#    soname literally, so no distro package or symlink can satisfy it. tilelang
+#    depends on z3-solver (<4.15.5) from PyPI, whose wheel vendors
+#    libz3.so.4.15 — put that directory on the loader path instead.
 RUN PYVER=$(python${PYTHON_VERSION} -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}')") \
   && cd /tmp \
   && curl --retry 3 -sSL https://www.python.org/ftp/python/${PYVER}/Python-${PYVER}.tgz | tar xz \
@@ -343,21 +339,12 @@ RUN PYVER=$(python${PYTHON_VERSION} -c "import sys; print(f'{sys.version_info.ma
   && cp _xxsubinterpreters.so ${SITE}/ \
   && cd / && rm -rf /tmp/Python-*
 
-RUN TILELANG=$(python${PYTHON_VERSION} -c "import tilelang, os; print(os.path.dirname(tilelang.__file__))") \
-  && python${PYTHON_VERSION} -c "\
-import os; \
-src = '${TILELANG}/src/target/stubs/cudart.cc'; \
-content = open(src).read(); \
-target = '  fprintf(stderr,\n          \"TileLang Error: libcudart symbols not found globally.'; \
-insert = '  // AL2023 fix: try dlopen as fallback\n  void *handle = dlopen(\"libcudart.so\", RTLD_NOW | RTLD_GLOBAL);\n  if (handle != nullptr) {\n    return handle;\n  }\n'; \
-assert target in content, 'cudart.cc patch target not found'; \
-open(src, 'w').write(content.replace(target, insert + target))" \
-  && g++ -shared -fPIC -O2 \
-     -I/usr/local/cuda/include \
-     -I${TILELANG}/3rdparty/tvm/include \
-     ${TILELANG}/src/target/stubs/cudart.cc \
-     -o ${TILELANG}/lib/libcudart_stub.so \
-     -ldl
+# The import below is the check: tilelang loads its bundled TVM eagerly, so it
+# fails here with a clear error if the vendored libz3 soname ever moves again.
+RUN python${PYTHON_VERSION} -c "import importlib.util, os; print(os.path.join(os.path.dirname(importlib.util.find_spec('z3').origin), 'lib'))" \
+      > /etc/ld.so.conf.d/z3-solver.conf \
+  && ldconfig \
+  && python${PYTHON_VERSION} -c "import tilelang; print('tilelang', tilelang.__version__)"
 
 
 # Telemetry, common scripts, and OSS compliance

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -412,7 +412,7 @@ ARG TRTLLM_GEN_MOE_CUBIN_POOL_SHA256=4900501cbe782a76b08a5858f9f07152287b97cb681
 ENV SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL=/opt/trtllm_gen_moe_cubin_pool
 RUN cd /tmp \
   && curl --retry 3 -sSLo pool.zip \
-     https://github.com/sgl-project/whl/releases/download/${TRTLLM_GEN_MOE_CUBIN_POOL_TAG}/${TRTLLM_GEN_MOE_CUBIN_POOL_VERSION}.zip \
+    https://github.com/sgl-project/whl/releases/download/${TRTLLM_GEN_MOE_CUBIN_POOL_TAG}/${TRTLLM_GEN_MOE_CUBIN_POOL_VERSION}.zip \
   && echo "${TRTLLM_GEN_MOE_CUBIN_POOL_SHA256}  pool.zip" | sha256sum -c - \
   && unzip -q pool.zip \
   && mv ${TRTLLM_GEN_MOE_CUBIN_POOL_VERSION} ${SGLANG_TRTLLM_GEN_MOE_CUBIN_POOL} \

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -265,6 +265,15 @@ RUN rm -rf /sgl-workspace/sglang/sgl-model-gateway \
 # Copy sglang-router binary
 COPY --from=builder /usr/local/bin/sglang-router /usr/local/bin/sglang-router
 
+# Console scripts from sglang's [project.scripts] entry points. These land in
+# /usr/local/bin, which is not otherwise copied from the builder stage. The
+# upstream test harness launches servers via the `sglang` executable rather than
+# `python -m`, so it must be on PATH.
+COPY --from=builder /usr/local/bin/sglang /usr/local/bin/sglang
+COPY --from=builder /usr/local/bin/killall_sglang /usr/local/bin/killall_sglang
+RUN command -v sglang && command -v killall_sglang \
+  && python${PYTHON_VERSION} -c "import sglang.cli.main"
+
 # Copy GDRCopy runtime libs
 COPY --from=builder /usr/local/lib/libgdrapi.so* /usr/local/lib/
 

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -11,7 +11,7 @@ ARG SGLANG_REF=bc8b3ab1f55c60951b586d84d4aec773a6f654df
 ARG SGLANG_KERNEL_VERSION=0.4.4
 ARG FLASHINFER_VERSION=0.6.12
 ARG DEEPEP_COMMIT=9af0e0d0e74f3577af1979c9b9e1ac2cad0104ee
-ARG MOONCAKE_VERSION=0.3.11.post1
+ARG MOONCAKE_VERSION=0.3.12.post1
 ARG GDRCOPY_VERSION=2.6
 ARG RUST_VERSION=1.96.1
 ARG TORCH_VERSION=2.11.0
@@ -139,12 +139,13 @@ RUN cd /sgl-workspace/DeepEP \
   && TORCH_CUDA_ARCH_LIST="${TORCH_CUDA_ARCH_LIST}" MAX_JOBS=${BUILD_PARALLEL} \
     uv pip install --system --no-cache --no-build-isolation .
 
-# Mooncake: force-install because the 0.3.9 wheel declares manylinux_2_35 (glibc 2.35)
-# but AL2023 ships glibc 2.34. The wheel's actual native code only needs 2.34 symbols,
-# so the force-install works today. If a future mooncake version starts using glibc 2.35+
-# symbols, this will segfault at runtime — re-test after any MOONCAKE_VERSION bump.
+# Mooncake: 0.3.12+ wheels are tagged manylinux_2_28 (glibc >= 2.28), which AL2023's
+# glibc 2.34 satisfies natively — unlike the 0.3.9-0.3.11 wheels, which declared
+# manylinux_2_35 and needed a force-install to land here at all.
+# --platform is matched literally, so re-check the wheel's platform tag on PyPI after
+# any MOONCAKE_VERSION bump; a retag surfaces as a misleading "no matching distribution".
 # Uses pip (not uv) because uv lacks --platform/--target flags.
-RUN python3 -m pip install mooncake-transfer-engine==${MOONCAKE_VERSION} --platform manylinux_2_35_x86_64 --only-binary :all: --target /tmp/mooncake \
+RUN python3 -m pip install mooncake-transfer-engine==${MOONCAKE_VERSION} --platform manylinux_2_28_x86_64 --only-binary :all: --target /tmp/mooncake \
     && cp -r /tmp/mooncake/* $(python3 -c "import site; print(site.getsitepackages()[0])") \
     && rm -rf /tmp/mooncake
 


### PR DESCRIPTION
## Purpose

Bump the AL2023 SGLang DLC from 0.5.14 to 0.5.17.

The AL2023 image is pinned to SGLang 0.5.14, which does not contain the
Kimi-K3 model implementation (`sglang/srt/models/kimi_k3.py`) or the
`kimi_k3` reasoning/tool-call parsers. As a result, the default EC2 SGLang
DLC cannot serve Kimi-K3 at all. The Ubuntu variant is already at 0.5.17
(auto-updated via `[Auto-Update] sglang` PRs) and serves K3 correctly. AL2023
lags because it builds SGLang from source rather than pulling an upstream
base image, so it is not covered by the currency automation.

This is a currency bump that delivers customer capability on B300-class
hardware. It does **not** add Kimi-K3 to the CI model-test matrix.

Pins updated, all sourced from upstream `v0.5.17`:

| Field | Old | New | Source |
|---|---|---|---|
| `framework_version` | `0.5.14+dlc1` | `0.5.17+dlc1` | matches Ubuntu config |
| `sglang_ref` | `bc8b3ab1...` | `b6a09f38fcc5e96574324b4acc19d421c539cfc6` | `refs/tags/v0.5.17` |
| `sglang_kernel_version` | `0.4.4` | `0.4.5` | upstream `pyproject.toml` + Dockerfile `SGL_KERNEL_VERSION` |
| `flashinfer_version` | `0.6.12` | `0.6.15.post1` | upstream `pyproject.toml` (`flashinfer_python[cu13]`) |
| `mooncake_version` | `0.3.11.post1` | `0.3.12.post1` | upstream Dockerfile `MOONCAKE_VERSION` |
| `dlc_minor_version` | `2` | `3` | rebuild |

Deliberately unchanged: `deepep_commit` (upstream v0.5.17 pins the same
`9af0e0d0...`), `torch_version` (`2.11.0`, matches upstream), and
`torch_cuda_arch_list` (`9.0;10.0;10.3`, already includes sm103/B300).

Note: the previous `sglang_ref` (`bc8b3ab1`) was a post-tag commit, not the
`v0.5.14` tag (`4289f36e`). This change moves to the clean `v0.5.17` tag SHA.

## Test Plan

**CI (automated):**
- Source build on `x86-sglang-build-runner` — primary risk is the
  `sglang-kernel` 0.4.4 -> 0.4.5 and FlashInfer 0.6.12 -> 0.6.15.post1
  source compilation.
- Sanity, telemetry, and security tests.
- `sglang.tests-upstream.yml` — upstream suite against 0.5.17.
- `sglang.tests-model.yml` — all existing entries in
  `sglang-model-tests.yml`, confirming no regression on currently
  shipped models.

**Manual (Kimi-K3, cannot run in CI):**
Kimi-K3 requires ~195 GB/GPU across 8 GPUs; the largest CI runner
(`gpu-h100-8gpu-runners`) provides 80 GB/GPU. K3 was therefore verified
manually against the CI-built AL2023 image on a `p6-b300.48xlarge`
(8x B300, 275 GB each):
- In-image check: `sglang.srt.models.kimi_k3` importable, `kimi_k3` present
  in `ReasoningParser.DetectorMap`.
- Serve: `--tp-size 8 --dcp-size 8 --trust-remote-code
  --mem-fraction-static 0.85 --reasoning-parser kimi_k3
  --tool-call-parser kimi_k3`
- `/health`, `/v1/completions`, `/v1/chat/completions`, `/get_model_info`.

## Test Result

*(fill in after the CI-built image is verified on the B300 droplet)*

- [ ] CI build green
- [ ] Upstream tests green
- [ ] Existing model tests green (no regression)
- [ ] Manual K3 verification on `p6-b300.48xlarge` against CI-built AL2023 image

**Out of scope:** no entry is added to `sglang-model-tests.yml`. Kimi-K3's
1.56 TB of weights (2.4x the largest runner's total VRAM, before KV cache)
cannot be scheduled on any available fleet, so a config entry would never run.

______________________________________________________________________

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [ ] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
