### PR TITLE
feat(vllm): pin AL2023 EC2 + SM images to Muse Glimmer preview commit

### DIFF
--- a/.github/config/image/vllm/ec2-amzn2023.yml
+++ b/.github/config/image/vllm/ec2-amzn2023.yml
@@ -17,8 +17,6 @@ build:
   target: "vllm-ec2-amzn2023"
   python_version: "3.12"
   cuda_version: "13.0.2"
-  # Preview pin: adds Muse Glimmer model support (vllm-project/vllm#51655),
-  # not yet in any released tag. Nearest ancestor tag: v0.26.1rc0.
   vllm_ref: "6adad08767583f52eb4d2122111af0bf638ed5e6"
   flashinfer_version: "0.6.15.post1"
   deepep_commit_hash: "d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb"

--- a/.github/config/image/vllm/ec2-amzn2023.yml
+++ b/.github/config/image/vllm/ec2-amzn2023.yml
@@ -17,11 +17,13 @@ build:
   target: "vllm-ec2-amzn2023"
   python_version: "3.12"
   cuda_version: "13.0.2"
-  vllm_ref: "d223c900d85224c02f2162ee2c757a769e99f519"
+  # Preview pin: adds Muse Glimmer model support (vllm-project/vllm#51655),
+  # not yet in any released tag. Nearest ancestor tag: v0.26.1rc0.
+  vllm_ref: "6adad08767583f52eb4d2122111af0bf638ed5e6"
   flashinfer_version: "0.6.15.post1"
   deepep_commit_hash: "d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb"
   dlc_major_version: "2"
-  dlc_minor_version: "2"
+  dlc_minor_version: "5"
   use_sccache: "true"
 
 release:

--- a/.github/config/image/vllm/sagemaker-amzn2023.yml
+++ b/.github/config/image/vllm/sagemaker-amzn2023.yml
@@ -18,9 +18,6 @@ build:
   target: "vllm-sagemaker-amzn2023"
   python_version: "3.12"
   cuda_version: "13.0.2"
-  # Preview pin: adds Muse Glimmer model support (vllm-project/vllm#51655),
-  # not yet in any released tag. Nearest ancestor tag: v0.26.1rc0.
-  # Kept in lockstep with ec2-amzn2023.yml -- same Dockerfile.
   vllm_ref: "6adad08767583f52eb4d2122111af0bf638ed5e6"
   flashinfer_version: "0.6.15.post1"
   deepep_commit_hash: "d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb"

--- a/.github/config/image/vllm/sagemaker-amzn2023.yml
+++ b/.github/config/image/vllm/sagemaker-amzn2023.yml
@@ -18,11 +18,14 @@ build:
   target: "vllm-sagemaker-amzn2023"
   python_version: "3.12"
   cuda_version: "13.0.2"
-  vllm_ref: "d223c900d85224c02f2162ee2c757a769e99f519"
+  # Preview pin: adds Muse Glimmer model support (vllm-project/vllm#51655),
+  # not yet in any released tag. Nearest ancestor tag: v0.26.1rc0.
+  # Kept in lockstep with ec2-amzn2023.yml -- same Dockerfile.
+  vllm_ref: "6adad08767583f52eb4d2122111af0bf638ed5e6"
   flashinfer_version: "0.6.15.post1"
   deepep_commit_hash: "d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb"
   dlc_major_version: "2"
-  dlc_minor_version: "2"
+  dlc_minor_version: "5"
   use_sccache: "true"
 
 release:


### PR DESCRIPTION
## What

Bumps \`vllm_ref\` on both AL2023 vLLM image configs from \`d223c90\` to **\`6adad08\`** and bumps \`dlc_minor_version\` 2 → 5.

- \`.github/config/image/vllm/ec2-amzn2023.yml\`
- \`.github/config/image/vllm/sagemaker-amzn2023.yml\`

## Why

\`6adad08\` is the merge commit of [vllm-project/vllm#51655](https://github.com/vllm-project/vllm/pull/51655) — "Add Muse Glimmer model support". It adds \`MuseGlimmerForCausalLM\` to the vLLM model registry (plus the model, config, tool/reasoning parsers, and processor). This commit is **only on vLLM \`main\`** — it is absent from every released tag (v0.26.x, v0.27.0, v0.27.1). Pinning to it makes these the first DLC images that can serve \`meta-models/Muse-Glimmer-30B\`.

## Notes

- **Preview pin.** Same config-only \`vllm_ref\` approach used for the prior \`d223c90\` pin.
- **Divergence is expected.** \`git describe\` gives \`v0.26.1rc0-769-g6adad08\`: the nearest *ancestor* tag on main is \`v0.26.1rc0\`. vLLM tags releases on release branches that are not merged back to main, so main carries the v0.27.x content via the original PRs while the tag commits themselves are not ancestors. This is the normal release-branch topology, not missing content.
- \`framework_version\` left at \`0.26.0\`; the \`dlc_minor_version\` bump (2.5) differentiates this build. \`2.4\` is intentionally skipped (in use elsewhere).