### PR TITLE
fix(xgboost): allowlist two unactionable HIGH CVEs for 3.0.5 ECR scan

### DIFF
--- a/test/security/data/ecr_scan_allowlist/xgboost/xgboost-3.0.5.json
+++ b/test/security/data/ecr_scan_allowlist/xgboost/xgboost-3.0.5.json
@@ -698,5 +698,15 @@
         "vulnerability_id": "CVE-2025-38083",
         "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-220.240 is Ubuntu Pro/ESM-only (Focal is past standard-support EOL) and is not installable without a paid Ubuntu Pro subscription. linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so the net_sched prio_tune race is not a runtime attack surface for this image. No exploit available.",
         "review_by": "2026-11-02"
+    },
+    {
+        "vulnerability_id": "CVE-2024-46787",
+        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-219.239 is Ubuntu Pro/ESM-only (Focal is past standard-support EOL) and is not installable without a paid Ubuntu Pro subscription. linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so the userfaultfd huge-PMD race is not a runtime attack surface for this image. No exploit available.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-54876",
+        "reason": "openssl 3.6.3 in the bundled miniconda3 environment. No fix is installable: per the upstream advisory of 2026-08-05 the project did not issue releases for this issue, so the nominal fixed versions 3.6.4 (for the 3.6 branch) and 4.0.2 are both unreleased and exist only as git commits. No openssl-3.6.4 or openssl-4.0.2 tag exists upstream and conda-forge tops out at 3.6.3 / 4.0.1, so the scanner's openssl>=4.0.2 pin is unsatisfiable; moving to 4.0.1 would not help since 4.0.1 is itself in the affected range. Upstream severity is Low (the High here is the NVD-derived score), impact is a client-side memory-leak DoS, and OCSP response checking is off by default and never enabled by the training or serving paths. No exploit available. Note the 3.6 branch reaches end-of-life on 2026-11-01, so if 3.6.4 does not ship the durable fix is moving this environment to the 3.5 LTS line, which is unaffected.",
+        "review_by": "2026-09-30"
     }
 ]


### PR DESCRIPTION
## Motivation

The XGBoost 3.0 SageMaker auto-release pipeline failed its ECR enhanced vulnerability scan on two
non-allowlisted HIGH CVEs, so the release gate did not pass and the image did not ship. Neither CVE
has an installable fix for this image today.

## CVE-2024-46787 — linux-libc-dev (userfaultfd huge-PMD race)

The 3.0.5 image is built on Ubuntu 20.04 (Focal, kernel 5.4.0). Ubuntu's tracker lists the Focal fix
`5.4.0-219.239` in the `esm-infra` pocket, i.e. Ubuntu Pro/ESM-only and not installable without a
paid subscription. `linux-libc-dev` ships kernel *headers*; the container runs on the host kernel, so
this is not a runtime attack surface for the image. Ubuntu priority: medium. No exploit available.

This matches the existing kernel-header entries already in this file. Note the script's
`is_esm_fix()` filter does not catch this one, because the scanner reports the bare version string
rather than an "esm"-tagged one, so an explicit entry is required.

## CVE-2026-54876 — openssl 3.6.3 in the bundled miniconda3 env

The scanner prescribes `openssl/openssl>=4.0.2`. That pin is unsatisfiable: per the upstream advisory
of 2026-08-05, the project explicitly did **not** issue releases for this issue —

> "Due to the low severity of this issue we are not issuing new releases of OpenSSL at this time."
> "OpenSSL 3.6 users should upgrade to OpenSSL 3.6.4 once it is released."

Both nominal fixed versions are unreleased. There is no `openssl-3.6.4` or `openssl-4.0.2` tag
upstream (verified via `git ls-remote --tags`), and conda-forge tops out at 3.6.3 / 4.0.1. The fix
exists only as git commits (`155b5fe` for 3.6, `d8c5104` for 4.0). Moving to 4.0.1 would not resolve
the finding, since 4.0.1 is itself within the affected range.

Risk is low and the finding is not actionable: upstream severity is **Low** (the HIGH here is the
NVD-derived score), impact is a client-side memory-leak DoS, and it requires the opt-in
`X509_V_FLAG_OCSP_RESP_CHECK` flag — the advisory notes "OCSP response checking is not enabled by
default." The training and serving paths never enable it. No exploit available.

`review_by` is set to 2026-09-30 to force a re-check for 3.6.4.

## Scope

Both entries are scoped to `xgboost-3.0.5.json` only. The 3.2.0 image is amzn2023-based with no
`linux-libc-dev` and a different openssl lineage (3.2.2 from the CUDA base, outside this CVE's
affected range), so it is unaffected.

