### PR TITLE
fix(llama-cpp): harden CI and container security

### DIFF
--- a/.github/config/image/llama_cpp/ec2-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-amzn2023.yml
@@ -16,7 +16,7 @@ build:
   dockerfile: "docker/llama_cpp/Dockerfile.cpu"
   target: "llama-cpp-ec2"
   python_version: "3.12"
-  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # llama.cpp release b10433
+  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # b10433
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/llama_cpp/ec2-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-amzn2023.yml
@@ -16,7 +16,7 @@ build:
   dockerfile: "docker/llama_cpp/Dockerfile.cpu"
   target: "llama-cpp-ec2"
   python_version: "3.12"
-  llama_cpp_ref: "b10433"
+  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # llama.cpp release b10433
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/llama_cpp/ec2-arm64-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-arm64-amzn2023.yml
@@ -16,7 +16,7 @@ build:
   dockerfile: "docker/llama_cpp/Dockerfile.arm64"
   target: "llama-cpp-ec2"
   python_version: "3.12"
-  llama_cpp_ref: "b10433"
+  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # llama.cpp release b10433
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/llama_cpp/ec2-arm64-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-arm64-amzn2023.yml
@@ -16,7 +16,7 @@ build:
   dockerfile: "docker/llama_cpp/Dockerfile.arm64"
   target: "llama-cpp-ec2"
   python_version: "3.12"
-  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # llama.cpp release b10433
+  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # b10433
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/llama_cpp/ec2-gpu-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-gpu-amzn2023.yml
@@ -17,7 +17,7 @@ build:
   target: "llama-cpp-ec2"
   python_version: "3.12"
   cuda_version: "13.0.2"
-  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # llama.cpp release b10433
+  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # b10433
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/llama_cpp/ec2-gpu-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-gpu-amzn2023.yml
@@ -17,7 +17,7 @@ build:
   target: "llama-cpp-ec2"
   python_version: "3.12"
   cuda_version: "13.0.2"
-  llama_cpp_ref: "b10433"
+  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # llama.cpp release b10433
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/llama_cpp/sagemaker-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-amzn2023.yml
@@ -17,7 +17,7 @@ build:
   dockerfile: "docker/llama_cpp/Dockerfile.cpu"
   target: "llama-cpp-sagemaker"
   python_version: "3.12"
-  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # llama.cpp release b10433
+  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # b10433
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/llama_cpp/sagemaker-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-amzn2023.yml
@@ -17,7 +17,7 @@ build:
   dockerfile: "docker/llama_cpp/Dockerfile.cpu"
   target: "llama-cpp-sagemaker"
   python_version: "3.12"
-  llama_cpp_ref: "b10433"
+  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # llama.cpp release b10433
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/llama_cpp/sagemaker-arm64-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-arm64-amzn2023.yml
@@ -17,7 +17,7 @@ build:
   dockerfile: "docker/llama_cpp/Dockerfile.arm64"
   target: "llama-cpp-sagemaker"
   python_version: "3.12"
-  llama_cpp_ref: "b10433"
+  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # llama.cpp release b10433
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/llama_cpp/sagemaker-arm64-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-arm64-amzn2023.yml
@@ -17,7 +17,7 @@ build:
   dockerfile: "docker/llama_cpp/Dockerfile.arm64"
   target: "llama-cpp-sagemaker"
   python_version: "3.12"
-  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # llama.cpp release b10433
+  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # b10433
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/llama_cpp/sagemaker-gpu-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-gpu-amzn2023.yml
@@ -18,7 +18,7 @@ build:
   target: "llama-cpp-sagemaker"
   python_version: "3.12"
   cuda_version: "13.0.2"
-  llama_cpp_ref: "b10433"
+  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # llama.cpp release b10433
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/config/image/llama_cpp/sagemaker-gpu-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-gpu-amzn2023.yml
@@ -18,7 +18,7 @@ build:
   target: "llama-cpp-sagemaker"
   python_version: "3.12"
   cuda_version: "13.0.2"
-  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # llama.cpp release b10433
+  llama_cpp_ref: "9b05354ec6fb58b4e665e9a39ebc40285c015638"  # b10433
   dlc_major_version: "1"
   dlc_minor_version: "0"
 

--- a/.github/workflows/llama-cpp.pr-amzn2023.yml
+++ b/.github/workflows/llama-cpp.pr-amzn2023.yml
@@ -44,7 +44,7 @@ jobs:
       telemetry-test-change: ${{ steps.changes.outputs.telemetry-test-change }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dorny/paths-filter@v4
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         id: changes
         with:
           filters: |

--- a/.github/workflows/llama-cpp.tests-model.yml
+++ b/.github/workflows/llama-cpp.tests-model.yml
@@ -85,31 +85,38 @@ jobs:
           model-name: ${{ matrix.name }}
 
       - name: Start container
+        env:
+          IMAGE_URI: ${{ needs.preflight.outputs.image-uri }}
+          DOCKER_GPUS: ${{ matrix.docker_gpus }}
         run: |
-          docker pull ${{ needs.preflight.outputs.image-uri }}
+          docker pull "${IMAGE_URI}"
           # GPU entries set docker_gpus=all for CUDA; CPU entries leave it empty.
           GPUS_FLAG=""
-          if [ -n "${{ matrix.docker_gpus }}" ]; then
-            GPUS_FLAG="--gpus ${{ matrix.docker_gpus }}"
+          if [ -n "${DOCKER_GPUS}" ]; then
+            GPUS_FLAG="--gpus ${DOCKER_GPUS}"
           fi
           CONTAINER_ID=$(docker run -d -it ${GPUS_FLAG} --entrypoint /bin/bash \
             --ipc=host --shm-size=10g \
             -v /dlc-models:/models \
-            ${{ needs.preflight.outputs.image-uri }})
+            "${IMAGE_URI}")
           echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
 
       - name: Copy test script into container
+        env:
+          TEST_SCRIPT: ${{ matrix.test_script || 'llama_cpp_model_smoke_test.sh' }}
         run: |
-          TEST_SCRIPT="${{ matrix.test_script || 'llama_cpp_model_smoke_test.sh' }}"
-          docker cp "test/llama_cpp/scripts/${TEST_SCRIPT}" ${CONTAINER_ID}:/models/
+          docker cp "test/llama_cpp/scripts/${TEST_SCRIPT}" "${CONTAINER_ID}:/models/"
 
       - name: Run model smoke test
+        env:
+          TEST_SCRIPT: ${{ matrix.test_script || 'llama_cpp_model_smoke_test.sh' }}
+          MODEL_NAME: ${{ matrix.name }}
+          EXTRA_ARGS: ${{ matrix.extra_args }}
         run: |
-          TEST_SCRIPT="${{ matrix.test_script || 'llama_cpp_model_smoke_test.sh' }}"
-          docker exec ${CONTAINER_ID} bash "/models/${TEST_SCRIPT}" \
-            "/models/${{ matrix.name }}" \
-            "${{ matrix.name }}" \
-            ${{ matrix.extra_args }}
+          docker exec "${CONTAINER_ID}" bash "/models/${TEST_SCRIPT}" \
+            "/models/${MODEL_NAME}" \
+            "${MODEL_NAME}" \
+            ${EXTRA_ARGS}
 
       - name: Cleanup
         if: always()

--- a/docker/llama_cpp/Dockerfile.arm64
+++ b/docker/llama_cpp/Dockerfile.arm64
@@ -7,7 +7,8 @@ ARG BASE_REF=2023
 FROM public.ecr.aws/amazonlinux/amazonlinux:${BASE_REF} AS builder
 
 # Pin the upstream ref for reproducible builds.
-ARG LLAMA_CPP_REF=b10433
+# llama.cpp release b10433 (https://github.com/ggml-org/llama.cpp/releases/tag/b10433)
+ARG LLAMA_CPP_REF=9b05354ec6fb58b4e665e9a39ebc40285c015638
 ARG BUILD_PARALLEL=16
 
 RUN dnf install -y --allowerasing --setopt=install_weak_deps=False \
@@ -40,7 +41,8 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:${BASE_REF} AS runtime
 ARG PYTHON="python3"
 ARG PYTHON_VERSION=3.12
 # Re-declared: ARGs don't cross build stages (used by OSS tracking below).
-ARG LLAMA_CPP_REF=b10433
+# llama.cpp release b10433 (https://github.com/ggml-org/llama.cpp/releases/tag/b10433)
+ARG LLAMA_CPP_REF=9b05354ec6fb58b4e665e9a39ebc40285c015638
 ARG DLC_MAJOR_VERSION
 ARG DLC_MINOR_VERSION
 LABEL maintainer="Amazon AI"

--- a/docker/llama_cpp/Dockerfile.arm64
+++ b/docker/llama_cpp/Dockerfile.arm64
@@ -7,7 +7,7 @@ ARG BASE_REF=2023
 FROM public.ecr.aws/amazonlinux/amazonlinux:${BASE_REF} AS builder
 
 # Pin the upstream ref for reproducible builds.
-# llama.cpp release b10433 (https://github.com/ggml-org/llama.cpp/releases/tag/b10433)
+# b10433
 ARG LLAMA_CPP_REF=9b05354ec6fb58b4e665e9a39ebc40285c015638
 ARG BUILD_PARALLEL=16
 
@@ -41,7 +41,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:${BASE_REF} AS runtime
 ARG PYTHON="python3"
 ARG PYTHON_VERSION=3.12
 # Re-declared: ARGs don't cross build stages (used by OSS tracking below).
-# llama.cpp release b10433 (https://github.com/ggml-org/llama.cpp/releases/tag/b10433)
+# b10433
 ARG LLAMA_CPP_REF=9b05354ec6fb58b4e665e9a39ebc40285c015638
 ARG DLC_MAJOR_VERSION
 ARG DLC_MINOR_VERSION

--- a/docker/llama_cpp/Dockerfile.cpu
+++ b/docker/llama_cpp/Dockerfile.cpu
@@ -4,7 +4,7 @@ ARG BASE_REF=2023
 FROM public.ecr.aws/amazonlinux/amazonlinux:${BASE_REF} AS builder
 
 # Pin the upstream ref for reproducible builds.
-# llama.cpp release b10433 (https://github.com/ggml-org/llama.cpp/releases/tag/b10433)
+# b10433
 ARG LLAMA_CPP_REF=9b05354ec6fb58b4e665e9a39ebc40285c015638
 ARG BUILD_PARALLEL=16
 
@@ -37,7 +37,7 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:${BASE_REF} AS runtime
 ARG PYTHON="python3"
 ARG PYTHON_VERSION=3.12
 # Re-declared: ARGs don't cross build stages (used by OSS tracking below).
-# llama.cpp release b10433 (https://github.com/ggml-org/llama.cpp/releases/tag/b10433)
+# b10433
 ARG LLAMA_CPP_REF=9b05354ec6fb58b4e665e9a39ebc40285c015638
 ARG DLC_MAJOR_VERSION
 ARG DLC_MINOR_VERSION

--- a/docker/llama_cpp/Dockerfile.cpu
+++ b/docker/llama_cpp/Dockerfile.cpu
@@ -4,7 +4,8 @@ ARG BASE_REF=2023
 FROM public.ecr.aws/amazonlinux/amazonlinux:${BASE_REF} AS builder
 
 # Pin the upstream ref for reproducible builds.
-ARG LLAMA_CPP_REF=b10433
+# llama.cpp release b10433 (https://github.com/ggml-org/llama.cpp/releases/tag/b10433)
+ARG LLAMA_CPP_REF=9b05354ec6fb58b4e665e9a39ebc40285c015638
 ARG BUILD_PARALLEL=16
 
 RUN dnf install -y --allowerasing --setopt=install_weak_deps=False \
@@ -36,7 +37,8 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:${BASE_REF} AS runtime
 ARG PYTHON="python3"
 ARG PYTHON_VERSION=3.12
 # Re-declared: ARGs don't cross build stages (used by OSS tracking below).
-ARG LLAMA_CPP_REF=b10433
+# llama.cpp release b10433 (https://github.com/ggml-org/llama.cpp/releases/tag/b10433)
+ARG LLAMA_CPP_REF=9b05354ec6fb58b4e665e9a39ebc40285c015638
 ARG DLC_MAJOR_VERSION
 ARG DLC_MINOR_VERSION
 LABEL maintainer="Amazon AI"

--- a/docker/llama_cpp/Dockerfile.gpu
+++ b/docker/llama_cpp/Dockerfile.gpu
@@ -8,7 +8,8 @@ ARG CUDA_VERSION=13.0.2
 FROM nvidia/cuda:${CUDA_VERSION}-devel-amzn2023 AS builder
 
 # Pin the upstream ref for reproducible builds.
-ARG LLAMA_CPP_REF=b10433
+# llama.cpp release b10433 (https://github.com/ggml-org/llama.cpp/releases/tag/b10433)
+ARG LLAMA_CPP_REF=9b05354ec6fb58b4e665e9a39ebc40285c015638
 ARG BUILD_PARALLEL=16
 
 RUN dnf install -y --allowerasing --setopt=install_weak_deps=False \
@@ -45,7 +46,8 @@ ARG PYTHON_VERSION=3.12
 # Re-declared: ARGs don't cross build stages (CUDA_VERSION drives cuda-compat below;
 # LLAMA_CPP_REF used by OSS tracking).
 ARG CUDA_VERSION=13.0.2
-ARG LLAMA_CPP_REF=b10433
+# llama.cpp release b10433 (https://github.com/ggml-org/llama.cpp/releases/tag/b10433)
+ARG LLAMA_CPP_REF=9b05354ec6fb58b4e665e9a39ebc40285c015638
 ARG DLC_MAJOR_VERSION
 ARG DLC_MINOR_VERSION
 LABEL maintainer="Amazon AI"

--- a/docker/llama_cpp/Dockerfile.gpu
+++ b/docker/llama_cpp/Dockerfile.gpu
@@ -8,7 +8,7 @@ ARG CUDA_VERSION=13.0.2
 FROM nvidia/cuda:${CUDA_VERSION}-devel-amzn2023 AS builder
 
 # Pin the upstream ref for reproducible builds.
-# llama.cpp release b10433 (https://github.com/ggml-org/llama.cpp/releases/tag/b10433)
+# b10433
 ARG LLAMA_CPP_REF=9b05354ec6fb58b4e665e9a39ebc40285c015638
 ARG BUILD_PARALLEL=16
 
@@ -46,7 +46,7 @@ ARG PYTHON_VERSION=3.12
 # Re-declared: ARGs don't cross build stages (CUDA_VERSION drives cuda-compat below;
 # LLAMA_CPP_REF used by OSS tracking).
 ARG CUDA_VERSION=13.0.2
-# llama.cpp release b10433 (https://github.com/ggml-org/llama.cpp/releases/tag/b10433)
+# b10433
 ARG LLAMA_CPP_REF=9b05354ec6fb58b4e665e9a39ebc40285c015638
 ARG DLC_MAJOR_VERSION
 ARG DLC_MINOR_VERSION

--- a/scripts/docker/llama_cpp/dockerd_entrypoint.sh
+++ b/scripts/docker/llama_cpp/dockerd_entrypoint.sh
@@ -1,6 +1,19 @@
 #!/usr/bin/env bash
 # EC2 entrypoint for the llama.cpp DLC.
+#
+# SECURITY: llama-server exposes an OpenAI-compatible HTTP API on 0.0.0.0:8080.
+# The endpoint is UNAUTHENTICATED unless an API key is supplied. Set LLAMA_API_KEY
+# (or pass --api-key via container args) to require a bearer token. Regardless of
+# auth, the endpoint MUST be network-isolated on any deployment target: use
+# restrictive security groups and/or an auth+TLS reverse proxy. Do not expose it
+# directly to untrusted networks.
+#
 # Emits telemetry (best-effort) then launches llama-server with the passed args.
 bash /usr/local/bin/bash_telemetry.sh >/dev/null 2>&1 || true
 
-exec llama-server --host 0.0.0.0 --port 8080 "$@"
+API_KEY_ARG=()
+if [ -n "${LLAMA_API_KEY:-}" ]; then
+  API_KEY_ARG=(--api-key "${LLAMA_API_KEY}")
+fi
+
+exec llama-server --host 0.0.0.0 --port 8080 "${API_KEY_ARG[@]}" "$@"


### PR DESCRIPTION
A security review flagged a few issues on the llama.cpp DLC. This fixes them.

- **Script injection in `llama-cpp.tests-model.yml`:** matrix values (`name`, `extra_args`, `test_script`, `docker_gpus`) and `image-uri` were interpolated straight into `run:` blocks. Moved them into `env:` and quoted the uses.
- **Mutable llama.cpp tag:** was pinned to tag `b10433`, which can be repointed upstream. Pinned to the commit it currently points at (`9b05354...`) in the 3 Dockerfiles and 6 configs. Tag kept in a comment and in `framework_version`.
- **Unpinned action:** `dorny/paths-filter` pinned to a commit SHA.
- **Unauthenticated endpoint:** `llama-server` binds `0.0.0.0:8080` with no auth. Entrypoint now passes `--api-key` when `LLAMA_API_KEY` is set, plus a note that it still needs network isolation.

Tested: all edited YAML parses, `bash -n` clean on the entrypoint, no mutable tag left as a checkout ref.