### PR TITLE
ray-train: release to production and publish to the public gallery

### DIFF
--- a/.github/config/image/ray-train/ec2-gpu.yml
+++ b/.github/config/image/ray-train/ec2-gpu.yml
@@ -36,8 +36,7 @@ build:
 release:
   release: true
   force_release: false
-  # Gamma-only for now (private ECR, no public gallery) until v1 is signed off.
-  public_registry: false
+  public_registry: true
   private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"


### PR DESCRIPTION
## Summary
Promotes the Ray Train DLC from gamma to production, including the public gallery.

```diff
 release:
   release: true
   force_release: false
-  public_registry: false
+  public_registry: true
   private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"
```

Publishes `ray:train-ml-cuda` to the private prod ECR and to `public.ecr.aws/deep-learning-containers/ray:train-ml-cuda`. The `ray` public repo already exists — Ray Serve publishes `serve-ml-cuda` there — so this adds a tag rather than requiring a new repo.

Merged main to pick up Ray 2.58.0 (#6639), which clears the expired allowlist entries that were failing the security scan on this branch.

## Readiness
Latest autorelease green: sanity, telemetry, unit, single-GPU, multi-node EFA, multi-node EKS (KubeRay FSDP, 8 GPU / 2 nodes). Functionally validated for DDP, FSDP, EFA engagement, and fault tolerance with checkpoint-resume.

## Follow-up
`docs/ray-train/` is not authored yet, so the release's `step4-docs-pr` early-exits. Not blocking, but it is the remaining gap for customer discoverability.
