### PR TITLE
ray-train: bump EFA to 1.49.0, DLC minor to v1.1

### DIFF
--- a/.github/config/image/ray-train/ec2-gpu.yml
+++ b/.github/config/image/ray-train/ec2-gpu.yml
@@ -26,12 +26,12 @@ build:
   torch_version: "2.13.0"
   transformer_engine_version: "2.13.0"
   flash_attn_version: "2.8.3"
-  efa_version: "1.47.0"
+  efa_version: "1.49.0"
   gdrcopy_version: "2.4.4"
   nccl_tests_version: "2.19.6"
   max_jobs: "8"
   dlc_major_version: "1"
-  dlc_minor_version: "0"
+  dlc_minor_version: "1"
 
 release:
   release: true

--- a/docker/ray-train/Dockerfile.cuda
+++ b/docker/ray-train/Dockerfile.cuda
@@ -16,7 +16,7 @@
 
 # ── Global ARGs ─────────────────────────────────────────────────────────────
 ARG DLC_MAJOR_VERSION=1
-ARG DLC_MINOR_VERSION=0
+ARG DLC_MINOR_VERSION=1
 ARG PYTHON_VERSION=3.13
 # Short X.Y form for venv site-packages paths.
 ARG PYTHON_SHORT_VERSION=3.13
@@ -25,7 +25,7 @@ ARG TORCH_VERSION=2.13.0
 ARG CUDA_VERSION=13.0.2
 ARG TRANSFORMER_ENGINE_VERSION=2.13.0
 ARG FLASH_ATTN_VERSION=2.8.3
-ARG EFA_VERSION=1.47.0
+ARG EFA_VERSION=1.49.0
 ARG GDRCOPY_VERSION=2.4.4
 # Compiler parallelism cap per stage — prevents OOM when nproc > available RAM.
 ARG MAX_JOBS=8


### PR DESCRIPTION
## Purpose

Brings Ray Train in line with the EFA version the rest of the AL2023 GPU fleet already ships. Ray Train was the last one still on 1.47.0:

| Config | EFA |
| --- | --- |
| pytorch 2.11 / 2.12 / 2.13, base cu132, tensorflow 2.21, sglang AL2023 | 1.49.0 |
| **ray-train** | **1.47.0 → 1.49.0** |
| vllm, vllm-omni | 1.47.0 |
| sglang Ubuntu | 1.48.0 |

Mirrors #6668 (`pytorch: bump EFA to 1.49.0 on 2.11/2.12 CUDA (aws-ofi-nccl 1.20.0)`), which was a config change only.

`.github/config/image/ray-train/ec2-gpu.yml`:

```diff
-  efa_version: "1.47.0"
+  efa_version: "1.49.0"
-  dlc_minor_version: "0"
+  dlc_minor_version: "1"
```

`docker/ray-train/Dockerfile.cuda` — the config block is the source of truth for pins, but the ARG defaults are the local-build fallbacks, so leaving them behind means a local `docker build` produces a different image than CI. `DLC_MINOR_VERSION` also feeds `LABEL dlc_minor_version`, so a local build would otherwise mislabel the image as 1.0. Same fallback bump ray-llm did in #6671:

```diff
-ARG EFA_VERSION=1.47.0
+ARG EFA_VERSION=1.49.0
-ARG DLC_MINOR_VERSION=0
+ARG DLC_MINOR_VERSION=1
```

I diffed every other ARG default against the config while here — torch, CUDA, python, TE, flash-attn, gdrcopy, nccl-tests, framework version, and max_jobs were all already in sync.

`dlc_minor_version` 0 → 1 per the versioning strategy, so the release publishes `train-ml-cuda-v1.1` and `-v1.1.0`, and moves `-v1`.

## Why no test or workflow changes are needed

There *is* a behavior difference across this range, and it is already handled in the shared installer. `scripts/docker/common/install_efa_amzn2023.sh` passes `--disable-ngc` for EFA >= 1.48.0:

> EFA 1.48+ auto-detects NGC containers via `/opt/nvidia/nvidia_entrypoint.sh` (present in `nvidia/cuda:*-amzn2023` bases) and then skips the AL2023 `libnccl-ofi` RPM. Force the standard install with `--disable-ngc` (EFA 1.48+).

Ray Train uses that same script, and the `>= 1.48.0` branch is already exercised in production by PyTorch, TensorFlow, base-cu132, and sglang-AL2023 at 1.49.0.

The only place that asserts an EFA version, `test/sanity/scripts/check_nccl_efa_gdrcopy.sh`, is gated on `framework == 'base'` so it never runs for `ray_train`, and it takes its expected values from image config rather than hardcoding them. No other EFA version literals exist in `test/`, `scripts/`, or `.github/workflows/`.

## Test Plan

Config-only change, so CI coverage is the test plan. The relevant gate is `efa-test` on 2x p4d.24xlarge, which asserts:

- `NET/OFI Selected provider is efa`
- `Using network Libfabric` and the `aws-ofi-nccl` plugin loaded
- `all_reduce_perf` bandwidth >= 3 GB/s at the 1 GiB message size

Plus the usual unit, sanity, single-GPU, and multi-node KubeRay EKS tests.

`pre-commit run --all-files` — exit 0, stable across two runs.

## The thing to watch

Ray Train has no `nccl_version` in config — NCCL comes from the `nvidia-nccl-cu13` wheel (currently 2.29.7), unlike PyTorch which pins it explicitly. EFA 1.49.0 ships aws-ofi-nccl 1.20.0, so the plugin ↔ NCCL pairing is the one genuinely new combination here. The `efa-test` assertions above are what would catch a mismatch, so that job is worth watching on this PR specifically.

## Follow-ups

- **Docs.** `docs/ray-train/index.md` and the changelog currently state EFA 1.47.0, which is correct for the released v1.0 image and stays correct until v1.1 ships. They will be updated in a separate docs PR after release, matching how #6668 left the PyTorch docs alone.
- The public gallery About/Usage content deliberately carries no EFA version pin, so it needs no change.

______________________________________________________________________

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [x] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
