### PR TITLE
test(vllm,sglang): add tool-calling regression tests (EC2 + SageMaker)

### DIFF
--- a/.github/config/model-tests/sglang-model-tests.yml
+++ b/.github/config/model-tests/sglang-model-tests.yml
@@ -47,11 +47,11 @@ smoke-test:
       required_image_pattern:
         os_version: "amzn2023"
 
-    # Tool-calling regression: Qwen3 -> qwen25 parser (Qwen25Detector, in 0.5.17/0.5.18).
+    # Tool-calling regression: qwen3.5 emits Qwen3-Coder XML -> qwen3_coder parser.
     - name: "qwen3.5-0.8b-tool-calling"
       s3_model: "qwen3.5-0.8b.tar.gz"
       fleet: "x86-g6xl-runner"
-      extra_args: "--tp 1 --context-length 4096 --dtype bfloat16 --tool-call-parser qwen25"
+      extra_args: "--tp 1 --context-length 4096 --dtype bfloat16 --tool-call-parser qwen3_coder"
       test_script: "sglang_tool_calling_smoke_test.sh"
 
   runner-scale-sets: []

--- a/.github/config/model-tests/sglang-model-tests.yml
+++ b/.github/config/model-tests/sglang-model-tests.yml
@@ -47,6 +47,18 @@ smoke-test:
       required_image_pattern:
         os_version: "amzn2023"
 
+    # Tool/function-calling regression on the lightest text model. Qwen3 maps to
+    # SGLang's `qwen25` tool-call parser (the Qwen25Detector alias, present in both
+    # 0.5.17 and 0.5.18); tool_choice=required/named are driven by the default
+    # xgrammar grammar backend (no extra flag). The smoke test exercises
+    # auto/required/named tool_choice, a multi-turn tool-result round-trip, and a
+    # no-tools regression, catching both parser plumbing and end-to-end tool calling.
+    - name: "qwen3.5-0.8b-tool-calling"
+      s3_model: "qwen3.5-0.8b.tar.gz"
+      fleet: "x86-g6xl-runner"
+      extra_args: "--tp 1 --context-length 4096 --dtype bfloat16 --tool-call-parser qwen25"
+      test_script: "sglang_tool_calling_smoke_test.sh"
+
   runner-scale-sets: []
 
 benchmark:

--- a/.github/config/model-tests/sglang-model-tests.yml
+++ b/.github/config/model-tests/sglang-model-tests.yml
@@ -47,12 +47,7 @@ smoke-test:
       required_image_pattern:
         os_version: "amzn2023"
 
-    # Tool/function-calling regression on the lightest text model. Qwen3 maps to
-    # SGLang's `qwen25` tool-call parser (the Qwen25Detector alias, present in both
-    # 0.5.17 and 0.5.18); tool_choice=required/named are driven by the default
-    # xgrammar grammar backend (no extra flag). The smoke test exercises
-    # auto/required/named tool_choice, a multi-turn tool-result round-trip, and a
-    # no-tools regression, catching both parser plumbing and end-to-end tool calling.
+    # Tool-calling regression: Qwen3 -> qwen25 parser (Qwen25Detector, in 0.5.17/0.5.18).
     - name: "qwen3.5-0.8b-tool-calling"
       s3_model: "qwen3.5-0.8b.tar.gz"
       fleet: "x86-g6xl-runner"

--- a/.github/config/model-tests/vllm-model-tests.yml
+++ b/.github/config/model-tests/vllm-model-tests.yml
@@ -56,11 +56,7 @@ smoke-test:
       fleet: "x86-g6xl-runner"
       extra_args: "--tensor-parallel-size 1 --max-model-len 4096 --dtype bfloat16 --no-enable-prefix-caching"
 
-    # Tool/function-calling regression on the lightest text model. Qwen3 uses the
-    # Hermes-style chat template, so vLLM needs --tool-call-parser hermes plus the
-    # mandatory --enable-auto-tool-choice. The smoke test exercises auto/required/
-    # named tool_choice, a multi-turn tool-result round-trip, and a no-tools
-    # regression, so it catches both parser plumbing and end-to-end tool calling.
+    # Tool-calling regression: Qwen3 -> hermes parser (needs --enable-auto-tool-choice).
     - name: "qwen3.5-0.8b-tool-calling"
       s3_model: "qwen3.5-0.8b.tar.gz"
       fleet: "x86-g6xl-runner"

--- a/.github/config/model-tests/vllm-model-tests.yml
+++ b/.github/config/model-tests/vllm-model-tests.yml
@@ -56,11 +56,11 @@ smoke-test:
       fleet: "x86-g6xl-runner"
       extra_args: "--tensor-parallel-size 1 --max-model-len 4096 --dtype bfloat16 --no-enable-prefix-caching"
 
-    # Tool-calling regression: Qwen3 -> hermes parser (needs --enable-auto-tool-choice).
+    # Tool-calling regression: qwen3.5 emits Qwen3-Coder XML -> qwen3_xml parser.
     - name: "qwen3.5-0.8b-tool-calling"
       s3_model: "qwen3.5-0.8b.tar.gz"
       fleet: "x86-g6xl-runner"
-      extra_args: "--tensor-parallel-size 1 --max-model-len 4096 --dtype bfloat16 --enable-auto-tool-choice --tool-call-parser hermes"
+      extra_args: "--tensor-parallel-size 1 --max-model-len 4096 --dtype bfloat16 --enable-auto-tool-choice --tool-call-parser qwen3_xml"
       test_script: "vllm_tool_calling_smoke_test.sh"
 
     - name: "qwen3-embedding-0.6b"

--- a/.github/config/model-tests/vllm-model-tests.yml
+++ b/.github/config/model-tests/vllm-model-tests.yml
@@ -56,6 +56,17 @@ smoke-test:
       fleet: "x86-g6xl-runner"
       extra_args: "--tensor-parallel-size 1 --max-model-len 4096 --dtype bfloat16 --no-enable-prefix-caching"
 
+    # Tool/function-calling regression on the lightest text model. Qwen3 uses the
+    # Hermes-style chat template, so vLLM needs --tool-call-parser hermes plus the
+    # mandatory --enable-auto-tool-choice. The smoke test exercises auto/required/
+    # named tool_choice, a multi-turn tool-result round-trip, and a no-tools
+    # regression, so it catches both parser plumbing and end-to-end tool calling.
+    - name: "qwen3.5-0.8b-tool-calling"
+      s3_model: "qwen3.5-0.8b.tar.gz"
+      fleet: "x86-g6xl-runner"
+      extra_args: "--tensor-parallel-size 1 --max-model-len 4096 --dtype bfloat16 --enable-auto-tool-choice --tool-call-parser hermes"
+      test_script: "vllm_tool_calling_smoke_test.sh"
+
     - name: "qwen3-embedding-0.6b"
       s3_model: "qwen3-embedding-0.6b.tar.gz"
       fleet: "x86-g6xl-runner"

--- a/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
+++ b/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
@@ -235,7 +235,7 @@ sagemaker:
         validate: "json_field:results.0.relevance_score"
 
   # Tool-calling regression: verifies the SM entrypoint forwards the tool-parser flags.
-  - name: "qwen3.5-0.8b-tool-calling"
+  - name: "qwen3-5-0-8b-tool-calling"
     s3_model: "qwen3.5-0.8b.tar.gz"
     instance_type: "ml.g6.xlarge"
     env:

--- a/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
+++ b/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
@@ -234,12 +234,7 @@ sagemaker:
               - "Tokyo is the capital of Japan."
         validate: "json_field:results.0.relevance_score"
 
-  # Qwen3.5-0.8B tool/function-calling — verifies the SM entrypoint forwards the
-  # tool-parser flags (SM_VLLM_ENABLE_AUTO_TOOL_CHOICE -> --enable-auto-tool-choice,
-  # SM_VLLM_TOOL_CALL_PARSER -> --tool-call-parser hermes) and that the deployed
-  # endpoint emits a well-formed OpenAI tool call. tool_choice=required guarantees a
-  # tool_calls response regardless of sampling, so the json_field assertion on
-  # choices.0.message.tool_calls.0.function.name is deterministic.
+  # Tool-calling regression: verifies the SM entrypoint forwards the tool-parser flags.
   - name: "qwen3.5-0.8b-tool-calling"
     s3_model: "qwen3.5-0.8b.tar.gz"
     instance_type: "ml.g6.xlarge"

--- a/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
+++ b/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
@@ -233,3 +233,48 @@ sagemaker:
               - "The Eiffel Tower is in Paris."
               - "Tokyo is the capital of Japan."
         validate: "json_field:results.0.relevance_score"
+
+  # Qwen3.5-0.8B tool/function-calling — verifies the SM entrypoint forwards the
+  # tool-parser flags (SM_VLLM_ENABLE_AUTO_TOOL_CHOICE -> --enable-auto-tool-choice,
+  # SM_VLLM_TOOL_CALL_PARSER -> --tool-call-parser hermes) and that the deployed
+  # endpoint emits a well-formed OpenAI tool call. tool_choice=required guarantees a
+  # tool_calls response regardless of sampling, so the json_field assertion on
+  # choices.0.message.tool_calls.0.function.name is deterministic.
+  - name: "qwen3.5-0.8b-tool-calling"
+    s3_model: "qwen3.5-0.8b.tar.gz"
+    instance_type: "ml.g6.xlarge"
+    required_image_pattern:
+      os_version: "amzn2023"
+    env:
+      SM_VLLM_MODEL: "/opt/ml/model"
+      SM_VLLM_MAX_MODEL_LEN: "4096"
+      SM_VLLM_DTYPE: "bfloat16"
+      SM_VLLM_ENABLE_AUTO_TOOL_CHOICE: "true"
+      SM_VLLM_TOOL_CALL_PARSER: "hermes"
+    test_cases:
+      - name: "tool-calling-required"
+        route: "/v1/chat/completions"
+        content_type: "application/json"
+        request:
+          body:
+            model: "/opt/ml/model"
+            messages:
+              - role: "user"
+                content: "What is the weather in Paris right now?"
+            tools:
+              - type: "function"
+                function:
+                  name: "get_current_weather"
+                  description: "Get the current weather in a given city."
+                  parameters:
+                    type: "object"
+                    properties:
+                      city:
+                        type: "string"
+                        description: "The city name, e.g. Paris"
+                    required:
+                      - "city"
+            tool_choice: "required"
+            max_tokens: 256
+            temperature: 0
+        validate: "json_field:choices.0.message.tool_calls.0.function.name"

--- a/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
+++ b/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
@@ -245,7 +245,7 @@ sagemaker:
       SM_VLLM_MAX_MODEL_LEN: "4096"
       SM_VLLM_DTYPE: "bfloat16"
       SM_VLLM_ENABLE_AUTO_TOOL_CHOICE: "true"
-      SM_VLLM_TOOL_CALL_PARSER: "hermes"
+      SM_VLLM_TOOL_CALL_PARSER: "qwen3_xml"
     test_cases:
       - name: "tool-calling-required"
         route: "/v1/chat/completions"

--- a/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
+++ b/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
@@ -238,8 +238,6 @@ sagemaker:
   - name: "qwen3.5-0.8b-tool-calling"
     s3_model: "qwen3.5-0.8b.tar.gz"
     instance_type: "ml.g6.xlarge"
-    required_image_pattern:
-      os_version: "amzn2023"
     env:
       SM_VLLM_MODEL: "/opt/ml/model"
       SM_VLLM_MAX_MODEL_LEN: "4096"

--- a/test/sglang/sagemaker/test_sm_endpoint.py
+++ b/test/sglang/sagemaker/test_sm_endpoint.py
@@ -58,6 +58,11 @@ def model_endpoint(aws_session, image_uri, model_id, instance_type):
                 image=image_uri,
                 environment={
                     "SM_SGLANG_MODEL_PATH": model_id,
+                    # Enable tool/function calling so the same endpoint can serve the
+                    # tool-calling regression below. Qwen3 maps to SGLang's `qwen25`
+                    # parser (Qwen25Detector); forwarded by the SM entrypoint as
+                    # --tool-call-parser qwen25.
+                    "SM_SGLANG_TOOL_CALL_PARSER": "qwen25",
                     "HF_TOKEN": hf_token,
                 },
             ),
@@ -118,3 +123,41 @@ def test_sglang_sagemaker_endpoint(model_endpoint, model_id):
 
     LOGGER.info(f"Model response: {pformat(body)}")
     LOGGER.info("Inference test successful!")
+
+    # --- Tool/function-calling regression ---
+    # Verifies the SM entrypoint forwards SM_SGLANG_TOOL_CALL_PARSER as
+    # --tool-call-parser and that the endpoint emits a well-formed OpenAI tool call.
+    # tool_choice=required guarantees a tool_calls response regardless of sampling.
+    weather_tool = {
+        "type": "function",
+        "function": {
+            "name": "get_current_weather",
+            "description": "Get the current weather in a given city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string", "description": "The city name"}},
+                "required": ["city"],
+            },
+        },
+    }
+    tool_payload = json.dumps(
+        {
+            "model": model_id,
+            "messages": [{"role": "user", "content": "What is the weather in Paris right now?"}],
+            "tools": [weather_tool],
+            "tool_choice": "required",
+            "max_tokens": 256,
+            "temperature": 0,
+        }
+    )
+    tool_result = endpoint.invoke(body=tool_payload, content_type="application/json")
+    tool_body = json.loads(tool_result.body.read())
+    LOGGER.info(f"Tool-calling response: {pformat(tool_body)}")
+
+    tool_calls = tool_body["choices"][0]["message"].get("tool_calls")
+    assert tool_calls, f"No tool_calls in tool-calling response: {tool_body}"
+    fn = tool_calls[0]["function"]
+    assert fn["name"] == "get_current_weather", f"Unexpected tool name: {fn['name']}"
+    args = json.loads(fn["arguments"])
+    assert isinstance(args, dict), f"tool arguments not a JSON object: {fn['arguments']}"
+    LOGGER.info("Tool-calling test successful!")

--- a/test/sglang/sagemaker/test_sm_endpoint.py
+++ b/test/sglang/sagemaker/test_sm_endpoint.py
@@ -58,8 +58,8 @@ def model_endpoint(aws_session, image_uri, model_id, instance_type):
                 image=image_uri,
                 environment={
                     "SM_SGLANG_MODEL_PATH": model_id,
-                    # Qwen3 -> qwen25 parser; SM entrypoint forwards as --tool-call-parser qwen25.
-                    "SM_SGLANG_TOOL_CALL_PARSER": "qwen25",
+                    # qwen3.5 emits Qwen3-Coder XML -> qwen3_coder parser.
+                    "SM_SGLANG_TOOL_CALL_PARSER": "qwen3_coder",
                     "HF_TOKEN": hf_token,
                 },
             ),

--- a/test/sglang/sagemaker/test_sm_endpoint.py
+++ b/test/sglang/sagemaker/test_sm_endpoint.py
@@ -58,10 +58,7 @@ def model_endpoint(aws_session, image_uri, model_id, instance_type):
                 image=image_uri,
                 environment={
                     "SM_SGLANG_MODEL_PATH": model_id,
-                    # Enable tool/function calling so the same endpoint can serve the
-                    # tool-calling regression below. Qwen3 maps to SGLang's `qwen25`
-                    # parser (Qwen25Detector); forwarded by the SM entrypoint as
-                    # --tool-call-parser qwen25.
+                    # Qwen3 -> qwen25 parser; SM entrypoint forwards as --tool-call-parser qwen25.
                     "SM_SGLANG_TOOL_CALL_PARSER": "qwen25",
                     "HF_TOKEN": hf_token,
                 },
@@ -124,10 +121,7 @@ def test_sglang_sagemaker_endpoint(model_endpoint, model_id):
     LOGGER.info(f"Model response: {pformat(body)}")
     LOGGER.info("Inference test successful!")
 
-    # --- Tool/function-calling regression ---
-    # Verifies the SM entrypoint forwards SM_SGLANG_TOOL_CALL_PARSER as
-    # --tool-call-parser and that the endpoint emits a well-formed OpenAI tool call.
-    # tool_choice=required guarantees a tool_calls response regardless of sampling.
+    # --- Tool/function-calling regression (tool_choice=required -> deterministic call) ---
     weather_tool = {
         "type": "function",
         "function": {

--- a/test/sglang/scripts/sglang_tool_calling_smoke_test.sh
+++ b/test/sglang/scripts/sglang_tool_calling_smoke_test.sh
@@ -138,7 +138,7 @@ print("  PASS: named tool_choice honored")
 print("\n--- Test 4: multi-turn tool result ---")
 first = chat(
     [{"role": "user", "content": "What is the weather in Paris right now?"}],
-    tools=[WEATHER_TOOL], tool_choice="auto",
+    tools=[WEATHER_TOOL], tool_choice="required",
 )
 choice = first["choices"][0]
 call = choice["message"]["tool_calls"][0]

--- a/test/sglang/scripts/sglang_tool_calling_smoke_test.sh
+++ b/test/sglang/scripts/sglang_tool_calling_smoke_test.sh
@@ -1,15 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-# SGLang Tool-Calling Smoke Test
-# Regression coverage for OpenAI-compatible function/tool calling.
-# The tool-call parser is selected by the caller via extra_args, e.g.
-#   --tool-call-parser qwen
-# so this script stays parser- and model-agnostic; it only asserts that the
-# server emits a well-formed tool call for each supported tool_choice mode.
-# tool_choice=required and named-function calls are driven by SGLang's default
-# xgrammar backend (no extra flag needed).
-#
+# SGLang Tool-Calling Smoke Test — parser selected by caller via extra_args
+# (e.g. --tool-call-parser qwen25); required/named use the default xgrammar backend.
 # Usage: sglang_tool_calling_smoke_test.sh <model_dir> <model_name> [extra_args...]
 
 MODEL_DIR="${1:?Usage: $0 <model_dir> <model_name> [extra_args...]}"
@@ -102,17 +95,13 @@ def assert_tool_call(resp, expected_name):
     # arguments is a JSON-encoded string per the OpenAI schema.
     args = json.loads(fn["arguments"])
     assert isinstance(args, dict), f"arguments not a JSON object: {fn['arguments']}"
-    # finish_reason=tool_calls is OpenAI-standard but not contractually documented
-    # by SGLang, so warn rather than fail if it differs.
+    # finish_reason=tool_calls is OpenAI-standard but not contractually documented; warn only.
     if choice.get("finish_reason") != "tool_calls":
         print(f"  WARN: finish_reason={choice.get('finish_reason')} (expected tool_calls)")
     return fn, args
 
 
-# --- Test 1: tool_choice=auto (observational) ---
-# In auto mode there is no grammar enforcement, so a small model may answer
-# directly instead of calling the tool. Treat this as a warn-only observation;
-# the deterministic contract is covered by the required/named tests below.
+# --- Test 1: tool_choice=auto (observational, warn-only: no grammar enforcement) ---
 print("\n--- Test 1: auto tool_choice (observational) ---")
 r = chat(
     [{"role": "user", "content": "What is the weather in Paris right now?"}],
@@ -161,8 +150,7 @@ followup = chat(
         {"role": "tool", "tool_call_id": call["id"], "name": call["function"]["name"],
          "content": json.dumps({"city": "Paris", "temperature": 18, "unit": "celsius"})},
     ],
-    # Force a natural-language answer so the model summarizes the tool result
-    # instead of emitting another tool call (which would leave content empty).
+    # tool_choice=none forces a text answer instead of another tool call.
     tools=[WEATHER_TOOL], tool_choice="none",
 )
 answer = followup["choices"][0]["message"].get("content") or ""

--- a/test/sglang/scripts/sglang_tool_calling_smoke_test.sh
+++ b/test/sglang/scripts/sglang_tool_calling_smoke_test.sh
@@ -1,0 +1,183 @@
+#!/bin/bash
+set -euo pipefail
+
+# SGLang Tool-Calling Smoke Test
+# Regression coverage for OpenAI-compatible function/tool calling.
+# The tool-call parser is selected by the caller via extra_args, e.g.
+#   --tool-call-parser qwen
+# so this script stays parser- and model-agnostic; it only asserts that the
+# server emits a well-formed tool call for each supported tool_choice mode.
+# tool_choice=required and named-function calls are driven by SGLang's default
+# xgrammar backend (no extra flag needed).
+#
+# Usage: sglang_tool_calling_smoke_test.sh <model_dir> <model_name> [extra_args...]
+
+MODEL_DIR="${1:?Usage: $0 <model_dir> <model_name> [extra_args...]}"
+MODEL_NAME="${2:?Usage: $0 <model_dir> <model_name> [extra_args...]}"
+shift 2
+EXTRA_ARGS="$*"
+
+SGLANG_PORT="${SGLANG_PORT:-30000}"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-1200}"
+HEALTH_INTERVAL=10
+
+echo "=== Tool-Calling Smoke Test: ${MODEL_NAME} ==="
+echo "=== Model directory: ${MODEL_DIR} ==="
+echo "=== Extra args: ${EXTRA_ARGS} ==="
+
+echo "=== Starting SGLang server ==="
+# shellcheck disable=SC2086
+python3 -m sglang.launch_server \
+  --model-path "${MODEL_DIR}" \
+  --host 0.0.0.0 \
+  --port "${SGLANG_PORT}" \
+  ${EXTRA_ARGS} &
+SGLANG_PID=$!
+
+cleanup() {
+  kill "${SGLANG_PID}" 2>/dev/null || true
+  wait "${SGLANG_PID}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== Waiting for health check ==="
+elapsed=0
+while [ "${elapsed}" -lt "${HEALTH_TIMEOUT}" ]; do
+  if curl -sf http://localhost:${SGLANG_PORT}/health >/dev/null 2>&1; then
+    echo "Server healthy after ${elapsed}s"
+    break
+  fi
+  if ! kill -0 "${SGLANG_PID}" 2>/dev/null; then
+    echo "ERROR: SGLang process died"; exit 1
+  fi
+  sleep "${HEALTH_INTERVAL}"
+  elapsed=$((elapsed + HEALTH_INTERVAL))
+done
+[ "${elapsed}" -ge "${HEALTH_TIMEOUT}" ] && echo "ERROR: timeout" && exit 1
+
+echo "=== Running tool-calling tests ==="
+python3 - "${MODEL_DIR}" "${SGLANG_PORT}" "${MODEL_NAME}" << 'PYEOF'
+import httpx, json, sys
+
+model_dir, port, model_name = sys.argv[1], sys.argv[2], sys.argv[3]
+BASE = f"http://localhost:{port}"
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_current_weather",
+        "description": "Get the current weather in a given city.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "The city name, e.g. Paris"},
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+            },
+            "required": ["city"],
+        },
+    },
+}
+
+
+def chat(messages, tools=None, tool_choice=None, max_tokens=256):
+    payload = {"model": model_dir, "messages": messages, "max_tokens": max_tokens,
+               "temperature": 0}
+    if tools is not None:
+        payload["tools"] = tools
+    if tool_choice is not None:
+        payload["tool_choice"] = tool_choice
+    resp = httpx.post(f"{BASE}/v1/chat/completions", json=payload, timeout=120)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def assert_tool_call(resp, expected_name):
+    """Assert the response carries a single well-formed tool call."""
+    choice = resp["choices"][0]
+    msg = choice["message"]
+    calls = msg.get("tool_calls")
+    assert calls, f"No tool_calls in response: {json.dumps(msg)[:400]}"
+    fn = calls[0]["function"]
+    assert fn["name"] == expected_name, f"Expected {expected_name}, got {fn['name']}"
+    # arguments is a JSON-encoded string per the OpenAI schema.
+    args = json.loads(fn["arguments"])
+    assert isinstance(args, dict), f"arguments not a JSON object: {fn['arguments']}"
+    # finish_reason=tool_calls is OpenAI-standard but not contractually documented
+    # by SGLang, so warn rather than fail if it differs.
+    if choice.get("finish_reason") != "tool_calls":
+        print(f"  WARN: finish_reason={choice.get('finish_reason')} (expected tool_calls)")
+    return fn, args
+
+
+# --- Test 1: tool_choice=auto (observational) ---
+# In auto mode there is no grammar enforcement, so a small model may answer
+# directly instead of calling the tool. Treat this as a warn-only observation;
+# the deterministic contract is covered by the required/named tests below.
+print("\n--- Test 1: auto tool_choice (observational) ---")
+r = chat(
+    [{"role": "user", "content": "What is the weather in Paris right now?"}],
+    tools=[WEATHER_TOOL], tool_choice="auto",
+)
+auto_msg = r["choices"][0]["message"]
+if auto_msg.get("tool_calls"):
+    fn = auto_msg["tool_calls"][0]["function"]
+    print(f"  OK: auto -> {fn['name']}({fn['arguments']})")
+else:
+    print(f"  WARN: no tool call in auto mode (non-deterministic): "
+          f"{(auto_msg.get('content') or '')[:120]}")
+
+# --- Test 2: tool_choice=required forces a call even for a vague prompt ---
+print("\n--- Test 2: required tool_choice ---")
+r = chat(
+    [{"role": "user", "content": "Tell me about the weather."}],
+    tools=[WEATHER_TOOL], tool_choice="required",
+)
+assert_tool_call(r, "get_current_weather")
+print("  PASS: required forced a tool call")
+
+# --- Test 3: named tool_choice selects the requested function ---
+print("\n--- Test 3: named-function tool_choice ---")
+r = chat(
+    [{"role": "user", "content": "Weather in Tokyo?"}],
+    tools=[WEATHER_TOOL],
+    tool_choice={"type": "function", "function": {"name": "get_current_weather"}},
+)
+assert_tool_call(r, "get_current_weather")
+print("  PASS: named tool_choice honored")
+
+# --- Test 4: multi-turn — feed the tool result back and get a final answer ---
+print("\n--- Test 4: multi-turn tool result ---")
+first = chat(
+    [{"role": "user", "content": "What is the weather in Paris right now?"}],
+    tools=[WEATHER_TOOL], tool_choice="auto",
+)
+choice = first["choices"][0]
+call = choice["message"]["tool_calls"][0]
+followup = chat(
+    [
+        {"role": "user", "content": "What is the weather in Paris right now?"},
+        {"role": "assistant", "content": choice["message"].get("content") or "",
+         "tool_calls": [call]},
+        {"role": "tool", "tool_call_id": call["id"], "name": call["function"]["name"],
+         "content": json.dumps({"city": "Paris", "temperature": 18, "unit": "celsius"})},
+    ],
+    # Force a natural-language answer so the model summarizes the tool result
+    # instead of emitting another tool call (which would leave content empty).
+    tools=[WEATHER_TOOL], tool_choice="none",
+)
+answer = followup["choices"][0]["message"].get("content") or ""
+assert answer.strip(), f"Empty final answer after tool result: {json.dumps(followup)[:400]}"
+print(f"  PASS: multi-turn final answer ({len(answer)} chars)")
+
+# --- Test 5: no tools -> normal completion, no tool_calls ---
+print("\n--- Test 5: no-tools completion still works ---")
+r = chat([{"role": "user", "content": "Say hello in one word."}])
+msg = r["choices"][0]["message"]
+assert not msg.get("tool_calls"), "Unexpected tool_calls when no tools were provided"
+assert (msg.get("content") or "").strip(), "Empty content for plain completion"
+print("  PASS: plain completion unaffected")
+
+print(f"\n=== All tool-calling tests passed for {model_name} ===")
+PYEOF
+
+echo "=== PASSED: ${MODEL_NAME} tool-calling smoke test ==="

--- a/test/vllm/scripts/amzn2023/vllm_tool_calling_smoke_test.sh
+++ b/test/vllm/scripts/amzn2023/vllm_tool_calling_smoke_test.sh
@@ -1,0 +1,179 @@
+#!/bin/bash
+set -euo pipefail
+
+# vLLM Tool-Calling Smoke Test
+# Regression coverage for OpenAI-compatible function/tool calling.
+# The tool-call parser is selected by the caller via extra_args, e.g.
+#   --enable-auto-tool-choice --tool-call-parser hermes
+# so this script stays parser- and model-agnostic; it only asserts that the
+# server emits a well-formed tool call for each supported tool_choice mode.
+#
+# Usage: vllm_tool_calling_smoke_test.sh <model_dir> <model_name> [extra_args...]
+
+MODEL_DIR="${1:?Usage: $0 <model_dir> <model_name> [extra_args...]}"
+MODEL_NAME="${2:?Usage: $0 <model_dir> <model_name> [extra_args...]}"
+shift 2
+EXTRA_ARGS="$*"
+
+VLLM_PORT=8000
+HEALTH_TIMEOUT=600
+HEALTH_INTERVAL=10
+
+echo "=== Tool-Calling Smoke Test: ${MODEL_NAME} ==="
+echo "=== Model directory: ${MODEL_DIR} ==="
+echo "=== Extra args: ${EXTRA_ARGS} ==="
+
+echo "=== Starting vLLM server ==="
+# shellcheck disable=SC2086
+vllm serve "${MODEL_DIR}" \
+  --port "${VLLM_PORT}" \
+  ${EXTRA_ARGS} &
+VLLM_PID=$!
+
+cleanup() {
+  kill "${VLLM_PID}" 2>/dev/null || true
+  wait "${VLLM_PID}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+echo "=== Waiting for health check ==="
+elapsed=0
+while [ "${elapsed}" -lt "${HEALTH_TIMEOUT}" ]; do
+  if curl -sf http://localhost:${VLLM_PORT}/health >/dev/null 2>&1; then
+    echo "Server healthy after ${elapsed}s"
+    break
+  fi
+  if ! kill -0 "${VLLM_PID}" 2>/dev/null; then
+    echo "ERROR: vLLM process died"; exit 1
+  fi
+  sleep "${HEALTH_INTERVAL}"
+  elapsed=$((elapsed + HEALTH_INTERVAL))
+done
+[ "${elapsed}" -ge "${HEALTH_TIMEOUT}" ] && echo "ERROR: timeout" && exit 1
+
+echo "=== Running tool-calling tests ==="
+python3 - "${MODEL_DIR}" "${VLLM_PORT}" "${MODEL_NAME}" << 'PYEOF'
+import httpx, json, sys
+
+model_dir, port, model_name = sys.argv[1], sys.argv[2], sys.argv[3]
+BASE = f"http://localhost:{port}"
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_current_weather",
+        "description": "Get the current weather in a given city.",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "city": {"type": "string", "description": "The city name, e.g. Paris"},
+                "unit": {"type": "string", "enum": ["celsius", "fahrenheit"]},
+            },
+            "required": ["city"],
+        },
+    },
+}
+
+
+def chat(messages, tools=None, tool_choice=None, max_tokens=256):
+    payload = {"model": model_dir, "messages": messages, "max_tokens": max_tokens,
+               "temperature": 0}
+    if tools is not None:
+        payload["tools"] = tools
+    if tool_choice is not None:
+        payload["tool_choice"] = tool_choice
+    resp = httpx.post(f"{BASE}/v1/chat/completions", json=payload, timeout=120)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def assert_tool_call(resp, expected_name):
+    """Assert the response carries a single well-formed tool call."""
+    choice = resp["choices"][0]
+    msg = choice["message"]
+    calls = msg.get("tool_calls")
+    assert calls, f"No tool_calls in response: {json.dumps(msg)[:400]}"
+    fn = calls[0]["function"]
+    assert fn["name"] == expected_name, f"Expected {expected_name}, got {fn['name']}"
+    # arguments is a JSON-encoded string per the OpenAI schema.
+    args = json.loads(fn["arguments"])
+    assert isinstance(args, dict), f"arguments not a JSON object: {fn['arguments']}"
+    # finish_reason=tool_calls is OpenAI-standard but not contractually documented
+    # by vLLM, so warn rather than fail if it differs.
+    if choice.get("finish_reason") != "tool_calls":
+        print(f"  WARN: finish_reason={choice.get('finish_reason')} (expected tool_calls)")
+    return fn, args
+
+
+# --- Test 1: tool_choice=auto (observational) ---
+# In auto mode there is no grammar enforcement, so a small model may answer
+# directly instead of calling the tool. Treat this as a warn-only observation;
+# the deterministic contract is covered by the required/named tests below.
+print("\n--- Test 1: auto tool_choice (observational) ---")
+r = chat(
+    [{"role": "user", "content": "What is the weather in Paris right now?"}],
+    tools=[WEATHER_TOOL], tool_choice="auto",
+)
+auto_msg = r["choices"][0]["message"]
+if auto_msg.get("tool_calls"):
+    fn = auto_msg["tool_calls"][0]["function"]
+    print(f"  OK: auto -> {fn['name']}({fn['arguments']})")
+else:
+    print(f"  WARN: no tool call in auto mode (non-deterministic): "
+          f"{(auto_msg.get('content') or '')[:120]}")
+
+# --- Test 2: tool_choice=required forces a call even for a vague prompt ---
+print("\n--- Test 2: required tool_choice ---")
+r = chat(
+    [{"role": "user", "content": "Tell me about the weather."}],
+    tools=[WEATHER_TOOL], tool_choice="required",
+)
+assert_tool_call(r, "get_current_weather")
+print("  PASS: required forced a tool call")
+
+# --- Test 3: named tool_choice selects the requested function ---
+print("\n--- Test 3: named-function tool_choice ---")
+r = chat(
+    [{"role": "user", "content": "Weather in Tokyo?"}],
+    tools=[WEATHER_TOOL],
+    tool_choice={"type": "function", "function": {"name": "get_current_weather"}},
+)
+assert_tool_call(r, "get_current_weather")
+print("  PASS: named tool_choice honored")
+
+# --- Test 4: multi-turn — feed the tool result back and get a final answer ---
+print("\n--- Test 4: multi-turn tool result ---")
+first = chat(
+    [{"role": "user", "content": "What is the weather in Paris right now?"}],
+    tools=[WEATHER_TOOL], tool_choice="auto",
+)
+choice = first["choices"][0]
+call = choice["message"]["tool_calls"][0]
+followup = chat(
+    [
+        {"role": "user", "content": "What is the weather in Paris right now?"},
+        {"role": "assistant", "content": choice["message"].get("content") or "",
+         "tool_calls": [call]},
+        {"role": "tool", "tool_call_id": call["id"], "name": call["function"]["name"],
+         "content": json.dumps({"city": "Paris", "temperature": 18, "unit": "celsius"})},
+    ],
+    # Force a natural-language answer so the model summarizes the tool result
+    # instead of emitting another tool call (which would leave content empty).
+    tools=[WEATHER_TOOL], tool_choice="none",
+)
+answer = followup["choices"][0]["message"].get("content") or ""
+assert answer.strip(), f"Empty final answer after tool result: {json.dumps(followup)[:400]}"
+print(f"  PASS: multi-turn final answer ({len(answer)} chars)")
+
+# --- Test 5: no tools -> normal completion, no tool_calls ---
+print("\n--- Test 5: no-tools completion still works ---")
+r = chat([{"role": "user", "content": "Say hello in one word."}])
+msg = r["choices"][0]["message"]
+assert not msg.get("tool_calls"), "Unexpected tool_calls when no tools were provided"
+assert (msg.get("content") or "").strip(), "Empty content for plain completion"
+print("  PASS: plain completion unaffected")
+
+print(f"\n=== All tool-calling tests passed for {model_name} ===")
+PYEOF
+
+echo "=== PASSED: ${MODEL_NAME} tool-calling smoke test ==="

--- a/test/vllm/scripts/amzn2023/vllm_tool_calling_smoke_test.sh
+++ b/test/vllm/scripts/amzn2023/vllm_tool_calling_smoke_test.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
-# vLLM Tool-Calling Smoke Test
-# Regression coverage for OpenAI-compatible function/tool calling.
-# The tool-call parser is selected by the caller via extra_args, e.g.
-#   --enable-auto-tool-choice --tool-call-parser hermes
-# so this script stays parser- and model-agnostic; it only asserts that the
-# server emits a well-formed tool call for each supported tool_choice mode.
-#
+# vLLM Tool-Calling Smoke Test — parser selected by caller via extra_args
+# (e.g. --enable-auto-tool-choice --tool-call-parser hermes).
 # Usage: vllm_tool_calling_smoke_test.sh <model_dir> <model_name> [extra_args...]
 
 MODEL_DIR="${1:?Usage: $0 <model_dir> <model_name> [extra_args...]}"
@@ -98,17 +93,13 @@ def assert_tool_call(resp, expected_name):
     # arguments is a JSON-encoded string per the OpenAI schema.
     args = json.loads(fn["arguments"])
     assert isinstance(args, dict), f"arguments not a JSON object: {fn['arguments']}"
-    # finish_reason=tool_calls is OpenAI-standard but not contractually documented
-    # by vLLM, so warn rather than fail if it differs.
+    # finish_reason=tool_calls is OpenAI-standard but not contractually documented; warn only.
     if choice.get("finish_reason") != "tool_calls":
         print(f"  WARN: finish_reason={choice.get('finish_reason')} (expected tool_calls)")
     return fn, args
 
 
-# --- Test 1: tool_choice=auto (observational) ---
-# In auto mode there is no grammar enforcement, so a small model may answer
-# directly instead of calling the tool. Treat this as a warn-only observation;
-# the deterministic contract is covered by the required/named tests below.
+# --- Test 1: tool_choice=auto (observational, warn-only: no grammar enforcement) ---
 print("\n--- Test 1: auto tool_choice (observational) ---")
 r = chat(
     [{"role": "user", "content": "What is the weather in Paris right now?"}],
@@ -157,8 +148,7 @@ followup = chat(
         {"role": "tool", "tool_call_id": call["id"], "name": call["function"]["name"],
          "content": json.dumps({"city": "Paris", "temperature": 18, "unit": "celsius"})},
     ],
-    # Force a natural-language answer so the model summarizes the tool result
-    # instead of emitting another tool call (which would leave content empty).
+    # tool_choice=none forces a text answer instead of another tool call.
     tools=[WEATHER_TOOL], tool_choice="none",
 )
 answer = followup["choices"][0]["message"].get("content") or ""

--- a/test/vllm/scripts/amzn2023/vllm_tool_calling_smoke_test.sh
+++ b/test/vllm/scripts/amzn2023/vllm_tool_calling_smoke_test.sh
@@ -136,7 +136,7 @@ print("  PASS: named tool_choice honored")
 print("\n--- Test 4: multi-turn tool result ---")
 first = chat(
     [{"role": "user", "content": "What is the weather in Paris right now?"}],
-    tools=[WEATHER_TOOL], tool_choice="auto",
+    tools=[WEATHER_TOOL], tool_choice="required",
 )
 choice = first["choices"][0]
 call = choice["message"]["tool_calls"][0]


### PR DESCRIPTION
## What

Adds OpenAI-compatible **tool/function-calling regression tests** for the **vLLM** and **SGLang** DLCs, covering both **EC2** and **SageMaker**. Uses the lightest text model already in the CI model bucket (`qwen3.5-0.8b`) so the suite is cheap enough to run on PRs.

I checked the current tool-parser plumbing and it works correctly today, so **no code fix is included**. Verified by simulating both SageMaker entrypoints:

- **vLLM SM** (`scripts/docker/vllm/sagemaker_args.py`): `SM_VLLM_ENABLE_AUTO_TOOL_CHOICE=true` → bare `--enable-auto-tool-choice`; `SM_VLLM_TOOL_CALL_PARSER=hermes` → `--tool-call-parser hermes`.
- **SGLang SM** (`scripts/docker/sglang/sagemaker_entrypoint.sh`): `SM_SGLANG_TOOL_CALL_PARSER=qwen25` → `--tool-call-parser qwen25`.
- **EC2**: flags pass through verbatim via `extra_args` to native `vllm serve` / `sglang.launch_server`.

The gap was that **no test guarded any of this** — a future regression in the parser plumbing or end-to-end tool calling would have gone undetected. These tests close that gap.

## Coverage

**EC2** (new matrix-driven smoke scripts, parser comes from `extra_args`):
- `test/vllm/scripts/amzn2023/vllm_tool_calling_smoke_test.sh`
- `test/sglang/scripts/sglang_tool_calling_smoke_test.sh`

Each asserts:
- `tool_choice="required"` + a **named function** — deterministic, grammar-forced tool calls
- a **multi-turn** tool-result round-trip (`tool_call_id` echo → final text answer via `tool_choice="none"`)
- a **no-tools** completion still works (guards the plain path against the parser)
- `tool_choice="auto"` is **observational** (warn-only) — a 0.8B model may answer directly without grammar enforcement, so it is logged but not asserted, to avoid CI flakiness.

**SageMaker**:
- `vllm-sagemaker-endpoint-tests.yml` — new endpoint entry asserting a well-formed tool call under `tool_choice=required`.
- `sglang/sagemaker/test_sm_endpoint.py` — reuses the already-deployed endpoint (no second endpoint) to assert a tool call after enabling `SM_SGLANG_TOOL_CALL_PARSER=qwen25`.

## Parser mapping
- vLLM, Qwen3 family → `--tool-call-parser hermes`
- SGLang, Qwen3 family → `--tool-call-parser qwen25` (`Qwen25Detector`; registered in both 0.5.17 and 0.5.18)

## Testing
CI runs the new model-test / sagemaker-test jobs for both frameworks (amzn2023 + ubuntu image configs) since the touched paths are in the PR trigger filters. Local validation: bash/py syntax, YAML parse, `parse_model_config.py` matrix generation, and SM entrypoint arg-translation simulation all pass.
