### PR TITLE
[auto-cve-patch] [pytorch] prune stale rustsec entries from framework_allowlist

### DIFF
--- a/test/security/data/ecr_scan_allowlist/pytorch_runtime/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/pytorch_runtime/framework_allowlist.json
@@ -1,12 +1,1 @@
-[
-    {
-        "vulnerability_id": "RUSTSEC-2026-0195",
-        "reason": "quick-xml 0.39.2 is bundled inside the uv binary at /usr/local/bin/uv (uv is statically compiled Rust). Advisory is a denial-of-service in NsReader's namespace resolution during Start/Empty XML event handling; the vulnerable code path is only reachable when uv parses attacker-controlled XML (e.g. a hostile PyPI mirror index). uv is retained in the image for customer-side venv management; the standard PyPI flow uses JSON/HTML endpoints and never exercises the XML path. No uv release containing the patched quick-xml>=0.41.0 has been published upstream yet; will swap to a pinned fixed version and drop this entry when upstream ships.",
-        "review_by": "2026-10-25"
-    },
-    {
-        "vulnerability_id": "RUSTSEC-2026-0185",
-        "reason": "quinn-proto bundled inside the uv binary (/usr/local/bin/uv). uv is shipped for customer use (e.g. venv management); cannot be patched independently of an upstream uv release.",
-        "review_by": "2026-09-30"
-    }
-]
+[]


### PR DESCRIPTION
## Purpose

Prune stale allowlist entries from `pytorch_runtime/framework_allowlist.json`. Both entries reference vulnerabilities in the bundled `uv` binary at `/usr/local/bin/uv`, which no longer ships in current pytorch DLC images.

## Images affected

All pytorch DLC images across framework_versions `2.11.0`, `2.12.1`, `2.13.0` (12 variants: `pytorch:2.11-cpu-amzn2023{,-sagemaker}`, `pytorch:2.11-cu130-amzn2023{,-sagemaker}`, `pytorch:2.12-cpu-amzn2023{,-sagemaker}`, `pytorch:2.12-cu130-amzn2023{,-sagemaker}`, `pytorch:2.13-cpu-amzn2023{,-sagemaker}`, `pytorch:2.13-cu133-amzn2023{,-sagemaker}`).

## Prunes

Two entries removed from `test/security/data/ecr_scan_allowlist/pytorch_runtime/framework_allowlist.json`:

- `RUSTSEC-2026-0195` (quick-xml bundled in `uv`)
- `RUSTSEC-2026-0185` (quinn-proto bundled in `uv`)

Verified against the current DLC-prod images: the `uv` binary is no longer present (`/usr/local/bin/uv` returns `No such file or directory`). Both CVEs are absent from the latest scans across all 12 pytorch variants (verified against today's raw ECR Inspector dumps).

## Test plan

- [ ] CI security tests pass for all affected pytorch variants
- [ ] CI sanity tests pass

---
🤖 Generated by [Claude Code](https://claude.com/claude-code).
