### PR TITLE
test(vllm): add baidu/Unlimited-OCR smoke test

### DIFF
--- a/.github/config/model-tests/vllm-model-tests.yml
+++ b/.github/config/model-tests/vllm-model-tests.yml
@@ -108,4 +108,12 @@ smoke-test:
           audio_fixture: "asr_en.wav"
           validate: "json_field:text"
 
+    # Baidu Unlimited-OCR: 3B MoE VLM for document OCR (UnlimitedOCRForCausalLM).
+    # DeepSeek-based, bf16 (~6GB weights). Native vLLM support (v0.27.0+).
+    # Fits a single L4 (g6.xl, 24GB) at tp=1. Mirrors lighton-ocr-2-1b pattern.
+    - name: "unlimited-ocr"
+      s3_model: "unlimited-ocr.tar.gz"
+      fleet: "x86-g6xl-runner"
+      extra_args: "--tensor-parallel-size 1 --max-model-len 4096 --dtype bfloat16 --no-enable-prefix-caching"
+
   runner-scale-sets: []


### PR DESCRIPTION
## Summary
- Adds `baidu/Unlimited-OCR` (3B MoE document-OCR, UnlimitedOCRForCausalLM) to vLLM smoke tests
- Targets `x86-g6xl-runner` (1× L4 24GB), mirrors `lighton-ocr-2-1b` pattern
- Model weights uploaded to `s3://dlc-cicd-models/llm-models/unlimited-ocr.tar.gz` (4.9 GB)

## Validation
- Phase 1 (text-only smoke): PASS on g5.xlarge (A10G 23GB), 18.8 GB VRAM, health 200, inference 200
- Level 2-3 (full recipe with image input): PASS — correct OCR text extraction with logits processor + recipe params
- GPU memory under vision load: 21.9/23 GB (95.2%) — text-only CI smoke stays well under limit

## Test plan
- [x] `test-model (unlimited-ocr)` job goes green on this PR
- [x] Verify no regressions in other model tests (`fail-fast: false` isolates)