### PR TITLE
test(metadata store): wire xgboost test suites into test-skip cache

### DIFF
--- a/.github/config/test-suites.yml
+++ b/.github/config/test-suites.yml
@@ -132,12 +132,14 @@ suites:
     code_paths:
       - test/xgboost/e2e/**
       - test/xgboost/conftest.py  # added for --xgboost-version + fixtures
+      - test/xgboost/requirements.txt  # sagemaker client pin
 
   xgboost/benchmarks:
     skip_eligible: true
     code_paths:
       - test/xgboost/benchmarks/**
       - test/xgboost/conftest.py  # added for --xgboost-version
+      - test/xgboost/requirements.txt  # sagemaker client pin
 
   xgboost/longevity:
     skip_eligible: true

--- a/.github/config/test-suites.yml
+++ b/.github/config/test-suites.yml
@@ -122,25 +122,6 @@ suites:
     code_paths:
       - test/openfold3/sagemaker/**
 
-  xgboost/container:
-    skip_eligible: true
-    code_paths:
-      - test/xgboost/container/**
-
-  xgboost/e2e:
-    skip_eligible: true
-    code_paths:
-      - test/xgboost/e2e/**
-      - test/xgboost/conftest.py  # added for --xgboost-version + fixtures
-      - test/xgboost/requirements.txt  # sagemaker client pin
-
-  xgboost/benchmarks:
-    skip_eligible: true
-    code_paths:
-      - test/xgboost/benchmarks/**
-      - test/xgboost/conftest.py  # added for --xgboost-version
-      - test/xgboost/requirements.txt  # sagemaker client pin
-
   xgboost/longevity:
     skip_eligible: true
     code_paths:

--- a/.github/config/test-suites.yml
+++ b/.github/config/test-suites.yml
@@ -131,8 +131,17 @@ suites:
     skip_eligible: true
     code_paths:
       - test/xgboost/e2e/**
+      - test/xgboost/conftest.py  # added for --xgboost-version + fixtures
 
   xgboost/benchmarks:
     skip_eligible: true
     code_paths:
       - test/xgboost/benchmarks/**
+      - test/xgboost/conftest.py  # added for --xgboost-version
+
+  xgboost/longevity:
+    skip_eligible: true
+    code_paths:
+      - test/xgboost/container/test_longevity.py
+      - test/xgboost/container/container_helper.py
+      - test/xgboost/container/conftest.py

--- a/.github/workflows/xgboost.pipeline.yml
+++ b/.github/workflows/xgboost.pipeline.yml
@@ -85,7 +85,7 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
-      suites: '["sanity"]'
+      suites: '["sanity", "xgboost/longevity"]'
 
   sanity-test:
     if: ${{ always() && !cancelled() && inputs.run-sanity-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['sanity'] != true }}
@@ -149,8 +149,11 @@ jobs:
   # Longevity test — sustained-load resource-impact check on the serving
   # container. Lightweight; runs on PRs alongside the local integ tests.
   longevity-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-integ-test }}
-    needs: [build]
+    if: >-
+      ${{ always() && !cancelled() && inputs.run-integ-test &&
+          needs.build.result != 'failure' &&
+          fromJSON(needs.check.outputs.skips || '{}')['xgboost/longevity'] != true }}
+    needs: [build, check]
     concurrency:
       group: ${{ github.workflow }}-longevity-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: true
@@ -158,6 +161,8 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['xgboost/longevity'] || '' }}
 
   # Full integration suite — GPU container tests + SageMaker e2e + benchmarks.
   # Heavy; only runs on the release pipeline, not on PRs.

--- a/.github/workflows/xgboost.pr-3.0.yml
+++ b/.github/workflows/xgboost.pr-3.0.yml
@@ -89,6 +89,6 @@ jobs:
       run-sanity-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.sanity-test-change == 'true' }}
       run-security-test: ${{ needs.check-changes.outputs.build-change == 'true' }}
       run-telemetry-test: false
-      run-unit-test: ${{ needs.check-changes.outputs.build-change == 'true' || needs.check-changes.outputs.unit-test-change == 'true' }}
+      run-unit-test: false
       release: false
     secrets: inherit

--- a/.github/workflows/xgboost.tests-longevity.yml
+++ b/.github/workflows/xgboost.tests-longevity.yml
@@ -16,6 +16,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image hash computed from hash_image_content.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "Test code hash computed from hash_suite_code.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -27,6 +37,8 @@ jobs:
         fleet:x86-g6xl-runner
         buildspec-override:true
     timeout-minutes: 30
+    outputs:
+      image-exists: ${{ steps.check.outputs.exists }}
     steps:
       - uses: actions/checkout@v6
 
@@ -73,3 +85,24 @@ jobs:
       - name: Skip notice
         if: steps.check.outputs.exists != 'true'
         run: echo "Image not found in ECR — skipping longevity test (first release scenario)"
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.longevity-test.result == 'success' &&
+          needs.longevity-test.outputs.image-exists == 'true' }}
+    needs: [longevity-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: xgboost/longevity
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/docker/xgboost/3.0-5/Dockerfile
+++ b/docker/xgboost/3.0-5/Dockerfile
@@ -1,3 +1,4 @@
+# no-op: trigger xgboost build to validate test-skip cache (record + hit)
 # ============================================================================
 # XGBoost DLC — Ubuntu 20.04 / Python 3.10 (CUDA 12.6)
 # Multi-stage build:


### PR DESCRIPTION
Verification PR for #6624 (xgboost test-skip cache). **Do not merge — test only.** No-op comment in `docker/xgboost/3.0-5/Dockerfile` triggers a build of the sagemaker-3.0 cpu image; run-unit-test disabled so only the wired cheap suites `sanity` and `xgboost/longevity` run. Expected: run 1 records PASS rows for both; re-run → cache hit (both skipped).