### PR TITLE
Enforce path validation on LLM-supplied file edits in Currency Fix Agent

### DIFF
--- a/.github/config/agent-context-files.yml
+++ b/.github/config/agent-context-files.yml
@@ -9,6 +9,7 @@
 common:
   - "docker/{framework}/Dockerfile"
   - ".github/config/image/{framework}/ec2-ubuntu.yml"
+  - ".github/config/image/{framework}/sagemaker-ubuntu.yml"
 
 # Job-specific files
 jobs:

--- a/scripts/ci/autocurrency/agent-fix.py
+++ b/scripts/ci/autocurrency/agent-fix.py
@@ -226,6 +226,7 @@ def load_context_files(framework: str, failed_jobs: list) -> dict:
             for p in [
                 f"docker/{framework}/Dockerfile",
                 f".github/config/image/{framework}/ec2-ubuntu.yml",
+                f".github/config/image/{framework}/sagemaker-ubuntu.yml",
                 f"test/security/data/ecr_scan_allowlist/{framework}/framework_allowlist.json",
             ]
             if read_file(p)
@@ -337,12 +338,43 @@ def find_match(content: str, search: str) -> tuple:
     return None, None
 
 
-def apply_blocks(blocks: list) -> tuple:
-    """Returns (modified_files, errors)."""
+def is_allowed_path(path: str, allowed_paths: set) -> bool:
+    """Security gate for LLM-supplied file paths.
+
+    A path is allowed ONLY if, after normalization, it exactly matches one
+    of the files returned by load_context_files(). This rejects absolute paths,
+    ``..`` traversal outside the repo, and any in-repo file that was never shown
+    to the model as editable (e.g. .github/workflows/*.yml).
+    """
+    if not path or os.path.isabs(path):
+        return False
+    normalized = os.path.normpath(path)
+    # normpath resolves '.'/'..' lexically; anything escaping the repo root
+    # keeps a leading '..' component and can never match an allowed path.
+    if normalized == ".." or normalized.startswith(".." + os.sep):
+        return False
+    return normalized in allowed_paths
+
+
+def apply_blocks(blocks: list, allowed_paths: set) -> tuple:
+    """Returns (modified_files, errors).
+
+    ``allowed_paths`` is the set of files the agent was given as editable
+    context (load_context_files() keys). Any block targeting a path outside this
+    set is rejected before touching the filesystem.
+    """
     modified, errors = [], []
+    normalized_allowed = {os.path.normpath(p) for p in allowed_paths}
 
     for b in blocks:
         path, search, replace = b["path"], b["search"], b["replace"]
+
+        if not is_allowed_path(path, normalized_allowed):
+            errors.append(
+                f"Path not in allowed context files, edit rejected: {path}. "
+                f"The agent may only edit files provided as context."
+            )
+            continue
 
         if not Path(path).exists():
             if not search.strip():  # Create new file
@@ -459,7 +491,7 @@ def main():
             print(f"  Response preview: {response[:200]}")
             continue
 
-        modified, errors = apply_blocks(blocks)
+        modified, errors = apply_blocks(blocks, set(context_files.keys()))
         if errors:
             retry_context = f"{len(modified)} applied, {len(errors)} failed:\n" + "\n".join(errors)
             print(f"{'Partial' if modified else 'All failed'}: {len(errors)} error(s), retrying...")


### PR DESCRIPTION
## Summary
- Add path validation for the currency fix agent so that it can only edit allowed files. The "ONLY edit files provided in context" rule existed only in the system prompt (natural language), not in code.
- Also added sagemaker context files that were missing before

## Changes
- Add `is_allowed_path()` — a path is allowed only if, after `os.path.normpath`, it **exactly matches** one of the `load_context_files()` keys. Rejects absolute paths, `..` traversal that escapes the repo, and any file never provided as editable context.
- `apply_blocks()` now takes the allowlist and rejects out-of-scope blocks **before** touching the filesystem, feeding the existing retry/error loop.
- `main()` passes `set(context_files.keys())` as the allowlist.