### PR TITLE
fix(ray-llm): correct allowlist path filter, pin cuda-rhel9 gpg key, drop unused ray_dist.jar

### DIFF
--- a/.github/workflows/ray-llm.pr-gpu.yml
+++ b/.github/workflows/ray-llm.pr-gpu.yml
@@ -14,7 +14,7 @@ on:
       - "scripts/docker/telemetry/**"
       - "test/ray-llm/**"
       - "test/sanity/**"
-      - "test/security/data/ecr_scan_allowlist/ray-llm/**"
+      - "test/security/data/ecr_scan_allowlist/ray_llm/**"
       - "test/telemetry/**"
       - "!docs/**"
 
@@ -54,7 +54,7 @@ jobs:
               - "docker/ray_llm/**"
               - "scripts/docker/common/**"
               - "scripts/docker/ray_llm/**"
-              - "test/security/data/ecr_scan_allowlist/ray-llm/**"
+              - "test/security/data/ecr_scan_allowlist/ray_llm/**"
             sanity-test-change:
               - "test/sanity/**"
             telemetry-test-change:

--- a/docker/ray_llm/Dockerfile.cuda
+++ b/docker/ray_llm/Dockerfile.cuda
@@ -91,9 +91,13 @@ ENV CC=/usr/bin/gcc \
 # Python venv from builder
 COPY --from=builder-venv /opt/venv /opt/venv
 
+# ray_dist.jar is for Ray Java workers, unused in this Python-only image.
+RUN rm -f /opt/venv/lib/python*/site-packages/ray/jars/ray_dist.jar
+
 # install EFA
 COPY scripts/docker/common/install_efa_amzn2023.sh /tmp/install_efa.sh
-RUN echo -e '[cuda-rhel9]\nname=cuda-rhel9\nbaseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64\nenabled=1\ngpgcheck=1' >/etc/yum.repos.d/cuda-rhel9.repo \
+# cuda-rhel9 repo retained for test-time libnccl-devel reinstall (setup_nccl_tests.sh).
+RUN echo -e '[cuda-rhel9]\nname=cuda-rhel9\nbaseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64\nenabled=1\ngpgcheck=1\ngpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA' >/etc/yum.repos.d/cuda-rhel9.repo \
   && dnf install -y --setopt=install_weak_deps=False libnccl libnccl-devel \
   && ldconfig \
   && bash /tmp/install_efa.sh ${EFA_VERSION} \

--- a/test/ray-llm/unit/test_imports.py
+++ b/test/ray-llm/unit/test_imports.py
@@ -38,3 +38,15 @@ def test_llm_config_importable():
 
 def test_vllm_openai_api_server_importable():
     from vllm.entrypoints.openai import api_server  # noqa: F401
+
+
+def test_ray_dist_jar_removed():
+    import os
+
+    import ray
+
+    jars_dir = os.path.join(os.path.dirname(ray.__file__), "jars")
+    jars = (
+        [f for f in os.listdir(jars_dir) if f.endswith(".jar")] if os.path.isdir(jars_dir) else []
+    )
+    assert not jars, jars

--- a/test/security/data/ecr_scan_allowlist/ray_llm/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/ray_llm/framework_allowlist.json
@@ -1,35 +1,5 @@
 [
     {
-        "vulnerability_id": "CVE-2026-34478",
-        "reason": "ray bundles log4j-core 2.25.3 in ray_dist.jar, cannot patch without upstream ray rebuild",
-        "review_by": "2026-11-17"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34480",
-        "reason": "ray bundles log4j-core 2.25.3 in ray_dist.jar, cannot patch without upstream ray rebuild",
-        "review_by": "2026-11-17"
-    },
-    {
-        "vulnerability_id": "CVE-2026-54513",
-        "reason": "jackson-databind 2.18.6 bundled in ray_dist.jar, cannot patch without upstream ray rebuild",
-        "review_by": "2026-11-17"
-    },
-    {
-        "vulnerability_id": "CVE-2026-54512",
-        "reason": "jackson-databind 2.18.6 bundled in ray_dist.jar, cannot patch without upstream ray rebuild",
-        "review_by": "2026-11-17"
-    },
-    {
-        "vulnerability_id": "GHSA-r7wm-3cxj-wff9",
-        "reason": "jackson-core 2.18.6 bundled in ray_dist.jar, cannot patch without upstream ray rebuild",
-        "review_by": "2026-11-17"
-    },
-    {
-        "vulnerability_id": "CVE-2026-54399",
-        "reason": "httpcore5 5.0.2 bundled in ray_dist.jar, cannot patch without upstream ray rebuild",
-        "review_by": "2026-11-17"
-    },
-    {
         "vulnerability_id": "CVE-2026-24747",
         "reason": "torch 2.9.1 pinned in vllm's benchmarks/requirements.txt spec file (not installed). Our runtime torch is 2.11.0 which is past the fix. Scanner reads the spec text and flags it. Cannot patch without vllm rebuild removing the stale spec.",
         "review_by": "2026-11-17"


### PR DESCRIPTION
Three ray-llm hardening fixes:
- Path filter `ecr_scan_allowlist/ray-llm/**` → `ray_llm/**` so allowlist edits trigger the ECR scan.
- Pin cuda-rhel9 `gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-NVIDIA` (matches base/cu132); repo retained for test-time libnccl-devel reinstall.
- Remove unused `ray_dist.jar` (no JVM → unreachable) + absence test; drop now-unneeded allowlist entries.