### PR TITLE
fix(currency agent): allowlist mooncake CVEs instead of pinning them

### DIFF
--- a/scripts/ci/autocurrency/agent-fix.py
+++ b/scripts/ci/autocurrency/agent-fix.py
@@ -36,6 +36,11 @@ A currency auto-update PR has failed CI. Diagnose the failure and produce minima
 - Do NOT modify files unrelated to the failure
 - ONLY edit files that are provided in the context below. If a file is not shown, do not edit it.
 - For CVE scan failures: pin a safe version in Dockerfile, or add to allowlist if vendored/unpatchable
+- Mooncake CVEs are allowlist-only, never pinned: the Go deps are statically linked into a prebuilt
+  shared object, so there is no pip package to bump. Identify them by `Package Manager` GOMOD/GOBINARY,
+  a `go/stdlib`/`golang.org/x/*`/`go.etcd.io/*`/`google.golang.org/grpc` package, or a `File paths`
+  entry like `.../mooncake/libetcd_wrapper.so`. Only an upstream mooncake-transfer-engine rebuild
+  fixes them, so the allowlist reason should name the package, its version, and that blocker.
 - For "file not found" errors: find the new path in the upstream repo
 - For build errors: check if upstream base image changed something
 


### PR DESCRIPTION
## Problem

On #6611 (sglang 0.5.18) the Currency Fix Agent tried to pin the mooncake Go CVEs. Those Go deps are statically linked into `mooncake/libetcd_wrapper.so`, so there is no pip package to bump — the pins had no effect and had to be reverted by hand.

The prompt's only CVE guidance left this to judgment:

```
- For CVE scan failures: pin a safe version in Dockerfile, or add to allowlist if vendored/unpatchable
```

## Change

Adds one rule: mooncake CVEs are allowlist-only, never pinned, with the signals to recognize them (`Package Manager` GOMOD/GOBINARY, a `go/stdlib` / `golang.org/x/*` / `go.etcd.io/*` / `google.golang.org/grpc` package, or a `File paths` entry pointing at `libetcd_wrapper.so`) and the reason it can't be pinned.

Prompt text only, 5 lines added, no control flow touched. Verified the module still imports.
