### PR TITLE
[auto-cve-patch] [vllm] bump cryptography floor, prune stale allowlist entries

### DIFF
--- a/docker/vllm/Dockerfile
+++ b/docker/vllm/Dockerfile
@@ -39,6 +39,7 @@ RUN uv pip install --system \
   "PyJWT>=2.12.0" \
   "model-hosting-container-standards>=0.1.16,<1.0.0" \
   "pyasn1>=0.6.3" \
+  "cryptography>=50.0.0" \
   && uv cache clean
 
 # Audio deps for voxtral / ASR serving (mistral_common is an optional import in vLLM 0.24.0)

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -353,7 +353,7 @@ RUN uv pip install --no-cache-dir \
   "PyJWT>=2.12.0" \
   "cbor2>=5.9.0" \
   "starlette>=1.3.1" \
-  "cryptography>=48.0.1" \
+  "cryptography>=50.0.0" \
   "model-hosting-container-standards>=0.1.16,<1.0.0" \
   # 8.0.1 fixes AttributeError on fastapi 0.138 _IncludedRouter that 500s /health (instrumentator #371)
   "prometheus-fastapi-instrumentator>=8.0.1"

--- a/test/security/data/ecr_scan_allowlist/vllm/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/vllm/framework_allowlist.json
@@ -16,8 +16,8 @@
     },
     {
         "vulnerability_id": "CVE-2026-24747",
-        "reason": "torch 2.9.1 is only a version pin in the upstream vllm/vllm-openai base image's benchmarks/requirements.txt (benchmark metadata), not the installed package. Installed torch is 2.11.0 (>= 2.10.0 fix). weights_only unpickler RCE requires loading a malicious checkpoint; the benchmark requirements file is inert. Not exploitable in the runtime.",
-        "review_by": "2026-09-25"
+        "reason": "torch 2.9.1 is a version pin in the upstream vllm/vllm-openai base image's benchmarks/requirements.txt (benchmark metadata), not the installed runtime package. weights_only unpickler RCE requires loading a malicious checkpoint; the benchmark requirements file is inert. Not exploitable in the runtime.",
+        "review_by": "2026-11-10"
     },
     {
         "vulnerability_id": "CVE-2026-39822",
@@ -56,22 +56,12 @@
     },
     {
         "vulnerability_id": "CVE-2026-42504",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-09-25"
+        "reason": "go/stdlib 1.25.9 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-11-10"
     },
     {
         "vulnerability_id": "CVE-2026-27145",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-09-25"
-    },
-    {
-        "vulnerability_id": "RUSTSEC-2026-0185",
-        "reason": "quinn-proto Rust crate vendored inside the upstream vllm wheel; cannot be bumped to 0.11.15 independently of a vllm wheel rebuild. Tracking upstream vllm-project release.",
-        "review_by": "2026-09-25"
-    },
-    {
-        "vulnerability_id": "CVE-2026-53923",
-        "reason": "Affects vllm itself; no fixed version published upstream (scanner reports fixed-version 99.999.9999). Tracking upstream vllm-project fix.",
-        "review_by": "2026-09-25"
+        "reason": "go/stdlib 1.25.9 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-11-10"
     }
 ]

--- a/test/security/data/ecr_scan_allowlist/vllm_server/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/vllm_server/framework_allowlist.json
@@ -1,103 +1,13 @@
 [
     {
-        "vulnerability_id": "CVE-2026-32281",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-33186",
-        "reason": "google.golang.org/grpc v1.59.0 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-25679",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32283",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32280",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-68121",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-61726",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-23339",
-        "reason": "cuda-toolkit-config-common (12.9.79 \u2192 0:13.0.48-1) cuda is a key dependency that cannot be upgraded",
-        "review_by": "2026-11-28"
-    },
-    {
-        "vulnerability_id": "CVE-2025-23308",
-        "reason": "cuda-toolkit-config-common (12.9.79 \u2192 0:13.0.48-1) cuda is a key dependency that cannot be upgraded",
-        "review_by": "2026-11-28"
-    },
-    {
-        "vulnerability_id": "CVE-2026-33811",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-39820",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-33814",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-39836",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-42499",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-39821",
-        "reason": "golang.org/x/net v0.38.0 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
         "vulnerability_id": "CVE-2026-42504",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
+        "reason": "go/stdlib 1.25.10 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-11-10"
     },
     {
         "vulnerability_id": "CVE-2026-27145",
-        "reason": "go/stdlib 1.24.11 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "RUSTSEC-2026-0185",
-        "reason": "quinn-proto Rust crate vendored inside the upstream vllm wheel; cannot be bumped to 0.11.15 independently of a vllm wheel rebuild. Tracking upstream vllm-project release.",
-        "review_by": "2026-09-25"
-    },
-    {
-        "vulnerability_id": "CVE-2026-53923",
-        "reason": "Affects vllm itself; no fixed version published upstream (scanner reports fixed-version 99.999.9999). Tracking upstream vllm-project fix.",
-        "review_by": "2026-09-25"
-    },
-    {
-        "vulnerability_id": "CVE-2026-27145",
-        "reason": "go/stdlib 1.24.11 embedded in mooncake libetcd_wrapper.so, x509 VerifyHostname CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
-        "review_by": "2026-09-10"
+        "reason": "go/stdlib 1.25.10 statically linked inside mooncake libetcd_wrapper.so, cannot be patched independently of mooncake-transfer-engine rebuild",
+        "review_by": "2026-11-10"
     },
     {
         "vulnerability_id": "CVE-2026-39822",
@@ -121,7 +31,7 @@
     },
     {
         "vulnerability_id": "CVE-2026-24747",
-        "reason": "torch 2.9.1 is only a version pin in the upstream vllm base image's benchmarks/requirements.txt (benchmark metadata), not the installed package. weights_only unpickler RCE requires loading a malicious checkpoint; the benchmark requirements file is inert. Not exploitable in the runtime.",
-        "review_by": "2026-09-25"
+        "reason": "torch 2.9.1 is a version pin in the upstream vllm base image's benchmarks/requirements.txt (benchmark metadata), not the installed runtime package. weights_only unpickler RCE requires loading a malicious checkpoint; the benchmark requirements file is inert. Not exploitable in the runtime.",
+        "review_by": "2026-11-10"
     }
 ]


### PR DESCRIPTION
## Purpose

Patch CVEs across vllm DLC images.

## Images affected

`vllm:0.26-gpu-py312`, `vllm:0.26-gpu-py312-ec2`, `vllm:server-cuda-v2`, `vllm:server-sagemaker-cuda-v2`

## CVEs handled

| CVE | Package | Severity | Affected images | Action | Notes |
|---|---|---|---|---|---|
| CVE-2026-69247 | cryptography | HIGH | `vllm:0.26-gpu-py312`, `vllm:0.26-gpu-py312-ec2` | Raise pip floor to `>=50.0.0` in `docker/vllm/Dockerfile` | |
| CVE-2026-69247 | cryptography | HIGH | `vllm:server-cuda-v2`, `vllm:server-sagemaker-cuda-v2` | Raise pip floor from `>=48.0.1` to `>=50.0.0` in `docker/vllm/Dockerfile.amzn2023` | Defense-in-depth; scan did not flag but base contract pin lagged |
| CVE-2026-42504 | go/stdlib (mooncake) | HIGH | Ubuntu + AL2023 | Reason refreshed (was `1.24.11`, installed is `1.25.9` / `1.25.10`) | Vendored inside `libetcd_wrapper.so`; still blocked on upstream mooncake rebuild |
| CVE-2026-27145 | go/stdlib (mooncake) | HIGH | Ubuntu + AL2023 | Reason refreshed (was `1.24.11`, installed is `1.25.9` / `1.25.10`) + dedup on AL2023 (2 entries → 1) | Vendored inside `libetcd_wrapper.so` |
| CVE-2026-24747 | torch (benchmarks/requirements.txt) | HIGH | Ubuntu + AL2023 | Reason refreshed to remove stale "installed torch is 2.11.0" claim | Version pin in inert benchmark metadata; not exploitable in runtime |

**Prunes:** 20 stale entries pruned across both allowlists — CVEs no longer firing in today's scan. Ubuntu (`vllm/`): 2 pruned (RUSTSEC-2026-0185, CVE-2026-53923). AL2023 (`vllm_server/`): 18 pruned including 14 go/stdlib mooncake entries whose CVE IDs have rolled forward, 2 cuda-toolkit-config-common entries no longer firing after base bump, and 2 upstream-vllm entries (RUSTSEC-2026-0185, CVE-2026-53923).

**Backfills:** none — every remaining entry already had `review_by`.

## Test plan

- [ ] CI security tests pass for all affected vllm variants
- [ ] CI sanity tests pass
- [ ] CI vllm-specific tests pass

---
🤖 Generated by [Claude Code](https://claude.com/claude-code).
