### PR TITLE
test(metadata store): wire sklearn test suites into test-skip cache

### DIFF
--- a/.github/config/test-suites.yml
+++ b/.github/config/test-suites.yml
@@ -136,3 +136,10 @@ suites:
     skip_eligible: true
     code_paths:
       - test/xgboost/benchmarks/**
+
+  sklearn/sagemaker:
+    skip_eligible: true
+    code_paths:
+      - test/sklearn/sagemaker/**
+      - test/sklearn/conftest.py
+      - test/sklearn/requirements.txt

--- a/.github/workflows/sklearn.pipeline.yml
+++ b/.github/workflows/sklearn.pipeline.yml
@@ -90,7 +90,7 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
-      suites: '["sanity"]'
+      suites: '["sanity", "sklearn/sagemaker"]'
 
   sanity-test:
     if: ${{ always() && !cancelled() && inputs.run-sanity-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['sanity'] != true }}
@@ -153,8 +153,12 @@ jobs:
 
   # SageMaker tests — real training jobs + endpoints
   sagemaker-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-sagemaker-test }}
-    needs: [build]
+    if: >-
+      ${{ always() && !cancelled() &&
+          inputs.run-sagemaker-test &&
+          needs.build.result != 'failure' &&
+          fromJSON(needs.check.outputs.skips || '{}')['sklearn/sagemaker'] != true }}
+    needs: [build, check]
     concurrency:
       group: ${{ github.workflow }}-sagemaker-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: true
@@ -162,6 +166,8 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['sklearn/sagemaker'] || '' }}
 
   release-gate:
     if: >-

--- a/.github/workflows/sklearn.pr-1.9-0.yml
+++ b/.github/workflows/sklearn.pr-1.9-0.yml
@@ -93,10 +93,10 @@ jobs:
     with:
       config-file: ${{ matrix.config_file }}
       tag-suffix: pr-${{ github.event.pull_request.number }}
-      build: ${{ needs.check-changes.outputs.build-change == 'true' }}
+      build: false  # test-only cache-hit verification: skip build, test the unchanged prod image
       run-integ-test: false
       run-sagemaker-test: false
-      run-sanity-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sanity-test-change == 'true' }}
+      run-sanity-test: true  # force sanity test-only against prod image (stable content hash → record→hit)
       run-security-test: ${{ needs.check-changes.outputs.build-change == 'true' }}
       run-telemetry-test: false
       run-unit-test: false

--- a/.github/workflows/sklearn.pr-1.9-0.yml
+++ b/.github/workflows/sklearn.pr-1.9-0.yml
@@ -94,11 +94,11 @@ jobs:
       config-file: ${{ matrix.config_file }}
       tag-suffix: pr-${{ github.event.pull_request.number }}
       build: ${{ needs.check-changes.outputs.build-change == 'true' }}
-      run-integ-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.integ-test-change == 'true' }}
-      run-sagemaker-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sagemaker-test-change == 'true' }}
+      run-integ-test: false
+      run-sagemaker-test: false
       run-sanity-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sanity-test-change == 'true' }}
       run-security-test: ${{ needs.check-changes.outputs.build-change == 'true' }}
       run-telemetry-test: false
-      run-unit-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.unit-test-change == 'true' }}
+      run-unit-test: false
       release: false
     secrets: inherit

--- a/.github/workflows/sklearn.tests-sagemaker.yml
+++ b/.github/workflows/sklearn.tests-sagemaker.yml
@@ -12,6 +12,14 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -88,3 +96,23 @@ jobs:
             --image-uri ${{ needs.preflight.outputs.image-uri }} \
             --sklearn-version ${{ needs.preflight.outputs.framework-version }} \
             sklearn/sagemaker/${{ matrix.test-module }}.py
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.sagemaker-test.result == 'success' }}
+    needs: [sagemaker-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: sklearn/sagemaker
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/docker/sklearn/1.9-0/Dockerfile
+++ b/docker/sklearn/1.9-0/Dockerfile
@@ -1,3 +1,4 @@
+# no-op: trigger sklearn build to validate test-skip cache (record + hit)
 # ============================================================================
 # Scikit-learn DLC — Amazon Linux 2023 / Python 3.12 (CPU)
 # Multi-stage build:

--- a/docker/sklearn/1.9-0/Dockerfile
+++ b/docker/sklearn/1.9-0/Dockerfile
@@ -1,4 +1,3 @@
-# no-op: trigger sklearn build to validate test-skip cache (record + hit)
 # ============================================================================
 # Scikit-learn DLC — Amazon Linux 2023 / Python 3.12 (CPU)
 # Multi-stage build:


### PR DESCRIPTION
Verification PR for #6614 (sklearn test-skip cache). **Do not merge — test only.** No-op comment in `docker/sklearn/1.9-0/Dockerfile` triggers a build of the sagemaker-1.9-0 cpu image; heavy suites disabled (run-sagemaker-test, run-integ-test, run-unit-test) so only `sanity` runs. Expected: run 1 records a PASS row for `sanity`; re-run → cache hit (sanity skipped).