### PR TITLE
pytorch: bump EFA to 1.49.0 on 2.11/2.12 CUDA (aws-ofi-nccl 1.20.0)

### DIFF
--- a/.github/config/image/pytorch/2.11-ec2-cuda.yml
+++ b/.github/config/image/pytorch/2.11-ec2-cuda.yml
@@ -24,7 +24,7 @@ build:
   deepspeed_version: "0.18.8"
   transformer_engine_version: "2.12.0"
   nccl_version: "2.26.2"
-  efa_version: "1.47.0"
+  efa_version: "1.49.0"
   gdrcopy_version: "2.4.4"
   max_jobs: "8"
   dlc_major_version: "1"

--- a/.github/config/image/pytorch/2.11-sagemaker-cuda.yml
+++ b/.github/config/image/pytorch/2.11-sagemaker-cuda.yml
@@ -25,7 +25,7 @@ build:
   deepspeed_version: "0.18.8"
   transformer_engine_version: "2.12.0"
   nccl_version: "2.26.2"
-  efa_version: "1.47.0"
+  efa_version: "1.49.0"
   gdrcopy_version: "2.4.4"
   max_jobs: "8"
   dlc_major_version: "1"

--- a/.github/config/image/pytorch/2.12-ec2-cuda.yml
+++ b/.github/config/image/pytorch/2.12-ec2-cuda.yml
@@ -24,7 +24,7 @@ build:
   deepspeed_version: "0.18.8"
   transformer_engine_version: "2.12.0"
   nccl_version: "2.26.2"
-  efa_version: "1.47.0"
+  efa_version: "1.49.0"
   gdrcopy_version: "2.4.4"
   max_jobs: "8"
   dlc_major_version: "1"

--- a/.github/config/image/pytorch/2.12-sagemaker-cuda.yml
+++ b/.github/config/image/pytorch/2.12-sagemaker-cuda.yml
@@ -25,7 +25,7 @@ build:
   deepspeed_version: "0.18.8"
   transformer_engine_version: "2.12.0"
   nccl_version: "2.26.2"
-  efa_version: "1.47.0"
+  efa_version: "1.49.0"
   gdrcopy_version: "2.4.4"
   max_jobs: "8"
   dlc_major_version: "1"

--- a/docker/pytorch/2.11/cuda/uv.lock
+++ b/docker/pytorch/2.11/cuda/uv.lock
@@ -3129,11 +3129,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]

--- a/docker/pytorch/2.12/cuda/uv.lock
+++ b/docker/pytorch/2.12/cuda/uv.lock
@@ -3126,11 +3126,11 @@ wheels = [
 
 [[package]]
 name = "sqlparse"
-version = "0.5.5"
+version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/90/76/437d71068094df0726366574cf3432a4ed754217b436eb7429415cf2d480/sqlparse-0.5.5.tar.gz", hash = "sha256:e20d4a9b0b8585fdf63b10d30066c7c94c5d7a7ec47c889a2d83a3caa93ff28e", size = 120815, upload-time = "2025-12-19T07:17:45.073Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/d3/3f06a1006f2261d1342aefb3c71eed02f5d4ca5bdbecd86ebc12ad38306e/sqlparse-0.6.0.tar.gz", hash = "sha256:113c35c75365ab9cc9c7231d68c6428fb11c085fc8e9eb1ad659b7ddbf6cd2b9", size = 178477, upload-time = "2026-08-13T19:16:06.396Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/49/4b/359f28a903c13438ef59ebeee215fb25da53066db67b305c125f1c6d2a25/sqlparse-0.5.5-py3-none-any.whl", hash = "sha256:12a08b3bf3eec877c519589833aed092e2444e68240a3577e8e26148acc7b1ba", size = 46138, upload-time = "2025-12-19T07:17:46.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/50/f00935da0ec7cbf325f8dc4f772ae46fbc7b672dd62876e73f0a94adda57/sqlparse-0.6.0-py3-none-any.whl", hash = "sha256:b861c0288ce2fa56209a9a6412d2e066ac664b3873b89c26c9d8415e8e32996f", size = 50070, upload-time = "2026-08-13T19:16:04.062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
EFA 1.47.0 → 1.49.0 on PyTorch 2.11/2.12 CUDA images — picks up aws-ofi-nccl 1.20.0, which fixes the large inter-node NCCL broadcast hang in 1.18.0. Matches 2.13; no tag change.