### PR TITLE
ci(tensorflow): restrict efa-test to EC2 configs only

### DIFF
--- a/.github/workflows/tensorflow.pipeline.yml
+++ b/.github/workflows/tensorflow.pipeline.yml
@@ -164,9 +164,9 @@ jobs:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
-  # EFA tests — only for GPU images (2-node p4d NCCL+EFA all_reduce_perf)
+  # EFA tests — only for GPU EC2 images (2-node p4d NCCL+EFA all_reduce_perf)
   efa-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-efa-test && needs.ci-config.outputs.device-type == 'gpu' }}
+    if: ${{ always() && !failure() && !cancelled() && inputs.run-efa-test && needs.ci-config.outputs.device-type == 'gpu' && needs.ci-config.outputs.customer-type == 'ec2' }}
     needs: [build, ci-config]
     concurrency:
       group: ${{ github.workflow }}-efa-test-${{ inputs.config-file }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

Add `customer-type == 'ec2'` to the tensorflow pipeline's `efa-test` `if:` condition, matching PyTorch's precedent. Currently the gate only checks `device-type == 'gpu'`, so EFA runs against SageMaker GPU images (like `tensorflow-2.21-sagemaker-cuda`)

## Test plan

- [x] `pre-commit run --files ...` passes