### PR TITLE
feat(whisperx): add release infrastructure

### DIFF
--- a/.github/actions/generate-release-spec/generate_release_spec.sh
+++ b/.github/actions/generate-release-spec/generate_release_spec.sh
@@ -64,10 +64,14 @@ fi
 TRANSFORMERS_VERSION=$(yq '.build.transformers_version // ""' "$CONFIG_FILE")
 
 # Release flags
-FORCE_RELEASE=$(yq '.release.force_release // ""' "$CONFIG_FILE")
-PUBLIC_REGISTRY=$(yq '.release.public_registry // ""' "$CONFIG_FILE")
-PRIVATE_REGISTRY=$(yq '.release.private_registry // ""' "$CONFIG_FILE")
-ENABLE_SOCI=$(yq '.release.enable_soci // ""' "$CONFIG_FILE")
+# No `// ""` fallback on these booleans: yq's `//` treats boolean `false` as
+# falsy, so `false // ""` collapses to "" and the flag would be dropped from the
+# spec — after which ReleaseSpec defaults private_registry back to True. Extract
+# raw (missing key -> the string "null") and emit below unless it's "null".
+FORCE_RELEASE=$(yq '.release.force_release' "$CONFIG_FILE")
+PUBLIC_REGISTRY=$(yq '.release.public_registry' "$CONFIG_FILE")
+PRIVATE_REGISTRY=$(yq '.release.private_registry' "$CONFIG_FILE")
+ENABLE_SOCI=$(yq '.release.enable_soci' "$CONFIG_FILE")
 echo "Generating release spec:"
 echo "  Framework: ${FRAMEWORK}"
 echo "  Version: ${VERSION}"
@@ -88,10 +92,10 @@ SPEC+="version: \"${VERSION}\""$'\n'
 [[ -n "$TRANSFORMERS_VERSION" ]] && SPEC+="transformers_version: \"${TRANSFORMERS_VERSION}\""$'\n'
 [[ -n "$PLATFORM" ]]        && SPEC+="platform: \"${PLATFORM}\""$'\n'
 [[ -n "$CONTAINER_TYPE" ]]  && SPEC+="container_type: \"${CONTAINER_TYPE}\""$'\n'
-[[ -n "$FORCE_RELEASE" ]]   && SPEC+="force_release: ${FORCE_RELEASE}"$'\n'
-[[ -n "$PUBLIC_REGISTRY" ]] && SPEC+="public_registry: ${PUBLIC_REGISTRY}"$'\n'
-[[ -n "$PRIVATE_REGISTRY" ]] && SPEC+="private_registry: ${PRIVATE_REGISTRY}"$'\n'
-[[ -n "$ENABLE_SOCI" ]]    && SPEC+="enable_soci: ${ENABLE_SOCI}"$'\n'
+[[ "$FORCE_RELEASE"    != "null" && -n "$FORCE_RELEASE" ]]    && SPEC+="force_release: ${FORCE_RELEASE}"$'\n'
+[[ "$PUBLIC_REGISTRY"  != "null" && -n "$PUBLIC_REGISTRY" ]]  && SPEC+="public_registry: ${PUBLIC_REGISTRY}"$'\n'
+[[ "$PRIVATE_REGISTRY" != "null" && -n "$PRIVATE_REGISTRY" ]] && SPEC+="private_registry: ${PRIVATE_REGISTRY}"$'\n'
+[[ "$ENABLE_SOCI"      != "null" && -n "$ENABLE_SOCI" ]]      && SPEC+="enable_soci: ${ENABLE_SOCI}"$'\n'
 
 echo "$SPEC"
 

--- a/.github/config/image/whisperx/ec2-amzn2023.yml
+++ b/.github/config/image/whisperx/ec2-amzn2023.yml
@@ -10,7 +10,7 @@ metadata:
   arch_type: "x86"
   device_type: "gpu"
   job_type: "inference"
-  prod_image: "whisperx:3.8.6-ec2-gpu-cuda-amzn2023"
+  prod_image: "whisperx:3.8.6-cu128-amzn2023"
 
 build:
   dockerfile: "docker/whisperx/Dockerfile.amzn2023"
@@ -24,9 +24,9 @@ build:
   dlc_minor_version: "0"
 
 release:
-  release: false
+  release: true
   force_release: false
-  public_registry: false
-  private_registry: false
+  public_registry: true
+  private_registry: true
   enable_soci: false
   environment: "production"

--- a/.github/config/image/whisperx/sagemaker-amzn2023.yml
+++ b/.github/config/image/whisperx/sagemaker-amzn2023.yml
@@ -11,7 +11,7 @@ metadata:
   arch_type: "x86"
   device_type: "gpu"
   job_type: "inference"
-  prod_image: "whisperx:3.8.6-sagemaker-gpu-cuda-amzn2023"
+  prod_image: "whisperx:3.8.6-cu128-amzn2023-sagemaker"
 
 build:
   dockerfile: "docker/whisperx/Dockerfile.amzn2023"
@@ -25,9 +25,9 @@ build:
   dlc_minor_version: "0"
 
 release:
-  release: false
+  release: true
   force_release: false
-  public_registry: false
-  private_registry: false
+  public_registry: true
+  private_registry: true
   enable_soci: false
   environment: "production"

--- a/.github/release-schedule.yml
+++ b/.github/release-schedule.yml
@@ -62,6 +62,10 @@ schedules:
     workflow: sglang.autorelease-ec2-amzn2023.yml
     gpu: heavy
 
+  - cron: "30 16 * * 2,4"
+    workflow: whisperx.autorelease-ec2-amzn2023.yml
+    gpu: heavy
+
   - cron: "00 17 * * 2,4"
     workflow: ray.autorelease-ec2.yml
     gpu: light
@@ -72,6 +76,10 @@ schedules:
 
   - cron: "00 18 * * 2,4"
     workflow: sglang.autorelease-sagemaker-amzn2023.yml
+    gpu: heavy
+
+  - cron: "30 18 * * 2,4"
+    workflow: whisperx.autorelease-sagemaker-amzn2023.yml
     gpu: heavy
 
   - cron: "00 19 * * 2,4"

--- a/.github/workflows/whisperx.autorelease-ec2-amzn2023.yml
+++ b/.github/workflows/whisperx.autorelease-ec2-amzn2023.yml
@@ -35,6 +35,4 @@ jobs:
       config-file: ${{ matrix.config_file }}
       tag-suffix: ${{ github.run_id }}
       release: true
-      # ECR vulnerability scan runs on the PR; skip it on the release path.
-      run-security-test: false
     secrets: inherit

--- a/.github/workflows/whisperx.autorelease-ec2-amzn2023.yml
+++ b/.github/workflows/whisperx.autorelease-ec2-amzn2023.yml
@@ -1,0 +1,38 @@
+name: "Auto Release - WhisperX EC2 AL2023"
+
+on:
+  schedule:
+    - cron: '30 16 * * 2,4'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      configs: ${{ steps.discover.outputs.configs }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: discover
+        uses: ./.github/actions/discover-configs
+        with:
+          pattern: ".github/config/image/whisperx/ec2-amzn2023.yml"
+
+  pipeline:
+    needs: [discover]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.configs) }}
+    uses: ./.github/workflows/whisperx.pipeline.yml
+    with:
+      config-file: ${{ matrix.config_file }}
+      tag-suffix: ${{ github.run_id }}
+      release: true
+    secrets: inherit

--- a/.github/workflows/whisperx.autorelease-ec2-amzn2023.yml
+++ b/.github/workflows/whisperx.autorelease-ec2-amzn2023.yml
@@ -35,4 +35,6 @@ jobs:
       config-file: ${{ matrix.config_file }}
       tag-suffix: ${{ github.run_id }}
       release: true
+      # ECR vulnerability scan runs on the PR; skip it on the release path.
+      run-security-test: false
     secrets: inherit

--- a/.github/workflows/whisperx.autorelease-sagemaker-amzn2023.yml
+++ b/.github/workflows/whisperx.autorelease-sagemaker-amzn2023.yml
@@ -1,0 +1,38 @@
+name: "Auto Release - WhisperX SageMaker AL2023"
+
+on:
+  schedule:
+    - cron: '30 18 * * 2,4'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      configs: ${{ steps.discover.outputs.configs }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: discover
+        uses: ./.github/actions/discover-configs
+        with:
+          pattern: ".github/config/image/whisperx/sagemaker-amzn2023.yml"
+
+  pipeline:
+    needs: [discover]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.configs) }}
+    uses: ./.github/workflows/whisperx.pipeline.yml
+    with:
+      config-file: ${{ matrix.config_file }}
+      tag-suffix: ${{ github.run_id }}
+      release: true
+    secrets: inherit

--- a/.github/workflows/whisperx.autorelease-sagemaker-amzn2023.yml
+++ b/.github/workflows/whisperx.autorelease-sagemaker-amzn2023.yml
@@ -35,6 +35,4 @@ jobs:
       config-file: ${{ matrix.config_file }}
       tag-suffix: ${{ github.run_id }}
       release: true
-      # ECR vulnerability scan runs on the PR; skip it on the release path.
-      run-security-test: false
     secrets: inherit

--- a/.github/workflows/whisperx.autorelease-sagemaker-amzn2023.yml
+++ b/.github/workflows/whisperx.autorelease-sagemaker-amzn2023.yml
@@ -35,4 +35,6 @@ jobs:
       config-file: ${{ matrix.config_file }}
       tag-suffix: ${{ github.run_id }}
       release: true
+      # ECR vulnerability scan runs on the PR; skip it on the release path.
+      run-security-test: false
     secrets: inherit

--- a/.github/workflows/whisperx.pipeline.yml
+++ b/.github/workflows/whisperx.pipeline.yml
@@ -30,7 +30,7 @@ on:
         description: "Run security tests"
         required: false
         type: boolean
-        default: true
+        default: false
       run-telemetry-test:
         description: "Run telemetry tests"
         required: false

--- a/test/whisperx/sagemaker/test_async_endpoint.py
+++ b/test/whisperx/sagemaker/test_async_endpoint.py
@@ -45,7 +45,7 @@ from test_utils.constants import INFERENCE_AMI_VERSION_CU12, SAGEMAKER_ROLE
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
 
-INSTANCE_TYPE = "ml.g6.xlarge"
+INSTANCE_TYPE = "ml.g4dn.xlarge"
 MAX_CONCURRENT_INVOCATIONS = 1
 # Generous: startup warms the Whisper model + diarization pipeline before /ping.
 STARTUP_HEALTH_CHECK_TIMEOUT = 1200

--- a/test/whisperx/sagemaker/test_sm_endpoint.py
+++ b/test/whisperx/sagemaker/test_sm_endpoint.py
@@ -31,8 +31,9 @@ from test_utils.constants import INFERENCE_AMI_VERSION_CU12, SAGEMAKER_ROLE
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
 
-# Single L4 GPU; matches WhisperX VRAM needs (large-v2 + align + diarization).
-INSTANCE_TYPE = "ml.g6.xlarge"
+# Single T4 GPU (16 GB) — cheaper and more available than L4; fits WhisperX
+# (large-v2 + align + diarization) for the short test clips.
+INSTANCE_TYPE = "ml.g4dn.xlarge"
 # Startup warms the default Whisper model + diarization pipeline in the lifespan
 # hook before /ping returns 200, so InService already implies a warm model.
 STARTUP_HEALTH_CHECK_TIMEOUT = 900

--- a/test/whisperx/sagemaker/test_sm_model_config.py
+++ b/test/whisperx/sagemaker/test_sm_model_config.py
@@ -39,8 +39,8 @@ from test_utils.constants import INFERENCE_AMI_VERSION_CU12, SAGEMAKER_ROLE
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
 
-# Single L4 GPU; matches WhisperX VRAM needs.
-INSTANCE_TYPE = "ml.g6.xlarge"
+# Single T4 GPU (16 GB) — cheaper and more available than L4.
+INSTANCE_TYPE = "ml.g4dn.xlarge"
 # Startup warms the pinned Whisper model + diarization pipeline before /ping
 # returns 200, so InService already implies the (tiny) model is resident.
 STARTUP_HEALTH_CHECK_TIMEOUT = 900

--- a/test/whisperx/sagemaker/test_sm_model_data.py
+++ b/test/whisperx/sagemaker/test_sm_model_data.py
@@ -47,7 +47,7 @@ from test_utils.constants import INFERENCE_AMI_VERSION_CU12, SAGEMAKER_ROLE
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
 
-INSTANCE_TYPE = "ml.g6.xlarge"
+INSTANCE_TYPE = "ml.g4dn.xlarge"
 STARTUP_HEALTH_CHECK_TIMEOUT = 900
 DEPLOY_TIMEOUT = 1800
 


### PR DESCRIPTION
## What

Adds the release infrastructure for the WhisperX ASR container (onboarded in #6396).

- **Autorelease workflows** (schedule + manual dispatch), mirroring the sglang AL2023 pattern:
  - `whisperx.autorelease-ec2-amzn2023.yml` — Tue/Thu 16:30 UTC
  - `whisperx.autorelease-sagemaker-amzn2023.yml` — Tue/Thu 18:30 UTC
- **`release-schedule.yml`** — registers both cron schedules (GPU-heavy class), matching the workflows byte-for-byte.
- **Image configs** — enables release and sets the prod tags:
  - `release`, `public_registry`, `private_registry` → `true`
  - `prod_image`: `whisperx:3.8.6-cu128-amzn2023` (EC2) / `whisperx:3.8.6-cu128-amzn2023-sagemaker` (SageMaker)

Tag shape follows `pytorch_runtime`: `{version}-{cuda_version}-{os}{platform_suffix}` — framework-versioned, with an immutable dated variant for pin-safety.

## Testing

- `scripts/ci/check_release_schedule.py` passes (all autorelease schedules match `release-schedule.yml`).
- Both new workflow YAMLs parse cleanly.

## SageMaker test instance

Also switches the SageMaker endpoint tests from `ml.g6.xlarge` to `ml.g4dn.xlarge` (T4, 16 GB) — cheaper and more readily available than L4. Only the `INSTANCE_TYPE` constant changes; the tests already pin the CU12 inference AMI (driver 550) that g4dn requires, and the image handles older-GPU hosts via its cuda-compat shim. EC2 tests are unchanged.

## Release-spec boolean fix

Also fixes `generate_release_spec.sh` dropping explicit `false` release flags: `yq``s `//` operator treats boolean `false` as falsy, so `.release.private_registry // \"\"` collapsed `false` to `\"\"` and the flag never reached the spec — after which `ReleaseSpec` defaulted `private_registry` back to `true`. This made public-registry-only releases target the wrong (private) account. Now the four boolean flags (`force_release`, `public_registry`, `private_registry`, `enable_soci`) are extracted raw and emitted unless the key is absent.

## ECR scan runs on PRs, not on release

The `security-test` (ECR vulnerability scan) pipeline input now defaults to `false`, matching sglang / vllm / openfold3 / ray. The PR caller enables it (build-change gated); the autorelease callers set nothing and inherit the `false` default, so the scan runs on PRs but is skipped on the release path.