### PR TITLE
test(metadata store): wire tei test-skip cache for sagemaker suite

### DIFF
--- a/.github/config/test-suites.yml
+++ b/.github/config/test-suites.yml
@@ -117,6 +117,11 @@ suites:
     code_paths:
       - test/vllm-omni/sagemaker/**
 
+  tei/sagemaker:
+    skip_eligible: true
+    code_paths:
+      - test/tei/sagemaker/**
+
   openfold3/sagemaker:
     skip_eligible: true
     code_paths:

--- a/.github/workflows/tei.pipeline.yml
+++ b/.github/workflows/tei.pipeline.yml
@@ -93,7 +93,7 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
-      suites: '["sanity"]'
+      suites: '["sanity", "tei/sagemaker"]'
 
   sanity-test:
     if: ${{ always() && !cancelled() && inputs.run-sanity-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['sanity'] != true }}
@@ -120,8 +120,8 @@ jobs:
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
   sagemaker-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-sagemaker-test }}
-    needs: [build]
+    if: ${{ always() && !cancelled() && inputs.run-sagemaker-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['tei/sagemaker'] != true }}
+    needs: [build, check]
     concurrency:
       group: ${{ github.workflow }}-sagemaker-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: false
@@ -129,6 +129,8 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['tei/sagemaker'] || '' }}
 
   release-gate:
     if: >-

--- a/.github/workflows/tei.tests-sagemaker.yml
+++ b/.github/workflows/tei.tests-sagemaker.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image hash computed from hash_image_content.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "Test code hash computed from hash_suite_code.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -82,3 +92,23 @@ jobs:
           cd test/
           PYTHONPATH=$(pwd):$PYTHONPATH python3 -m pytest -v --tb=short -rA --log-cli-level=INFO \
             tei/sagemaker/
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.sagemaker-test.result == 'success' }}
+    needs: [sagemaker-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: tei/sagemaker
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/test/tei/sagemaker/sagemaker_dlc_test.py
+++ b/test/tei/sagemaker/sagemaker_dlc_test.py
@@ -1,3 +1,4 @@
+# no-op: verify the tei/sagemaker test-skip cache (record + hit) against the prod image
 import argparse
 import json
 import logging


### PR DESCRIPTION
Verification PR for #6607 (tei test-skip cache). **Do not merge — test only.**

**Change:** no-op comment in `test/tei/sagemaker/sagemaker_dlc_test.py`. Test-only (`build-change=false`) → no build; runs `tei/sagemaker` against the **prod** image. Changes the suite hash → guaranteed miss on run 1.

**Expected:** run 1 → `check` miss → `tei/sagemaker` runs → `record-test-pass` writes a PASS row. Re-run → `check` hit → `tei/sagemaker` skipped.
