### PR TITLE
feat(metadata store): wire ray-llm test-skip logic for sanity/telemetry/efa/unit/ec2/eks-multi-node tests

### DIFF
--- a/.github/config/test-suites.yml
+++ b/.github/config/test-suites.yml
@@ -98,6 +98,21 @@ suites:
     code_paths:
       - test/ray-train/eks/**
 
+  ray-llm/unit:
+    skip_eligible: true
+    code_paths:
+      - test/ray-llm/unit/**
+
+  ray-llm/ec2:
+    skip_eligible: true
+    code_paths:
+      - test/ray-llm/ec2/**
+
+  ray-llm/eks-multi-node:
+    skip_eligible: true
+    code_paths:
+      - test/ray-llm/eks-multi-node/**
+
   vllm/upstream:
     skip_eligible: true
     code_paths:

--- a/.github/workflows/ray-llm.pipeline.yml
+++ b/.github/workflows/ray-llm.pipeline.yml
@@ -96,9 +96,22 @@ jobs:
           aws-region: ${{ vars.AWS_REGION }}
           tag-suffix: ${{ inputs.tag-suffix }}
 
-  sanity-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-sanity-test }}
+  # Check to see which tests have passed before on the given image build
+  check:
+    if: ${{ always() && !failure() && !cancelled() }}
     needs: [build]
+    concurrency:
+      group: ${{ github.workflow }}-check-${{ inputs.config-file }}-${{ github.ref }}
+      cancel-in-progress: true
+    uses: ./.github/workflows/_reusable.check-test-pass.yml
+    with:
+      config-file: ${{ inputs.config-file }}
+      image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      suites: '["sanity", "telemetry", "efa", "ray-llm/unit", "ray-llm/ec2", "ray-llm/eks-multi-node"]'
+
+  sanity-test:
+    if: ${{ always() && !cancelled() && inputs.run-sanity-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['sanity'] != true }}
+    needs: [build, check]
     concurrency:
       group: ${{ github.workflow }}-sanity-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: true
@@ -106,6 +119,8 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['sanity'] || '' }}
 
   security-test:
     if: ${{ always() && !failure() && !cancelled() && inputs.run-security-test }}
@@ -119,8 +134,8 @@ jobs:
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
 
   telemetry-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-telemetry-test }}
-    needs: [build]
+    if: ${{ always() && !cancelled() && inputs.run-telemetry-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['telemetry'] != true }}
+    needs: [build, check]
     concurrency:
       group: ${{ github.workflow }}-telemetry-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: false
@@ -128,10 +143,12 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['telemetry'] || '' }}
 
   unit-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-unit-test }}
-    needs: [build]
+    if: ${{ always() && !cancelled() && inputs.run-unit-test && needs.build.result != 'failure' && fromJSON(needs.check.outputs.skips || '{}')['ray-llm/unit'] != true }}
+    needs: [build, check]
     concurrency:
       group: ${{ github.workflow }}-unit-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: true
@@ -139,10 +156,17 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['ray-llm/unit'] || '' }}
 
   ec2-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-ec2-test && needs.ci-config.outputs.device-type == 'gpu' && needs.ci-config.outputs.customer-type == 'ec2' }}
-    needs: [ci-config, build]
+    if: >-
+      ${{ always() && !cancelled() && inputs.run-ec2-test &&
+          needs.build.result != 'failure' &&
+          needs.ci-config.outputs.device-type == 'gpu' &&
+          needs.ci-config.outputs.customer-type == 'ec2' &&
+          fromJSON(needs.check.outputs.skips || '{}')['ray-llm/ec2'] != true }}
+    needs: [ci-config, build, check]
     concurrency:
       group: ${{ github.workflow }}-ec2-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: false
@@ -150,11 +174,19 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['ray-llm/ec2'] || '' }}
 
   eks-multi-node-test:
     # Fail-fast: skip the multi-node run if ec2-test already failed.
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-eks-multi-node-test && needs.ci-config.outputs.device-type == 'gpu' && needs.ci-config.outputs.customer-type == 'ec2' }}
-    needs: [ci-config, build, ec2-test]
+    if: >-
+      ${{ always() && !cancelled() && inputs.run-eks-multi-node-test &&
+          needs.build.result != 'failure' &&
+          needs.ec2-test.result != 'failure' &&
+          needs.ci-config.outputs.device-type == 'gpu' &&
+          needs.ci-config.outputs.customer-type == 'ec2' &&
+          fromJSON(needs.check.outputs.skips || '{}')['ray-llm/eks-multi-node'] != true }}
+    needs: [ci-config, build, ec2-test, check]
     concurrency:
       group: ${{ github.workflow }}-eks-multi-node-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: false
@@ -162,10 +194,17 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['ray-llm/eks-multi-node'] || '' }}
 
   efa-test:
-    if: ${{ always() && !failure() && !cancelled() && inputs.run-efa-test && needs.ci-config.outputs.device-type == 'gpu' && needs.ci-config.outputs.customer-type == 'ec2' }}
-    needs: [ci-config, build]
+    if: >-
+      ${{ always() && !cancelled() && inputs.run-efa-test &&
+          needs.build.result != 'failure' &&
+          needs.ci-config.outputs.device-type == 'gpu' &&
+          needs.ci-config.outputs.customer-type == 'ec2' &&
+          fromJSON(needs.check.outputs.skips || '{}')['efa'] != true }}
+    needs: [ci-config, build, check]
     concurrency:
       group: ${{ github.workflow }}-efa-test-${{ inputs.config-file }}-${{ github.ref }}
       cancel-in-progress: false
@@ -173,3 +212,5 @@ jobs:
     with:
       config-file: ${{ inputs.config-file }}
       image-uri: ${{ needs.build.outputs.image-uri || '' }}
+      image-content-hash: ${{ needs.check.outputs.image-content-hash }}
+      suite-code-hash: ${{ fromJSON(needs.check.outputs.suite-code-hashes || '{}')['efa'] || '' }}

--- a/.github/workflows/ray-llm.tests-ec2.yml
+++ b/.github/workflows/ray-llm.tests-ec2.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image hash computed from hash_image_content.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "Test code hash computed from hash_suite_code.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -97,3 +107,23 @@ jobs:
           if [[ -n "${{ steps.model.outputs.lock-pid }}" ]]; then
             kill "${{ steps.model.outputs.lock-pid }}" 2>/dev/null || true
           fi
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.ec2-test.result == 'success' }}
+    needs: [ec2-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: ray-llm/ec2
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/ray-llm.tests-eks-multi-node.yml
+++ b/.github/workflows/ray-llm.tests-eks-multi-node.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image hash computed from hash_image_content.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "Test code hash computed from hash_suite_code.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -86,3 +96,23 @@ jobs:
           RAY_VERSION: ${{ needs.preflight.outputs.framework-version }}
         run: |
           bash test/ray-llm/eks-multi-node/run_eks_test.sh
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.eks-multi-node-test.result == 'success' }}
+    needs: [eks-multi-node-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: ray-llm/eks-multi-node
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/ray-llm.tests-unit.yml
+++ b/.github/workflows/ray-llm.tests-unit.yml
@@ -12,6 +12,16 @@ on:
         required: false
         type: string
         default: ""
+      image-content-hash:
+        description: "Image hash computed from hash_image_content.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
+      suite-code-hash:
+        description: "Test code hash computed from hash_suite_code.py for caching a test pass."
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -80,3 +90,23 @@ jobs:
             -e EXPECTED_FRAMEWORK_VERSION=${{ needs.preflight.outputs.framework-version }} \
             ${CONTAINER_ID} pytest /workdir/test/ray-llm/unit/ -v
           docker kill ${CONTAINER_ID}
+
+  # Record a PASS row in the ci-images-table if the test passed.
+  record-test-pass:
+    if: >-
+      ${{ always() && !cancelled() && !failure() &&
+          inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
+          needs.unit-test.result == 'success' }}
+    needs: [unit-test]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/record-test-pass
+        with:
+          suite: ray-llm/unit
+          image-content-hash: ${{ inputs.image-content-hash }}
+          suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}


### PR DESCRIPTION
## Purpose

Wire the `ray-llm` pipeline into the content-addressed test-skip cache. `ray-llm` was added after the shared-suite wiring landed and bypassed the cache entirely — its sanity/telemetry/efa and framework (unit/ec2/eks-multi-node) test jobs re-ran unconditionally on every image build. This is the drift catch-up that enrolls ray-llm like the other frameworks, covering both the shared suites and its framework suites in one PR.

- `test-suites.yml`: add `ray-llm/unit`, `ray-llm/ec2`, `ray-llm/eks-multi-node` (each scoped to its own disjoint `test/ray-llm/<subdir>/**` subtree).
- `ray-llm.pipeline.yml`: add the `check` job (batched lookup over all six skip-eligible suites) and gate `sanity`, `telemetry`, `efa`, `unit`, `ec2`, and `eks-multi-node` on the cache with guarded, fail-open hash threading.
- Add a `record-test-pass` job to the three ray-llm framework reusables (`ray-llm.tests-unit.yml`, `ray-llm.tests-ec2.yml`, `ray-llm.tests-eks-multi-node.yml`). All three are job-level-gated preflight topologies, so the record gate keys on `<test-job>.result == 'success'` + non-empty hashes.
- `security` is `skip_eligible: false` and remains intentionally unwired.
- Fail-open preserved: every `fromJSON(needs.check.outputs.*)` read is guarded with `|| '{}'`, and no test job gates on the `check` job's status — a degraded cache lookup runs the suite, never skips it.
- The `eks-multi-node-test` fail-fast (skip the multi-node run if `ec2-test` failed) is preserved explicitly via `needs.ec2-test.result != 'failure'` rather than the blanket `!failure()`, so a `check` infra blip cannot fail it closed while a `skipped` ec2-test (cache hit) still lets it proceed.

## Test Plan

- `pytest test/db` — reconciliation suite that validates every gated suite is configured and every `check` accessor is checked.
- YAML parse of all five edited files.
- Non-vacuous accessor check: confirm the reconciliation test actually detects the six new ray-llm gate accessors.
- `pre-commit` runs in CI.

## Test Result

- `test/db`: **37 passed**.
- All five edited YAML files parse cleanly.
- `_check_accessor_keys(ray-llm.pipeline.yml)` returns exactly `['efa', 'ray-llm/ec2', 'ray-llm/eks-multi-node', 'ray-llm/unit', 'sanity', 'telemetry']` — all six gates are seen by the reconciliation test and present in the check-job suites list; `security` correctly absent.

______________________________________________________________________

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>
