### PR TITLE
[ray-llm] promote gamma -> production release

### DIFF
--- a/.github/config/image/ray-llm/ec2-gpu.yml
+++ b/.github/config/image/ray-llm/ec2-gpu.yml
@@ -32,4 +32,4 @@ release:
   public_registry: true
   private_registry: true
   enable_soci: true
-  environment: "gamma"
+  environment: "production"


### PR DESCRIPTION
## What
Promote the ray-llm image (`ray:serve-llm-cuda`) from **gamma** to **production**. [Gamma](https://github.com/aws/deep-learning-containers/actions/runs/33423150514) released cleanly (v1 / v1.0 / v1.0.0 + SOCI tags published), so flip `release.environment` to match ray-train / ray.

Only change: `environment: "gamma" → "production"`.

## Test
CI build + full suite + release-gate. 