### PR TITLE
Bound the CI job logs agent-fix.py sends to Bedrock

### DIFF
--- a/.github/workflows/_prcheck.tooling-tests.yml
+++ b/.github/workflows/_prcheck.tooling-tests.yml
@@ -1,0 +1,57 @@
+name: Tooling Tests
+
+# Unit tests for the CI tooling under scripts/ci/. These run on the runner and
+# need no image, no AWS credentials and no GPU — just python and bash.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "scripts/ci/**"
+      - "test/autocurrency/**"
+      - ".github/workflows/_prcheck.tooling-tests.yml"
+
+permissions:
+  contents: read
+
+env:
+  FORCE_COLOR: "1"
+
+jobs:
+  tooling-tests:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout DLC source
+        uses: actions/checkout@v6
+
+      - name: Setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: python3 -m pip install --quiet -r test/requirements.txt
+
+      - name: Run python tooling tests
+        # Run from test/ so test_utils resolves, matching docs.pr-test.yml
+        run: |
+          cd test/
+          python3 -m pytest -vs -rA autocurrency
+
+      - name: Run shell tooling tests
+        run: |
+          status=0
+          found=0
+          while IFS= read -r suite; do
+            found=1
+            echo "::group::${suite}"
+            bash "${suite}" || status=1
+            echo "::endgroup::"
+          done < <(find scripts/ci -name '*_test.sh' -type f | sort)
+          if [[ "${found}" -eq 0 ]]; then
+            echo "No shell test suites found."
+          fi
+          exit "${status}"

--- a/scripts/ci/autocurrency/agent-fix.py
+++ b/scripts/ci/autocurrency/agent-fix.py
@@ -6,11 +6,14 @@ Called by agent-currency-fix.yml workflow.
 """
 
 import argparse
+import io
 import json
 import os
 import re
 import subprocess
 import sys
+import urllib.request
+import zipfile
 from pathlib import Path
 
 import boto3
@@ -18,9 +21,18 @@ import boto3
 MODEL_ID = "us.anthropic.claude-opus-4-6-v1"
 MAX_TOKENS = 16384
 REGION = os.environ.get("AWS_REGION", "us-west-2")
-MAX_LOG_LINES = 500
+MAX_LOG_LINES = 500  # per failed job; the tail is kept — that is where the failure is
 MAX_LLM_RETRIES = 3
 CONTEXT_MAP_PATH = ".github/config/agent-context-files.yml"
+
+TRACKED_JOBS = [
+    "build-image",
+    "sanity-test",
+    "security-test",
+    "telemetry-test",
+    "upstream-tests",
+    "sagemaker-test",
+]
 
 SEARCH_REPLACE_PATTERN = re.compile(
     r"^([^\n]*?/[^\n]*)\n<<<<<<< SEARCH\n(.*?)\n=======\n(.*?)\n>>>>>>> REPLACE$",
@@ -71,52 +83,75 @@ def parse_args():
     return p.parse_args()
 
 
+def _github_request(url: str, token: str) -> urllib.request.Request:
+    return urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"token {token}",
+            "Accept": "application/vnd.github+json",
+        },
+    )
+
+
+def _match_tracked_job(job_name: str) -> str | None:
+    """Map a workflow job name onto one of TRACKED_JOBS, or None if untracked."""
+    normalized = job_name.lower().replace("-", "").replace(" ", "")
+    for key in TRACKED_JOBS:
+        if key.replace("-", "") in normalized:
+            return key
+    return None
+
+
+def _tail_log(log_bytes: bytes, max_lines: int = MAX_LOG_LINES) -> list:
+    """Return the last `max_lines` lines, with an explicit marker when clipped.
+
+    The failure is almost always at the end of a job log, while the head is
+    build chatter. Keeping the tail bounds the prompt without losing the part
+    that matters — and the marker tells the model the log was clipped rather
+    than letting it assume it is reading from the start.
+    """
+    lines = log_bytes.decode(errors="replace").splitlines()
+    if len(lines) <= max_lines:
+        return lines
+    omitted = len(lines) - max_lines
+    return [f"... {omitted} earlier lines omitted ..."] + lines[-max_lines:]
+
+
+def _fetch_run_logs(run_id: str, token: str, repo: str, cache: dict) -> zipfile.ZipFile:
+    """Return the log archive for a run, downloading it at most once per run."""
+    if run_id not in cache:
+        zip_url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/logs"
+        resp = urllib.request.urlopen(_github_request(zip_url, token))
+        cache[run_id] = zipfile.ZipFile(io.BytesIO(resp.read()))
+    return cache[run_id]
+
+
 def extract_failure_info(run_ids: str, token: str, repo: str) -> tuple:
     """Use GitHub API to get structured failure info. Returns (error_text, failed_job_names)."""
     print("Using GitHub API for structured failure extraction")
-    import urllib.request
 
     results = []
     failed_job_names = []
+    log_archives: dict = {}  # run_id -> ZipFile; the archive covers the whole run
+
     for run_id in run_ids.strip().split():
         if not run_id:
             continue
         # Get jobs for this run
         url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/jobs?per_page=100"
-        req = urllib.request.Request(
-            url,
-            headers={
-                "Authorization": f"token {token}",
-                "Accept": "application/vnd.github+json",
-            },
-        )
         try:
-            resp = urllib.request.urlopen(req)
+            resp = urllib.request.urlopen(_github_request(url, token))
             data = json.loads(resp.read())
         except Exception as e:
             results.append(f"Failed to fetch jobs for run {run_id}: {e}")
             continue
 
-        # Find failed jobs and steps
-        tracked_jobs = [
-            "build-image",
-            "sanity-test",
-            "security-test",
-            "telemetry-test",
-            "upstream-tests",
-            "sagemaker-test",
-        ]
         for job in data.get("jobs", []):
             if job.get("conclusion") != "failure":
                 continue
 
             # Only process jobs that match our tracked job names
-            job_lower = job["name"].lower()
-            matched_key = None
-            for key in tracked_jobs:
-                if key.replace("-", "") in job_lower.replace("-", "").replace(" ", ""):
-                    matched_key = key
-                    break
+            matched_key = _match_tracked_job(job["name"])
             if not matched_key:
                 continue
 
@@ -127,26 +162,13 @@ def extract_failure_info(run_ids: str, token: str, repo: str) -> tuple:
             failed_job_names.append(matched_key)
             results.append(f"  Failed steps: {', '.join(failed_steps)}")
 
-            # Download log from run zip
-            import io
-            import zipfile
-
-            zip_url = f"https://api.github.com/repos/{repo}/actions/runs/{run_id}/logs"
-            zip_req = urllib.request.Request(
-                zip_url,
-                headers={
-                    "Authorization": f"token {token}",
-                    "Accept": "application/vnd.github+json",
-                },
-            )
             try:
-                resp = urllib.request.urlopen(zip_req)
-                z = zipfile.ZipFile(io.BytesIO(resp.read()))
+                z = _fetch_run_logs(run_id, token, repo, log_archives)
                 target = job["name"].replace(" / ", " _ ")
                 for name in z.namelist():
                     if target in name:
-                        log_lines = z.read(name).decode(errors="replace").splitlines()
-                        results.append(f"  Log ({name}, {len(log_lines)} lines):")
+                        log_lines = _tail_log(z.read(name))
+                        results.append(f"  Log ({name}, last {MAX_LOG_LINES} lines):")
                         results.extend(f"    {line}" for line in log_lines)
                         break
                 else:
@@ -159,59 +181,11 @@ def extract_failure_info(run_ids: str, token: str, repo: str) -> tuple:
     return "\n".join(results) or "No failure info extracted.", failed_job_names
 
 
-def _extract_via_grep(logs_dir: str) -> str:
-    """Fallback: grep log files for error keywords."""
-    logs_path = Path(logs_dir)
-    if not logs_path.exists():
-        return "No logs available."
-
-    error_lines = []
-    keywords = ["error", "failed", "failure", "cve-", "not found", "exception", "denied"]
-
-    for log_file in sorted(logs_path.rglob("*.txt")):
-        try:
-            lines = log_file.read_text(errors="replace").splitlines()
-        except Exception:
-            continue
-        for i, line in enumerate(lines):
-            if any(kw in line.lower() for kw in keywords):
-                start, end = max(0, i - 2), min(len(lines), i + 3)
-                error_lines.append(f"--- {log_file.name}:{i + 1} ---")
-                error_lines.extend(lines[start:end])
-                error_lines.append("")
-        if len(error_lines) > MAX_LOG_LINES:
-            break
-
-    return "\n".join(error_lines[:MAX_LOG_LINES]) or "No error patterns found in logs."
-
-
 def read_file(path: str) -> str:
     try:
         return Path(path).read_text()
     except (FileNotFoundError, PermissionError):
         return ""
-
-
-def detect_failed_jobs(logs_dir: str) -> list:
-    """Detect which CI jobs failed based on log filenames."""
-    logs_path = Path(logs_dir)
-    if not logs_path.exists():
-        return []
-    # Log files are named like "8_security-test _ ecr-vulnerability-scan.txt"
-    job_names = set()
-    for f in logs_path.rglob("*.txt"):
-        name = f.stem.lower()
-        for job in [
-            "build-image",
-            "sanity-test",
-            "security-test",
-            "telemetry-test",
-            "upstream-tests",
-            "sagemaker-test",
-        ]:
-            if job in name:
-                job_names.add(job)
-    return list(job_names)
 
 
 def load_context_files(framework: str, failed_jobs: list) -> dict:
@@ -414,9 +388,9 @@ def main():
     args = parse_args()
     print(f"=== Currency Fix Agent: {args.framework} @ {args.branch} ===\n")
 
-    error_lines, api_failed_jobs = extract_failure_info(args.run_ids, args.token, args.repo)
-    # Use API-detected jobs if available, otherwise fall back to log filename detection
-    failed_jobs = api_failed_jobs
+    # An empty failed_jobs list makes load_context_files fall back to every
+    # job's context files rather than a job-specific subset.
+    error_lines, failed_jobs = extract_failure_info(args.run_ids, args.token, args.repo)
     context_files = load_context_files(args.framework, failed_jobs)
     previous_fixes = get_previous_fixes()
 

--- a/test/autocurrency/__init__.py
+++ b/test/autocurrency/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the autocurrency CI tooling under scripts/ci/autocurrency."""

--- a/test/autocurrency/conftest.py
+++ b/test/autocurrency/conftest.py
@@ -1,0 +1,37 @@
+"""Pytest fixtures for the autocurrency CI tooling tests.
+
+`agent-fix.py` is not importable by name (the hyphen is not a valid identifier),
+so it is loaded from its path via importlib. It imports boto3 at module scope
+purely for the Bedrock client; none of the code under test here touches AWS, so
+a stub stands in when boto3 is absent, keeping these unit tests runnable without
+the AWS dependencies.
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+AGENT_FIX_PATH = (
+    Path(__file__).parent.parent.parent / "scripts" / "ci" / "autocurrency" / "agent-fix.py"
+)
+
+
+def _load_agent_fix() -> ModuleType:
+    try:
+        import boto3  # noqa: F401
+    except ImportError:
+        sys.modules["boto3"] = ModuleType("boto3")
+
+    spec = importlib.util.spec_from_file_location("agent_fix", AGENT_FIX_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def agent_fix() -> ModuleType:
+    """The agent-fix module, loaded from its path."""
+    return _load_agent_fix()

--- a/test/autocurrency/test_agent_fix.py
+++ b/test/autocurrency/test_agent_fix.py
@@ -1,0 +1,169 @@
+"""Tests for the CI-failure extraction in scripts/ci/autocurrency/agent-fix.py.
+
+What this guards: everything extract_failure_info() returns is embedded verbatim
+into the Bedrock prompt, so the size of that return value is a correctness
+concern, not a cosmetic one. An unbounded job log overruns the model's context
+window and the request is rejected outright.
+"""
+
+import io
+import json
+import zipfile
+
+
+def _zip_with(entries: dict) -> bytes:
+    """Build an in-memory log archive shaped like GitHub's run-logs zip."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        for name, content in entries.items():
+            z.writestr(name, content)
+    return buf.getvalue()
+
+
+class _FakeResponse:
+    def __init__(self, payload: bytes):
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+class _FakeGitHub:
+    """Stands in for urllib.request.urlopen, counting requests per URL."""
+
+    def __init__(self, jobs_payload: dict, logs_zip: bytes):
+        self.jobs_payload = jobs_payload
+        self.logs_zip = logs_zip
+        self.calls = []
+
+    def __call__(self, req, *args, **kwargs):
+        url = req.full_url
+        self.calls.append(url)
+        if url.endswith("/logs"):
+            return _FakeResponse(self.logs_zip)
+        return _FakeResponse(json.dumps(self.jobs_payload).encode())
+
+    def log_downloads(self) -> int:
+        return sum(1 for url in self.calls if url.endswith("/logs"))
+
+
+def _job(name: str, step: str = "Run tests") -> dict:
+    return {
+        "name": name,
+        "conclusion": "failure",
+        "steps": [{"name": step, "conclusion": "failure"}],
+    }
+
+
+class TestTailLog:
+    """_tail_log keeps the end of a log — that is where the failure is."""
+
+    def test_short_log_is_returned_whole(self, agent_fix):
+        lines = _tail_log_lines(agent_fix, ["line %d" % i for i in range(10)])
+        assert lines == ["line %d" % i for i in range(10)]
+
+    def test_long_log_is_clipped_to_max_lines(self, agent_fix):
+        source = ["line %d" % i for i in range(5000)]
+        lines = _tail_log_lines(agent_fix, source)
+
+        # One marker line plus MAX_LOG_LINES of content
+        assert len(lines) == agent_fix.MAX_LOG_LINES + 1
+        assert lines[0] == f"... {5000 - agent_fix.MAX_LOG_LINES} earlier lines omitted ..."
+
+    def test_clipped_log_keeps_the_tail_not_the_head(self, agent_fix):
+        source = ["build chatter %d" % i for i in range(5000)]
+        source[-1] = "ERROR: the actual failure"
+        lines = _tail_log_lines(agent_fix, source)
+
+        assert lines[-1] == "ERROR: the actual failure"
+        assert "build chatter 0" not in lines
+
+    def test_boundary_at_exactly_max_lines_is_not_marked_as_clipped(self, agent_fix):
+        source = ["line %d" % i for i in range(agent_fix.MAX_LOG_LINES)]
+        lines = _tail_log_lines(agent_fix, source)
+
+        assert len(lines) == agent_fix.MAX_LOG_LINES
+        assert not lines[0].startswith("...")
+
+
+def _tail_log_lines(agent_fix, lines: list) -> list:
+    return agent_fix._tail_log("\n".join(lines).encode())
+
+
+class TestMatchTrackedJob:
+    def test_matches_ignoring_separators_and_case(self, agent_fix):
+        assert agent_fix._match_tracked_job("Security Test / ecr-scan") == "security-test"
+        assert agent_fix._match_tracked_job("build-image (vllm)") == "build-image"
+
+    def test_untracked_job_returns_none(self, agent_fix):
+        assert agent_fix._match_tracked_job("pre-commit") is None
+
+
+class TestExtractFailureInfo:
+    def test_prompt_payload_is_bounded_by_max_log_lines(self, agent_fix, monkeypatch):
+        """A huge job log must not reach the prompt untruncated (issue #3)."""
+        huge_log = "\n".join("line %d" % i for i in range(200_000))
+        fake = _FakeGitHub(
+            jobs_payload={"jobs": [_job("build-image")]},
+            logs_zip=_zip_with({"0_build-image.txt": huge_log}),
+        )
+        monkeypatch.setattr(agent_fix.urllib.request, "urlopen", fake)
+
+        error_text, failed_jobs = agent_fix.extract_failure_info("123", "token", "owner/repo")
+
+        assert failed_jobs == ["build-image"]
+        # Header lines + the omission marker + at most MAX_LOG_LINES of log
+        assert len(error_text.splitlines()) < agent_fix.MAX_LOG_LINES + 10
+        assert "earlier lines omitted" in error_text
+        # The tail survived
+        assert "line 199999" in error_text
+
+    def test_log_archive_is_downloaded_once_per_run(self, agent_fix, monkeypatch):
+        """Three failed jobs in one run share one archive (issue #3)."""
+        fake = _FakeGitHub(
+            jobs_payload={
+                "jobs": [_job("build-image"), _job("sanity-test"), _job("security-test")]
+            },
+            logs_zip=_zip_with(
+                {
+                    "0_build-image.txt": "boom",
+                    "1_sanity-test.txt": "boom",
+                    "2_security-test.txt": "boom",
+                }
+            ),
+        )
+        monkeypatch.setattr(agent_fix.urllib.request, "urlopen", fake)
+
+        _, failed_jobs = agent_fix.extract_failure_info("123", "token", "owner/repo")
+
+        assert sorted(failed_jobs) == ["build-image", "sanity-test", "security-test"]
+        assert fake.log_downloads() == 1
+
+    def test_untracked_and_successful_jobs_are_skipped(self, agent_fix, monkeypatch):
+        jobs = {
+            "jobs": [
+                _job("pre-commit"),
+                {"name": "build-image", "conclusion": "success", "steps": []},
+                _job("sanity-test"),
+            ]
+        }
+        fake = _FakeGitHub(jobs, _zip_with({"0_sanity-test.txt": "boom"}))
+        monkeypatch.setattr(agent_fix.urllib.request, "urlopen", fake)
+
+        error_text, failed_jobs = agent_fix.extract_failure_info("123", "token", "owner/repo")
+
+        assert failed_jobs == ["sanity-test"]
+        assert "pre-commit" not in error_text
+
+    def test_log_download_failure_does_not_abort_extraction(self, agent_fix, monkeypatch):
+        def exploding_urlopen(req, *args, **kwargs):
+            if req.full_url.endswith("/logs"):
+                raise OSError("503 from GitHub")
+            return _FakeResponse(json.dumps({"jobs": [_job("build-image")]}).encode())
+
+        monkeypatch.setattr(agent_fix.urllib.request, "urlopen", exploding_urlopen)
+
+        error_text, failed_jobs = agent_fix.extract_failure_info("123", "token", "owner/repo")
+
+        assert failed_jobs == ["build-image"]
+        assert "Failed to download logs" in error_text


### PR DESCRIPTION
> **Note on CONTRIBUTING.md**: I am aware this repo currently states it is not accepting external contributions. This PR is offered only as a ready-made patch for aws/deep-learning-containers#6518 — please close it without review if that is the standing policy, and treat the issue as the real report. No offence taken.

## Purpose

Fixes aws/deep-learning-containers#6518.

`extract_failure_info()` in `scripts/ci/autocurrency/agent-fix.py` appended **every line of every failed job's log** to the string that becomes the Bedrock prompt. `MAX_LOG_LINES = 500` existed for exactly this, but was referenced only inside `_extract_via_grep()` — a helper nothing calls. The cap lived in the extraction path that the GitHub API path replaced, and the replacement never picked it up.

A GPU build or a vLLM upstream test job produces tens of thousands of log lines, so the request overruns the model's context window and Bedrock raises `ValidationException`. That exception is unhandled, so `agent-fix.py` dies with a traceback and the currency-fix workflow reports a failure unrelated to the CI failure it was invoked to diagnose. Each of the three `MAX_LLM_RETRIES` attempts re-sends the same payload.

The log archive was also downloaded once per failed job: the zip URL is per-**run** (L134) but the download sat inside the per-**job** loop, so a PR failing `build-image`, `sanity-test` and `security-test` together pulled and re-parsed the identical archive three times.

Changes:

- **Truncate to the tail.** `_tail_log()` keeps the last `MAX_LOG_LINES` lines with an explicit `... N earlier lines omitted ...` marker, so the model knows the log was clipped rather than assuming it starts at the beginning. The failure is at the end; the head is build chatter.
- **Fetch each run's archive once.** `_fetch_run_logs()` caches per `run_id`.
- **Delete dead code.** `_extract_via_grep()` and `detect_failed_jobs()` are called from nowhere and both take a `logs_dir` argument that no longer exists — `parse_args()` has no such flag and `_prcheck.currency-fix.yml` never passes one. Also drops the stale `# ... otherwise fall back to log filename detection` comment in `main()` describing a fallback that was already gone, and hoists the duplicated tracked-job list to `TRACKED_JOBS`.

## Test Plan

New `test/autocurrency/`, following the existing `test/docs/` precedent for testing repo tooling rather than container behaviour. `agent-fix.py` is not importable by name (the hyphen is not a valid identifier), so the fixture loads it via `importlib`; `boto3` is stubbed when absent, since nothing under test touches AWS.

```bash
cd test/
python3 -m pytest -vs -rA autocurrency
```

Ten tests covering the truncation boundary, tail retention, the single-download guarantee, job filtering and log-download failure. The two that carry the actual defect:

- `test_prompt_payload_is_bounded_by_max_log_lines` — a 200,000-line job log must produce bounded output
- `test_log_archive_is_downloaded_once_per_run` — three failed jobs in one run must trigger exactly one download

Also adds `.github/workflows/_prcheck.tooling-tests.yml`, triggered on `scripts/ci/**` and `test/autocurrency/**`. Without it these tests would never run — `docs.pr-test.yml` is path-filtered to docs, and no existing workflow covers `scripts/ci/`. It also discovers any `*_test.sh` under `scripts/ci/`, so the shell suite in #6516's patch gets picked up if both land.

## Test Result

```
$ cd test/ && python3 -m pytest autocurrency -q
..........                                                               [100%]
10 passed in 0.06s
```

All ten fail against the pre-fix code. Most fail on a missing symbol (expected, for new helpers), but the two behavioural ones fail for the real defect — verified by stashing the source change and re-running:

```
FAILED autocurrency/test_agent_fix.py::TestExtractFailureInfo::test_prompt_payload_is_bounded_by_max_log_lines
FAILED autocurrency/test_agent_fix.py::TestExtractFailureInfo::test_log_archive_is_downloaded_once_per_run
```

Checks on the changed files:

```
$ ruff format --check <4 changed python files>
4 files already formatted

$ check-jsonschema --builtin-schema vendor.github-workflows .github/workflows/_prcheck.tooling-tests.yml
ok -- validation done
```

The new workflow's shell discovery loop was exercised both empty (prints `No shell test suites found.`, exits 0) and populated.

______________________________________________________________________

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [ ] I ran `pre-commit run --all-files` locally before creating this PR.

**Not fully run — disclosing rather than checking the box.** `pre-commit` could not install its hook environments in my sandbox (`URLError: CERTIFICATE_VERIFY_FAILED` fetching the hook repos). What I ran instead, directly:

- `ruff format --check` on all four changed Python files — pass (`4 files already formatted`), using the repo's `pyproject.toml` config
- `check-jsonschema --builtin-schema vendor.github-workflows` on the new workflow — pass

Not run, and the one I would most want CI to confirm: **actionlint**, since this PR adds a workflow file. Also not run: typos, gitleaks, shfmt.

</details>
