### PR TITLE
test(whisperx): gamma release validation for EC2 [DO NOT MERGE]

### DIFF
--- a/.github/actions/generate-release-spec/generate_release_spec.sh
+++ b/.github/actions/generate-release-spec/generate_release_spec.sh
@@ -64,10 +64,14 @@ fi
 TRANSFORMERS_VERSION=$(yq '.build.transformers_version // ""' "$CONFIG_FILE")
 
 # Release flags
-FORCE_RELEASE=$(yq '.release.force_release // ""' "$CONFIG_FILE")
-PUBLIC_REGISTRY=$(yq '.release.public_registry // ""' "$CONFIG_FILE")
-PRIVATE_REGISTRY=$(yq '.release.private_registry // ""' "$CONFIG_FILE")
-ENABLE_SOCI=$(yq '.release.enable_soci // ""' "$CONFIG_FILE")
+# No `// ""` fallback on these booleans: yq's `//` treats boolean `false` as
+# falsy, so `false // ""` collapses to "" and the flag would be dropped from the
+# spec — after which ReleaseSpec defaults private_registry back to True. Extract
+# raw (missing key -> the string "null") and emit below unless it's "null".
+FORCE_RELEASE=$(yq '.release.force_release' "$CONFIG_FILE")
+PUBLIC_REGISTRY=$(yq '.release.public_registry' "$CONFIG_FILE")
+PRIVATE_REGISTRY=$(yq '.release.private_registry' "$CONFIG_FILE")
+ENABLE_SOCI=$(yq '.release.enable_soci' "$CONFIG_FILE")
 echo "Generating release spec:"
 echo "  Framework: ${FRAMEWORK}"
 echo "  Version: ${VERSION}"
@@ -88,10 +92,10 @@ SPEC+="version: \"${VERSION}\""$'\n'
 [[ -n "$TRANSFORMERS_VERSION" ]] && SPEC+="transformers_version: \"${TRANSFORMERS_VERSION}\""$'\n'
 [[ -n "$PLATFORM" ]]        && SPEC+="platform: \"${PLATFORM}\""$'\n'
 [[ -n "$CONTAINER_TYPE" ]]  && SPEC+="container_type: \"${CONTAINER_TYPE}\""$'\n'
-[[ -n "$FORCE_RELEASE" ]]   && SPEC+="force_release: ${FORCE_RELEASE}"$'\n'
-[[ -n "$PUBLIC_REGISTRY" ]] && SPEC+="public_registry: ${PUBLIC_REGISTRY}"$'\n'
-[[ -n "$PRIVATE_REGISTRY" ]] && SPEC+="private_registry: ${PRIVATE_REGISTRY}"$'\n'
-[[ -n "$ENABLE_SOCI" ]]    && SPEC+="enable_soci: ${ENABLE_SOCI}"$'\n'
+[[ "$FORCE_RELEASE"    != "null" && -n "$FORCE_RELEASE" ]]    && SPEC+="force_release: ${FORCE_RELEASE}"$'\n'
+[[ "$PUBLIC_REGISTRY"  != "null" && -n "$PUBLIC_REGISTRY" ]]  && SPEC+="public_registry: ${PUBLIC_REGISTRY}"$'\n'
+[[ "$PRIVATE_REGISTRY" != "null" && -n "$PRIVATE_REGISTRY" ]] && SPEC+="private_registry: ${PRIVATE_REGISTRY}"$'\n'
+[[ "$ENABLE_SOCI"      != "null" && -n "$ENABLE_SOCI" ]]      && SPEC+="enable_soci: ${ENABLE_SOCI}"$'\n'
 
 echo "$SPEC"
 

--- a/.github/config/image/whisperx/ec2-amzn2023.yml
+++ b/.github/config/image/whisperx/ec2-amzn2023.yml
@@ -10,7 +10,7 @@ metadata:
   arch_type: "x86"
   device_type: "gpu"
   job_type: "inference"
-  prod_image: "whisperx:3.8.6-ec2-gpu-cuda-amzn2023"
+  prod_image: "whisperx:3.8.6-cu128-amzn2023"
 
 build:
   dockerfile: "docker/whisperx/Dockerfile.amzn2023"
@@ -24,9 +24,9 @@ build:
   dlc_minor_version: "0"
 
 release:
-  release: false
+  release: true
   force_release: false
-  public_registry: false
-  private_registry: false
+  public_registry: true
+  private_registry: true
   enable_soci: false
   environment: "production"

--- a/.github/config/image/whisperx/ec2-amzn2023.yml
+++ b/.github/config/image/whisperx/ec2-amzn2023.yml
@@ -27,6 +27,6 @@ release:
   release: true
   force_release: false
   public_registry: true
-  private_registry: true
+  private_registry: false
   enable_soci: false
-  environment: "production"
+  environment: "gamma"

--- a/.github/config/image/whisperx/sagemaker-amzn2023.yml
+++ b/.github/config/image/whisperx/sagemaker-amzn2023.yml
@@ -11,7 +11,7 @@ metadata:
   arch_type: "x86"
   device_type: "gpu"
   job_type: "inference"
-  prod_image: "whisperx:3.8.6-sagemaker-gpu-cuda-amzn2023"
+  prod_image: "whisperx:3.8.6-cu128-amzn2023-sagemaker"
 
 build:
   dockerfile: "docker/whisperx/Dockerfile.amzn2023"
@@ -25,9 +25,9 @@ build:
   dlc_minor_version: "0"
 
 release:
-  release: false
+  release: true
   force_release: false
-  public_registry: false
-  private_registry: false
+  public_registry: true
+  private_registry: true
   enable_soci: false
   environment: "production"

--- a/.github/release-schedule.yml
+++ b/.github/release-schedule.yml
@@ -62,6 +62,10 @@ schedules:
     workflow: sglang.autorelease-ec2-amzn2023.yml
     gpu: heavy
 
+  - cron: "30 16 * * 2,4"
+    workflow: whisperx.autorelease-ec2-amzn2023.yml
+    gpu: heavy
+
   - cron: "00 17 * * 2,4"
     workflow: ray.autorelease-ec2.yml
     gpu: light
@@ -72,6 +76,10 @@ schedules:
 
   - cron: "00 18 * * 2,4"
     workflow: sglang.autorelease-sagemaker-amzn2023.yml
+    gpu: heavy
+
+  - cron: "30 18 * * 2,4"
+    workflow: whisperx.autorelease-sagemaker-amzn2023.yml
     gpu: heavy
 
   - cron: "00 19 * * 2,4"

--- a/.github/workflows/whisperx.autorelease-ec2-amzn2023.yml
+++ b/.github/workflows/whisperx.autorelease-ec2-amzn2023.yml
@@ -1,0 +1,38 @@
+name: "Auto Release - WhisperX EC2 AL2023"
+
+on:
+  schedule:
+    - cron: '30 16 * * 2,4'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      configs: ${{ steps.discover.outputs.configs }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: discover
+        uses: ./.github/actions/discover-configs
+        with:
+          pattern: ".github/config/image/whisperx/ec2-amzn2023.yml"
+
+  pipeline:
+    needs: [discover]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.configs) }}
+    uses: ./.github/workflows/whisperx.pipeline.yml
+    with:
+      config-file: ${{ matrix.config_file }}
+      tag-suffix: ${{ github.run_id }}
+      release: true
+    secrets: inherit

--- a/.github/workflows/whisperx.autorelease-sagemaker-amzn2023.yml
+++ b/.github/workflows/whisperx.autorelease-sagemaker-amzn2023.yml
@@ -1,0 +1,38 @@
+name: "Auto Release - WhisperX SageMaker AL2023"
+
+on:
+  schedule:
+    - cron: '30 18 * * 2,4'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      configs: ${{ steps.discover.outputs.configs }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: discover
+        uses: ./.github/actions/discover-configs
+        with:
+          pattern: ".github/config/image/whisperx/sagemaker-amzn2023.yml"
+
+  pipeline:
+    needs: [discover]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.configs) }}
+    uses: ./.github/workflows/whisperx.pipeline.yml
+    with:
+      config-file: ${{ matrix.config_file }}
+      tag-suffix: ${{ github.run_id }}
+      release: true
+    secrets: inherit

--- a/.github/workflows/whisperx.pipeline.yml
+++ b/.github/workflows/whisperx.pipeline.yml
@@ -158,13 +158,19 @@ jobs:
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
   release-gate:
+    # Production path: main + autorelease/dispatch-release (not .pr).
+    # Gamma-test path: any pull_request — the check step below hard-guards this
+    # to environment=gamma only, so a PR can never trigger a production release.
     if: >-
-      github.ref == 'refs/heads/main' &&
-      (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
-      !contains(github.workflow_ref, '.pr') &&
       inputs.release &&
       !failure() && !cancelled() &&
-      needs.build.result == 'success'
+      needs.build.result == 'success' &&
+      (
+        (github.ref == 'refs/heads/main' &&
+          (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
+          !contains(github.workflow_ref, '.pr'))
+        || github.event_name == 'pull_request'
+      )
     needs: [build, sanity-test, unit-test, security-test, telemetry-test, ec2-test, sagemaker-test]
     runs-on: ubuntu-latest
     outputs:
@@ -177,6 +183,12 @@ jobs:
         run: |
           SHOULD_RELEASE=$(yq '.release.release' "${{ inputs.config-file }}")
           ENVIRONMENT=$(yq '.release.environment' "${{ inputs.config-file }}")
+          # Safety guard: off main (e.g. a PR gamma test), ONLY gamma may
+          # release — never production/preprod — regardless of the config.
+          if [[ "${{ github.ref }}" != "refs/heads/main" && "${ENVIRONMENT}" != "gamma" ]]; then
+            echo "::notice::Refusing '${ENVIRONMENT}' release off non-main ref (${{ github.ref }}); only gamma is permitted here."
+            SHOULD_RELEASE=false
+          fi
           echo "should-release=${SHOULD_RELEASE}" >> $GITHUB_OUTPUT
           echo "environment=${ENVIRONMENT}" >> $GITHUB_OUTPUT
       - id: spec

--- a/.github/workflows/whisperx.pr-amzn2023.yml
+++ b/.github/workflows/whisperx.pr-amzn2023.yml
@@ -2,26 +2,29 @@ name: "PR - WhisperX AL2023"
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches: [main]
-    types: [opened, reopened, synchronize]
-    paths:
-      - ".github/config/image/whisperx/*.yml"
-      - ".github/workflows/whisperx.pipeline.yml"
-      - ".github/workflows/whisperx.pr-amzn2023.yml"
-      - ".github/workflows/whisperx.tests-ec2.yml"
-      - ".github/workflows/whisperx.tests-sagemaker.yml"
-      - ".github/workflows/whisperx.tests-unit.yml"
-      - "docker/whisperx/**"
-      - "scripts/docker/whisperx/**"
-      - "scripts/docker/common/**"
-      - "scripts/docker/telemetry/**"
-      - "scripts/ci/build/whisperx/**"
-      - "test/sanity/**"
-      - "test/telemetry/**"
-      - "test/whisperx/**"
-      - "test/security/data/ecr_scan_allowlist/whisperx/**"
-      - "!docs/**"
+  # TEMP DISABLED on the whisperx-gamma-test branch (do-not-merge): the
+  # pull_request trigger is commented out so the normal PR CI does not run
+  # alongside the gamma-test workflow. Uncomment to restore before merging.
+  # pull_request:
+  #   branches: [main]
+  #   types: [opened, reopened, synchronize]
+  #   paths:
+  #     - ".github/config/image/whisperx/*.yml"
+  #     - ".github/workflows/whisperx.pipeline.yml"
+  #     - ".github/workflows/whisperx.pr-amzn2023.yml"
+  #     - ".github/workflows/whisperx.tests-ec2.yml"
+  #     - ".github/workflows/whisperx.tests-sagemaker.yml"
+  #     - ".github/workflows/whisperx.tests-unit.yml"
+  #     - "docker/whisperx/**"
+  #     - "scripts/docker/whisperx/**"
+  #     - "scripts/docker/common/**"
+  #     - "scripts/docker/telemetry/**"
+  #     - "scripts/ci/build/whisperx/**"
+  #     - "test/sanity/**"
+  #     - "test/telemetry/**"
+  #     - "test/whisperx/**"
+  #     - "test/security/data/ecr_scan_allowlist/whisperx/**"
+  #     - "!docs/**"
 
 permissions:
   contents: read

--- a/.github/workflows/whisperx.pr-gamma-ec2.yml
+++ b/.github/workflows/whisperx.pr-gamma-ec2.yml
@@ -1,0 +1,41 @@
+name: "PR Gamma Test - WhisperX EC2 AL2023"
+
+# TEST-ONLY workflow (whisperx-gamma-test branch): triggers a gamma release of
+# the EC2 image from the PR so the release path can be validated before going to
+# production. The pipeline release-gate only permits gamma (never production)
+# off main. Do NOT merge this workflow to main.
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  discover:
+    runs-on: ubuntu-latest
+    outputs:
+      configs: ${{ steps.discover.outputs.configs }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: discover
+        uses: ./.github/actions/discover-configs
+        with:
+          pattern: ".github/config/image/whisperx/ec2-amzn2023.yml"
+
+  pipeline:
+    needs: [discover]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.discover.outputs.configs) }}
+    uses: ./.github/workflows/whisperx.pipeline.yml
+    with:
+      config-file: ${{ matrix.config_file }}
+      tag-suffix: pr-${{ github.event.pull_request.number }}
+      release: true
+    secrets: inherit


### PR DESCRIPTION
## ⚠️ Do not merge — throwaway gamma-test PR

Validates the WhisperX **EC2** release path against the **gamma** public registry before the production release (#6543). This branch carries test-only changes (a `pull_request` release trigger + a release-gate relaxation) that must not land on `main`. It will be closed once gamma validation is complete.

### What this exercises
- Builds the EC2 image and runs the standard test suite.
- Releases it to the **public gamma** registry only (`environment: gamma`, `private_registry: false`).

### Test-only changes on this branch
- `.github/config/image/whisperx/ec2-amzn2023.yml` → `environment: gamma`, `private_registry: false`.
- `.github/workflows/whisperx.pr-gamma-ec2.yml` (new) → `on: pull_request`, EC2 only, `release: true`.
- `.github/workflows/whisperx.pipeline.yml` release-gate → also allows the `pull_request` path, **hard-guarded** so anything off `main` can only release to gamma, never production. Normal PR CI (`release: false`) is unaffected.