### PR TITLE
ray-train: give each EKS test run its own RayCluster

### DIFF
--- a/test/ray-train/eks/raycluster.yml
+++ b/test/ray-train/eks/raycluster.yml
@@ -1,7 +1,7 @@
 apiVersion: ray.io/v1
 kind: RayCluster
 metadata:
-  name: ray-train-test
+  name: "${CLUSTER_NAME}"
   namespace: ray-train
 spec:
   rayVersion: "${RAY_VERSION}"

--- a/test/ray-train/eks/run_eks_test.sh
+++ b/test/ray-train/eks/run_eks_test.sh
@@ -20,7 +20,8 @@ TIMEOUT_READY=600
 TIMEOUT_JOB=1800
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-CLUSTER_NAME=$(yq '.metadata.name' "${SCRIPT_DIR}/raycluster.yml")
+# Per-run name so concurrent runs never share one RayCluster.
+export CLUSTER_NAME="ray-train-test-${GITHUB_RUN_ID:-local}-${GITHUB_RUN_ATTEMPT:-1}"
 
 cleanup() {
     echo "=== Cleanup: deleting RayCluster ${CLUSTER_NAME} ==="
@@ -34,7 +35,7 @@ echo "=== Configuring kubectl for ${EKS_CLUSTER} ==="
 aws eks update-kubeconfig --name "${EKS_CLUSTER}" --region "${AWS_REGION}"
 
 echo "=== Applying RayCluster manifest ==="
-envsubst '${IMAGE_URI} ${RAY_VERSION}' < "${SCRIPT_DIR}/raycluster.yml" | kubectl apply -f -
+envsubst '${IMAGE_URI} ${RAY_VERSION} ${CLUSTER_NAME}' < "${SCRIPT_DIR}/raycluster.yml" | kubectl apply -f -
 
 echo "=== Waiting for head pod Ready (timeout ${TIMEOUT_READY}s) ==="
 kubectl wait --for=condition=Ready pod \


### PR DESCRIPTION
## Problem
Two overlapping Ray Train runs could destroy each other. The RayCluster name was hardcoded `ray-train-test` in one shared namespace on one shared cluster.

Verified from logs (PR #6617 vs PR #6619, 2026-08-24):

| Time | Run | Event |
|---|---|---|
| 18:46:54 | PR-A (#6617) | apply -> **CREATE** `ray-train-test`, training starts |
| 19:01:37 | PR-B (#6619) | apply -> object exists -> **PATCH** -> `forbidden` (Role has no `patch` verb) |
| 19:01:41 | PR-B | cleanup trap -> **DELETE PR-A's live cluster** |
| 19:01:43 | PR-A | websocket closes 2s later, job still `RUNNING` -> **FAIL** |

Both failed, and PR-B took PR-A down with it. This also means a red `eks-test` on one PR can be caused by an unrelated PR.

## Fix
Name the RayCluster per run: `ray-train-test-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}`.

**Every** kubectl operation is scoped to the run, not just apply/delete:

| Operation | Scoped by |
|---|---|
| `apply` | `${CLUSTER_NAME}` via envsubst |
| `delete raycluster` | `${CLUSTER_NAME}` |
| `wait --for=delete pod` | `-l ray.io/cluster=${CLUSTER_NAME}` |
| wait head / workers Ready | `-l ray.io/cluster=${CLUSTER_NAME},ray.io/node-type=...` |
| `get pods`, resolve `HEAD_POD` | `-l ray.io/cluster=${CLUSTER_NAME}` |
| `exec` / `cp` | target `${HEAD_POD}` from the scoped lookup |

KubeRay sets the `ray.io/cluster` label to the RayCluster name, so a per-run name makes the label selectors per-run too. That matters beyond cleanup: otherwise `wait --for=delete` would block on another run's pods, and `HEAD_POD` could resolve to someone else's head.

Concurrency settings are deliberately left unchanged — PR runs are *expected* to overlap, and the namespace quota covers 2 concurrent clusters (CR-299648954, shipped: cpu 192 / 768Gi / 16 GPU).

Side effect: **no `patch` RBAC verb is needed**. Each run only ever CREATEs its own object, so `kubectl apply` never takes the patch path.

## Verification
- Manifest renders with no unsubstituted vars: `name: ray-train-test-32764449119-1`
- RFC1123-valid; longest derived pod name 53 chars (under the 63 limit)
- No hardcoded `ray-train-test` literal remains except the `CLUSTER_NAME` prefix
- `bash -n` and pre-commit clean

## Note: CI cannot exercise this yet
On this PR every job **skipped**, because ray-train is gamma-only:
1. No `build-change` path touched -> `build` skipped
2. Empty image-uri -> falls back to prod `ray:train-ml-cuda`
3. `check-image-exists` probes prod ECR -> not found (never released to prod)
4. `eks-test` is gated on `image-exists == true` -> skipped

```
##[warning]ECR image not found: .../ray:train-ml-cuda - skipping test
```

So the green check here does not mean the change was tested; the first real exercise will be the post-merge autorelease. Worth noting more broadly: while ray-train is gamma-only, *any* test-only PR silently skips all tests and still reports green.