### PR TITLE
ci: exclude telemetry script from build-change filter on base + sklearn

### DIFF
--- a/.github/workflows/base.pr-cu129.yml
+++ b/.github/workflows/base.pr-cu129.yml
@@ -47,7 +47,6 @@ jobs:
               - ".github/config/image/base/cu129-*.yml"
               - "docker/base/cu129/**"
               - "scripts/docker/common/**"
-              - "scripts/docker/telemetry/**"
               - "test/security/data/ecr_scan_allowlist/base/**"
             sanity-test-change:
               - "test/sanity/**"

--- a/.github/workflows/base.pr-cu130.yml
+++ b/.github/workflows/base.pr-cu130.yml
@@ -47,7 +47,6 @@ jobs:
               - ".github/config/image/base/cu130-*.yml"
               - "docker/base/cu130/**"
               - "scripts/docker/common/**"
-              - "scripts/docker/telemetry/**"
               - "test/security/data/ecr_scan_allowlist/base/**"
             sanity-test-change:
               - "test/sanity/**"

--- a/.github/workflows/base.pr-cu132.yml
+++ b/.github/workflows/base.pr-cu132.yml
@@ -47,7 +47,6 @@ jobs:
               - ".github/config/image/base/cu132-*.yml"
               - "docker/base/cu132/**"
               - "scripts/docker/common/**"
-              - "scripts/docker/telemetry/**"
               - "test/security/data/ecr_scan_allowlist/base/**"
             sanity-test-change:
               - "test/sanity/**"

--- a/.github/workflows/sklearn.pr-1.4-2-py312.yml
+++ b/.github/workflows/sklearn.pr-1.4-2-py312.yml
@@ -16,7 +16,6 @@ on:
       - "docker/sklearn/resources/**"
       - "scripts/ci/build/sklearn/**"
       - "scripts/docker/common/**"
-      - "scripts/docker/telemetry/**"
       - "test/sanity/**"
       - "test/security/data/ecr_scan_allowlist/sklearn_1_4_2_py312/**"
       - "test/sklearn/**"
@@ -59,7 +58,6 @@ jobs:
               - "docker/sklearn/resources/**"
               - "scripts/ci/build/sklearn/**"
               - "scripts/docker/common/**"
-              - "scripts/docker/telemetry/**"
               - "test/security/data/ecr_scan_allowlist/sklearn_1_4_2_py312/**"
             integ-test-change:
               - "test/sklearn/**"

--- a/.github/workflows/sklearn.pr-1.9-0.yml
+++ b/.github/workflows/sklearn.pr-1.9-0.yml
@@ -16,7 +16,6 @@ on:
       - "docker/sklearn/resources/**"
       - "scripts/ci/build/sklearn/**"
       - "scripts/docker/common/**"
-      - "scripts/docker/telemetry/**"
       - "test/sanity/**"
       - "test/security/data/ecr_scan_allowlist/sklearn/**"
       - "test/sklearn/**"
@@ -59,7 +58,6 @@ jobs:
               - "docker/sklearn/resources/**"
               - "scripts/ci/build/sklearn/**"
               - "scripts/docker/common/**"
-              - "scripts/docker/telemetry/**"
               - "test/security/data/ecr_scan_allowlist/sklearn/**"
             integ-test-change:
               - "test/sklearn/**"


### PR DESCRIPTION
## Summary

Remove `scripts/docker/telemetry/**` from the `build-change` path filter on 5 PR workflows (`sklearn.pr-1.4-2-py312`, `sklearn.pr-1.9-0`, `base.pr-cu129/130/132`). All other framework PR workflows already exclude it.

## Motivation

Edits to the shared telemetry script were classifying as `build-change: true` in these 5 workflows, unnecessarily triggering full build + security-test + sanity-test pipelines for unrelated PRs. Base workflows keep telemetry under `telemetry-test-change:` so telemetry-only edits still run the telemetry test. Sklearn workflows hardcode `run-telemetry-test: false` so telemetry edits should not trigger sklearn at all — removed from top-level `on.paths` as well.

## Test plan

- [x] `pre-commit run --files ...` passes on all 5 workflows
- [x] `github-actions · Validate gh workflow files` passes