### PR TITLE
fix(telemetry): parse os-release so Amazon Linux images report their OS

### DIFF
--- a/scripts/docker/telemetry/deep_learning_container.py
+++ b/scripts/docker/telemetry/deep_learning_container.py
@@ -209,15 +209,28 @@ def _retrieve_cuda():
     return cuda_version
 
 
-def _retrieve_os():
-    version = ""
+def _retrieve_os(os_release_path="/etc/os-release"):
+    """Return "<ID><VERSION_ID>" from os-release, e.g. "amzn2023" or "ubuntu24.04".
+
+    Values in os-release may be quoted ('ID="amzn"') or bare ('ID=ubuntu'), and
+    VERSION_ID is not always dotted ("2023" on Amazon Linux 2023), so strip the
+    quotes and take both values verbatim. This mirrors
+    `source /etc/os-release && echo "${ID}${VERSION_ID}"` and matches the
+    os_version naming used in .github/config/image (amzn2023, ubuntu24.04).
+    """
     name = ""
-    with open("/etc/os-release", "r") as f:
-        for line in f.readlines():
-            if re.match(r"^ID=\w+$", line):
-                name = re.search(r"^ID=(\w+)$", line).group(1)
-            if re.match(r'^VERSION_ID="\d+\.\d+"$', line):
-                version = re.search(r'^VERSION_ID="(\d+\.\d+)"$', line).group(1)
+    version = ""
+    try:
+        with open(os_release_path, "r") as f:
+            for line in f:
+                key, _, value = line.strip().partition("=")
+                value = value.strip().strip('"').strip("'")
+                if key == "ID":
+                    name = value
+                elif key == "VERSION_ID":
+                    version = value
+    except OSError as e:
+        logging.error(f"Failed to read {os_release_path}: {e}")
     return name + version
 
 

--- a/test/telemetry/test_os_detection.py
+++ b/test/telemetry/test_os_detection.py
@@ -1,0 +1,99 @@
+"""Unit tests for telemetry OS detection.
+
+These run locally against real /etc/os-release payloads — no EC2 instance or
+image is required, so they execute alongside the instance telemetry tests in
+_reusable.telemetry-tests.yml.
+"""
+
+import pytest
+from deep_learning_container import _retrieve_os
+
+# Verbatim /etc/os-release excerpts from the base images DLC builds on.
+AMZN2023 = """\
+NAME="Amazon Linux"
+VERSION="2023"
+ID="amzn"
+ID_LIKE="fedora"
+VERSION_ID="2023"
+PLATFORM_ID="platform:al2023"
+PRETTY_NAME="Amazon Linux 2023.12.20260727"
+CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2023"
+HOME_URL="https://aws.amazon.com/linux/amazon-linux-2023/"
+SUPPORT_END="2029-06-30"
+"""
+
+UBUNTU_24_04 = """\
+PRETTY_NAME="Ubuntu 24.04.3 LTS"
+NAME="Ubuntu"
+VERSION_ID="24.04"
+VERSION="24.04.3 LTS (Noble Numbat)"
+VERSION_CODENAME=noble
+ID=ubuntu
+ID_LIKE=debian
+UBUNTU_CODENAME=noble
+"""
+
+UBUNTU_22_04 = """\
+PRETTY_NAME="Ubuntu 22.04.5 LTS"
+NAME="Ubuntu"
+VERSION_ID="22.04"
+VERSION="22.04.5 LTS (Jammy Jellyfish)"
+ID=ubuntu
+ID_LIKE=debian
+UBUNTU_CODENAME=jammy
+"""
+
+UBUNTU_20_04 = """\
+NAME="Ubuntu"
+VERSION="20.04.6 LTS (Focal Fossa)"
+ID=ubuntu
+ID_LIKE=debian
+VERSION_ID="20.04"
+UBUNTU_CODENAME=focal
+"""
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        # Amazon Linux 2023 quotes ID and ships an undotted VERSION_ID.
+        (AMZN2023, "amzn2023"),
+        (UBUNTU_24_04, "ubuntu24.04"),
+        (UBUNTU_22_04, "ubuntu22.04"),
+        (UBUNTU_20_04, "ubuntu20.04"),
+    ],
+    ids=["amzn2023", "ubuntu24.04", "ubuntu22.04", "ubuntu20.04"],
+)
+def test_retrieve_os_matches_image_os_version(tmp_path, content, expected):
+    """OS string matches the os_version naming used in .github/config/image."""
+    path = tmp_path / "os-release"
+    path.write_text(content)
+    assert _retrieve_os(str(path)) == expected
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        ('ID=ubuntu\nVERSION_ID="24.04"\n', "ubuntu24.04"),
+        ('ID="amzn"\nVERSION_ID="2023"\n', "amzn2023"),
+        ("ID='amzn'\nVERSION_ID='2023'\n", "amzn2023"),
+        ("ID=amzn\nVERSION_ID=2023\n", "amzn2023"),
+    ],
+    ids=["bare-id", "double-quoted", "single-quoted", "all-bare"],
+)
+def test_retrieve_os_handles_quoting_variants(tmp_path, content, expected):
+    path = tmp_path / "os-release"
+    path.write_text(content)
+    assert _retrieve_os(str(path)) == expected
+
+
+def test_retrieve_os_ignores_keys_that_merely_start_with_id(tmp_path):
+    """ID_LIKE / VERSION_ID must not be mistaken for ID."""
+    path = tmp_path / "os-release"
+    path.write_text('ID_LIKE="fedora"\nID="amzn"\nVERSION_ID="2023"\n')
+    assert _retrieve_os(str(path)) == "amzn2023"
+
+
+def test_retrieve_os_missing_file_does_not_raise(tmp_path):
+    """Telemetry runs at shell startup in customer containers; it must not crash."""
+    assert _retrieve_os(str(tmp_path / "does-not-exist")) == ""


### PR DESCRIPTION
Fixes #6529.

## Problem

`_retrieve_os()` parses `/etc/os-release` with two regexes that only accept an unquoted `ID` and a quoted, dotted `VERSION_ID`:

```python
if re.match(r"^ID=\w+$", line):
    name = re.search(r"^ID=(\w+)$", line).group(1)
if re.match(r'^VERSION_ID="\d+\.\d+"$', line):
    version = re.search(r'^VERSION_ID="(\d+\.\d+)"$', line).group(1)
```

Amazon Linux 2023 satisfies neither — it ships `ID="amzn"` (quoted) and `VERSION_ID="2023"` (no dot). Both captures fail and the function returns `""`, so the OS segment of the instance tag is blank:

```
vllm_server_training_0.26.0_python3.12.0_gpu_cuda13.0_
```

Ubuntu ships `ID=ubuntu` bare and `VERSION_ID="24.04"` dotted, which is why this went unnoticed.

## Measured impact

Across released image configs on `main`, cross-referencing each config's `build.dockerfile` for whether it wires in the telemetry script:

| | count |
|---|---|
| Unique released images | 46 |
| ...shipping the telemetry script | 43 |
| ...of those, on `amzn2023` → **empty OS field** | **35 (81%)** |
| ...of those, on Ubuntu → correct OS field | 8 |

Affected frameworks: `base`, `huggingface-pytorch-training`, `openfold3`, `pytorch_runtime`, `ray`, `sglang_server`, `sklearn`, `tensorflow`, `vllm_omni`, `vllm_server`, `xgboost`. The share is growing as images migrate to AL2023, and telemetry reached the base images in #6499.

## Fix

Parse `os-release` as the `key=value` format it is: split on the first `=`, strip surrounding quotes, take `ID` and `VERSION_ID` verbatim. This mirrors `source /etc/os-release && echo "${ID}${VERSION_ID}"` — the idiom already used by `scripts/ci/autocurrency/detect-versions.sh:111` — and produces the same `os_version` spelling as `.github/config/image` (`amzn2023`, `ubuntu24.04`).

The new parse is a **strict superset** of the old regexes: any file they accepted parses to the identical value, so Ubuntu output is unchanged.

Two smaller changes in the same function:

- It takes an optional path argument (defaulting to `/etc/os-release`) so it is unit-testable without patching `builtins.open`. No caller changes.
- The read is guarded with `OSError` handling. Telemetry runs at shell startup inside customer containers, and `tag_instance()` calls `_retrieve_os()` *before* its own `try` block — so an unreadable `os-release` previously raised and killed the tagging process before it could tag at all.

## Verification

Old vs. new against the verbatim `/etc/os-release` payloads from `amazonlinux:2023` and `ubuntu:24.04`:

```
OLD _retrieve_os() on amzn2023     -> ''
OLD _retrieve_os() on ubuntu24.04  -> 'ubuntu24.04'

NEW _retrieve_os() on amzn2023     -> 'amzn2023'
NEW _retrieve_os() on ubuntu24.04  -> 'ubuntu24.04'      # unchanged
```

## Tests

Adds `test/telemetry/test_os_detection.py` — 10 unit tests covering:

- verbatim `os-release` payloads from the `amzn2023` and Ubuntu 20.04 / 22.04 / 24.04 base images, asserting the result matches the `os_version` naming in `.github/config/image`
- quoting variants (bare, double-quoted, single-quoted, fully bare)
- the prefix trap — `ID_LIKE` and `VERSION_ID` must not be mistaken for `ID`
- a missing file, which must return `""` rather than raise

These need no EC2 instance and no image, so they run alongside the existing suite in `_reusable.telemetry-tests.yml` with no workflow change:

```
$ cd test/ && PYTHONPATH=$(pwd)/../scripts/docker/telemetry pytest telemetry/test_os_detection.py \
    --framework vllm_server --framework-version 0.26.0 --container-type inference
10 passed in 0.07s
```

Full telemetry suite still collects cleanly (10 new + 6 existing = 16). Lint/format clean under the pinned pre-commit toolchain (`ruff 0.14.3`): `ruff check`, `ruff format --check`, and `ruff check --select I` all pass.
