### PR TITLE
feat(whisperx): enable SOCI for ec2 and sagemaker images

### DIFF
--- a/.github/config/image/whisperx/ec2-amzn2023.yml
+++ b/.github/config/image/whisperx/ec2-amzn2023.yml
@@ -28,5 +28,5 @@ release:
   force_release: false
   public_registry: true
   private_registry: true
-  enable_soci: false
+  enable_soci: true
   environment: "production"

--- a/.github/config/image/whisperx/sagemaker-amzn2023.yml
+++ b/.github/config/image/whisperx/sagemaker-amzn2023.yml
@@ -29,5 +29,5 @@ release:
   force_release: false
   public_registry: true
   private_registry: true
-  enable_soci: false
+  enable_soci: true
   environment: "production"


### PR DESCRIPTION
Enable SOCI (Seekable OCI) index generation for the WhisperX images by setting enable_soci: true in both image configs (ec2-amzn2023.yml and sagemaker-amzn2023.yml).

WhisperX was the only inference framework still opted out of SOCI — vLLM, vLLM-Omni, SGLang, and Ray already publish -soci-suffixed tags. This brings WhisperX in line so both the EC2 and SageMaker variants get a -soci tag, giving customers faster container cold starts via lazy layer loading.

Config-only: SOCI index creation is already wired into the shared release workflow and gated solely on this flag, so no workflow or Dockerfile changes are needed. On the next release the pipeline will produce -soci-suffixed tags for both variants.