### PR TITLE
feat(metadata store): wire tei test-skip cache for sagemaker suite

### DIFF
--- a/.github/config/test-suites.yml
+++ b/.github/config/test-suites.yml
@@ -117,6 +117,11 @@ suites:
     code_paths:
       - test/vllm-omni/sagemaker/**
 
+  tei/sagemaker:
+    skip_eligible: true
+    code_paths:
+      - test/tei/sagemaker/**
+
   openfold3/sagemaker:
     skip_eligible: true
     code_paths:

--- a/.github/workflows/tei.pipeline.yml
+++ b/.github/workflows/tei.pipeline.yml
@@ -93,7 +93,7 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
-      suites: '["sanity"]'
+      suites: '["sanity", "tei/sagemaker"]'
 
   sanity-test:
     if: ${{ always() && !cancelled() && inputs.run-sanity-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['sanity'] != true }}
@@ -120,8 +120,8 @@ jobs:
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
   sagemaker-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-sagemaker-test }}
-    needs: [build]
+    if: ${{ always() && !cancelled() && inputs.run-sagemaker-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['tei/sagemaker'] != true }}
+    needs: [build, check]
     concurrency:
       group: ${{ github.workflow }}-sagemaker-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: false
@@ -129,6 +129,8 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['tei/sagemaker'] || '' }}
 
   release-gate:
     if: >-

--- a/.github/workflows/tei.tests-sagemaker.yml
+++ b/.github/workflows/tei.tests-sagemaker.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image hash computed from hash_image_content.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "Test code hash computed from hash_suite_code.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -82,3 +92,23 @@ jobs:
           cd test/
           PYTHONPATH=$(pwd):$PYTHONPATH python3 -m pytest -v --tb=short -rA --log-cli-level=INFO \
             tei/sagemaker/
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.sagemaker-test.result == 'success' }}
+    needs: [sagemaker-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: tei/sagemaker
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}


### PR DESCRIPTION
## Purpose

Wire the `tei/sagemaker` test suite (Text Embeddings Inference) into the content-addressed test-skip cache: CI skips it when a prior PASS exists for the same image content + test code, and records a PASS once it genuinely runs and passes. Fail-open throughout — any cache miss, degraded lookup, or infra failure just runs the suite.

- **`tei.tests-sagemaker.yml`** — add optional `image-content-hash` / `suite-code-hash` inputs and a `record-test-pass` job. The `sagemaker-test` job is already gated at the job level on the `preflight` image probe, so an absent image leaves it `skipped` (never `success`); the record job keys on that job's success, so a self-skipped run records no false PASS.
- **`tei.pipeline.yml`** — add `tei/sagemaker` to the `check` job, gate `sagemaker-test` on its `skips[...]` result (fail-open via `skips || '{}'`, gated only on build failure — never on the check job), and thread the hashes.
- **`.github/config/test-suites.yml`** — author `tei/sagemaker` → `test/tei/sagemaker/**`. Verified this captures everything the reusable runs (the lone test file + its `requirements.txt`); it parses no external matrix config, so nothing outside `test/tei/sagemaker/` belongs in the hash.

## Test Plan

- `python -m pytest test/db/test_config_matches_workflows.py test/db/test_hash_suite_code.py` — reconciliation (invoked suites exist in config; skip accessors are configured and checked) + suite-code hashing resolves to real files.
- Verified the edited workflow files parse as YAML.
- Independent fresh-eyes review of the diff.

## Test Result

- Reconciliation + suite-hash tests: **13 passed**.
- All edited `*.yml` parse as YAML; the `tei/sagemaker` accessor is present in both the check-job suites list and the gated job's `if:`.
- Fresh-eyes review: **0 findings**.

## Live CI validation

Validated via test PR #6630. Record→hit is validated without a live endpoint. On the GPU config `tei/sagemaker` can't run in PR CI due to recurring `InsufficientInstanceCapacity` (endpoint never reaches `InService`, so the suite never passes and correctly records nothing); on the CPU config the prod fallback image isn't published yet, so `check` can't hash it and fail-opens to running all suites — nothing wrongly skipped. Both are the intended fail-open behavior, not cache defects. The record/hit logic is suite-agnostic shared code, covered by moto unit tests in `test/db` (Database Unit Tests workflow), and its live record→hit was proven on capacity-independent suites — telemetry (#6599), EFA (#6602), Ray (#6633), PyTorch (#6632) — each recording on run 1 and getting a cache HIT (suite skipped) on a same-day re-run.

______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [x] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>

