### PR TITLE
sec(tensorflow): pin sqlparse>=0.6.0 in TF 2.21 training images

### DIFF
--- a/docker/tensorflow/2.21/cpu/pyproject.toml
+++ b/docker/tensorflow/2.21/cpu/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pyasn1>=0.6.4",  # CVE-2026-59885 + CVE-2026-59886 (HIGH)
     "keras>=3.15.0",  # CVE-2026-12481 (CRITICAL) + CVE-2026-12484 (HIGH)
     "jupyterlab>=4.6.0",  # GHSA-pppj-hq3g-57pj + GHSA-gx64-gj6p-pc4c (HIGH)
+    "sqlparse>=0.6.0",  # CVE-2026-71491 + CVE-2026-54284 + CVE-2026-59893 (HIGH)
     "numpy>=2.1,<2.5",
     "requests",
     "packaging",

--- a/docker/tensorflow/2.21/cpu/uv.lock
+++ b/docker/tensorflow/2.21/cpu/uv.lock
@@ -3175,11 +3175,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]
@@ -3347,6 +3347,7 @@ dependencies = [
     { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "scipy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "soupsieve", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "sqlparse", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "tensorflow-cpu", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "tornado", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -3428,6 +3429,7 @@ requires-dist = [
     { name = "smclarify", marker = "extra == 'sagemaker'" },
     { name = "soupsieve", specifier = ">=2.8.4" },
     { name = "sparkmagic", marker = "extra == 'sagemaker'", specifier = "==0.22.0" },
+    { name = "sqlparse", specifier = ">=0.6.0" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "tensorflow-cpu", specifier = "==2.21.0" },
     { name = "tensorflow-datasets", marker = "extra == 'sagemaker'" },

--- a/docker/tensorflow/2.21/cuda/pyproject.toml
+++ b/docker/tensorflow/2.21/cuda/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "pyasn1>=0.6.4",  # CVE-2026-59885 + CVE-2026-59886 (HIGH)
     "keras>=3.15.0",  # CVE-2026-12481 (CRITICAL) + CVE-2026-12484 (HIGH)
     "jupyterlab>=4.6.0",  # GHSA-pppj-hq3g-57pj + GHSA-gx64-gj6p-pc4c (HIGH)
+    "sqlparse>=0.6.0",  # CVE-2026-71491 + CVE-2026-54284 + CVE-2026-59893 (HIGH)
     "numpy>=2.1,<2.5",
     "requests",
     "packaging",

--- a/docker/tensorflow/2.21/cuda/uv.lock
+++ b/docker/tensorflow/2.21/cuda/uv.lock
@@ -3409,11 +3409,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]
@@ -3582,6 +3582,7 @@ dependencies = [
     { name = "requests", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "scipy", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "soupsieve", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "sqlparse", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "starlette", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "tensorflow", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
     { name = "tornado", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
@@ -3663,6 +3664,7 @@ requires-dist = [
     { name = "smclarify", marker = "extra == 'sagemaker'" },
     { name = "soupsieve", specifier = ">=2.8.4" },
     { name = "sparkmagic", marker = "extra == 'sagemaker'", specifier = "==0.22.0" },
+    { name = "sqlparse", specifier = ">=0.6.0" },
     { name = "starlette", specifier = ">=1.3.1" },
     { name = "tensorflow", specifier = "==2.21.0" },
     { name = "tensorflow-datasets", marker = "extra == 'sagemaker'" },


### PR DESCRIPTION
## Issue

The `ecr-vulnerability-scan` job fails on both TensorFlow 2.21 SageMaker training images (CPU and CUDA) with 3 non-allowlisted HIGH CVEs. All three are in `sqlparse` 0.5.5, pulled in transitively via `mlflow`:

| CVE | Issue |
|---|---|
| CVE-2026-71491 | `group_comments` repeatedly rescans comment-only statements before the `MAX_GROUPING_TOKENS` guard |
| CVE-2026-54284 | `TokenList` construction / string conversion repeatedly flattens nested token subtrees |
| CVE-2026-59893 | `SQL_REGEX` + the per-position lexer loop repeatedly scan unmatched dollar-quoted literals |

All three are quadratic-work DoS issues, all fixed in sqlparse 0.6.0.

## Description

- Pin `sqlparse>=0.6.0` in `docker/tensorflow/2.21/{cpu,cuda}/pyproject.toml`, following the existing convention in those files of declaring a direct pin to force the patched line for a transitive dependency.
- Regenerate both `uv.lock` files with `uv lock --upgrade-package sqlparse`. The diff is limited to the `sqlparse` block plus the two new dependency entries — no other package resolution moved.
- sqlparse 0.6.0 publishes a py3 wheel, so this does not introduce a source build.

## Tests run

Lockfiles regenerated and verified minimal (`git diff` touches only the `sqlparse` entries). CI ECR scan on this branch is the verification for the CVE clearance.

## PR Checklist

- [x] I've prepended PR tag with framework/job this PR applies to
- [x] If this PR changes existing code, the change is backwards compatible
- [x] I've made sure the changes are limited to the scope described above