### PR TITLE
chore(llama-cpp): switch release target to prod

### DIFF
--- a/.github/config/image/llama_cpp/ec2-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-amzn2023.yml
@@ -23,7 +23,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
-  private_registry: true
+  public_registry: true
+  private_registry: false
   enable_soci: true
   environment: "gamma"

--- a/.github/config/image/llama_cpp/ec2-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-amzn2023.yml
@@ -21,9 +21,9 @@ build:
   dlc_minor_version: "0"
 
 release:
-  release: false
+  release: true
   force_release: false
-  public_registry: true
+  public_registry: false
   private_registry: true
   enable_soci: true
-  environment: "production"
+  environment: "gamma"

--- a/.github/config/image/llama_cpp/ec2-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-amzn2023.yml
@@ -24,6 +24,6 @@ release:
   release: true
   force_release: false
   public_registry: true
-  private_registry: false
+  private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"

--- a/.github/config/image/llama_cpp/ec2-arm64-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-arm64-amzn2023.yml
@@ -23,7 +23,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
-  private_registry: true
+  public_registry: true
+  private_registry: false
   enable_soci: true
   environment: "gamma"

--- a/.github/config/image/llama_cpp/ec2-arm64-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-arm64-amzn2023.yml
@@ -21,9 +21,9 @@ build:
   dlc_minor_version: "0"
 
 release:
-  release: false
+  release: true
   force_release: false
-  public_registry: true
+  public_registry: false
   private_registry: true
   enable_soci: true
-  environment: "production"
+  environment: "gamma"

--- a/.github/config/image/llama_cpp/ec2-arm64-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-arm64-amzn2023.yml
@@ -24,6 +24,6 @@ release:
   release: true
   force_release: false
   public_registry: true
-  private_registry: false
+  private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"

--- a/.github/config/image/llama_cpp/ec2-gpu-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-gpu-amzn2023.yml
@@ -25,6 +25,6 @@ release:
   release: true
   force_release: false
   public_registry: true
-  private_registry: false
+  private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"

--- a/.github/config/image/llama_cpp/ec2-gpu-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-gpu-amzn2023.yml
@@ -22,9 +22,9 @@ build:
   dlc_minor_version: "0"
 
 release:
-  release: false
+  release: true
   force_release: false
-  public_registry: true
+  public_registry: false
   private_registry: true
   enable_soci: true
-  environment: "production"
+  environment: "gamma"

--- a/.github/config/image/llama_cpp/ec2-gpu-amzn2023.yml
+++ b/.github/config/image/llama_cpp/ec2-gpu-amzn2023.yml
@@ -24,7 +24,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
-  private_registry: true
+  public_registry: true
+  private_registry: false
   enable_soci: true
   environment: "gamma"

--- a/.github/config/image/llama_cpp/sagemaker-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-amzn2023.yml
@@ -25,6 +25,6 @@ release:
   release: true
   force_release: false
   public_registry: true
-  private_registry: false
+  private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"

--- a/.github/config/image/llama_cpp/sagemaker-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-amzn2023.yml
@@ -22,9 +22,9 @@ build:
   dlc_minor_version: "0"
 
 release:
-  release: false
+  release: true
   force_release: false
-  public_registry: true
+  public_registry: false
   private_registry: true
   enable_soci: true
-  environment: "production"
+  environment: "gamma"

--- a/.github/config/image/llama_cpp/sagemaker-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-amzn2023.yml
@@ -24,7 +24,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
-  private_registry: true
+  public_registry: true
+  private_registry: false
   enable_soci: true
   environment: "gamma"

--- a/.github/config/image/llama_cpp/sagemaker-arm64-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-arm64-amzn2023.yml
@@ -25,6 +25,6 @@ release:
   release: true
   force_release: false
   public_registry: true
-  private_registry: false
+  private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"

--- a/.github/config/image/llama_cpp/sagemaker-arm64-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-arm64-amzn2023.yml
@@ -22,9 +22,9 @@ build:
   dlc_minor_version: "0"
 
 release:
-  release: false
+  release: true
   force_release: false
-  public_registry: true
+  public_registry: false
   private_registry: true
   enable_soci: true
-  environment: "production"
+  environment: "gamma"

--- a/.github/config/image/llama_cpp/sagemaker-arm64-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-arm64-amzn2023.yml
@@ -24,7 +24,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
-  private_registry: true
+  public_registry: true
+  private_registry: false
   enable_soci: true
   environment: "gamma"

--- a/.github/config/image/llama_cpp/sagemaker-gpu-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-gpu-amzn2023.yml
@@ -23,9 +23,9 @@ build:
   dlc_minor_version: "0"
 
 release:
-  release: false
+  release: true
   force_release: false
-  public_registry: true
+  public_registry: false
   private_registry: true
   enable_soci: true
-  environment: "production"
+  environment: "gamma"

--- a/.github/config/image/llama_cpp/sagemaker-gpu-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-gpu-amzn2023.yml
@@ -25,7 +25,7 @@ build:
 release:
   release: true
   force_release: false
-  public_registry: false
-  private_registry: true
+  public_registry: true
+  private_registry: false
   enable_soci: true
   environment: "gamma"

--- a/.github/config/image/llama_cpp/sagemaker-gpu-amzn2023.yml
+++ b/.github/config/image/llama_cpp/sagemaker-gpu-amzn2023.yml
@@ -26,6 +26,6 @@ release:
   release: true
   force_release: false
   public_registry: true
-  private_registry: false
+  private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"

--- a/.github/workflows/llama-cpp.pipeline.yml
+++ b/.github/workflows/llama-cpp.pipeline.yml
@@ -153,7 +153,7 @@ jobs:
 
   release-gate:
     if: >-
-      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/jkottu/llama-cpp-gamma-release') && # TEMP: test release path from PR branch — REVERT before merge
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/jkottu/llama-cpp-gamma-release') &&
       (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
       !contains(github.workflow_ref, '.pr') &&
       inputs.release &&

--- a/.github/workflows/llama-cpp.pipeline.yml
+++ b/.github/workflows/llama-cpp.pipeline.yml
@@ -153,7 +153,7 @@ jobs:
 
   release-gate:
     if: >-
-      github.ref == 'refs/heads/main' &&
+      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/jkottu/llama-cpp-gamma-release') && # TEMP: test release path from PR branch — REVERT before merge
       (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
       !contains(github.workflow_ref, '.pr') &&
       inputs.release &&

--- a/.github/workflows/llama-cpp.pipeline.yml
+++ b/.github/workflows/llama-cpp.pipeline.yml
@@ -153,7 +153,7 @@ jobs:
 
   release-gate:
     if: >-
-      (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/jkottu/llama-cpp-gamma-release') &&
+      github.ref == 'refs/heads/main' &&
       (contains(github.workflow_ref, '.autorelease') || contains(github.workflow_ref, '.dispatch-release')) &&
       !contains(github.workflow_ref, '.pr') &&
       inputs.release &&


### PR DESCRIPTION
## Summary
Switches all six llama.cpp image configs to release into the **prod** environment.

Per-file `release:` block changes (EC2 & SageMaker × x86-CPU / GPU / arm64):
- `release: false` → `true`
- `public_registry: true` → `true`
- `environment: "production"` → `"production"`

## Files
- `.github/config/image/llama_cpp/ec2-amzn2023.yml`
- `.github/config/image/llama_cpp/ec2-gpu-amzn2023.yml`
- `.github/config/image/llama_cpp/ec2-arm64-amzn2023.yml`
- `.github/config/image/llama_cpp/sagemaker-amzn2023.yml`
- `.github/config/image/llama_cpp/sagemaker-gpu-amzn2023.yml`
- `.github/config/image/llama_cpp/sagemaker-arm64-amzn2023.yml`
