### PR TITLE
ray: attribute tqdm source url in serve dockerfiles

### DIFF
--- a/docker/ray/Dockerfile.cpu
+++ b/docker/ray/Dockerfile.cpu
@@ -110,6 +110,9 @@ RUN chmod +x /usr/local/bin/deep_learning_container.py \
   && HAPROXY_VERSION=$(pip show ray-haproxy | awk '/^Version:/{print $2}') \
   && [ -n "$HAPROXY_VERSION" ] || { echo "ray-haproxy not installed" >&2; exit 1; } \
   && printf '\nray-haproxy %s https://github.com/ray-project/ray-haproxy/archive/refs/tags/v%s.tar.gz\n' "$HAPROXY_VERSION" "$HAPROXY_VERSION" >> /root/THIRD_PARTY_SOURCE_CODE_URLS \
+  && TQDM_VERSION=$(pip show tqdm | awk '/^Version:/{print $2}') \
+  && [ -n "$TQDM_VERSION" ] || { echo "tqdm not installed" >&2; exit 1; } \
+  && printf '\ntqdm %s https://github.com/tqdm/tqdm/archive/refs/tags/v%s.tar.gz\n' "$TQDM_VERSION" "$TQDM_VERSION" >> /root/THIRD_PARTY_SOURCE_CODE_URLS \
   && rm setup_oss_compliance.sh \
   && rm -rf /root/oss_compliance* \
   && rm -rf /tmp/tmp* \

--- a/docker/ray/Dockerfile.cuda
+++ b/docker/ray/Dockerfile.cuda
@@ -145,6 +145,9 @@ RUN chmod +x /usr/local/bin/deep_learning_container.py \
   && HAPROXY_VERSION=$(pip show ray-haproxy | awk '/^Version:/{print $2}') \
   && [ -n "$HAPROXY_VERSION" ] || { echo "ray-haproxy not installed" >&2; exit 1; } \
   && printf '\nray-haproxy %s https://github.com/ray-project/ray-haproxy/archive/refs/tags/v%s.tar.gz\n' "$HAPROXY_VERSION" "$HAPROXY_VERSION" >> /root/THIRD_PARTY_SOURCE_CODE_URLS \
+  && TQDM_VERSION=$(pip show tqdm | awk '/^Version:/{print $2}') \
+  && [ -n "$TQDM_VERSION" ] || { echo "tqdm not installed" >&2; exit 1; } \
+  && printf '\ntqdm %s https://github.com/tqdm/tqdm/archive/refs/tags/v%s.tar.gz\n' "$TQDM_VERSION" "$TQDM_VERSION" >> /root/THIRD_PARTY_SOURCE_CODE_URLS \
   && rm setup_oss_compliance.sh \
   && rm -rf /root/oss_compliance* \
   && rm -rf /tmp/tmp* \

--- a/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/ray/framework_allowlist.json
@@ -12,12 +12,12 @@
     {
         "vulnerability_id": "CVE-2026-34478",
         "reason": "ray bundles log4j-core 2.25.3 in ray_dist.jar, cannot patch without upstream ray rebuild",
-        "review_by": "2026-08-24"
+        "review_by": "2026-09-29"
     },
     {
         "vulnerability_id": "CVE-2026-34480",
         "reason": "ray bundles log4j-core 2.25.3 in ray_dist.jar, cannot patch without upstream ray rebuild",
-        "review_by": "2026-08-24"
+        "review_by": "2026-09-29"
     },
     {
         "vulnerability_id": "CVE-2026-54513",


### PR DESCRIPTION
## Why
tqdm ships transitively in the ray serve images (via `docker/ray/uv.lock`), add source-code URL.

## Test plan
- [x] `THIRD_PARTY_SOURCE_CODE_URLS` gains a tqdm line in the built CPU + GPU images
- [x] `testOSSCompliance` still passes