### PR TITLE
feat(metadata store): wire tensorflow-training test suites into test-skip cache

### DIFF
--- a/.github/config/test-suites.yml
+++ b/.github/config/test-suites.yml
@@ -61,6 +61,21 @@ suites:
     code_paths:
       - test/tensorflow/integration/inference/**
 
+  tensorflow-training/unit:
+    skip_eligible: true
+    code_paths:
+      - test/tensorflow/unit/**
+
+  tensorflow-training/single_gpu:
+    skip_eligible: true
+    code_paths:
+      - test/tensorflow/single_gpu/**
+
+  tensorflow-training/sagemaker:
+    skip_eligible: true
+    code_paths:
+      - test/tensorflow/integration/training/**
+
   ray/unit:
     skip_eligible: true
     code_paths:

--- a/.github/workflows/tensorflow-training.pipeline.yml
+++ b/.github/workflows/tensorflow-training.pipeline.yml
@@ -107,7 +107,7 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
-      suites: '["sanity", "telemetry", "efa"]'
+      suites: '["sanity", "telemetry", "efa", "tensorflow-training/unit", "tensorflow-training/single_gpu", "tensorflow-training/sagemaker"]'
 
   sanity-test:
     if: ${{ always() && !cancelled() && inputs.run-sanity-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['sanity'] != true }}
@@ -147,8 +147,11 @@ jobs:
       suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['telemetry'] || '' }}
 
   unit-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-unit-test }}
-    needs: [build]
+    if: >-
+      ${{ always() && !cancelled() && inputs.run-unit-test &&
+          needs.build.result != 'failure' &&
+          fromJSON(needs.check.outputs.skips || '{}')['tensorflow-training/unit'] != true }}
+    needs: [build, check]
     concurrency:
       group: ${{ github.workflow }}-unit-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: true
@@ -156,11 +159,17 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['tensorflow-training/unit'] || '' }}
 
   # Single-GPU tests — only for GPU images
   single-gpu-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-single-gpu-test && needs.ci-config.outputs.device-type == 'gpu' }}
-    needs: [build, ci-config]
+    if: >-
+      ${{ always() && !cancelled() && inputs.run-single-gpu-test &&
+          needs.ci-config.outputs.device-type == 'gpu' &&
+          needs.build.result != 'failure' &&
+          fromJSON(needs.check.outputs.skips || '{}')['tensorflow-training/single_gpu'] != true }}
+    needs: [build, ci-config, check]
     concurrency:
       group: ${{ github.workflow }}-single-gpu-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: true
@@ -168,11 +177,17 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['tensorflow-training/single_gpu'] || '' }}
 
   # SageMaker integration tests — only for sagemaker images (TF DLC is SM-only)
   sagemaker-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-sagemaker-test && needs.ci-config.outputs.customer-type == 'sagemaker' }}
-    needs: [build, ci-config]
+    if: >-
+      ${{ always() && !cancelled() && inputs.run-sagemaker-test &&
+          needs.ci-config.outputs.customer-type == 'sagemaker' &&
+          needs.build.result != 'failure' &&
+          fromJSON(needs.check.outputs.skips || '{}')['tensorflow-training/sagemaker'] != true }}
+    needs: [build, ci-config, check]
     concurrency:
       group: ${{ github.workflow }}-sagemaker-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: true
@@ -180,6 +195,8 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['tensorflow-training/sagemaker'] || '' }}
 
   # EFA tests — only for GPU EC2 images (2-node p4d NCCL+EFA all_reduce_perf)
   efa-test:

--- a/.github/workflows/tensorflow-training.tests-sagemaker.yml
+++ b/.github/workflows/tensorflow-training.tests-sagemaker.yml
@@ -12,6 +12,14 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -88,3 +96,23 @@ jobs:
               -v \
               --image-uri "${{ needs.preflight.outputs.image-uri }}"
           fi
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.sagemaker-test.result == 'success' }}
+    needs: [sagemaker-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: tensorflow-training/sagemaker
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/tensorflow-training.tests-single-gpu.yml
+++ b/.github/workflows/tensorflow-training.tests-single-gpu.yml
@@ -12,6 +12,14 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -22,6 +30,8 @@ jobs:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
         fleet:x86-g6xl-runner
         buildspec-override:true
+    outputs:
+      image-exists: ${{ steps.check.outputs.exists }}
     steps:
       - uses: actions/checkout@v6
 
@@ -73,3 +83,24 @@ jobs:
             ${CONTAINER_ID} \
             pytest /workdir/test/tensorflow/single_gpu/ -v
           docker kill ${CONTAINER_ID}
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.single-gpu-test.result == 'success' &&
+          needs.single-gpu-test.outputs.image-exists == 'true' }}
+    needs: [single-gpu-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: tensorflow-training/single_gpu
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/tensorflow-training.tests-unit.yml
+++ b/.github/workflows/tensorflow-training.tests-unit.yml
@@ -12,6 +12,14 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -22,6 +30,8 @@ jobs:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
         fleet:default-runner
         buildspec-override:true
+    outputs:
+      image-exists: ${{ steps.check.outputs.exists }}
     steps:
       - uses: actions/checkout@v6
 
@@ -72,3 +82,24 @@ jobs:
             ${CONTAINER_ID} \
             pytest /workdir/test/tensorflow/unit/ -v
           docker kill ${CONTAINER_ID}
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.unit-test.result == 'success' &&
+          needs.unit-test.outputs.image-exists == 'true' }}
+    needs: [unit-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: tensorflow-training/unit
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}


### PR DESCRIPTION
## Purpose

Wire the three `tensorflow-training` framework test suites — `tensorflow-training/unit`, `tensorflow-training/single_gpu`, `tensorflow-training/sagemaker` — into the content-addressed test-skip cache: CI skips a suite when a prior PASS exists for the same image content + test code, and records a PASS once the suite genuinely runs and passes. Fail-open throughout — any cache miss, degraded lookup, or infra failure just runs the suite.

- **`tensorflow-training.tests-{unit,single-gpu,sagemaker}.yml`** — each reusable gains optional `image-content-hash` / `suite-code-hash` inputs and a `record-test-pass` job, gated to match each suite's topology:
  - **`sagemaker`** runs a `preflight` job and gates `sagemaker-test` at the job level on the image probe, so an absent image leaves it `skipped` (never `success`) → the record keys on `sagemaker-test.result == 'success'`.
  - **`unit`** and **`single_gpu`** run as a single job whose steps self-skip on the image-exists check, so the job can report `success` even when the image is absent. To avoid recording a false PASS, that job exposes an `image-exists` output and the record additionally requires `needs.<job>.outputs.image-exists == 'true'`.
- **`tensorflow-training.pipeline.yml`** — add all three suites to the `check` job, gate `unit-test` / `single-gpu-test` / `sagemaker-tests` on their `skips[...]` result (fail-open via `skips || '{}'`, gated only on build failure — never on the check job), thread the hashes, and preserve the existing gates (`single-gpu-test` keeps `device-type == 'gpu'`, `sagemaker-tests` keeps `customer-type == 'sagemaker'`).
- **`.github/config/test-suites.yml`** — author `tensorflow-training/unit` → `test/tensorflow/unit/**`, `tensorflow-training/single_gpu` → `test/tensorflow/single_gpu/**`, `tensorflow-training/sagemaker` → `test/tensorflow/integration/training/**`. `test/tensorflow/` is shared with tensorflow-inference, so the globs are scoped to the training-specific subpaths (disjoint from `test/tensorflow/integration/inference/**`). The sagemaker glob captures the suite's test modules plus its `conftest.py`, `resources/` training scripts, and in-dir `requirements.txt`. Generic shared harness (root `test/conftest.py`, `test/test_utils/**`, root `test/requirements.txt`) is excluded as an accepted cache-hit tradeoff.

## Test Plan

- `python -m pytest test/db/test_config_matches_workflows.py test/db/test_hash_suite_code.py` — reconciliation (invoked suites exist in config; skip accessors are configured and checked) + suite-code hashing resolves to real files.
- Verified the edited workflow files parse as YAML.
- Independent fresh-eyes review of the diff, with specific scrutiny of the per-suite record-gate topology (the self-skipping `unit`/`single_gpu` jobs vs. the job-level-gated `sagemaker`) and code_paths disjointness from tensorflow-inference.

## Test Result

- Reconciliation + suite-hash tests: **13 passed**.
- All edited `*.yml` parse as YAML; every `tensorflow-training/*` accessor is present in the check-job suites list and the gated jobs' `if:`.
- Fresh-eyes review: **0 findings** (unit/single-gpu image-exists gate confirmed correct; sagemaker job-level gate confirmed safe; paths confirmed disjoint from inference).

## Live CI validation — record → hit (clean HIT)

Validated via test PR #6644 (no-op Dockerfile edit → CPU build; single-gpu/sagemaker disabled). Run [`32877989279`](https://github.com/aws/deep-learning-containers/actions/runs/32877989279):

- **Run 1 (record):** `sanity` + `telemetry` + `tensorflow-training/unit` recorded PASS rows → [sanity](https://github.com/aws/deep-learning-containers/actions/runs/32877989279/job/97902567335), [telemetry](https://github.com/aws/deep-learning-containers/actions/runs/32877989279/job/97903788031), [unit](https://github.com/aws/deep-learning-containers/actions/runs/32877989279/job/97902577117).
- **Run 2 (cache HIT):** [`check` hit](https://github.com/aws/deep-learning-containers/actions/runs/32877989279/attempts/2) → all three **skipped** with no re-record: [sanity](https://github.com/aws/deep-learning-containers/actions/runs/32877989279/job/97924499618), [telemetry](https://github.com/aws/deep-learning-containers/actions/runs/32877989279/job/97924499754), [unit](https://github.com/aws/deep-learning-containers/actions/runs/32877989279/job/97924499768).

______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [x] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>

