### PR TITLE
fix(vllm-omni): pin sagemaker bidi SDK to v0.10.0 and port test to its new API

### DIFF
--- a/examples/vllm-omni/bidi/deploy_bidi_stream.py
+++ b/examples/vllm-omni/bidi/deploy_bidi_stream.py
@@ -11,7 +11,11 @@ Transport: boto3 has no bidirectional API — this uses the experimental
 `aws_sdk_sagemaker_runtime_http2` client (needs Python >= 3.12). Install it with:
 
     pip install "sagemaker>=3.0.0" boto3 \
-      "git+https://github.com/awslabs/aws-sdk-python.git#subdirectory=clients/aws-sdk-sagemaker-runtime-http2"
+      "git+https://github.com/awslabs/aws-sdk-python.git@aws-sdk-sagemaker-runtime-http2/v0.10.0#subdirectory=clients/aws-sdk-sagemaker-runtime-http2"
+
+This example targets the pinned v0.10.0 client API. If you are on v0.9.0 or
+earlier, the config class was `Config` (built synchronously) — see the commented
+old-SDK alternate in make_bidi_client() for that construction.
 
 Fill in EXECUTION_ROLE_ARN (a SageMaker execution role in your account) before running.
 """
@@ -44,9 +48,9 @@ SPEECH_STREAM_PATH = "v1/audio/speech/stream"
 BIDI_ENDPOINT_URI = f"https://runtime.sagemaker.{REGION}.amazonaws.com:8443"
 
 
-def make_bidi_client():
+async def make_bidi_client():
     from aws_sdk_sagemaker_runtime_http2.client import AsyncSageMakerRuntimeHTTP2Client
-    from aws_sdk_sagemaker_runtime_http2.config import Config, SigV4AuthScheme
+    from aws_sdk_sagemaker_runtime_http2.config import AsyncSageMakerRuntimeHTTP2Config
     from smithy_aws_core.identity import EnvironmentCredentialsResolver
 
     # The experimental HTTP/2 SDK signs with EnvironmentCredentialsResolver, which
@@ -65,15 +69,35 @@ def make_bidi_client():
         os.environ["AWS_SESSION_TOKEN"] = frozen.token
     os.environ.setdefault("AWS_REGION", REGION)
 
-    scheme = SigV4AuthScheme(service="sagemaker")
-    return AsyncSageMakerRuntimeHTTP2Client(
-        config=Config(
-            endpoint_uri=BIDI_ENDPOINT_URI,
-            region=REGION,
-            auth_schemes={scheme.scheme_id: scheme},
-            aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
-        )
+    # Build the client. The two blocks below differ ONLY by which SDK version you
+    # installed (see the pip line in the module docstring).
+    #
+    # Old SDK (v0.9.0 and earlier): the config class was `Config`, built
+    # synchronously, and the SigV4 auth scheme had to be wired up by hand. If you
+    # pin the older client (…@aws-sdk-sagemaker-runtime-http2/v0.9.0), make this
+    # function non-async (`def make_bidi_client()`), drop the `await` at the call
+    # site, and use this instead of the block below:
+    #
+    #     from aws_sdk_sagemaker_runtime_http2.config import Config, SigV4AuthScheme
+    #     scheme = SigV4AuthScheme(service="sagemaker")
+    #     return AsyncSageMakerRuntimeHTTP2Client(
+    #         config=Config(
+    #             endpoint_uri=BIDI_ENDPOINT_URI,
+    #             region=REGION,
+    #             auth_schemes={scheme.scheme_id: scheme},
+    #             aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
+    #         )
+    #     )
+    #
+    # New SDK (v0.10.0+, the pinned default): config is async-resolved and
+    # SigV4-for-sagemaker is the built-in default auth scheme, so we only override
+    # the bidi endpoint (:8443), region, and the env-based credentials resolver.
+    config = await AsyncSageMakerRuntimeHTTP2Config.resolve(
+        endpoint_uri=BIDI_ENDPOINT_URI,
+        region=REGION,
+        aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
     )
+    return AsyncSageMakerRuntimeHTTP2Client(config=config)
 
 
 async def _send_json(stream, obj):
@@ -97,7 +121,7 @@ async def stream_tts(endpoint_name, text, deadline_s=180):
         ResponseStreamEventPayloadPart,
     )
 
-    client = make_bidi_client()
+    client = await make_bidi_client()
     inp = InvokeEndpointWithBidirectionalStreamInput(
         endpoint_name=endpoint_name, model_invocation_path=SPEECH_STREAM_PATH
     )

--- a/test/security/data/ecr_scan_allowlist/vllm_omni/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/vllm_omni/framework_allowlist.json
@@ -88,5 +88,10 @@
         "vulnerability_id": "RUSTSEC-2026-0195",
         "reason": "quick-xml vendored in uv binary, unbounded namespace allocation DoS, fixed in uv>=0.11.32 (Cargo.lock quick-xml 0.41.0); auto-resolves on next image rebuild via curl|sh unpinned install — prune once next scan is clean",
         "review_by": "2026-10-22"
+    },
+    {
+        "vulnerability_id": "CVE-2026-73500",
+        "reason": "go.etcd.io/etcd/client/pkg/v3 in mooncake/libetcd_wrapper.so, TLS listener TCP connection exhaustion DoS, unpatchable without mooncake rebuild with etcd client >=3.7.1",
+        "review_by": "2026-10-22"
     }
 ]

--- a/test/vllm-omni/sagemaker/requirements.txt
+++ b/test/vllm-omni/sagemaker/requirements.txt
@@ -1,7 +1,10 @@
 # Experimental async HTTP/2 client for the SageMaker Bidirectional Streaming
 # API (InvokeEndpointWithBidirectionalStream). Not on PyPI — installed from the
-# awslabs monorepo subdirectory. Pinned per the SDK's own "strictly pin for
-# non-experimental use" guidance. Used by the bidi WebSocket endpoint test.
-aws-sdk-sagemaker-runtime-http2 @ git+https://github.com/awslabs/aws-sdk-python.git@main#subdirectory=clients/aws-sdk-sagemaker-runtime-http2
+# awslabs monorepo subdirectory. Pinned to a release TAG (not @main) per the
+# SDK's own "strictly pin for non-experimental use" guidance: its pre-1.0 API
+# breaks without notice — v0.10.0 renamed the config class Config ->
+# AsyncSageMakerRuntimeHTTP2Config and made it async-resolved. Used by the bidi
+# WebSocket endpoint test; bump this tag deliberately alongside the test.
+aws-sdk-sagemaker-runtime-http2 @ git+https://github.com/awslabs/aws-sdk-python.git@aws-sdk-sagemaker-runtime-http2/v0.10.0#subdirectory=clients/aws-sdk-sagemaker-runtime-http2
 sagemaker>=3.0.0
 starlette

--- a/test/vllm-omni/sagemaker/test_sm_omni_bidi_endpoint.py
+++ b/test/vllm-omni/sagemaker/test_sm_omni_bidi_endpoint.py
@@ -111,21 +111,23 @@ def bidi_endpoint(aws_session, image_uri, model_id, instance_type):
         _cleanup([endpoint, endpoint_config, model])
 
 
-def _make_bidi_client(aws_session):
+async def _make_bidi_client(aws_session):
     """Construct the experimental async HTTP/2 SageMaker runtime client.
 
     Imported lazily so a missing/renamed experimental SDK fails this test only,
-    not collection of the whole sagemaker suite.
+    not collection of the whole sagemaker suite. As of the pinned SDK (v0.10.0)
+    the config class is AsyncSageMakerRuntimeHTTP2Config and is *async-resolved*,
+    so this is a coroutine and must run inside the event loop that drives the
+    stream. SigV4-for-sagemaker is the SDK's built-in default auth scheme, so we
+    only override the bidi endpoint (:8443), region, and env-based credentials.
     """
     from aws_sdk_sagemaker_runtime_http2.client import AsyncSageMakerRuntimeHTTP2Client
-    from aws_sdk_sagemaker_runtime_http2.config import Config, SigV4AuthScheme
+    from aws_sdk_sagemaker_runtime_http2.config import AsyncSageMakerRuntimeHTTP2Config
     from smithy_aws_core.identity import EnvironmentCredentialsResolver
 
-    scheme = SigV4AuthScheme(service="sagemaker")
-    config = Config(
+    config = await AsyncSageMakerRuntimeHTTP2Config.resolve(
         endpoint_uri=BIDI_ENDPOINT_URI,
         region=aws_session.region,
-        auth_schemes={scheme.scheme_id: scheme},
         aws_credentials_identity_resolver=EnvironmentCredentialsResolver(),
     )
     return AsyncSageMakerRuntimeHTTP2Client(config=config)
@@ -152,7 +154,7 @@ async def _send_json(stream, obj):
     await stream.input_stream.send(RequestStreamEventPayloadPart(value=part))
 
 
-async def _stream_tts(client, endpoint_name, deadline_s=180):
+async def _stream_tts(aws_session, endpoint_name, deadline_s=180):
     """Open a bidi WS to /v1/audio/speech/stream, request TTS, collect audio.
 
     Returns dict: {audio_bytes, saw_start, saw_done, error}. Reads with a single
@@ -164,6 +166,7 @@ async def _stream_tts(client, endpoint_name, deadline_s=180):
         ResponseStreamEventPayloadPart,
     )
 
+    client = await _make_bidi_client(aws_session)
     inp = InvokeEndpointWithBidirectionalStreamInput(
         endpoint_name=endpoint_name,
         model_invocation_path=SPEECH_STREAM_PATH,  # slashless
@@ -258,14 +261,13 @@ def test_vllm_omni_bidi_speech_stream(bidi_endpoint, aws_session):
         os.environ["AWS_SESSION_TOKEN"] = creds.token
     os.environ.setdefault("AWS_REGION", aws_session.region)
 
-    client = _make_bidi_client(aws_session)
-
     # First request also pays torch.compile + CUDA graph warmup, which can be
     # slow; the 180s stream deadline absorbs it. One retry covers a transient
-    # first-call warmup that overruns.
+    # first-call warmup that overruns. The client is (re)built inside each run
+    # since its config is async-resolved and must live on the run's event loop.
     result = None
     for attempt in range(2):
-        result = asyncio.run(_stream_tts(client, bidi_endpoint.endpoint_name))
+        result = asyncio.run(_stream_tts(aws_session, bidi_endpoint.endpoint_name))
         LOGGER.info(f"Bidi TTS attempt {attempt + 1}: {result}")
         if result["saw_start"] and result["audio_bytes"] > 2000 and not result["error"]:
             break
@@ -294,9 +296,8 @@ def test_vllm_omni_bidi_default_path_rejected(bidi_endpoint, aws_session):
         os.environ["AWS_SESSION_TOKEN"] = creds.token
     os.environ.setdefault("AWS_REGION", aws_session.region)
 
-    client = _make_bidi_client(aws_session)
-
     async def _probe():
+        client = await _make_bidi_client(aws_session)
         # No model_invocation_path -> default /invocations-bidirectional-stream.
         inp = InvokeEndpointWithBidirectionalStreamInput(endpoint_name=bidi_endpoint.endpoint_name)
         try:


### PR DESCRIPTION
## What

Fixes the vLLM-Omni SageMaker bidi WebSocket endpoint test, which broke the scheduled *Auto Release - vLLM-Omni SageMaker* workflow's `endpoint-test (realtime)` leg and blocked the release gate.

## Root cause

`test/vllm-omni/sagemaker/requirements.txt` installed the experimental `aws-sdk-sagemaker-runtime-http2` client from `@main` (the branch tip), so it floated with upstream instead of being pinned. The upstream v0.10.0 release renamed the config class `Config` → `AsyncSageMakerRuntimeHTTP2Config` and made config resolution async. That surfaced as an import-time failure during test collection:

```
ImportError: cannot import name 'Config' from 'aws_sdk_sagemaker_runtime_http2.config'
```

Both bidi subtests (`test_vllm_omni_bidi_speech_stream`, `test_vllm_omni_bidi_default_path_rejected`) failed at collection, before deploying any endpoint. The container image and every other test (HTTP TTS endpoint, middleware unit tests, model smoke tests, sanity, telemetry) were unaffected — this was purely test-harness dependency drift.

## Fix

- **`requirements.txt`**: pin to the release **tag** `aws-sdk-sagemaker-runtime-http2/v0.10.0` instead of `@main`, so this pre-1.0 API can only change on a deliberate bump (the file's own comment already called for a strict pin).
- **`test_sm_omni_bidi_endpoint.py`**: port `_make_bidi_client` to the v0.10.0 API —
  - `Config(...)` → `await AsyncSageMakerRuntimeHTTP2Config.resolve(...)`
  - drop the manual `SigV4AuthScheme` wiring — SigV4-for-sagemaker is now the SDK's built-in default auth scheme
  - because `resolve()` is async, build the client inside the event loop (in `_stream_tts` / `_probe`) rather than in a sync helper

## Testing

- `pre-commit run` on all changed files: all hooks pass (ruff-format/check, import-sort, typos, secret scanners, JSON/requirements validators).
- Offline smoke test against the pinned v0.10.0 SDK confirms imports, `AsyncSageMakerRuntimeHTTP2Config.resolve()`, client construction, all required config fields populated by the resolved defaults, and the model classes all construct cleanly.
- The live-endpoint assertions run in CI (they require a deployed SageMaker endpoint).

## Also in this PR (unrelated, pre-existing)

Second commit allowlists **`CVE-2026-73500`** — a newly-published HIGH in `go.etcd.io/etcd/client/pkg/v3`, compiled into `mooncake/libetcd_wrapper.so`. It is **not introduced by this change** (this diff doesn't touch the image); it began surfacing in ECR enhanced scans on 2026-08-21 and gates the image build for every current vllm-omni PR. It's the same class as the 11 existing `mooncake/libetcd_wrapper.so` entries in the allowlist: mooncake ships a precompiled Go `.so` and isn't pinned/built at the DLC layer, so the etcd client can't be bumped without an upstream mooncake rebuild. Allowlisted with a `review_by` date, matching its siblings. Folded in here only to unblock this PR's scan; happy to split it into its own PR if preferred.
