### PR TITLE
docs: add missing SGLang entry to User Guide index

### DIFF
--- a/docs/user_guide/index.md
+++ b/docs/user_guide/index.md
@@ -4,6 +4,7 @@ Choose a framework to get started:
 
 - **[vLLM](../vllm/index.md)** — serve large language models on {{ ec2_short }}, {{ eks_short }}, or {{ sagemaker }}
 - **[vLLM-Omni](../vllm-omni/index.md)** — serve multimodal models (TTS, image, video, audio, omni-chat)
+- **[SGLang](../sglang/index.md)** — serve large language models on {{ ec2_short }}, {{ eks_short }}, or {{ sagemaker }}
 - **[TEI](../tei/index.md)** — serve text embedding, reranker, and classification models with Text Embeddings Inference on {{ sagemaker }}
 - **[Ray](../ray/index.md)** — deploy any ML model with Ray Serve (NLP, vision, audio, tabular)
 - **[Ray Train](../ray-train/index.md)** — distributed training with Ray Train on any {{ eks_short }} cluster via KubeRay, or on {{ ec2_short }}


### PR DESCRIPTION
## Issue

The [User Guide](https://aws.github.io/deep-learning-containers/user_guide/) landing page lists every framework *except* SGLang, even though:

- `docs/.nav.yml` includes `SGLang: sglang` in the User Guide nav section
- Full SGLang guides exist under `docs/sglang/` (overview, configuration, deployment, models, changelog)
- The home page and `get_started/using_dlcs.md` both reference SGLang

So a reader landing on the User Guide page sees no SGLang link even though it is in the sidebar.

## Change

Adds the missing SGLang bullet to `docs/user_guide/index.md`, positioned after vLLM-Omni to match `.nav.yml` ordering, using the same macro style (`{{ ec2_short }}`, `{{ eks_short }}`, `{{ sagemaker }}`) as the neighboring entries. Platforms match `docs/sglang/index.md`.

Docs-only change; no image or build logic touched.