### PR TITLE
[Testing Only] test-skip cache e2e: wire sanity + telemetry into sglang pipeline

### DIFF
--- a/.github/actions/check-test-pass/action.yml
+++ b/.github/actions/check-test-pass/action.yml
@@ -1,0 +1,103 @@
+name: 'Check test skips'
+description: >
+  Compute the image content hash, test suite hash, and query the dlc-ci-images
+  table for every skip-eligible suite in a single query.
+
+inputs:
+  image-uri:
+    description: 'Image URI (uses prod image if empty).'
+    required: false
+    default: ''
+  config-file:
+    description: 'Path to image config YAML (used for the prod-image fallback).'
+    required: true
+  suites:
+    description: 'JSON array of test suites to check for this pipeline.'
+    required: true
+  ci-aws-account-id:
+    description: 'CI ECR account ID.'
+    required: true
+  prod-aws-account-id:
+    description: 'Prod ECR account ID (for the prod-image fallback).'
+    required: true
+  ci-images-table-account-id:
+    description: 'Account ID hosting the dlc-ci-images DynamoDB table.'
+    required: true
+  aws-region:
+    description: 'AWS region for ECR + the dlc-ci-images table.'
+    required: false
+    default: 'us-west-2'
+
+outputs:
+  skips:
+    description: 'JSON object: test suite -> true (skip) | false (run). {} means run all.'
+    value: ${{ steps.check.outputs.skips }}
+  image-content-hash:
+    description: "Computed image content hash (reused by the record path)."
+    value: ${{ steps.check.outputs.image-content-hash }}
+  suite-code-hashes:
+    description: "JSON map: suite -> suite_code_hash computed by the check."
+    value: ${{ steps.check.outputs.suite-code-hashes }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve image URI
+      id: image
+      uses: ./.github/actions/resolve-image-uri
+      with:
+        image-uri: ${{ inputs.image-uri }}
+        ci-aws-account-id: ${{ inputs.ci-aws-account-id }}
+        prod-aws-account-id: ${{ inputs.prod-aws-account-id }}
+        aws-region: ${{ inputs.aws-region }}
+        config-file: ${{ inputs.config-file }}
+
+    - name: ECR authenticate
+      uses: ./.github/actions/ecr-authenticate
+      with:
+        aws-account-id: ${{ steps.image.outputs.aws-account-id }}
+        aws-region: ${{ inputs.aws-region }}
+
+    - name: Compute skips
+      id: check
+      shell: bash
+      env:
+        CI_IMAGES_TABLE_ACCOUNT_ID: ${{ inputs.ci-images-table-account-id }}
+        CI_IMAGES_TABLE_REGION: ${{ inputs.aws-region }}
+        RESOLVED_IMAGE_URI: ${{ steps.image.outputs.image-uri }}
+        SUITES: ${{ inputs.suites }}
+      run: |
+        set +e
+        uv venv --python 3.12 --clear
+        source .venv/bin/activate
+        uv pip install boto3 pyyaml
+        RESULT=$(python3 "${{ github.action_path }}/check_test_pass.py" \
+          --image-uri "$RESOLVED_IMAGE_URI" \
+          --suites "$SUITES" \
+          --repo-root "$(git rev-parse --show-toplevel)")
+        [ -n "$RESULT" ] || RESULT='{"skips":{},"image_content_hash":"","suite_code_hashes":{}}'
+        {
+          echo "skips=$(printf '%s' "$RESULT" | jq -c '.skips')"
+          echo "image-content-hash=$(printf '%s' "$RESULT" | jq -r '.image_content_hash')"
+          echo "suite-code-hashes=$(printf '%s' "$RESULT" | jq -c '.suite_code_hashes')"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Report cache hits
+      shell: bash
+      env:
+        SKIPS: ${{ steps.check.outputs.skips }}
+      run: |
+        HITS=$(printf '%s' "$SKIPS" | jq -r 'to_entries[] | select(.value) | .key' 2>/dev/null || true)
+        {
+          if [ -n "$HITS" ]; then
+            echo "### ✅ Test-pass cache hit"
+            echo "The following suites will be skipped (no test runner provisioned):"
+            printf '%s\n' "$HITS" | sed 's/^/- /'
+          else
+            echo "### Test-skip cache check"
+            echo "No cache hits — all checked suites will run."
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"
+        if [ -n "$HITS" ]; then
+          echo "::notice title=✅ Test-skip cache hits::$(printf '%s' "$HITS" | paste -sd, -)"
+        fi

--- a/.github/actions/check-test-pass/check_test_pass.py
+++ b/.github/actions/check-test-pass/check_test_pass.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Batch test-pass check.
+
+Checks for skip-eligible suites and returns which ones already passed for
+the current image content hash.
+
+Usage:
+    python3 check_test_pass.py --image-uri <ref> --repo-root <path> \
+        --suites '["sanity", "sglang/upstream", "sglang/model"]'
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+DEFAULT_PLATFORM = "linux/amd64"
+
+
+def _load_helpers(repo_root):
+    """Import the shared test-skip modules from the repo checkout."""
+    scripts_dir = Path(repo_root) / "scripts" / "ci" / "test_skip"
+    sys.path.insert(0, str(scripts_dir))
+    import hash_image_content
+    import hash_suite_code
+    import test_skip_db
+
+    return hash_image_content, hash_suite_code, test_skip_db
+
+
+def compute_skips(repo_root, image_uri, suites, platform=DEFAULT_PLATFORM):
+    """Return (skips, image_content_hash, suite_code_hashes) for the eligible suites."""
+    hash_image_content, hash_suite_code, store = _load_helpers(repo_root)
+    eligible = [s for s in dict.fromkeys(suites) if hash_suite_code.is_skip_eligible(repo_root, s)]
+    # Skip the image hash + DB call and run everything.
+    if not eligible:
+        return {}, "", {}
+
+    image_content_hash = hash_image_content.compute_image_content_hash(image_uri, platform=platform)
+
+    suite_code_hashes = {}
+    for s in eligible:
+        try:
+            suite_code_hashes[s] = hash_suite_code.hash_suite_code(repo_root, s)
+        except (KeyError, ValueError) as e:
+            print(f"::warning::skipping test-pass check for {s!r} ({e})", file=sys.stderr)
+
+    skippable = (
+        store.check_test_pass(image_content_hash, suite_code_hashes) if suite_code_hashes else set()
+    )
+    skips = {s: (s in skippable) for s in suite_code_hashes}
+    return skips, image_content_hash, suite_code_hashes
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Batch test-pass check.")
+    parser.add_argument("--image-uri", required=True, help="Resolved image reference to hash.")
+    parser.add_argument(
+        "--suites", required=True, help="JSON array of test-suites.yml keys to check."
+    )
+    parser.add_argument("--repo-root", default=".", help="Repo checkout root.")
+    parser.add_argument(
+        "--platform", default=DEFAULT_PLATFORM, help=f"Platform (default {DEFAULT_PLATFORM})."
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        suites = json.loads(args.suites)
+        if not isinstance(suites, list):
+            raise ValueError(f"--suites must be a JSON array, got {type(suites).__name__}")
+        skips, image_content_hash, suite_code_hashes = compute_skips(
+            args.repo_root, args.image_uri, suites, args.platform
+        )
+    except Exception as e:
+        print(f"::warning::test-pass check failed ({e}); running all suites", file=sys.stderr)
+        print(
+            json.dumps(
+                {"skips": {}, "image_content_hash": "", "suite_code_hashes": {}},
+                separators=(",", ":"),
+            )
+        )
+        return 0
+
+    print(
+        json.dumps(
+            {
+                "skips": skips,
+                "image_content_hash": image_content_hash,
+                "suite_code_hashes": suite_code_hashes,
+            },
+            separators=(",", ":"),
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/actions/record-test-pass/action.yml
+++ b/.github/actions/record-test-pass/action.yml
@@ -1,0 +1,39 @@
+name: 'Record test pass'
+description: >
+  Write a PASS row to the dlc-ci-images table after a test suite fully passes,
+  so future runs on the same image content + test code can skip it.
+
+inputs:
+  suite:
+    description: 'Name of the test suite.'
+    required: true
+  image-content-hash:
+    description: "Hash of the image's ordered layer diff ids."
+    required: true
+  suite-code-hash:
+    description: "Hash of the test suite's files."
+    required: true
+  ci-image-tag:
+    description: 'CI image tag for the image build being tested.'
+    required: false
+    default: ''
+  ci-images-table-account-id:
+    description: 'Account ID hosting the dlc-ci-images DynamoDB table.'
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Record PASS
+      shell: bash
+      env:
+        SUITE: ${{ inputs.suite }}
+        IMAGE_CONTENT_HASH: ${{ inputs.image-content-hash }}
+        SUITE_CODE_HASH: ${{ inputs.suite-code-hash }}
+        CI_IMAGE_TAG: ${{ inputs.ci-image-tag }}
+        CI_IMAGES_TABLE_ACCOUNT_ID: ${{ inputs.ci-images-table-account-id }}
+      run: |
+        uv venv --python 3.12 --clear
+        source .venv/bin/activate
+        uv pip install boto3 pyyaml
+        bash "${{ github.action_path }}/record_pass.sh"

--- a/.github/actions/record-test-pass/record_pass.sh
+++ b/.github/actions/record-test-pass/record_pass.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Record a PASS row in the dlc-ci-images table for a fully-passed test suite.
+#
+# Usage:
+#   SUITE=<name> IMAGE_CONTENT_HASH=<hash> SUITE_CODE_HASH=<hash> \
+#     CI_IMAGES_TABLE_ACCOUNT_ID=<id> bash record_pass.sh
+#
+# Output: writes the PASS row to DynamoDB and a summary to $GITHUB_STEP_SUMMARY
+#
+# Requires: python3, and scripts/ci/test_skip/test_skip_db.py
+set -euo pipefail
+
+SCRIPTS="$(git rev-parse --show-toplevel)/scripts/ci/test_skip"
+
+# Suites with skip_eligible=false are always run. Don't write them to the store.
+ELIGIBLE=$(python3 "$SCRIPTS/hash_suite_code.py" --suite "$SUITE" --eligible-only) || ELIGIBLE=""
+if [[ "$ELIGIBLE" != "true" ]]; then
+  echo "Suite '$SUITE' is not skip-eligible — not recording a PASS row."
+  exit 0
+fi
+
+if [[ -z "$IMAGE_CONTENT_HASH" || -z "$SUITE_CODE_HASH" ]]; then
+  echo "::warning::Skipping cache write for '$SUITE': empty hash" \
+       "(image='$IMAGE_CONTENT_HASH' suite_code='$SUITE_CODE_HASH')" \
+       "— suite still passed."
+  exit 0
+fi
+
+if python3 "$SCRIPTS/test_skip_db.py" record \
+  --image-content-hash "$IMAGE_CONTENT_HASH" \
+  --suite "$SUITE" \
+  --suite-code-hash "$SUITE_CODE_HASH" \
+  --ci-image-tag "${CI_IMAGE_TAG:-}"; then
+  {
+    echo "### ✅ Recorded test PASS"
+    echo "Suite \`$SUITE\` passed and was cached."
+    echo ""
+    echo "- image_content_hash: \`$IMAGE_CONTENT_HASH\`"
+    echo "- suite_code_hash: \`$SUITE_CODE_HASH\`"
+  } >>"$GITHUB_STEP_SUMMARY"
+else
+  echo "::warning::Failed to record PASS for '$SUITE' (cache write) — suite still passed."
+fi

--- a/.github/config/test-suites.yml
+++ b/.github/config/test-suites.yml
@@ -1,0 +1,138 @@
+# Test-skip suite configuration.
+#
+# One entry per test suite. Drives the content-addressed test-skip store, which
+# lets CI skip a suite whose exact test code already passed on a given image build.
+# To add or change the definition of a test suite for the test-skip store, simply
+# add or change the file paths for the desired test suite here.
+# Per suite:
+#   skip_eligible: whether a test suite can be skipped at all.
+#   code_paths: repo-relative globs for the files that make up the suite. Their
+#     combined contents produce the suite_code_hash.
+
+suites:
+  sanity:
+    skip_eligible: true
+    code_paths:
+      - test/sanity/**
+
+  security:
+    skip_eligible: false
+    code_paths:
+      - test/security/**
+
+  telemetry:
+    skip_eligible: true
+    code_paths:
+      - test/telemetry/**
+
+  efa:
+    skip_eligible: true
+    code_paths:
+      - test/efa/**
+
+  pytorch/unit:
+    skip_eligible: true
+    code_paths:
+      - test/pytorch/unit/**
+
+  pytorch/single_gpu:
+    skip_eligible: true
+    code_paths:
+      - test/pytorch/single_gpu/**
+
+  pytorch/multi_gpu:
+    skip_eligible: true
+    code_paths:
+      - test/pytorch/multi_gpu/**
+
+  pytorch/multi_node:
+    skip_eligible: true
+    code_paths:
+      - test/pytorch/multi_node/**
+
+  pytorch/integration/sagemaker:
+    skip_eligible: true
+    code_paths:
+      - test/pytorch/integration/sagemaker/**
+
+  ray/ec2:
+    skip_eligible: true
+    code_paths:
+      - test/ray/ec2/**
+      - test/ray/utils.py
+      - test/ray/test_ffmpeg_codecs.sh
+      - test/ray/test_ffmpeg_gpu.sh
+
+  ray/sagemaker:
+    skip_eligible: true
+    code_paths:
+      - test/ray/sagemaker/**
+      - test/ray/utils.py
+      - test/ray/test_ffmpeg_codecs.sh
+      - test/ray/test_ffmpeg_gpu.sh
+
+  ray/ffmpeg:
+    skip_eligible: true
+    code_paths:
+      - test/ray/test_ffmpeg_codecs.sh
+      - test/ray/test_ffmpeg_gpu.sh
+
+  vllm/upstream:
+    skip_eligible: true
+    code_paths:
+      - test/vllm/**
+
+  vllm/model:
+    skip_eligible: true
+    code_paths:
+      - test/vllm/**
+
+  vllm/sagemaker:
+    skip_eligible: true
+    code_paths:
+      - test/vllm/sagemaker/**
+
+  sglang/upstream:
+    skip_eligible: true
+    code_paths:
+      - test/sglang/**
+
+  sglang/model:
+    skip_eligible: true
+    code_paths:
+      - test/sglang/**
+
+  sglang/sagemaker:
+    skip_eligible: true
+    code_paths:
+      - test/sglang/sagemaker/**
+
+  vllm-omni/model:
+    skip_eligible: true
+    code_paths:
+      - test/vllm-omni/**
+
+  vllm-omni/sagemaker:
+    skip_eligible: true
+    code_paths:
+      - test/vllm-omni/sagemaker/**
+
+  openfold3/sagemaker:
+    skip_eligible: true
+    code_paths:
+      - test/openfold3/sagemaker/**
+
+  xgboost/container:
+    skip_eligible: true
+    code_paths:
+      - test/xgboost/container/**
+
+  xgboost/e2e:
+    skip_eligible: true
+    code_paths:
+      - test/xgboost/e2e/**
+
+  xgboost/benchmarks:
+    skip_eligible: true
+    code_paths:
+      - test/xgboost/benchmarks/**

--- a/.github/workflows/_reusable.check-test-pass.yml
+++ b/.github/workflows/_reusable.check-test-pass.yml
@@ -1,0 +1,55 @@
+name: Reusable Check Test-Pass
+
+on:
+  workflow_call:
+    inputs:
+      config-file:
+        description: "Path to image config YAML"
+        required: true
+        type: string
+      image-uri:
+        description: "Image URI to hash. If empty, derives prod URI from config."
+        required: false
+        type: string
+        default: ""
+      suites:
+        description: "JSON array of test suites to check for this pipeline."
+        required: true
+        type: string
+    outputs:
+      skips:
+        description: "JSON object: test suite -> true (skip) | false (run). {} means run all."
+        value: ${{ jobs.check.outputs.skips }}
+      image-content-hash:
+        description: "Computed image content hash."
+        value: ${{ jobs.check.outputs.image-content-hash }}
+      suite-code-hashes:
+        description: "JSON map: suite -> suite_code_hash."
+        value: ${{ jobs.check.outputs.suite-code-hashes }}
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    outputs:
+      skips: ${{ steps.check.outputs.skips || '{}' }}
+      image-content-hash: ${{ steps.check.outputs.image-content-hash }}
+      suite-code-hashes: ${{ steps.check.outputs.suite-code-hashes || '{}' }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: check
+        continue-on-error: true
+        uses: ./.github/actions/check-test-pass
+        with:
+          image-uri: ${{ inputs.image-uri }}
+          config-file: ${{ inputs.config-file }}
+          suites: ${{ inputs.suites }}
+          ci-aws-account-id: ${{ vars.CI_AWS_ACCOUNT_ID }}
+          prod-aws-account-id: ${{ vars.PROD_AWS_ACCOUNT_ID }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}
+          aws-region: ${{ vars.AWS_REGION }}

--- a/.github/workflows/_reusable.sanity-tests.yml
+++ b/.github/workflows/_reusable.sanity-tests.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image content hash from the test-skip check. Empty disables the cache write."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "suite_code_hash for the sanity suite. Empty disables the cache write."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -297,3 +307,26 @@ jobs:
           needs.preflight.outputs.nccl-version != ''
         run: |
           docker exec ${CONTAINER_ID} bash /workdir/test/sanity/scripts/nccl_single_node_test.sh
+
+  # Record a PASS row in dlc-ci-images once the sanity suite fully passes, so a
+  # future run on the same image content + test code can skip it. Gated on the
+  # hashes being present (the caller only passes them for skip-eligible runs) and
+  # the image existing; no-ops for callers that don't opt in.
+  record-pass:
+    if: >-
+      always() && !failure() && !cancelled() &&
+      needs.preflight.outputs.image-exists == 'true' &&
+      inputs.image-content-hash != '' && inputs.suite-code-hash != ''
+    needs: [preflight, sanity-test, sanity-sagemaker, sanity-gpu]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: sanity
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/_reusable.telemetry-tests.yml
+++ b/.github/workflows/_reusable.telemetry-tests.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image content hash from the test-skip check. Empty disables the cache write."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "suite_code_hash for the telemetry suite. Empty disables the cache write."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -125,3 +135,26 @@ jobs:
             --container-type "${{ needs.preflight.outputs.job-type }}" \
             --arch-type "${{ needs.preflight.outputs.arch-type }}" \
             --region "${{ vars.AWS_REGION }}"
+
+  # Record a PASS row in dlc-ci-images once the telemetry suite fully passes, so a
+  # future run on the same image content + test code can skip it. Gated on the
+  # hashes being present (the caller only passes them for skip-eligible runs) and
+  # the image existing; no-ops for callers that don't opt in.
+  record-pass:
+    if: >-
+      always() && !failure() && !cancelled() &&
+      needs.preflight.outputs.image-exists == 'true' &&
+      inputs.image-content-hash != '' && inputs.suite-code-hash != ''
+    needs: [preflight, telemetry-environment, telemetry-instance]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: telemetry
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/sglang.pipeline.yml
+++ b/.github/workflows/sglang.pipeline.yml
@@ -96,9 +96,21 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           tag-suffix: ${{ inputs.tag-suffix }}
 
-  sanity-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-sanity-test }}
+  # Content-addressed test-skip check: computes the image_content_hash and each
+  # suite's suite_code_hash, then reads dlc-ci-images to see which suites already
+  # passed on this exact image content + test code. Outputs gate the test jobs.
+  check-test-skip:
+    if: ${{ always() && !failure() && !cancelled() && (inputs.run-sanity-test || inputs.run-telemetry-test) }}
     needs: [build]
+    uses: ./.github/workflows/_reusable.check-test-pass.yml
+    with:
+      config-file: ${{ inputs.config-file }}
+      image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      suites: '["sanity","telemetry"]'
+
+  sanity-test:
+    if: ${{ always() && !failure() && !cancelled() && inputs.run-sanity-test && !fromJSON(needs.check-test-skip.outputs.skips || '{}')['sanity'] }}
+    needs: [build, check-test-skip]
     concurrency:
       group: ${{ github.workflow }}-sanity-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: true
@@ -106,6 +118,8 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check-test-skip.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check-test-skip.outputs.suite-code-hashes || '{}')['sanity'] }}
 
   security-test:
     if: ${{ always() && !failure() && !cancelled() && inputs.run-security-test }}
@@ -119,8 +133,8 @@ jobs:
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
   telemetry-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-telemetry-test }}
-    needs: [build]
+    if: ${{ always() && !failure() && !cancelled() && inputs.run-telemetry-test && !fromJSON(needs.check-test-skip.outputs.skips || '{}')['telemetry'] }}
+    needs: [build, check-test-skip]
     concurrency:
       group: ${{ github.workflow }}-telemetry-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: false
@@ -128,6 +142,8 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check-test-skip.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check-test-skip.outputs.suite-code-hashes || '{}')['telemetry'] }}
 
   upstream-tests:
     if: ${{ always() && !failure() && !cancelled() && inputs.run-upstream-test }}

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -409,6 +409,9 @@ RUN dnf upgrade -y --security --releasever latest \
 COPY ./scripts/docker/sglang/dockerd_entrypoint.sh /usr/bin/serve
 RUN chmod +x /usr/bin/serve
 
+# no-op comment change: re-trigger CI to validate the test-skip read/skip path.
+# Comments are not build instructions, so image content (diff_ids) is unchanged
+# and the previously-recorded PASS rows should produce a cache hit + skip.
 # test-skip e2e validation: final-layer marker to force a new image_content_hash
 # so the rebuild produces a distinct content hash for the test-skip cache write.
 RUN echo "test-skip-e2e-v2" >/etc/dlc_test_skip_marker

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -411,7 +411,7 @@ RUN chmod +x /usr/bin/serve
 
 # test-skip e2e validation: final-layer marker to force a new image_content_hash
 # so the rebuild produces a distinct content hash for the test-skip cache write.
-RUN echo "test-skip-e2e-v2" > /etc/dlc_test_skip_marker
+RUN echo "test-skip-e2e-v2" >/etc/dlc_test_skip_marker
 
 ENTRYPOINT ["/usr/bin/serve"]
 

--- a/docker/sglang/Dockerfile.amzn2023
+++ b/docker/sglang/Dockerfile.amzn2023
@@ -409,6 +409,10 @@ RUN dnf upgrade -y --security --releasever latest \
 COPY ./scripts/docker/sglang/dockerd_entrypoint.sh /usr/bin/serve
 RUN chmod +x /usr/bin/serve
 
+# test-skip e2e validation: final-layer marker to force a new image_content_hash
+# so the rebuild produces a distinct content hash for the test-skip cache write.
+RUN echo "test-skip-e2e-v2" > /etc/dlc_test_skip_marker
+
 ENTRYPOINT ["/usr/bin/serve"]
 
 # ====================== sagemaker =========================================

--- a/scripts/ci/test_skip/hash_image_content.py
+++ b/scripts/ci/test_skip/hash_image_content.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""Compute image_content_hash for a pushed image with no layer pull.
+
+Read the config, resolve the reference in the registry, and return the image
+config JSON, then hash its rootfs.diff_ids. DLC builds single-platform x86-64
+images, so we expect a single config and verify its os/architecture matches
+--platform.
+
+Usage:
+    python3 hash_image_content.py --image-uri <ref> [--platform linux/amd64]
+"""
+
+import argparse
+import hashlib
+import json
+import subprocess
+import sys
+
+DEFAULT_PLATFORM = "linux/amd64"
+
+
+class PlatformNotFoundError(Exception):
+    """Raised when the image's platform does not match the requested one."""
+
+
+def hash_diff_ids(diff_ids):
+    """sha256 of the ordered diff_ids list (``sha256:<hex>``)."""
+    if not diff_ids:
+        raise ValueError("empty diff_ids — refusing to emit a content hash")
+    digest = hashlib.sha256()
+    for diff_id in diff_ids:
+        digest.update(diff_id.encode("utf-8"))
+        digest.update(b"\n")
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _diff_ids_from_config(config):
+    """Pull rootfs.diff_ids out of one image config object."""
+    rootfs = config.get("rootfs") if isinstance(config, dict) else None
+    if not isinstance(rootfs, dict) or "diff_ids" not in rootfs:
+        raise ValueError("image config has no rootfs.diff_ids")
+    return rootfs["diff_ids"]
+
+
+def _assert_platform_matches(config, platform):
+    """Raise PlatformNotFoundError if a config's own os/architecture ≠ platform."""
+    if not isinstance(config, dict):
+        return
+    want_os, want_arch = platform.split("/")[0], platform.split("/")[-1]
+    got_os, got_arch = config.get("os"), config.get("architecture")
+    if got_os is not None and got_os != want_os:
+        raise PlatformNotFoundError(
+            f"image os {got_os!r} does not match requested platform {platform!r}"
+        )
+    if got_arch is not None and got_arch != want_arch:
+        raise PlatformNotFoundError(
+            f"image architecture {got_arch!r} does not match requested platform {platform!r}"
+        )
+
+
+def extract_diff_ids(inspect_json, platform=DEFAULT_PLATFORM):
+    """Extract diff_ids from a single-platform `imagetools inspect` config."""
+    payload = json.loads(inspect_json)
+    if not isinstance(payload, dict):
+        raise ValueError("unexpected imagetools inspect output (not an object)")
+    if not payload.keys() & {"rootfs", "config", "architecture", "os"}:
+        raise ValueError("expected a single image config (got no config fields)")
+
+    _assert_platform_matches(payload, platform)
+    return _diff_ids_from_config(payload)
+
+
+def _inspect_image_config(image_uri):
+    """Return the raw `imagetools inspect --format '{{json .Image}}'` stdout.
+
+    Reads only manifest + config from the registry — no layer pull. Requires a
+    prior `docker login` to the registry (the CI runner already authenticates).
+    """
+    result = subprocess.run(
+        [
+            "docker",
+            "buildx",
+            "imagetools",
+            "inspect",
+            image_uri,
+            "--format",
+            "{{json .Image}}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def compute_image_content_hash(image_uri, platform=DEFAULT_PLATFORM):
+    """Compute the image_content_hash for a pushed image reference."""
+    inspect_json = _inspect_image_config(image_uri)
+    diff_ids = extract_diff_ids(inspect_json, platform=platform)
+    return hash_diff_ids(diff_ids)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Compute image_content_hash from a pushed image (no layer pull)."
+    )
+    parser.add_argument(
+        "--image-uri", required=True, help="ECR image reference (prefer digest-pinned)."
+    )
+    parser.add_argument(
+        "--platform",
+        default=DEFAULT_PLATFORM,
+        help=f"Platform to hash (default {DEFAULT_PLATFORM}).",
+    )
+    args = parser.parse_args(argv)
+    print(compute_image_content_hash(args.image_uri, platform=args.platform))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test_skip/hash_suite_code.py
+++ b/scripts/ci/test_skip/hash_suite_code.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Compute suite_code_hash for a test suite.
+
+suite_code_hash is sha256 over the file set from .github/config/test-suites.yml —
+each file's repo-relative path plus its bytes, sorted by path so the result is
+order-independent. Editing, adding, moving, or removing a captured file changes
+the hash.
+
+Usage:
+    python3 hash_suite_code.py --suite pytorch/single_gpu
+    python3 hash_suite_code.py --suite sanity --repo-root /path/to/repo
+"""
+
+import argparse
+import hashlib
+import sys
+from pathlib import Path
+
+import yaml
+
+# scripts/ci/test_skip/hash_suite_code.py -> repo root is three parents up.
+DEFAULT_REPO_ROOT = Path(__file__).resolve().parent.parent.parent.parent
+CONFIG_REL = ".github/config/test-suites.yml"
+
+
+def load_config(repo_root):
+    """Load the test-skip suite config as a dict keyed by suite name."""
+    config_path = Path(repo_root) / CONFIG_REL
+    data = yaml.safe_load(config_path.read_text())
+    return data.get("suites", {})
+
+
+def resolve_files(repo_root, code_paths):
+    """Resolve code_paths globs to a sorted, de-duplicated list of existing files.
+    Paths are specified relative to repo_root.
+    """
+    repo_root = Path(repo_root)
+    matched = set()
+    for pattern in code_paths:
+        # pathlib's trailing `**` matches directories only; `**/*` is what
+        # captures files recursively.
+        if pattern.endswith("/**"):
+            pattern = pattern + "/*"
+        for path in repo_root.glob(pattern):
+            if path.is_file():
+                matched.add(path)
+    return sorted(matched, key=lambda p: p.relative_to(repo_root).as_posix())
+
+
+def hash_suite_code(repo_root, suite):
+    """Return the suite_code_hash (``sha256:<hex>``) for one suite.
+
+    Raises KeyError if the suite is not in the config, or ValueError if its
+    code_paths match no files.
+    """
+    suites = load_config(repo_root)
+    if suite not in suites:
+        raise KeyError(f"unknown suite: {suite!r} (not in {CONFIG_REL})")
+    code_paths = suites[suite].get("code_paths", [])
+    files = resolve_files(repo_root, code_paths)
+    if not files:
+        raise ValueError(f"suite {suite!r} matched no files (code_paths={code_paths!r})")
+
+    digest = hashlib.sha256()
+    repo_root = Path(repo_root)
+    for path in files:
+        rel = path.relative_to(repo_root).as_posix()
+        # Bind path to content so a rename (same bytes, new path) is a real change.
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(path.read_bytes())
+        digest.update(b"\0")
+    return f"sha256:{digest.hexdigest()}"
+
+
+def is_skip_eligible(repo_root, suite):
+    """Return True iff the suite exists and is marked skip_eligible in the config.
+    An unknown suite is treated as not eligible.
+    """
+    suite_cfg = load_config(repo_root).get(suite)
+    return bool(suite_cfg and suite_cfg.get("skip_eligible"))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Compute suite_code_hash for a test suite.")
+    parser.add_argument("--suite", required=True, help="Suite name (key in test-suites.yml).")
+    parser.add_argument(
+        "--repo-root",
+        default=str(DEFAULT_REPO_ROOT),
+        help="Repo root (defaults to the checkout containing this script).",
+    )
+    parser.add_argument(
+        "--eligible-only",
+        action="store_true",
+        help="Print skip_eligible (true|false) for the suite instead of its hash.",
+    )
+    args = parser.parse_args(argv)
+    if args.eligible_only:
+        print("true" if is_skip_eligible(args.repo_root, args.suite) else "false")
+        return 0
+    try:
+        print(hash_suite_code(args.repo_root, args.suite))
+    except (KeyError, ValueError) as e:
+        print(str(e), file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test_skip/test_skip_db.py
+++ b/scripts/ci/test_skip/test_skip_db.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""dlc-ci-images test-skip cache: read (check skip) and write (record pass)."""
+
+import argparse
+import logging
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+import boto3
+from botocore.exceptions import BotoCoreError, ClientError
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+LOG = logging.getLogger(__name__)
+
+TABLE_NAME = "dlc-ci-images"
+TABLE_REGION = "us-west-2"
+# 3 day TTL for TEST rows for unforeseen edge cases. Layer caches are currently
+# set to refresh every 1 day in .github/actions/build-image/action.yml.
+# Test caches will thus be available for min{CACHE_REFRESH, TEST_ROW_TTL} = 1 day.
+TEST_ROW_TTL_SECONDS = 3 * 24 * 60 * 60
+
+
+def sort_key(suite, suite_code_hash):
+    return f"TEST#{suite}#{suite_code_hash}"
+
+
+def table_arn():
+    account = os.environ["CI_IMAGES_TABLE_ACCOUNT_ID"]
+    region = os.environ.get("CI_IMAGES_TABLE_REGION", TABLE_REGION)
+    name = os.environ.get("CI_IMAGES_TABLE_NAME", TABLE_NAME)
+    return f"arn:aws:dynamodb:{region}:{account}:table/{name}"
+
+
+def _client():
+    region = os.environ.get("CI_IMAGES_TABLE_REGION", TABLE_REGION)
+    return boto3.client("dynamodb", region_name=region)
+
+
+def check_test_pass(image_content_hash, suite_code_hashes, client=None):
+    """Return the set of suites that may be skipped, in one BatchGetItem.
+
+    ``suite_code_hashes`` maps suite name -> its suite_code_hash. A suite is in
+    the returned set iff a matching PASS row exists.
+    """
+    if not suite_code_hashes:
+        return set()
+    client = client or _client()
+    arn = table_arn()
+    sk_to_suite = {sort_key(s, h): s for s, h in suite_code_hashes.items()}
+    keys = [
+        {"image_content_hash": {"S": image_content_hash}, "sort_key": {"S": sk}}
+        for sk in sk_to_suite
+    ]
+    try:
+        resp = client.batch_get_item(RequestItems={arn: {"Keys": keys, "ConsistentRead": True}})
+    except (ClientError, BotoCoreError) as e:
+        LOG.warning("batch test-skip read failed (%s); running all suites", e)
+        return set()
+
+    hits = {item["sort_key"]["S"] for item in resp.get("Responses", {}).get(arn, [])}
+    skippable = {sk_to_suite[sk] for sk in hits if sk in sk_to_suite}
+    LOG.info(
+        "batch test-skip: %d/%d suites skippable for hash=%s",
+        len(skippable),
+        len(suite_code_hashes),
+        image_content_hash,
+    )
+    return skippable
+
+
+def record_test_pass(
+    image_content_hash, suite, suite_code_hash, client=None, now=None, ci_image_tag=None
+):
+    """Write the PASS row for a fully-passed suite."""
+    client = client or _client()
+    sk = sort_key(suite, suite_code_hash)
+    now = now if now is not None else time.time()
+    passed_at = datetime.fromtimestamp(now, tz=timezone.utc).isoformat()
+    ttl = int(now) + TEST_ROW_TTL_SECONDS
+    item = {
+        "image_content_hash": {"S": image_content_hash},
+        "sort_key": {"S": sk},
+        "passed_at": {"S": passed_at},
+        "ttl": {"N": str(ttl)},
+    }
+    if ci_image_tag:
+        item["ci_image_tag"] = {"S": ci_image_tag}
+    client.put_item(TableName=table_arn(), Item=item)
+    LOG.info("recorded PASS for suite=%s hash=%s sk=%s", suite, image_content_hash, sk)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="dlc-ci-images test-skip cache read/write.")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    common = argparse.ArgumentParser(add_help=False)
+    common.add_argument("--image-content-hash", required=True)
+    common.add_argument("--suite", required=True)
+    common.add_argument("--suite-code-hash", required=True)
+
+    record = sub.add_parser("record", parents=[common], help="Record a PASS row.")
+    record.add_argument(
+        "--ci-image-tag",
+        default=None,
+        help="CI image tag for the image build being tested.",
+    )
+
+    args = parser.parse_args(argv)
+
+    if args.command == "record":
+        record_test_pass(
+            args.image_content_hash,
+            args.suite,
+            args.suite_code_hash,
+            ci_image_tag=args.ci_image_tag,
+        )
+        return 0
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/test_skip/tests/test_config_matches_workflows.py
+++ b/scripts/ci/test_skip/tests/test_config_matches_workflows.py
@@ -1,0 +1,124 @@
+"""Consistency check: every suite a workflow invokes must exist in test-suites.yml."""
+
+import importlib.util
+import json
+import re
+from pathlib import Path
+
+import yaml
+
+# Extract the suite name out of the GitHub Actions expression, e.g.
+# fromJSON(needs.check.outputs.skips)['pytorch/unit'] -> pytorch/unit
+_ACCESSOR_RE = re.compile(r"outputs\.skips\)\s*(?:\[\s*['\"]([^'\"]+)['\"]\s*\]|\.([A-Za-z_]\w*))")
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
+TEST_SKIP_ACTIONS = ("check-test-pass", "record-test-pass")
+CHECK_WORKFLOW = "_reusable.check-test-pass.yml"
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "hash_suite_code.py"
+spec = importlib.util.spec_from_file_location("hash_suite_code", MODULE_PATH)
+hsc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hsc)
+
+
+def _iter_steps(workflow):
+    """Yield every step mapping across all jobs in a parsed workflow."""
+    jobs = workflow.get("jobs", {}) if isinstance(workflow, dict) else {}
+    for job in jobs.values():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps", []) or []:
+            if isinstance(step, dict):
+                yield step
+
+
+def _uses_test_skip_action(step):
+    uses = step.get("uses", "")
+    return isinstance(uses, str) and any(a in uses for a in TEST_SKIP_ACTIONS)
+
+
+def _suites_from_step(step):
+    """Yield the suite names that a step/job references, (skipping ${{ }} expressions)."""
+    with_ = step.get("with") or {}
+
+    suite = with_.get("suite")
+    if isinstance(suite, str) and "${{" not in suite:
+        yield suite
+
+    suites = with_.get("suites")
+    if isinstance(suites, str) and "${{" not in suites:
+        try:
+            parsed = json.loads(suites)
+        except (ValueError, TypeError):
+            parsed = None
+        if isinstance(parsed, list):
+            yield from (s for s in parsed if isinstance(s, str))
+
+
+def _check_suites(workflow):
+    """Return the set of suites the check job is asked to check."""
+    suites = set()
+    jobs = workflow.get("jobs", {}) if isinstance(workflow, dict) else {}
+    for job in jobs.values():
+        uses = job.get("uses", "") if isinstance(job, dict) else ""
+        if isinstance(uses, str) and CHECK_WORKFLOW in uses:
+            suites.update(_suites_from_step(job))
+    return suites
+
+
+def _check_accessor_keys(workflow):
+    """Yield suite keys read from the check output in any job `if:` condition."""
+    jobs = workflow.get("jobs", {}) if isinstance(workflow, dict) else {}
+    for job in jobs.values():
+        cond = job.get("if") if isinstance(job, dict) else None
+        if not isinstance(cond, str):
+            continue
+        for bracket, dotted in _ACCESSOR_RE.findall(cond):
+            yield bracket or dotted
+
+
+def collect_invoked_suites():
+    """Return [(workflow_file, suite), ...] for every test suite invoked by a workflow."""
+    invoked = []
+    for wf_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        try:
+            workflow = yaml.safe_load(wf_path.read_text())
+        except yaml.YAMLError:
+            continue
+        for step in _iter_steps(workflow):
+            if not _uses_test_skip_action(step):
+                continue
+            for suite in _suites_from_step(step):
+                invoked.append((wf_path.name, suite))
+        for suite in _check_suites(workflow):
+            invoked.append((wf_path.name, suite))
+    return invoked
+
+
+def test_invoked_suites_are_configured():
+    configured = set(hsc.load_config(REPO_ROOT))
+    invoked = collect_invoked_suites()
+    unknown = [(wf, s) for wf, s in invoked if s not in configured]
+    assert not unknown, (
+        "workflow steps invoke suites that are missing from .github/config/test-suites.yml "
+        f"(this test will never skip): {unknown}"
+    )
+
+
+def test_check_accessors_are_configured_and_checked():
+    """Every `skips[...]` key in a job `if:` must be a real suite AND one the check job checks."""
+    configured = set(hsc.load_config(REPO_ROOT))
+    problems = []
+    for wf_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        try:
+            workflow = yaml.safe_load(wf_path.read_text())
+        except yaml.YAMLError:
+            continue
+        check_suites = _check_suites(workflow)
+        for key in _check_accessor_keys(workflow):
+            if key not in configured:
+                problems.append((wf_path.name, key, "not in test-suites.yml"))
+            elif key not in check_suites:
+                problems.append((wf_path.name, key, "not in the check job's suites list"))
+    assert not problems, f"A job that is skippable was not checked by the check job: {problems}"

--- a/scripts/ci/test_skip/tests/test_hash_image_content.py
+++ b/scripts/ci/test_skip/tests/test_hash_image_content.py
@@ -1,0 +1,98 @@
+"""Unit tests for hash_image_content.
+
+image_content_hash = sha256 of the ordered list of RootFS.Layers DiffIDs, read
+from the pushed image's registry config (no layer pull). These tests exercise
+the pure hashing + parsing core.
+"""
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "hash_image_content.py"
+spec = importlib.util.spec_from_file_location("hash_image_content", MODULE_PATH)
+hic = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hic)
+
+
+DIFF_IDS = [
+    "sha256:aaaa000000000000000000000000000000000000000000000000000000000000",
+    "sha256:bbbb000000000000000000000000000000000000000000000000000000000000",
+    "sha256:cccc000000000000000000000000000000000000000000000000000000000000",
+]
+
+
+def test_hash_of_diff_ids_is_deterministic():
+    h1 = hic.hash_diff_ids(DIFF_IDS)
+    h2 = hic.hash_diff_ids(DIFF_IDS)
+    assert h1 == h2
+    assert h1.startswith("sha256:")
+
+
+def test_hash_is_order_sensitive():
+    reordered = [DIFF_IDS[1], DIFF_IDS[0], DIFF_IDS[2]]
+    assert hic.hash_diff_ids(DIFF_IDS) != hic.hash_diff_ids(reordered)
+
+
+def test_hash_changes_when_a_layer_changes():
+    changed = DIFF_IDS[:-1] + [
+        "sha256:dddd000000000000000000000000000000000000000000000000000000000000"
+    ]
+    assert hic.hash_diff_ids(DIFF_IDS) != hic.hash_diff_ids(changed)
+
+
+def test_empty_diff_ids_raises():
+    with pytest.raises(ValueError):
+        hic.hash_diff_ids([])
+
+
+def test_extract_diff_ids_from_single_platform_config():
+    config = {"rootfs": {"type": "layers", "diff_ids": DIFF_IDS}}
+    assert hic.extract_diff_ids(json.dumps(config), platform="linux/amd64") == DIFF_IDS
+
+
+def test_extract_diff_ids_rejects_multiarch_index():
+    payload = {
+        "linux/amd64": {"rootfs": {"diff_ids": DIFF_IDS}},
+        "linux/arm64": {"rootfs": {"diff_ids": ["sha256:ffff"]}},
+    }
+    with pytest.raises(ValueError):
+        hic.extract_diff_ids(json.dumps(payload), platform="linux/amd64")
+
+
+def test_extract_diff_ids_missing_rootfs_raises():
+    with pytest.raises(ValueError):
+        hic.extract_diff_ids(json.dumps({"config": {}}), platform="linux/amd64")
+
+
+def test_single_config_wrong_arch_raises():
+    config = {"architecture": "arm64", "os": "linux", "rootfs": {"diff_ids": DIFF_IDS}}
+    with pytest.raises(hic.PlatformNotFoundError):
+        hic.extract_diff_ids(json.dumps(config), platform="linux/amd64")
+
+
+def test_single_config_wrong_os_raises():
+    config = {"architecture": "amd64", "os": "windows", "rootfs": {"diff_ids": DIFF_IDS}}
+    with pytest.raises(hic.PlatformNotFoundError):
+        hic.extract_diff_ids(json.dumps(config), platform="linux/amd64")
+
+
+def test_single_config_matching_platform_ok():
+    config = {"architecture": "amd64", "os": "linux", "rootfs": {"diff_ids": DIFF_IDS}}
+    assert hic.extract_diff_ids(json.dumps(config), platform="linux/amd64") == DIFF_IDS
+
+
+def test_single_config_without_platform_fields_proceeds():
+    config = {"rootfs": {"diff_ids": DIFF_IDS}}
+    assert hic.extract_diff_ids(json.dumps(config), platform="linux/amd64") == DIFF_IDS
+
+
+def test_compute_end_to_end_with_stubbed_inspect(monkeypatch):
+    config = {"rootfs": {"type": "layers", "diff_ids": DIFF_IDS}}
+    monkeypatch.setattr(hic, "_inspect_image_config", lambda uri: json.dumps(config))
+    got = hic.compute_image_content_hash(
+        "123.dkr.ecr.us-west-2.amazonaws.com/ci:tag", platform="linux/amd64"
+    )
+    assert got == hic.hash_diff_ids(DIFF_IDS)

--- a/scripts/ci/test_skip/tests/test_hash_suite_code.py
+++ b/scripts/ci/test_skip/tests/test_hash_suite_code.py
@@ -1,0 +1,113 @@
+"""Unit tests for hash_suite_code.
+
+suite_code_hash must be a deterministic, order-independent function of the
+resolved file set's contents + relative paths, and must change iff a captured
+file's bytes or the set membership changes.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "hash_suite_code.py"
+spec = importlib.util.spec_from_file_location("hash_suite_code", MODULE_PATH)
+hsc = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(hsc)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """A fake repo root with a test-suites.yml and a small test tree."""
+    (tmp_path / ".github" / "config").mkdir(parents=True)
+    (tmp_path / "test" / "suitea" / "sub").mkdir(parents=True)
+    (tmp_path / "test" / "suiteb").mkdir(parents=True)
+    (tmp_path / "test" / "suitea" / "a.py").write_text("print('a')\n")
+    (tmp_path / "test" / "suitea" / "sub" / "b.py").write_text("print('b')\n")
+    (tmp_path / "test" / "suitea" / "top.ini").write_text("[x]\n")
+    (tmp_path / "test" / "suiteb" / "c.py").write_text("print('c')\n")
+    (tmp_path / ".github" / "config" / "test-suites.yml").write_text(
+        "suites:\n"
+        "  suitea:\n"
+        "    skip_eligible: true\n"
+        "    code_paths:\n"
+        "      - test/suitea/**\n"
+        "      - test/suitea/top.ini\n"
+        "  suiteb:\n"
+        "    skip_eligible: true\n"
+        "    code_paths:\n"
+        "      - test/suiteb/**\n"
+        "  security:\n"
+        "    skip_eligible: false\n"
+        "    code_paths:\n"
+        "      - test/security/**\n"
+    )
+    return tmp_path
+
+
+def test_hash_is_deterministic(repo):
+    h1 = hsc.hash_suite_code(repo, "suitea")
+    h2 = hsc.hash_suite_code(repo, "suitea")
+    assert h1 == h2
+    assert h1.startswith("sha256:")
+
+
+def test_hash_changes_when_a_captured_file_changes(repo):
+    before = hsc.hash_suite_code(repo, "suitea")
+    (repo / "test" / "suitea" / "a.py").write_text("print('changed')\n")
+    after = hsc.hash_suite_code(repo, "suitea")
+    assert before != after
+
+
+def test_hash_changes_when_a_file_is_added_to_the_subtree(repo):
+    before = hsc.hash_suite_code(repo, "suitea")
+    (repo / "test" / "suitea" / "sub" / "new.py").write_text("print('new')\n")
+    after = hsc.hash_suite_code(repo, "suitea")
+    assert before != after
+
+
+def test_hash_changes_when_a_captured_file_is_removed(repo):
+    before = hsc.hash_suite_code(repo, "suitea")
+    (repo / "test" / "suitea" / "sub" / "b.py").unlink()
+    after = hsc.hash_suite_code(repo, "suitea")
+    assert before != after
+
+
+def test_unrelated_suite_change_does_not_affect_hash(repo):
+    before = hsc.hash_suite_code(repo, "suitea")
+    (repo / "test" / "suiteb" / "c.py").write_text("print('unrelated')\n")
+    after = hsc.hash_suite_code(repo, "suitea")
+    assert before == after
+
+
+def test_distinct_suites_hash_differently(repo):
+    assert hsc.hash_suite_code(repo, "suitea") != hsc.hash_suite_code(repo, "suiteb")
+
+
+def test_unknown_suite_raises(repo):
+    with pytest.raises(KeyError):
+        hsc.hash_suite_code(repo, "does-not-exist")
+
+
+def test_suite_matching_no_files_raises(repo):
+    with pytest.raises(ValueError):
+        hsc.hash_suite_code(repo, "security")
+
+
+def test_is_skip_eligible(repo):
+    assert hsc.is_skip_eligible(repo, "suitea") is True
+    assert hsc.is_skip_eligible(repo, "security") is False
+
+
+def test_unknown_suite_is_not_skip_eligible(repo):
+    assert hsc.is_skip_eligible(repo, "does-not-exist") is False
+
+
+def test_moving_a_file_changes_hash(repo):
+    before = hsc.hash_suite_code(repo, "suitea")
+    src = repo / "test" / "suitea" / "a.py"
+    content = src.read_text()
+    src.unlink()
+    (repo / "test" / "suitea" / "renamed.py").write_text(content)
+    after = hsc.hash_suite_code(repo, "suitea")
+    assert before != after

--- a/scripts/ci/test_skip/tests/test_test_skip_db.py
+++ b/scripts/ci/test_skip/tests/test_test_skip_db.py
@@ -1,0 +1,114 @@
+"""Unit tests for the dlc-ci-images test-skip store read/write."""
+
+import importlib.util
+import os
+from pathlib import Path
+from unittest import mock
+
+import boto3
+import pytest
+from moto import mock_aws
+
+MODULE_PATH = Path(__file__).resolve().parent.parent / "test_skip_db.py"
+spec = importlib.util.spec_from_file_location("store", MODULE_PATH)
+store = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(store)
+
+HASH = "sha256:abc123"
+SUITE = "pytorch/single_gpu"
+CODE_HASH = "sha256:def456"
+OTHER_SUITE = "sanity"
+OTHER_CODE_HASH = "sha256:ghi789"
+
+
+@pytest.fixture
+def dynamo():
+    """A moto DynamoDB with the cache table, wired so table_arn() resolves to it."""
+    with mock_aws():
+        client = boto3.client("dynamodb", region_name=store.TABLE_REGION)
+        with mock.patch.dict(os.environ, {"CI_IMAGES_TABLE_ACCOUNT_ID": "123456789012"}):
+            client.create_table(
+                TableName=store.TABLE_NAME,
+                AttributeDefinitions=[
+                    {"AttributeName": "image_content_hash", "AttributeType": "S"},
+                    {"AttributeName": "sort_key", "AttributeType": "S"},
+                ],
+                KeySchema=[
+                    {"AttributeName": "image_content_hash", "KeyType": "HASH"},
+                    {"AttributeName": "sort_key", "KeyType": "RANGE"},
+                ],
+                BillingMode="PAY_PER_REQUEST",
+            )
+            yield client
+
+
+def _get_row(client):
+    return client.get_item(
+        TableName=store.table_arn(),
+        Key={
+            "image_content_hash": {"S": HASH},
+            "sort_key": {"S": store.sort_key(SUITE, CODE_HASH)},
+        },
+    )["Item"]
+
+
+def test_sort_key_format():
+    assert store.sort_key("sanity", "sha256:7c1e") == "TEST#sanity#sha256:7c1e"
+
+
+def test_record_writes_ci_image_tag_attribute(dynamo):
+    ci_image_tag = "sglang-ec2-amzn2023-0.5.12.dlc1-gpu-py312-cu130-pr-123"
+    store.record_test_pass(HASH, SUITE, CODE_HASH, client=dynamo, ci_image_tag=ci_image_tag)
+    assert _get_row(dynamo)["ci_image_tag"]["S"] == ci_image_tag
+
+
+def test_record_omits_ci_image_tag_when_not_given(dynamo):
+    store.record_test_pass(HASH, SUITE, CODE_HASH, client=dynamo)
+    assert "ci_image_tag" not in _get_row(dynamo)
+
+
+def test_record_omits_ci_image_tag_when_empty_string(dynamo):
+    store.record_test_pass(HASH, SUITE, CODE_HASH, client=dynamo, ci_image_tag="")
+    assert "ci_image_tag" not in _get_row(dynamo)
+
+
+def test_check_test_pass_empty_input_returns_empty(dynamo):
+    assert store.check_test_pass(HASH, {}, client=dynamo) == set()
+
+
+def test_check_test_pass_all_miss_returns_empty(dynamo):
+    result = store.check_test_pass(
+        HASH, {SUITE: CODE_HASH, OTHER_SUITE: OTHER_CODE_HASH}, client=dynamo
+    )
+    assert result == set()
+
+
+def test_check_test_pass_returns_only_recorded_suites(dynamo):
+    store.record_test_pass(HASH, SUITE, CODE_HASH, client=dynamo)
+    # OTHER_SUITE is not recorded, so only SUITE should come back as a hit.
+    result = store.check_test_pass(
+        HASH, {SUITE: CODE_HASH, OTHER_SUITE: OTHER_CODE_HASH}, client=dynamo
+    )
+    assert result == {SUITE}
+
+
+def test_check_test_pass_returns_multiple_hits(dynamo):
+    store.record_test_pass(HASH, SUITE, CODE_HASH, client=dynamo)
+    store.record_test_pass(HASH, OTHER_SUITE, OTHER_CODE_HASH, client=dynamo)
+    result = store.check_test_pass(
+        HASH, {SUITE: CODE_HASH, OTHER_SUITE: OTHER_CODE_HASH}, client=dynamo
+    )
+    assert result == {SUITE, OTHER_SUITE}
+
+
+def test_check_test_pass_respects_code_hash(dynamo):
+    store.record_test_pass(HASH, SUITE, CODE_HASH, client=dynamo)
+    # Same suite, different code hash -> no hit.
+    result = store.check_test_pass(HASH, {SUITE: "sha256:changed"}, client=dynamo)
+    assert result == set()
+
+
+def test_check_test_pass_respects_image_hash(dynamo):
+    store.record_test_pass(HASH, SUITE, CODE_HASH, client=dynamo)
+    result = store.check_test_pass("sha256:different", {SUITE: CODE_HASH}, client=dynamo)
+    assert result == set()


### PR DESCRIPTION
## ⚠️ TESTING ONLY — do not review or merge

This PR exists solely to validate the content-addressed **test-skip cache** wiring end-to-end on real CI runs. It is **not** intended for review or merge.

### What it does
Wires the existing test-skip actions into the **sglang** pipeline for the `sanity` and `telemetry` suites:
- New `check-test-skip` job computes the `image_content_hash` + each suite's `suite_code_hash` and reads `dlc-ci-images` to see which suites already passed for this exact image content + test code.
- `sanity-test` / `telemetry-test` are gated on that result (skip on a cache hit).
- On a full suite pass, a `record-pass` job writes the PASS row so a future run on identical content can skip.

### Validation plan
1. **This PR** — a Dockerfile marker forces a fresh `image_content_hash`; expect a rebuild, sanity + telemetry to run, and two PASS rows written to `dlc-ci-images` (**write path**).
2. **Follow-up no-op push** — expect the check job to hit the cache and skip sanity + telemetry (**read + skip path**).

### ⚠️ Scaffolding that must never merge
- `docker/sglang/Dockerfile.amzn2023` adds a throwaway marker layer (`/etc/dlc_test_skip_marker`) purely to bust the image content hash. Revert before any real merge.
