### PR TITLE
test(metadata store): wire vLLM-Omni test-skip cache for model/sagemaker suites

### DIFF
--- a/.github/config/test-suites.yml
+++ b/.github/config/test-suites.yml
@@ -111,6 +111,7 @@ suites:
     skip_eligible: true
     code_paths:
       - test/vllm-omni/**
+      - .github/config/model-tests/vllm-omni-model-tests.yml
 
   vllm-omni/sagemaker:
     skip_eligible: true

--- a/.github/workflows/vllm-omni.pipeline.yml
+++ b/.github/workflows/vllm-omni.pipeline.yml
@@ -102,7 +102,7 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
-      suites: '["sanity"]'
+      suites: '["sanity", "vllm-omni/model", "vllm-omni/sagemaker"]'
 
   sanity-test:
     if: ${{ always() && !cancelled() && inputs.run-sanity-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['sanity'] != true }}
@@ -150,8 +150,8 @@ jobs:
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
   model-tests:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-model-test }}
-    needs: [build]
+    if: ${{ always() && !cancelled() && inputs.run-model-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['vllm-omni/model'] != true }}
+    needs: [build, check]
     concurrency:
       group: ${{ github.workflow }}-model-tests-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: true
@@ -159,11 +159,17 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['vllm-omni/model'] || '' }}
     secrets: inherit
 
   sagemaker-tests:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-sagemaker-test && needs.ci-config.outputs.customer-type == 'sagemaker' }}
-    needs: [build, ci-config]
+    if: >-
+      ${{ always() && !cancelled() && inputs.run-sagemaker-test &&
+          needs.build.result != 'failure' &&
+          needs.ci-config.outputs.customer-type == 'sagemaker' &&
+          fromJSON(needs.check.outputs.skips || '{}')['vllm-omni/sagemaker'] != true }}
+    needs: [build, ci-config, check]
     concurrency:
       group: ${{ github.workflow }}-sagemaker-tests-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: false
@@ -171,6 +177,8 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['vllm-omni/sagemaker'] || '' }}
 
   release-gate:
     if: >-

--- a/.github/workflows/vllm-omni.tests-model.yml
+++ b/.github/workflows/vllm-omni.tests-model.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image hash computed from hash_image_content.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "Test code hash computed from hash_suite_code.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -205,3 +215,23 @@ jobs:
           docker rm -f ${CONTAINER_ID} 2>/dev/null || true
           docker rmi ${{ needs.preflight.outputs.image-uri }} 2>/dev/null || true
           rm -rf /dlc-models
+
+  # Record a PASS row in the ci-images-table if the test suite passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.smoke-test.result == 'success' }}
+    needs: [smoke-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: vllm-omni/model
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/vllm-omni.tests-sagemaker.yml
+++ b/.github/workflows/vllm-omni.tests-sagemaker.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image hash computed from hash_image_content.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "Test code hash computed from hash_suite_code.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -101,3 +111,23 @@ jobs:
           python3 -m pytest -vs -rA --image-uri ${{ needs.preflight.outputs.image-uri }} \
             -k "${{ matrix.group.filter }}" \
             vllm-omni/sagemaker
+
+  # Record a PASS row in the ci-images-table if the test suite passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.endpoint-test.result == 'success' }}
+    needs: [endpoint-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: vllm-omni/sagemaker
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/test/vllm-omni/sagemaker/test_sm_omni_endpoint.py
+++ b/test/vllm-omni/sagemaker/test_sm_omni_endpoint.py
@@ -1,3 +1,4 @@
+# no-op: verify the vllm-omni/sagemaker + model test-skip cache (record + hit) against the prod image
 """Integration test for vLLM-Omni SageMaker endpoint — SageMaker SDK v3"""
 
 import json


### PR DESCRIPTION
Verification PR for #6605 (vLLM-Omni test-skip cache). **Do not merge — test only.**

**Change:** a no-op comment in `test/vllm-omni/sagemaker/test_sm_omni_endpoint.py`. Test-only change (`build-change=false`) → no GPU build; runs against the **prod** vLLM-Omni image. The path trips `sagemaker-test-change` **and** `model-test-change` (`model` watches `test/vllm-omni/**`), so **both** `vllm-omni/sagemaker` and `vllm-omni/model` run — both are wired, both get verified. The edit changes both suites' `suite_code_hash` → guaranteed miss on run 1.

**Expected:**
- Run 1: `check` misses → both suites run against the prod image → each `record-test-pass` writes a PASS row.
- Re-run all jobs: `check` hits → both suites skipped.
