### PR TITLE
feat(metadata store): wire openfold3 test-skip cache for sagemaker suite

### DIFF
--- a/.github/workflows/openfold3.pipeline.yml
+++ b/.github/workflows/openfold3.pipeline.yml
@@ -85,7 +85,7 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
-      suites: '["sanity"]'
+      suites: '["sanity", "openfold3/sagemaker"]'
 
   sanity-test:
     if: ${{ always() && !cancelled() && inputs.run-sanity-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['sanity'] != true }}
@@ -112,8 +112,12 @@ jobs:
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
   sagemaker-tests:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-sagemaker-test && needs.ci-config.outputs.customer-type == 'sagemaker' }}
-    needs: [build, ci-config]
+    if: >-
+      ${{ always() && !cancelled() && inputs.run-sagemaker-test &&
+          needs.ci-config.outputs.customer-type == 'sagemaker' &&
+          needs.build.result != 'failure' &&
+          fromJSON(needs.check.outputs.skips || '{}')['openfold3/sagemaker'] != true }}
+    needs: [build, ci-config, check]
     concurrency:
       group: ${{ github.workflow }}-sagemaker-tests-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: false
@@ -121,6 +125,8 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['openfold3/sagemaker'] || '' }}
 
   release-gate:
     if: >-

--- a/.github/workflows/openfold3.tests-sagemaker.yml
+++ b/.github/workflows/openfold3.tests-sagemaker.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image hash computed from hash_image_content.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "Test code hash computed from hash_suite_code.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -78,3 +88,23 @@ jobs:
           cd test/
           PYTHONPATH=$(pwd):$PYTHONPATH python3 -m pytest -v --tb=short -rA --log-cli-level=INFO \
             openfold3/sagemaker/test_async_endpoint.py
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.endpoint-test.result == 'success' }}
+    needs: [endpoint-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: openfold3/sagemaker
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}


### PR DESCRIPTION
## Purpose

Wire the `openfold3/sagemaker` test suite into the content-addressed test-skip cache: CI skips it when a prior PASS exists for the same image content + test code, and records a PASS once it genuinely runs and passes. Fail-open throughout — any cache miss, degraded lookup, or infra failure just runs the suite.

- **`openfold3.tests-sagemaker.yml`** — add optional `image-content-hash` / `suite-code-hash` inputs and a `record-test-pass` job. The `endpoint-test` job is already gated at the job level on the `preflight` image probe, so an absent image leaves it `skipped` (never `success`); the record job keys on `endpoint-test`'s success, so a self-skipped run records no false PASS.
- **`openfold3.pipeline.yml`** — add `openfold3/sagemaker` to the `check` job, gate `sagemaker-tests` on its `skips[...]` result (fail-open via `skips || '{}'`, gated only on build failure — never on the check job), thread the hashes, and preserve the existing `customer-type == 'sagemaker'` gate.
- **`.github/config/test-suites.yml`** — no change needed: the existing `openfold3/sagemaker` → `test/openfold3/sagemaker/**` already captures the suite's only test file and its `requirements.txt`, and the reusable parses no external matrix config.

## Test Plan

- `python -m pytest test/db/test_config_matches_workflows.py test/db/test_hash_suite_code.py` — reconciliation (invoked suites exist in config; skip accessors are configured and checked) + suite-code hashing resolves to real files.
- Verified the edited workflow files parse as YAML.
- Independent fresh-eyes review of the diff.

## Test Result

- Reconciliation + suite-hash tests: **13 passed**.
- All edited `*.yml` parse as YAML; the `openfold3/sagemaker` accessor is present in both the check-job suites list and the gated job's `if:`.
- Fresh-eyes review: **0 findings**.

## Live CI validation

Validated via test PR #6629. Record→hit is validated without a live endpoint: `openfold3/sagemaker` can't run in PR CI due to recurring GPU `InsufficientInstanceCapacity` (the endpoint never reaches `InService` even after the test's 3 retries, so the suite never passes and correctly records nothing — fail-open). The record/hit logic is suite-agnostic shared code, covered by moto unit tests in `test/db` (Database Unit Tests workflow), and its live record→hit was proven on capacity-independent suites — telemetry (#6599), EFA (#6602), Ray (#6633), PyTorch (#6632) — each recording on run 1 and getting a cache HIT (suite skipped) on a same-day re-run.

______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [x] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>

