### PR TITLE
test(metadata store): wire openfold3 test-skip cache for sagemaker suite

### DIFF
--- a/.github/workflows/openfold3.pipeline.yml
+++ b/.github/workflows/openfold3.pipeline.yml
@@ -85,7 +85,7 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
-      suites: '["sanity"]'
+      suites: '["sanity", "openfold3/sagemaker"]'
 
   sanity-test:
     if: ${{ always() && !cancelled() && inputs.run-sanity-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['sanity'] != true }}
@@ -112,8 +112,12 @@ jobs:
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
   sagemaker-tests:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-sagemaker-test && needs.ci-config.outputs.customer-type == 'sagemaker' }}
-    needs: [build, ci-config]
+    if: >-
+      ${{ always() && !cancelled() && inputs.run-sagemaker-test &&
+          needs.ci-config.outputs.customer-type == 'sagemaker' &&
+          needs.build.result != 'failure' &&
+          fromJSON(needs.check.outputs.skips || '{}')['openfold3/sagemaker'] != true }}
+    needs: [build, ci-config, check]
     concurrency:
       group: ${{ github.workflow }}-sagemaker-tests-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: false
@@ -121,6 +125,8 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['openfold3/sagemaker'] || '' }}
 
   release-gate:
     if: >-

--- a/.github/workflows/openfold3.tests-sagemaker.yml
+++ b/.github/workflows/openfold3.tests-sagemaker.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image hash computed from hash_image_content.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "Test code hash computed from hash_suite_code.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -78,3 +88,23 @@ jobs:
           cd test/
           PYTHONPATH=$(pwd):$PYTHONPATH python3 -m pytest -v --tb=short -rA --log-cli-level=INFO \
             openfold3/sagemaker/test_async_endpoint.py
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.endpoint-test.result == 'success' }}
+    needs: [endpoint-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: openfold3/sagemaker
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/test/openfold3/sagemaker/test_async_endpoint.py
+++ b/test/openfold3/sagemaker/test_async_endpoint.py
@@ -1,3 +1,4 @@
+# no-op: verify the openfold3/sagemaker test-skip cache (record + hit) against the prod image
 """OpenFold3 SageMaker async-inference integration tests.
 
 Uses the SageMaker Python SDK v3. Launches a real async inference endpoint and


### PR DESCRIPTION
Verification PR for #6606 (openfold3 test-skip cache). **Do not merge — test only.**

**Change:** a no-op comment in `test/openfold3/sagemaker/test_async_endpoint.py`. Test-only change (`build-change=false`) → no GPU build; runs against the **prod** openfold3 image. Trips only `sagemaker-test-change`, so just `openfold3/sagemaker` runs, and it changes that suite's `suite_code_hash` → guaranteed miss on run 1.

**Expected:**
- Run 1: `check` misses → `openfold3/sagemaker` runs against the prod image → `record-test-pass` writes a PASS row.
- Re-run all jobs: `check` hits → `openfold3/sagemaker` skipped.
