### PR TITLE
add(docs): enable autocurrency for huggingface-vllm

### DIFF
--- a/.github/config/autocurrency-tracker.yml
+++ b/.github/config/autocurrency-tracker.yml
@@ -39,3 +39,18 @@ frameworks:
       - path: "docker/sglang/Dockerfile"
         base_image_template: "lmsysorg/sglang:v{version}"
     version_detection: true
+
+  huggingface-vllm:
+    github_repo: "vllm-project/vllm"
+    tag_prefix: "v"
+    # Layered on the AWS vLLM DLC: only open the auto-update PR once the
+    # vllm:{version}-*-sagemaker base image exists on ECR.
+    wait_for_base_image: true
+    config_files:
+      - path: ".github/config/image/huggingface-vllm/sagemaker.yml"
+        prod_image_template: "huggingface-vllm:{major}.{minor}-gpu-py312-cu130-ubuntu22.04"
+        base_image_template: "public.ecr.aws/deep-learning-containers/vllm:{version}-gpu-py312-cu130-ubuntu22.04-sagemaker-v1.0"
+    dockerfiles:
+      - path: "docker/huggingface/vllm/Dockerfile"
+        base_image_template: "public.ecr.aws/deep-learning-containers/vllm:{version}-gpu-py312-cu130-ubuntu22.04-sagemaker-v1.0"
+    version_detection: true

--- a/docs/src/data/huggingface-vllm/0.26.0-gpu-sagemaker.yml
+++ b/docs/src/data/huggingface-vllm/0.26.0-gpu-sagemaker.yml
@@ -1,0 +1,11 @@
+framework: vLLM
+version: "0.26.0"
+accelerator: gpu
+python: py312
+cuda: cu130
+transformers: "5.10.2"
+os: ubuntu22.04
+platform: sagemaker
+
+tags:
+  - "0.26.0-transformers5.10.2-gpu-py312-cu130-ubuntu22.04"

--- a/docs/src/data/huggingface-vllm/0.27.1-gpu-sagemaker.yml
+++ b/docs/src/data/huggingface-vllm/0.27.1-gpu-sagemaker.yml
@@ -1,0 +1,11 @@
+framework: vLLM
+version: "0.27.1"
+accelerator: gpu
+python: py312
+cuda: cu130
+transformers: "5.10.2"
+os: ubuntu22.04
+platform: sagemaker
+
+tags:
+  - "0.27.1-transformers5.10.2-gpu-py312-cu130-ubuntu22.04"

--- a/scripts/ci/autocurrency/check-upstream-releases.sh
+++ b/scripts/ci/autocurrency/check-upstream-releases.sh
@@ -204,6 +204,27 @@ for framework in ${FRAMEWORKS}; do
     echo "${framework}: New version detected! ${current_version} -> ${latest_version}"
 
     # -----------------------------------------------------------------
+    # Optional: wait for the base image to be published first.
+    # Frameworks layered on another DLC (e.g. huggingface-vllm on the AWS
+    # vLLM image) must not open an auto-update PR before the base exists —
+    # its CI build would fail until then. Skip quietly and retry on the
+    # next scheduled run.
+    # -----------------------------------------------------------------
+    wait_for_base=$(yq eval ".frameworks.${framework}.wait_for_base_image // false" "${TRACKER_FILE}")
+    if [[ "${wait_for_base}" == "true" ]]; then
+      base_template=$(yq eval ".frameworks.${framework}.config_files[0].base_image_template // \"\"" "${TRACKER_FILE}")
+      if [[ -n "${base_template}" && "${base_template}" != "null" ]]; then
+        base_image="${base_template//\{version\}/${latest_version}}"
+        echo "${framework}: wait_for_base_image — checking ${base_image}"
+        if ! base_image_exists "${base_image}"; then
+          echo "${framework}: Base image not available yet. Skipping; will retry on the next run."
+          exit 0
+        fi
+        echo "${framework}: Base image is available."
+      fi
+    fi
+
+    # -----------------------------------------------------------------
     # Check if branch already exists (idempotency guard)
     # -----------------------------------------------------------------
     branch_name="auto-update/${framework}-${latest_version}"

--- a/scripts/ci/autocurrency/docs-pr.sh
+++ b/scripts/ci/autocurrency/docs-pr.sh
@@ -103,6 +103,7 @@ OS=$(yq '.os_version' "$RELEASE_SPEC")
 PLATFORM=$(yq '.customer_type' "$RELEASE_SPEC")
 DEVICE=$(yq '.device_type' "$RELEASE_SPEC")
 PUBLIC_REGISTRY=$(yq '.public_registry' "$RELEASE_SPEC")
+TRANSFORMERS=$(yq '.transformers_version // ""' "$RELEASE_SPEC")
 
 TRACKER="${REPO_ROOT}/${TRACKER_FILE:-".github/config/autocurrency-tracker.yml"}"
 
@@ -160,31 +161,38 @@ echo "============================================================"
 
 display_name=$(get_display_name "$FRAMEWORK")
 
-tags=$(generate_tags "$VERSION" "$DEVICE" "$PYTHON" "$CUDA" "$OS" "$PLATFORM")
-tag1=$(echo "$tags" | sed -n '1p')
-tag2=$(echo "$tags" | sed -n '2p')
-tag3=$(echo "$tags" | sed -n '3p')
-tag4=$(echo "$tags" | sed -n '4p')
+# HuggingFace-contributed images carry transformers_version in the release spec
+# and publish transformers-scoped tags (e.g.
+# 0.27.1-transformers5.10.2-gpu-py312-cu130-ubuntu22.04); the AWS-scheme tags
+# from generate_tags do not exist in those ECR repos. The docs convention for
+# these families is the single canonical tag.
+if [[ -n "${TRANSFORMERS}" && "${TRANSFORMERS}" != "null" ]]; then
+  tags="${VERSION}-transformers${TRANSFORMERS}-${DEVICE}-${PYTHON}-${CUDA}-${OS}"
+else
+  tags=$(generate_tags "$VERSION" "$DEVICE" "$PYTHON" "$CUDA" "$OS" "$PLATFORM")
+fi
 
 output_dir="$(dirname "$OUTPUT_FILE")"
 mkdir -p "$output_dir"
 
-cat > "$OUTPUT_FILE" <<EOF
-framework: ${display_name}
-version: "${VERSION}"
-accelerator: ${DEVICE}
-python: ${PYTHON}
-cuda: ${CUDA}
-os: ${OS}
-platform: ${PLATFORM}
-public_registry: ${PUBLIC_REGISTRY}
-
-tags:
-  - "${tag1}"
-  - "${tag2}"
-  - "${tag3}"
-  - "${tag4}"
-EOF
+{
+  echo "framework: ${display_name}"
+  echo "version: \"${VERSION}\""
+  echo "accelerator: ${DEVICE}"
+  echo "python: ${PYTHON}"
+  echo "cuda: ${CUDA}"
+  if [[ -n "${TRANSFORMERS}" && "${TRANSFORMERS}" != "null" ]]; then
+    echo "transformers: \"${TRANSFORMERS}\""
+  fi
+  echo "os: ${OS}"
+  echo "platform: ${PLATFORM}"
+  echo "public_registry: ${PUBLIC_REGISTRY}"
+  echo ""
+  echo "tags:"
+  while IFS= read -r tag; do
+    echo "  - \"${tag}\""
+  done <<< "${tags}"
+} > "$OUTPUT_FILE"
 
 echo "✅ Generated docs data file: ${OUTPUT_FILE}"
 cat "$OUTPUT_FILE"

--- a/scripts/ci/autocurrency/utils.sh
+++ b/scripts/ci/autocurrency/utils.sh
@@ -291,3 +291,52 @@ send_release_notification() {
     return 1
   fi
 }
+
+###############################################################################
+# base_image_exists(image_ref)
+#   Checks whether a container image exists in its registry, without pulling.
+#   Supports public.ecr.aws/<repo>:<tag> via the anonymous token API.
+#
+#   Exit codes: 0 = exists, 1 = definitively absent (HTTP 404).
+#   Any lookup error (network, token, unexpected status) logs a warning and
+#   returns 0 — the gate fails open so a transient error never blocks an
+#   auto-update; only a clean 404 means "not published yet".
+#
+#   Usage: base_image_exists "public.ecr.aws/deep-learning-containers/vllm:0.27.1-gpu-py312"
+###############################################################################
+base_image_exists() {
+  local image="${1:?Usage: base_image_exists IMAGE_REF}"
+
+  case "${image}" in
+    public.ecr.aws/*)
+      local repo_tag="${image#public.ecr.aws/}"
+      local repo="${repo_tag%%:*}"
+      local tag="${repo_tag#*:}"
+
+      local token
+      token=$(curl -sf --max-time 10 "https://public.ecr.aws/token/" | jq -r '.token') || {
+        echo "Warning: could not fetch public.ecr.aws token; assuming ${image} exists" >&2
+        return 0
+      }
+
+      local http_code
+      http_code=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+        -H "Authorization: Bearer ${token}" \
+        -H "Accept: application/vnd.oci.image.manifest.v1+json, application/vnd.docker.distribution.manifest.v2+json, application/vnd.oci.image.index.v1+json, application/vnd.docker.distribution.manifest.list.v2+json" \
+        "https://public.ecr.aws/v2/${repo}/manifests/${tag}")
+
+      case "${http_code}" in
+        200) return 0 ;;
+        404) return 1 ;;
+        *)
+          echo "Warning: existence check for ${image} returned HTTP ${http_code}; assuming it exists" >&2
+          return 0
+          ;;
+      esac
+      ;;
+    *)
+      echo "Warning: base_image_exists does not know how to check '${image}'; assuming it exists" >&2
+      return 0
+      ;;
+  esac
+}


### PR DESCRIPTION
## Purpose

huggingface-vllm 0.26.0 and 0.27.1 are published on ECR but missing from the Available Images page. Root cause: `docs-pr.sh` skips frameworks not defined in the autocurrency tracker, and huggingface-vllm was never added (past entries were manual: #6393, #6429).

This PR:

1. **Adds the two missing available-images entries** (0.26.0, 0.27.1 — both already live on ECR).
2. **Adds huggingface-vllm to the autocurrency tracker**, so future releases get the docs entry auto-generated at release time.
3. **Gates the version auto-bump on base-image availability** (`wait_for_base_image: true`). huggingface-vllm layers on the AWS vLLM DLC, so an upstream vllm release does not imply a usable base image. With the flag set, the checker verifies the rendered base image exists on ECR before opening the auto-update PR — the PR arrives green instead of failing CI until the base is published. The flag is opt-in; `vllm`/`sglang` behavior is unchanged. The existence check is an anonymous HTTPS call to public.ecr.aws (no credentials) and fails open on lookup errors, so a transient error never blocks an update.
4. **Fixes the tag scheme in `docs-pr.sh`** for HF-contributed images: they publish transformers-scoped tags (`0.27.1-transformers5.10.2-gpu-py312-cu130-ubuntu22.04`), which the AWS-scheme `generate_tags` would get wrong. Detected via `transformers_version` in the release spec; AWS path unchanged.

## Test Plan

- `base_image_exists` run against live public ECR: existing tag → exists; nonexistent tag → absent; unknown registry → warn + proceed.
- Gate block executed against the real tracker config: base published → PR proceeds; base missing → clean skip; frameworks without the flag → gate off.
- `docs-pr.sh` generation simulated for both paths: HF output matches the published ECR tag exactly; AWS output identical to before.
- `mkdocs build --strict` + `pytest test/docs` (74/74) pass; both new tags render in the generated available_images page.

## Test Result

All of the above pass locally. The full checker run happens in CI (the script requires bash 4+).

______________________________________________________________________

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [x] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>