### PR TITLE
feat(tensorflow): enable scheduled production autorelease for TF 2.20 inference

### DIFF
--- a/.github/config/image/tensorflow/2.20-inference-sagemaker-cpu.yml
+++ b/.github/config/image/tensorflow/2.20-inference-sagemaker-cpu.yml
@@ -25,7 +25,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
+  public_registry: true
   private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"

--- a/.github/config/image/tensorflow/2.20-inference-sagemaker-cuda.yml
+++ b/.github/config/image/tensorflow/2.20-inference-sagemaker-cuda.yml
@@ -26,7 +26,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
+  public_registry: true
   private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"

--- a/.github/release-schedule.yml
+++ b/.github/release-schedule.yml
@@ -94,6 +94,10 @@ schedules:
     workflow: sglang.autorelease-ec2-ubuntu.yml
     gpu: heavy
 
+  - cron: "30 20 * * 2,4"
+    workflow: tensorflow-inference.autorelease-2.20-sagemaker.yml
+    gpu: light
+
   - cron: "00 21 * * 2,4"
     workflow: ray.autorelease-sagemaker.yml
     gpu: light

--- a/.github/workflows/tensorflow-inference.autorelease-2.20-sagemaker.yml
+++ b/.github/workflows/tensorflow-inference.autorelease-2.20-sagemaker.yml
@@ -1,11 +1,8 @@
 name: "Auto Release - TensorFlow Inference 2.20 SageMaker"
 
 on:
-  # No `schedule:` yet — the image config is still `environment: gamma`, so a
-  # cron here would autorelease into gamma on a schedule. The Tue/Thu 17:30 UTC
-  # cron (matching tensorflow-training.autorelease-2.21-sagemaker.yml) is added
-  # in the same PR that flips 2.20-inference-sagemaker-{cpu,cuda}.yml to
-  # `environment: production`.
+  schedule:
+    - cron: "30 20 * * 2,4"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Follow-up to #6243 (TF Serving 2.20 inference DLC) — post-merge steps 1 and 2.

## Changes

1. **Flip to production** — in `.github/config/image/tensorflow/2.20-inference-sagemaker-cpu.yml` and `-cuda.yml`:
   - `release.environment`: `gamma` → `production`
   - `release.public_registry`: `false` → `true`

   Both now match the `2.21-sagemaker-{cpu,cuda}.yml` training configs (and every PyTorch config), which release to the public registry.
2. **Enable the autorelease cron** — added `schedule: - cron: "30 20 * * 2,4"` to
   `tensorflow-inference.autorelease-2.20-sagemaker.yml` (replacing the placeholder comment
   that documented this exact follow-up) plus the matching `.github/release-schedule.yml`
   entry (`gpu: light`).

## Slot choice

The placeholder comment named Tue/Thu 17:30 UTC, but `30 17 * * 2,4` is already held by
`tensorflow-training.autorelease-2.21-sagemaker.yml`. `30 20 * * 2,4` is the nearest free
slot inside the 16:00–23:00 release window and keeps the heavy/light GPU interleave
(20:00 Tue/Thu is heavy `sglang.autorelease-ec2-ubuntu.yml`, 21:00 is light `ray`).

## Verification

`python3 scripts/ci/check_release_schedule.py` → `OK: All 29 autorelease schedules match release-schedule.yml`