### PR TITLE
minor fixes: add new page to nav and cleanup

### DIFF
--- a/.github/workflows/base.autorelease-cu132.yml
+++ b/.github/workflows/base.autorelease-cu132.yml
@@ -40,8 +40,5 @@ jobs:
     with:
       config-file: ${{ matrix.config_file }}
       tag-suffix: ${{ github.run_id }}
-      # Off on the cron schedule (inputs is empty there); opt in per-run via
-      # workflow_dispatch. 2x p4d.24xlarge is too costly for every release.
-      run-efa-test: ${{ inputs.run-efa-test == true }}
       release: true
     secrets: inherit

--- a/.github/workflows/base.pipeline.yml
+++ b/.github/workflows/base.pipeline.yml
@@ -120,8 +120,7 @@ jobs:
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
   # Multi-node EFA/NCCL over Libfabric — devel only (runtime has no NCCL/EFA
-  # stack). Opt-in: launches 2x p4d.24xlarge, so it's off by default and enabled
-  # via workflow_dispatch or by a caller passing run-efa-test: true.
+  # stack). Opt-in: launches 2x p4d.24xlarge, so it's off by default.
   efa-test:
     if: ${{ always() && !failure() && !cancelled() && inputs.run-efa-test && needs.ci-config.outputs.target == 'devel' && needs.ci-config.outputs.device-type == 'gpu' }}
     needs: [build, ci-config]

--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -21,6 +21,7 @@ nav:
       - Release Notifications: get_started/release_notifications.md
     - Security:
       - security/index.md
+      - CVE Patching SLA: security/cve-patching-sla.md
       - Data Protection: security/data-protection.md
       - Identity and Access Management: security/identity-and-access-management.md
       - Monitoring and Usage Tracking: security/logging-and-monitoring.md


### PR DESCRIPTION
## Purpose
- We won't ever want to run efa test for base images in the release workflow so removing that option; should be toggled in PR only. This makes the cu132 autorelease file consistent with cu129 and cu130
- The docs change is something that was missed in previous PR https://github.com/aws/deep-learning-containers/pull/6534

## Test Plan

## Test Result

______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
