### PR TITLE
docs(vllm-omni): add available-image versions v1.2-v1.5

### DIFF
--- a/docs/src/data/vllm-omni/0.20.0-v1.2-gpu-ec2.yml
+++ b/docs/src/data/vllm-omni/0.20.0-v1.2-gpu-ec2.yml
@@ -1,0 +1,12 @@
+framework: vLLM-Omni
+version: "0.20.0"
+ecr_repository: vllm
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: default
+public_registry: true
+
+tags:
+  - "omni-cuda-v1.2"

--- a/docs/src/data/vllm-omni/0.20.0-v1.2-gpu-sagemaker.yml
+++ b/docs/src/data/vllm-omni/0.20.0-v1.2-gpu-sagemaker.yml
@@ -1,0 +1,12 @@
+framework: vLLM-Omni
+version: "0.20.0"
+ecr_repository: vllm
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: sagemaker
+public_registry: true
+
+tags:
+  - "omni-sagemaker-cuda-v1.2"

--- a/docs/src/data/vllm-omni/0.21.0rc1-v1.3-gpu-ec2.yml
+++ b/docs/src/data/vllm-omni/0.21.0rc1-v1.3-gpu-ec2.yml
@@ -1,0 +1,12 @@
+framework: vLLM-Omni
+version: "0.21.0rc1"
+ecr_repository: vllm
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: default
+public_registry: true
+
+tags:
+  - "omni-cuda-v1.3"

--- a/docs/src/data/vllm-omni/0.21.0rc1-v1.3-gpu-sagemaker.yml
+++ b/docs/src/data/vllm-omni/0.21.0rc1-v1.3-gpu-sagemaker.yml
@@ -1,0 +1,12 @@
+framework: vLLM-Omni
+version: "0.21.0rc1"
+ecr_repository: vllm
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: sagemaker
+public_registry: true
+
+tags:
+  - "omni-sagemaker-cuda-v1.3"

--- a/docs/src/data/vllm-omni/0.21.0rc1-v1.4-gpu-ec2.yml
+++ b/docs/src/data/vllm-omni/0.21.0rc1-v1.4-gpu-ec2.yml
@@ -1,0 +1,12 @@
+framework: vLLM-Omni
+version: "0.21.0rc1"
+ecr_repository: vllm
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: default
+public_registry: true
+
+tags:
+  - "omni-cuda-v1.4"

--- a/docs/src/data/vllm-omni/0.21.0rc1-v1.4-gpu-sagemaker.yml
+++ b/docs/src/data/vllm-omni/0.21.0rc1-v1.4-gpu-sagemaker.yml
@@ -1,0 +1,12 @@
+framework: vLLM-Omni
+version: "0.21.0rc1"
+ecr_repository: vllm
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: sagemaker
+public_registry: true
+
+tags:
+  - "omni-sagemaker-cuda-v1.4"

--- a/docs/src/data/vllm-omni/0.26.0-gpu-ec2.yml
+++ b/docs/src/data/vllm-omni/0.26.0-gpu-ec2.yml
@@ -1,0 +1,12 @@
+framework: vLLM-Omni
+version: "0.26.0"
+ecr_repository: vllm
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: default
+public_registry: true
+
+tags:
+  - "omni-cuda-v1.5"

--- a/docs/src/data/vllm-omni/0.26.0-gpu-sagemaker.yml
+++ b/docs/src/data/vllm-omni/0.26.0-gpu-sagemaker.yml
@@ -1,0 +1,12 @@
+framework: vLLM-Omni
+version: "0.26.0"
+ecr_repository: vllm
+accelerator: gpu
+python: py312
+cuda: cu130
+os: amzn2023
+platform: sagemaker
+public_registry: true
+
+tags:
+  - "omni-sagemaker-cuda-v1.5"


### PR DESCRIPTION
## Summary

The vLLM-Omni available-images listing (`docs/src/data/vllm-omni/`) had stopped at v1.1 (0.20.0) and was missing every DLC release since. This adds one data file per DLC release per platform, bringing the listing current through **v1.5 (0.26.0)**.

| DLC release | Framework version | CUDA | Python | Tags (EC2 · SageMaker) |
|---|---|---|---|---|
| v1.2 | 0.20.0 | cu130 | py312 | `omni-cuda-v1.2` · `omni-sagemaker-cuda-v1.2` |
| v1.3 | 0.21.0rc1 | cu130 | py312 | `omni-cuda-v1.3` · `omni-sagemaker-cuda-v1.3` |
| v1.4 | 0.21.0rc1 | cu130 | py312 | `omni-cuda-v1.4` · `omni-sagemaker-cuda-v1.4` |
| v1.5 | 0.26.0 | cu130 | py312 | `omni-cuda-v1.5` · `omni-sagemaker-cuda-v1.5` |

(v1.0/0.18.0 and v1.1/0.20.0 already had data files.)

## Sourcing

- Versions and tags: `docs/vllm-omni/changelog/index.md`.
- CUDA / Python: verified against `docker/vllm_omni/Dockerfile.amzn2023` (`CUDA_VERSION=13.0.2`, `PYTHON_VERSION=3.12`) at HEAD and at the v1.3 release commit.

## Notes

- **One file per DLC release**, matching the existing v1.0/v1.1 pattern. v1.2 and v1.4 repeat their framework versions (0.20.0, 0.21.0rc1) because those DLC minors shipped without a framework bump — each is a distinct, independently pinnable tag.
- Filenames disambiguate the shared-version releases (`0.20.0-v1.2-…`, `0.21.0rc1-v1.3-…`, `0.21.0rc1-v1.4-…`); v1.5 uses the bare `0.26.0-…` convention.
- Each file lists only its per-minor patch-floating tag (`omni-*-cuda-v1.N`), consistent with the existing files; the minor-floating `omni-*-cuda-v1` tag is documented separately in `docs/vllm-omni/index.md`.

## Test plan

- [x] `python docs/src/main.py --available-images-only` regenerates cleanly (no errors); the vLLM-Omni table goes 4 → 12 rows.
- [x] `pytest test/docs` → 74 passed.
- [x] Spot-check the rendered available-images table after merge.
