### PR TITLE
ray-train: add missing attribution for nccl-tests and tqdm

### DIFF
--- a/docker/ray-train/Dockerfile.cuda
+++ b/docker/ray-train/Dockerfile.cuda
@@ -186,6 +186,13 @@ COPY --from=builder-oss /root/LINUX_PACKAGES_LICENSES /root/LINUX_PACKAGES_LICEN
 COPY --from=builder-oss /root/BUILD_FROM_SOURCE_PACKAGES_LICENCES /root/BUILD_FROM_SOURCE_PACKAGES_LICENCES
 COPY --from=builder-oss /usr/local/bin/testOSSCompliance /usr/local/bin/testOSSCompliance
 
+# Attribution the generator misses; must follow the COPY above or it gets overwritten.
+RUN TQDM_VERSION=$(/opt/venv/bin/python -c "import importlib.metadata as m; print(m.version('tqdm'))") \
+  && printf '\nnccl-tests %s https://github.com/NVIDIA/nccl-tests\ntqdm %s https://github.com/tqdm/tqdm\n' \
+    "${NCCL_TESTS_VERSION}" "${TQDM_VERSION}" >>/root/THIRD_PARTY_SOURCE_CODE_URLS \
+  && printf '\n** nccl-tests; version %s -- https://github.com/NVIDIA/nccl-tests\n' "${NCCL_TESTS_VERSION}" \
+    >>/root/BUILD_FROM_SOURCE_PACKAGES_LICENCES
+
 ENV PATH="/opt/venv/bin:/opt/amazon/openmpi/bin:/opt/amazon/efa/bin:/usr/local/cuda/bin:${PATH}" \
   LD_LIBRARY_PATH="/opt/venv/lib/python${PYTHON_SHORT_VERSION}/site-packages/nvidia/cudnn/lib:/opt/venv/lib/python${PYTHON_SHORT_VERSION}/site-packages/nvidia/nccl/lib:/opt/amazon/ofi-nccl/lib64:/opt/amazon/openmpi/lib:/opt/amazon/openmpi/lib64:/opt/amazon/efa/lib:/opt/amazon/efa/lib64:/usr/local/cuda/lib64:/usr/local/lib:${LD_LIBRARY_PATH}"
 


### PR DESCRIPTION
## Why
The OSS compliance run on the ray-train image (for IP review [V2340433268](https://t.corp.amazon.com/V2340433268)) surfaced two missing entries in `/root/THIRD_PARTY_SOURCE_CODE_URLS`.

**1. nccl-tests 2.19.6 (BSD-3-Clause)** — `all_reduce_perf` is built from source in this Dockerfile and appeared as an `UNTRACKED` binary in the compliance scan. The other 5 untracked binaries are Amazon-authored or ship with already-tracked pip packages; this one is genuinely third-party.

**2. tqdm (MPL-2.0 AND MIT)** — tqdm's `LICENCE` declares:
```
* files: *
  MPL-2.0 2015-2026 (c) Casper da Costa-Luis
* files: tqdm/_tqdm.py
  MIT 2016 (c) [PR #96] on behalf of Google Inc.
```
So MPL-2.0 is the default for the whole codebase, with only `_tqdm.py` / `README.rst` / `.gitignore` carved out as MIT. The `oss_compliance` generator records it as `Package License: MIT` and therefore emits no source URL — contrast `certifi`, also MPL-2.0, which does get one.

Per the [Source Code Compliance wiki](https://w.amazon.com/index.php/Open%20Source/Distributions/Source%20Code%20Compliance), both are shipped **unmodified**, so the obligation is *attribution plus a link to the original download site* — no tarball, no S3 publication, no IP-lawyer trigger.

## Implementation notes
- **Placement matters.** The append sits after the `COPY --from=builder-oss` lines (183-187). Putting it earlier — e.g. next to the nccl-tests build at line 165, or in the `builder-oss` stage — would be silently overwritten by that COPY. Verified: ARG at 165, COPY at 183, append at 192, all within `runtime-base`.
- **`printf` not `echo`**, with a leading `\n`: the generated file has no trailing newline, so a plain append would concatenate onto the `docutils` line. Both URL entries go in a single `printf` so no blank line is introduced between them.
- **tqdm version read at build time** rather than hardcoded — tqdm arrives transitively (via `transformers`/`datasets`) and is unpinned, so a literal version would silently drift out of date.

Simulated against a file with no trailing newline:
```
certifi 2026.6.17 https://github.com/certifi/python-certifi
docutils 0.19 https://github.com/docutils/docutils
nccl-tests 2.19.6 https://github.com/NVIDIA/nccl-tests
tqdm 4.68.4 https://github.com/tqdm/tqdm
```

## Scope
**The tqdm gap is not ray-train specific** — `THIRD_PARTY_SOURCE_CODE_URLS` is produced by the AWS-hosted `oss_compliance.zip` tooling, so any DLC shipping tqdm has the same gap, including Ray Serve which is already on the public gallery. This PR unblocks ray-train; the durable fix is correcting the classification in the shared tooling, which we are raising with OSA.

## Test plan
- [ ] Build succeeds
- [ ] `/root/THIRD_PARTY_SOURCE_CODE_URLS` contains the nccl-tests and tqdm lines with no blank line and no concatenation onto `docutils`
- [ ] `/root/BUILD_FROM_SOURCE_PACKAGES_LICENCES` lists nccl-tests
- [ ] `testOSSCompliance` still PASSes