### PR TITLE
test(metadata store): wire vLLM test-skip cache for upstream/model/sagemaker suites

### DIFF
--- a/.github/config/test-suites.yml
+++ b/.github/config/test-suites.yml
@@ -86,11 +86,13 @@ suites:
     skip_eligible: true
     code_paths:
       - test/vllm/**
+      - .github/config/model-tests/vllm-model-tests.yml
 
   vllm/sagemaker:
     skip_eligible: true
     code_paths:
       - test/vllm/sagemaker/**
+      - .github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
 
   sglang/upstream:
     skip_eligible: true

--- a/.github/workflows/huggingface-vllm.pipeline.yml
+++ b/.github/workflows/huggingface-vllm.pipeline.yml
@@ -80,7 +80,7 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
-      suites: '["sanity"]'
+      suites: '["sanity", "vllm/sagemaker"]'
 
   sanity-test:
     if: ${{ always() && !cancelled() && inputs.run-sanity-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['sanity'] != true }}
@@ -162,8 +162,8 @@ jobs:
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
   sagemaker-tests:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-sagemaker-test }}
-    needs: [build]
+    if: ${{ always() && !cancelled() && inputs.run-sagemaker-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['vllm/sagemaker'] != true }}
+    needs: [build, check]
     concurrency:
       group: ${{ github.workflow }}-sagemaker-tests-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: false
@@ -171,6 +171,8 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['vllm/sagemaker'] || '' }}
 
   hf-endpoint-boot-test:
     # vllm.tests-sagemaker.yml gates its whole endpoint-test job on the

--- a/.github/workflows/vllm.pipeline.yml
+++ b/.github/workflows/vllm.pipeline.yml
@@ -112,7 +112,7 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
-      suites: '["sanity"]'
+      suites: '["sanity", "vllm/upstream", "vllm/model", "vllm/sagemaker"]'
 
   sanity-test:
     if: ${{ always() && !cancelled() && inputs.run-sanity-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['sanity'] != true }}
@@ -160,8 +160,8 @@ jobs:
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
   upstream-tests:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-upstream-test }}
-    needs: [build]
+    if: ${{ always() && !cancelled() && inputs.run-upstream-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['vllm/upstream'] != true }}
+    needs: [build, check]
     concurrency:
       group: ${{ github.workflow }}-upstream-tests-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: true
@@ -169,11 +169,13 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['vllm/upstream'] || '' }}
     secrets: inherit
 
   model-tests:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-model-test }}
-    needs: [build]
+    if: ${{ always() && !cancelled() && inputs.run-model-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['vllm/model'] != true }}
+    needs: [build, check]
     concurrency:
       group: ${{ github.workflow }}-model-tests-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: true
@@ -181,11 +183,17 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['vllm/model'] || '' }}
     secrets: inherit
 
   sagemaker-tests:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-sagemaker-test && needs.ci-config.outputs.customer-type == 'sagemaker' }}
-    needs: [build, ci-config]
+    if: >-
+      ${{ always() && !cancelled() && inputs.run-sagemaker-test &&
+          needs.build.result != 'failure' &&
+          needs.ci-config.outputs.customer-type == 'sagemaker' &&
+          fromJSON(needs.check.outputs.skips || '{}')['vllm/sagemaker'] != true }}
+    needs: [build, ci-config, check]
     concurrency:
       group: ${{ github.workflow }}-sagemaker-tests-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: false
@@ -193,6 +201,8 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['vllm/sagemaker'] || '' }}
 
   efa-test:
     if: ${{ always() && !failure() && !cancelled() && inputs.run-efa-test }}

--- a/.github/workflows/vllm.tests-model.yml
+++ b/.github/workflows/vllm.tests-model.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image hash computed from hash_image_content.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "Test code hash computed from hash_suite_code.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -211,3 +221,24 @@ jobs:
         run: |
           docker stop ${CONTAINER_ID} 2>/dev/null || true
           docker rm -f ${CONTAINER_ID} 2>/dev/null || true
+
+  # Record a PASS row in the ci-images-table if the test suite passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          (needs.test-model-codebuild-fleet.result == 'success' ||
+           needs.test-model-runner-scale-sets.result == 'success') }}
+    needs: [test-model-codebuild-fleet, test-model-runner-scale-sets]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: vllm/model
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/vllm.tests-sagemaker.yml
+++ b/.github/workflows/vllm.tests-sagemaker.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image hash computed from hash_image_content.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "Test code hash computed from hash_suite_code.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -87,3 +97,23 @@ jobs:
           source .venv/bin/activate
           cd test/
           python3 -m pytest -vs -rA --image-uri ${{ needs.preflight.outputs.image-uri }} vllm/sagemaker
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.endpoint-test.result == 'success' }}
+    needs: [endpoint-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: vllm/sagemaker
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/vllm.tests-upstream.yml
+++ b/.github/workflows/vllm.tests-upstream.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image hash computed from hash_image_content.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "Test code hash computed from hash_suite_code.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -241,3 +251,25 @@ jobs:
             # EC2 example tests are shared across OSes (amzn2023 wraps this script).
             docker exec ${CONTAINER_ID} test/vllm/scripts/vllm_ec2_examples_test.sh
           fi
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.regression-test.result == 'success' &&
+          needs.cuda-test.result == 'success' &&
+          needs.example-test.result == 'success' }}
+    needs: [regression-test, cuda-test, example-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: vllm/upstream
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/test/vllm/sagemaker/test_sm_endpoint.py
+++ b/test/vllm/sagemaker/test_sm_endpoint.py
@@ -1,3 +1,4 @@
+# no-op: verify the vllm/sagemaker test-skip cache (record + hit) against the prod image
 """Integration test for serving endpoint with vLLM DLC — SageMaker SDK v3"""
 
 import json


### PR DESCRIPTION
Verification PR for #6604 (vLLM test-skip cache). **Do not merge — test only.**

**Change:** a no-op comment in `test/vllm/sagemaker/test_sm_endpoint.py`. This is a test-only change (`build-change=false`), so no GPU build runs — `resolve-image-uri` falls back to the **prod** vLLM image. It trips only `sagemaker-test-change` (upstream/model watch `test/vllm/scripts/**`), so just `vllm/sagemaker` runs, and it changes that suite's `suite_code_hash` → guaranteed cache miss on run 1.

**Expected:**
- Run 1: `check` misses → `vllm/sagemaker` runs against the prod image → `record-test-pass` writes a PASS row.
- Re-run all jobs: `check` hits the row → `vllm/sagemaker` skipped.
