### PR TITLE
sklearn 1.4-2-py312: bump cryptography to 50.0.0 for CVE-2026-69247 and CVE-2026-69249

### DIFF
--- a/docker/sklearn/1.4-2-py312/Dockerfile
+++ b/docker/sklearn/1.4-2-py312/Dockerfile
@@ -133,7 +133,8 @@ RUN chmod +x /usr/local/bin/deep_learning_container.py \
   && bash setup_oss_compliance.sh python${PYTHON_VERSION} && rm setup_oss_compliance.sh \
   && rm -rf /root/oss_compliance* /tmp/tmp*
 
-# Install remaining Python deps from upstream requirements.txt (verbatim)
+# Install remaining Python deps from requirements.txt.
+# Seeded from upstream sagemaker-scikit-learn-container, maintained here.
 COPY docker/sklearn/1.4-2-py312/requirements.txt /requirements.txt
 RUN uv pip install --system --break-system-packages -r /requirements.txt \
   && rm /requirements.txt

--- a/docker/sklearn/1.4-2-py312/requirements.txt
+++ b/docker/sklearn/1.4-2-py312/requirements.txt
@@ -1,7 +1,7 @@
 boto3==1.28.57
 botocore>=1.31.57,<1.32.0
 certifi
-cryptography==46.0.7
+cryptography==50.0.0
 Flask==1.1.1
 gevent==23.9.1
 gunicorn==23.0.0


### PR DESCRIPTION
## Summary

Bump `cryptography` from `46.0.7` to `50.0.0` in the sklearn 1.4-2-py312 image to fix two HIGH CVEs:

- **CVE-2026-69247** — pkcs7 decrypt (`pkcs7_decrypt_der/pem/smime`); fixed in 50.0.0.
- **CVE-2026-69249** — invalid cert-chain resolution with duplicate copies; fixed in 49.0.0.

## Notes

- Same pin as the 1.9-0 line already uses.
- Also clarifies the Dockerfile comment that previously said "from upstream requirements.txt (verbatim)" — the file is DLC-maintained; seeded from upstream. 

## Test plan

- [x] `pre-commit run --files ...` passes