### PR TITLE
fix(whisperx): prevent CPU-host startup crash in start_cuda_compat.sh

### DIFF
--- a/.github/workflows/whisperx.tests-ec2.yml
+++ b/.github/workflows/whisperx.tests-ec2.yml
@@ -82,4 +82,39 @@ jobs:
           cd test/
           python3 -m pytest -v --tb=short -rA --log-cli-level=INFO \
             --image-uri ${{ needs.preflight.outputs.image-uri }} \
-            whisperx/ec2
+            whisperx/ec2 --ignore=whisperx/ec2/test_ec2_cpu.py
+
+  ec2-cpu:
+    # Not gated on device-type: the whisperx image is device_type gpu, and this
+    # job validates that it still starts and serves when run on a CPU-only host.
+    if: ${{ needs.preflight.outputs.image-exists == 'true' }}
+    needs: [preflight]
+    timeout-minutes: 40
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: ECR login
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ needs.preflight.outputs.aws-account-id }}
+          aws-region: ${{ vars.AWS_REGION }}
+          image-uri: ${{ needs.preflight.outputs.image-uri }}
+
+      - name: Install test dependencies
+        run: |
+          uv venv --python 3.12
+          source .venv/bin/activate
+          uv pip install -r test/requirements.txt
+          uv pip install -r test/whisperx/ec2/requirements.txt
+
+      - name: Run EC2 CPU tests
+        run: |
+          source .venv/bin/activate
+          cd test/
+          python3 -m pytest -v --tb=short -rA --log-cli-level=INFO \
+            --image-uri ${{ needs.preflight.outputs.image-uri }} \
+            whisperx/ec2/test_ec2_cpu.py

--- a/.github/workflows/whisperx.tests-unit.yml
+++ b/.github/workflows/whisperx.tests-unit.yml
@@ -42,4 +42,5 @@ jobs:
             whisperx/test_server_options.py \
             whisperx/test_transcribe_behavior.py \
             whisperx/test_subtitle_format.py \
-            whisperx/test_sagemaker_entrypoint_model_resolution.py
+            whisperx/test_sagemaker_entrypoint_model_resolution.py \
+            whisperx/test_start_cuda_compat.py

--- a/scripts/docker/whisperx/start_cuda_compat.sh
+++ b/scripts/docker/whisperx/start_cuda_compat.sh
@@ -25,7 +25,15 @@ if [ -f /usr/local/cuda/compat/libcuda.so.1 ]; then
     NVIDIA_DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader --id=0 2>/dev/null || true)
   fi
   echo "Current installed NVIDIA driver version is ${NVIDIA_DRIVER_VERSION}"
-  if verlte $NVIDIA_DRIVER_VERSION $CUDA_COMPAT_MAX_DRIVER_VERSION; then
+  # No driver detected (CPU host / undetectable): leave LD_LIBRARY_PATH untouched —
+  # compat only bridges an OLD driver, and there is nothing to bridge. This guard is
+  # load-bearing: the entrypoints `source` this under `set -u`, and an empty version
+  # passed unquoted to verlte collapses to a single arg, tripping an unbound-$2 abort
+  # in verlte that kills the entrypoint before uvicorn. Quote the args for the same
+  # reason (defense in depth if a driver version ever contains whitespace).
+  if [ -z "$NVIDIA_DRIVER_VERSION" ]; then
+    echo "Skipping CUDA compat setup as no NVIDIA driver was detected"
+  elif verlte "$NVIDIA_DRIVER_VERSION" "$CUDA_COMPAT_MAX_DRIVER_VERSION"; then
     echo "Adding CUDA compat to LD_LIBRARY_PATH"
     export LD_LIBRARY_PATH=/usr/local/cuda/compat:$LD_LIBRARY_PATH
     echo $LD_LIBRARY_PATH

--- a/scripts/docker/whisperx/start_cuda_compat.sh
+++ b/scripts/docker/whisperx/start_cuda_compat.sh
@@ -25,12 +25,8 @@ if [ -f /usr/local/cuda/compat/libcuda.so.1 ]; then
     NVIDIA_DRIVER_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader --id=0 2>/dev/null || true)
   fi
   echo "Current installed NVIDIA driver version is ${NVIDIA_DRIVER_VERSION}"
-  # No driver detected (CPU host / undetectable): leave LD_LIBRARY_PATH untouched —
-  # compat only bridges an OLD driver, and there is nothing to bridge. This guard is
-  # load-bearing: the entrypoints `source` this under `set -u`, and an empty version
-  # passed unquoted to verlte collapses to a single arg, tripping an unbound-$2 abort
-  # in verlte that kills the entrypoint before uvicorn. Quote the args for the same
-  # reason (defense in depth if a driver version ever contains whitespace).
+  # Skip when no driver is detected (CPU host): an empty version passed unquoted to
+  # verlte trips an unbound-$2 abort under `set -u`. Quoting hardens the same call.
   if [ -z "$NVIDIA_DRIVER_VERSION" ]; then
     echo "Skipping CUDA compat setup as no NVIDIA driver was detected"
   elif verlte "$NVIDIA_DRIVER_VERSION" "$CUDA_COMPAT_MAX_DRIVER_VERSION"; then

--- a/test/whisperx/ec2/common.py
+++ b/test/whisperx/ec2/common.py
@@ -141,17 +141,19 @@ def stop_container(container_id):
 # ---------------------------------------------------------------------------
 
 
-def make_container_fixture(device, docker_run_flags=None):
+def make_container_fixture(device, docker_run_flags=None, env=None):
     """Create the container fixture: start container, health-check, cleanup.
 
     Yields a dict with container_id and port for the test to use. On a health
     timeout the container logs are dumped and the container is removed before
-    failing, so failures point directly at an image/server problem.
+    failing, so failures point directly at an image/server problem. Optional
+    `env` is forwarded to `docker run` as `-e K=V` flags (e.g. pin a fast-warming
+    served model with {"WHISPERX_DEFAULT_MODEL": "tiny"}).
     """
 
     @pytest.fixture(scope="function")
     def container(image_uri):
-        container_id, port = start_container(image_uri, device, docker_run_flags)
+        container_id, port = start_container(image_uri, device, docker_run_flags, env=env)
         try:
             wait_for_health(port=port)
         except TimeoutError:

--- a/test/whisperx/ec2/test_ec2_cpu.py
+++ b/test/whisperx/ec2/test_ec2_cpu.py
@@ -1,0 +1,106 @@
+# Copyright 2018-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+"""End-to-end EC2 test that runs the WhisperX GPU image on a CPU-only host.
+
+The container is started with NO `--gpus` flag to force CPU execution, which
+validates that it still starts and serves on CPU — the regression guarded by the
+start_cuda_compat.sh fix — and that real transcription works on CPU.
+
+Assertions are deliberately loose about ASR *content* (ASR output is
+nondeterministic): we assert the response contract — status codes, response
+shapes, and timestamp structure — not exact transcript strings. Container
+lifecycle lives in common.py; this file only sets device config and the CPU test
+cases. The suite is kept bounded (no diarization / response-format / error
+cases) so it stays fast on a CPU runner.
+"""
+
+import requests
+from whisperx.ec2.common import (
+    AUDIO_EN,
+    download_fixture,
+    make_container_fixture,
+    post_transcription,
+)
+
+DEVICE = "cpu"
+DOCKER_RUN_FLAGS = None  # no --gpus: force CPU
+
+# Register the container fixture for this module (function-scoped: fresh
+# container per test, mirroring the GPU module). tiny keeps CPU warm-load +
+# inference fast enough for CI.
+container = make_container_fixture(
+    DEVICE, docker_run_flags=DOCKER_RUN_FLAGS, env={"WHISPERX_DEFAULT_MODEL": "tiny"}
+)
+
+
+def test_ping_and_models(container):
+    """/ping is healthy and /v1/models advertises at least one served model id.
+
+    Core e2e proof that the container STARTS and serves on CPU (no --gpus, no
+    S3/audio needed).
+    """
+    port = container["port"]
+
+    resp = requests.get(f"http://localhost:{port}/ping", timeout=10)
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+    resp = requests.get(f"http://localhost:{port}/v1/models", timeout=10)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body.get("object") == "list"
+    data = body.get("data")
+    assert isinstance(data, list) and len(data) >= 1, f"expected >=1 model, got {body}"
+    assert data[0].get("id"), "expected a non-empty model id"
+
+
+def test_basic_transcription(container, aws_session, tmp_path):
+    """Default json transcription of English audio returns non-empty text on CPU."""
+    audio = download_fixture(aws_session, AUDIO_EN, str(tmp_path / AUDIO_EN))
+
+    resp = post_transcription(container["port"], audio, response_format="json")
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    # json response shape is exactly {"text": "..."}.
+    assert body.get("text", "").strip(), "expected non-empty transcription text"
+
+
+def test_word_timestamps(container, aws_session, tmp_path):
+    """verbose_json + timestamp_granularities[]=word yields coherent word timings on CPU."""
+    audio = download_fixture(aws_session, AUDIO_EN, str(tmp_path / AUDIO_EN))
+
+    resp = post_transcription(
+        container["port"],
+        audio,
+        response_format="verbose_json",
+        # The server reads the list off the literal "timestamp_granularities[]" key.
+        **{"timestamp_granularities[]": ["word"]},
+    )
+    assert resp.status_code == 200, resp.text
+
+    body = resp.json()
+    words = body.get("words")
+    assert isinstance(words, list) and words, f"expected non-empty words list, got {body.keys()}"
+    for w in words:
+        assert {"word", "start", "end"} <= set(w), f"word entry missing keys: {w}"
+
+    # WhisperX alignment can leave a few tokens (e.g. digits) without timings;
+    # assert coherence on the words that ARE timed and require at least one.
+    timed = [
+        (w["start"], w["end"]) for w in words if w["start"] is not None and w["end"] is not None
+    ]
+    assert timed, "expected at least one word with start/end timestamps"
+    for start, end in timed:
+        assert isinstance(start, (int, float)) and isinstance(end, (int, float))
+        assert start <= end, f"word start {start} after end {end}"

--- a/test/whisperx/test_start_cuda_compat.py
+++ b/test/whisperx/test_start_cuda_compat.py
@@ -1,0 +1,138 @@
+"""Unit tests for scripts/docker/whisperx/start_cuda_compat.sh.
+
+CPU-only, no container and no GPU: we copy the shipped script, retarget its
+hard-coded compat-lib probe at a temp fixture, and simulate driver detection with
+a fake ``nvidia-smi`` on PATH. This drives the script's driver-detection +
+compat-activation branches directly, including the regression where an empty
+``NVIDIA_DRIVER_VERSION`` (CPU host, no driver) must NOT abort the entrypoint: the
+whisperx entrypoints ``source`` this under ``set -euo pipefail``, and the pre-fix
+code passed the empty version unquoted to ``verlte`` -- collapsing two args to one
+so ``verlte`` dereferenced an unbound ``$2`` and ``set -u`` killed the container
+before uvicorn started. The ``[ -z ]`` guard + quoted args fix that.
+
+The script reads ``/proc/driver/nvidia/version`` before falling back to
+``nvidia-smi``; these tests assume a CPU host where that file is absent (true on
+the CPU-only ``default-runner`` the unit suite runs on), so ``nvidia-smi`` is the
+sole detection path we control.
+"""
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+# start_cuda_compat.sh lives in the image-build tree, two levels up from test/whisperx/.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "docker" / "whisperx" / "start_cuda_compat.sh"
+
+# The versioned lib the compat symlink points at. The script derives the max
+# supported driver version by `readlink libcuda.so.1 | cut -d. -f3-`, so this name
+# yields CUDA_COMPAT_MAX_DRIVER_VERSION=570.211.01 -- the pivot the tests bracket.
+_COMPAT_SO = "libcuda.so.570.211.01"
+
+# The literal probe path in the shipped script; we retarget only this at our
+# fixture. The `export LD_LIBRARY_PATH=/usr/local/cuda/compat:...` line is left
+# untouched so the "add" case can assert on that literal directory.
+_PROBE_PATH = "/usr/local/cuda/compat/libcuda.so.1"
+
+
+def _ldlp_line(out: str) -> str:
+    """Return the wrapper's ``LDLP=[...]`` line ('' if the script aborted first)."""
+    for line in out.splitlines():
+        if line.startswith("LDLP="):
+            return line
+    return ""
+
+
+def _run(tmp_path, *, compat_present: bool, driver_version: str | None):
+    """Source a retargeted copy of the script and return the CompletedProcess.
+
+    ``compat_present`` builds a fake compat dir (empty versioned lib + the
+    ``libcuda.so.1`` symlink the script readlinks); otherwise the probe path points
+    at a nonexistent file so the script's ``[ -f ]`` test fails. ``driver_version``
+    drives a fake ``nvidia-smi`` on PATH -- ``None`` installs none, so detection
+    yields an empty version (the CPU-host case).
+    """
+    if compat_present:
+        compat_dir = tmp_path / "compat"
+        compat_dir.mkdir()
+        (compat_dir / _COMPAT_SO).write_bytes(b"")
+        compat_lib = compat_dir / "libcuda.so.1"
+        # Relative target so `readlink | cut -d. -f3-` yields "570.211.01".
+        os.symlink(_COMPAT_SO, compat_lib)
+    else:
+        # Nonexistent path -> the script's `[ -f ]` probe fails ("package not found").
+        compat_lib = tmp_path / "compat" / "libcuda.so.1"
+
+    script_copy = tmp_path / "start_cuda_compat.sh"
+    script_copy.write_text(SCRIPT.read_text().replace(_PROBE_PATH, str(compat_lib)))
+
+    # Simulate driver detection with a fake nvidia-smi on PATH. This test assumes a
+    # CPU host where /proc/driver/nvidia/version is absent, so nvidia-smi (or its
+    # absence, for driver_version=None) is the only detection signal.
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    if driver_version is not None:
+        nvidia_smi = bin_dir / "nvidia-smi"
+        nvidia_smi.write_text(f'#!/bin/sh\necho "{driver_version}"\n')
+        nvidia_smi.chmod(nvidia_smi.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    # Source the copy exactly as the entrypoints do: under `set -euo pipefail`, with
+    # LD_LIBRARY_PATH pre-seeded. We deliberately omit LD_LIBRARY_PATH from env so the
+    # `${LD_LIBRARY_PATH:-}` preseed is what keeps the unguarded `$LD_LIBRARY_PATH`
+    # reference in the script from tripping `set -u`.
+    prog = (
+        "set -euo pipefail; "
+        'export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"; '
+        f'. "{script_copy}"; '
+        'echo "REACHED_END"; '
+        'echo "LDLP=[$LD_LIBRARY_PATH]"'
+    )
+    return subprocess.run(
+        ["bash", "-c", prog],
+        env={"PATH": f"{bin_dir}:/usr/bin:/bin"},
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_no_driver_does_not_abort_and_skips(tmp_path):
+    """Regression: an empty driver version must not abort the sourced script.
+
+    Pre-fix, the empty ``NVIDIA_DRIVER_VERSION`` reached ``verlte`` unquoted and
+    ``set -u`` aborted on an unbound ``$2`` before uvicorn. Now the ``[ -z ]`` guard
+    skips compat and leaves LD_LIBRARY_PATH empty.
+    """
+    cp = _run(tmp_path, compat_present=True, driver_version=None)
+    out = cp.stdout + cp.stderr
+    assert cp.returncode == 0, out
+    assert "REACHED_END" in out
+    assert "no NVIDIA driver was detected" in out
+    assert "unbound variable" not in out
+    assert _ldlp_line(out) == "LDLP=[]"  # compat dir NOT prepended
+
+
+def test_old_driver_adds_compat(tmp_path):
+    """An older driver (< compat max 570.211.01) prepends the compat dir."""
+    cp = _run(tmp_path, compat_present=True, driver_version="400.00.00")
+    out = cp.stdout + cp.stderr
+    assert cp.returncode == 0, out
+    assert "Adding CUDA compat to LD_LIBRARY_PATH" in out
+    assert "/usr/local/cuda/compat" in _ldlp_line(out)
+
+
+def test_new_driver_skips_compat(tmp_path):
+    """A newer driver (> compat max) needs no compat, so it is left off LD_LIBRARY_PATH."""
+    cp = _run(tmp_path, compat_present=True, driver_version="999.99.99")
+    out = cp.stdout + cp.stderr
+    assert cp.returncode == 0, out
+    assert "newer NVIDIA driver is installed" in out
+    assert "/usr/local/cuda/compat" not in _ldlp_line(out)
+
+
+def test_compat_absent_skips(tmp_path):
+    """No compat package (CPU image) -> the `[ -f ]` probe fails, script skips cleanly."""
+    cp = _run(tmp_path, compat_present=False, driver_version=None)
+    out = cp.stdout + cp.stderr
+    assert cp.returncode == 0, out
+    assert "package not found" in out

--- a/test/whisperx/test_start_cuda_compat.py
+++ b/test/whisperx/test_start_cuda_compat.py
@@ -68,14 +68,20 @@ def _run(tmp_path, *, compat_present: bool, driver_version: str | None):
     script_copy.write_text(SCRIPT.read_text().replace(_PROBE_PATH, str(compat_lib)))
 
     # Simulate driver detection with a fake nvidia-smi on PATH. This test assumes a
-    # CPU host where /proc/driver/nvidia/version is absent, so nvidia-smi (or its
-    # absence, for driver_version=None) is the only detection signal.
+    # CPU host where /proc/driver/nvidia/version is absent, so nvidia-smi is the
+    # only detection signal. We ALWAYS install a stub (bin_dir is first on PATH) so
+    # the host's real nvidia-smi cannot leak in: CI CPU runners ship an nvidia-smi
+    # that, with no GPU, prints an error to stdout that would masquerade as a driver
+    # version. driver_version=None installs a stub that emits nothing and fails,
+    # i.e. the "no driver detected" (empty version) case.
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
+    nvidia_smi = bin_dir / "nvidia-smi"
     if driver_version is not None:
-        nvidia_smi = bin_dir / "nvidia-smi"
         nvidia_smi.write_text(f'#!/bin/sh\necho "{driver_version}"\n')
-        nvidia_smi.chmod(nvidia_smi.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    else:
+        nvidia_smi.write_text("#!/bin/sh\nexit 1\n")
+    nvidia_smi.chmod(nvidia_smi.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
 
     # Source the copy exactly as the entrypoints do: under `set -euo pipefail`, with
     # LD_LIBRARY_PATH pre-seeded. We deliberately omit LD_LIBRARY_PATH from env so the
@@ -136,3 +142,22 @@ def test_compat_absent_skips(tmp_path):
     out = cp.stdout + cp.stderr
     assert cp.returncode == 0, out
     assert "package not found" in out
+
+
+def test_failing_nvidia_smi_does_not_abort(tmp_path):
+    """A broken nvidia-smi (present but no GPU) prints a multi-word error string as
+    the "version"; quoting the verlte args must keep that from tripping ``set -u``,
+    and compat is still skipped. Mirrors CPU hosts that ship nvidia-smi without a
+    working driver (e.g. the CI CPU runner).
+    """
+    cp = _run(
+        tmp_path,
+        compat_present=True,
+        driver_version="NVIDIA-SMI has failed because it could not communicate with the driver",
+    )
+    out = cp.stdout + cp.stderr
+    assert cp.returncode == 0, out
+    assert "REACHED_END" in out
+    assert "unbound variable" not in out
+    # A non-version string is not < the compat max, so compat is not prepended.
+    assert "/usr/local/cuda/compat" not in _ldlp_line(out), out

--- a/test/whisperx/test_start_cuda_compat.py
+++ b/test/whisperx/test_start_cuda_compat.py
@@ -67,13 +67,8 @@ def _run(tmp_path, *, compat_present: bool, driver_version: str | None):
     script_copy = tmp_path / "start_cuda_compat.sh"
     script_copy.write_text(SCRIPT.read_text().replace(_PROBE_PATH, str(compat_lib)))
 
-    # Simulate driver detection with a fake nvidia-smi on PATH. This test assumes a
-    # CPU host where /proc/driver/nvidia/version is absent, so nvidia-smi is the
-    # only detection signal. We ALWAYS install a stub (bin_dir is first on PATH) so
-    # the host's real nvidia-smi cannot leak in: CI CPU runners ship an nvidia-smi
-    # that, with no GPU, prints an error to stdout that would masquerade as a driver
-    # version. driver_version=None installs a stub that emits nothing and fails,
-    # i.e. the "no driver detected" (empty version) case.
+    # Always stub nvidia-smi (bin_dir is first on PATH) so a host's real one can't
+    # leak in; driver_version=None => an empty-output stub (the "no driver" case).
     bin_dir = tmp_path / "bin"
     bin_dir.mkdir()
     nvidia_smi = bin_dir / "nvidia-smi"


### PR DESCRIPTION
## Summary

On a CPU-only host (or any host where the NVIDIA driver version can't be
detected), `scripts/docker/whisperx/start_cuda_compat.sh` aborts the container
entrypoint, so the WhisperX image fails to start even though `server.py` already
falls back to CPU (`DEVICE = "cuda" if torch.cuda.is_available() else "cpu"`).

## Root cause

On a driverless host `NVIDIA_DRIVER_VERSION` resolves to an empty string and is
passed **unquoted** to `verlte`:

```sh
if verlte $NVIDIA_DRIVER_VERSION $CUDA_COMPAT_MAX_DRIVER_VERSION; then
```

so `verlte` receives a single argument and its `[ "$1" = "$2" ]` dereferences an
unbound `$2`. The entrypoints (`dockerd_entrypoint.sh`, `sagemaker_entrypoint.sh`)
`source` this script under `set -euo pipefail`, so `set -u` aborts the entrypoint
before `exec uvicorn`:

```
start_cuda_compat.sh: line 17: $2: unbound variable
```

## Fix

- Add an explicit `[ -z "$NVIDIA_DRIVER_VERSION" ]` guard that skips compat when
  no driver is detected (matching the script's documented "CPU hosts ... left
  untouched" intent).
- Quote the `verlte` arguments.

No behavior change on GPU: a non-empty driver version takes the same `verlte`
comparison as before.

## Testing

**Unit** — `test/whisperx/test_start_cuda_compat.py` (CPU-only unit suite, no
container/GPU) covers the no-driver regression plus the older-driver (compat
added), newer-driver (skipped), and no-compat-package branches. Verified it
**fails on the pre-fix script** (`$2: unbound variable`) and passes after the fix.

**End-to-end** — `test/whisperx/ec2/test_ec2_cpu.py` runs the image with no
`--gpus` on a CPU host and asserts the container starts and serves (`/ping`,
`/v1/models`) plus real transcription (basic json + word timestamps, `tiny`
model for speed). A new `ec2-cpu` job in `whisperx.tests-ec2.yml` runs it on the
CPU `default-runner`; the existing `ec2-gpu` job now ignores the file so it does
not double-run.

Validated on a CPU-only host against the image built from this branch: the
patched entrypoint logs `Skipping CUDA compat setup as no NVIDIA driver was
detected`, reaches `Application startup complete`, and `GET /ping` returns `200`
with `/v1/models` advertising the served model. The e2e test reproduces the
pre-fix abort (`$2: unbound variable`) exactly against the current prod image.

## Note

The same unquoted `verlte` line exists in
`scripts/docker/pytorch/start_cuda_compat.sh` and
`scripts/docker/common/start_cuda_compat.sh`, but those do not currently crash
because their entrypoints invoke the script via `bash` (a child shell that does
not inherit `set -u`) rather than `source`. These can be hardened in a follow-up.
