### PR TITLE
docs(ray-train): v1.1 changelog entry and README highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ ______________________________________________________________________
 
 ### 🚀 Release Highlights
 
+- **[2026/09/01]** [Ray Train v1.1 (2.58.0, AL2023)](https://gallery.ecr.aws/deep-learning-containers/ray) — EC2/EKS: `train-ml-cuda-v1.1` · EFA `1.49.0` (up from 1.47.0).
 - **[2026/08/26]** [vLLM v0.28.0 (Ubuntu)](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.28.0-gpu-py312-ec2` · SageMaker: `0.28.0-gpu-py312` · Kimi-K3 stack-wide optimization (Decode Context Parallel, fused FlashKDA kernels, GEMM-RS sequence parallelism); DeepSeek V4 sparse MLA end-to-end with MTP and DSpark speculative decoding; new models Muse Glimmer, Ling 3.0 Flash, Dots3, Interns2mobius; tiered KV cache offloading to disk; runtime base moves to Ubuntu 24.04 and Transformers 5.15.0; `max_num_batched_tokens` default 8192 -> 16384.
 - **[2026/08/26]** [Ray Train v1.0 (2.58.0, AL2023)](https://gallery.ecr.aws/deep-learning-containers/ray) — EC2/EKS: `train-ml-cuda-v1.0` · Initial release: multi-node, multi-GPU distributed training with Ray Train/Tune/Data on PyTorch 2.13.0 / CUDA 13.0.2 / Python 3.13, with EFA 1.47.0, the AWS NCCL OFI plugin, GDRCopy, flash-attn, Transformer Engine, and DeepSpeed pre-installed; one image runs as either a Ray head or worker under KubeRay on any EKS cluster (including SageMaker HyperPod-EKS), or standalone on EC2.
 - **[2026/08/25]** [vLLM-Omni v1.6 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `omni-cuda-v1.6` · SageMaker: `omni-sagemaker-cuda-v1.6` · SageMaker `SM_VLLM_*` fix — JSON-array env vars (e.g. `SM_VLLM_LORA_MODULES`) now expand into multiple argv values so multi-value flags parse correctly; no framework bump (still vLLM-Omni `0.26.0`).
@@ -44,7 +45,6 @@ ______________________________________________________________________
 - **[2026/08/14]** [WhisperX v3.8.6 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/whisperx) — EC2: `3.8.6-cu128-amzn2023` · SageMaker: `3.8.6-cu128-amzn2023-sagemaker` · Initial release: speech transcription with word-level alignment (wav2vec2) and speaker diarization (pyannote) through an OpenAI-compatible API on CUDA 12.8 / Python 3.12; real-time and asynchronous SageMaker endpoints.
 - **[2026/08/12]** [Ray v1.4 (2.57.0, AL2023)](https://gallery.ecr.aws/deep-learning-containers/ray) — EC2: `serve-ml-cuda-v1.4` · `serve-ml-cpu-v1.4` · SageMaker: `serve-ml-sagemaker-cuda-v1.4` · `serve-ml-sagemaker-cpu-v1.4` · Ray `2.57.0` (up from 2.56.1).
 - **[2026/08/08]** [SGLang v0.5.17 (Ubuntu)](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.17-gpu-py312-ec2` · SageMaker: `0.5.17-gpu-py312` · Kimi K3, MiniMax H3.
-- **[2026/08/07]** [vLLM-Omni v1.5 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `omni-cuda-v1.5` · SageMaker: `omni-sagemaker-cuda-v1.5` · vLLM-Omni `0.26.0` (up from 0.21.0rc1) on vLLM v0.26.0 with the new Rust frontend; SageMaker bidirectional WebSocket streaming (`InvokeEndpointWithBidirectionalStream`) for low-latency TTS and realtime sessions; FlashInfer 0.6.14; s3tokenizer bundled for CosyVoice3.
 
 ### 📢 Support Updates
 

--- a/docs/ray-train/changelog/index.md
+++ b/docs/ray-train/changelog/index.md
@@ -4,6 +4,19 @@ Changelog for the Amazon Linux 2023-based Ray Train DLC images (`train-ml-cuda`)
 
 * * *
 
+## Ray Train v1.1 — 2026-09-01
+
+**Tags:** `train-ml-cuda` · `train-ml-cuda-v1` · `train-ml-cuda-v1.1` · `train-ml-cuda-v1.1.0`
+
+**Bundled versions:** Ray 2.58.0 · PyTorch 2.13.0 · `torchvision` 0.28.0 · CUDA 13.0.2 · Python 3.13 · NCCL 2.29.7 · EFA 1.49.0 · GDRCopy 2.4.4 ·
+flash-attn 2.8.3 · Transformer Engine 2.13.0 · DeepSpeed 0.19.2 · PyTorch Lightning 2.6.5 · Transformers 5.13.0
+
+### Changes
+
+- Upgraded EFA from 1.47.0 to 1.49.0 (aws-ofi-nccl 1.20.0)
+
+* * *
+
 ## Ray Train v1.0 — 2026-08-26
 
 **Tags:** `train-ml-cuda` · `train-ml-cuda-v1` · `train-ml-cuda-v1.0` · `train-ml-cuda-v1.0.0`

--- a/docs/ray-train/index.md
+++ b/docs/ray-train/index.md
@@ -15,7 +15,7 @@ KubeRay clusters on {{ eks }} and manually bootstrapped clusters on {{ ec2_short
 | {{ ec2_short }} / {{ eks_short }} | GPU | `public.ecr.aws/deep-learning-containers/ray:train-ml-cuda` |
 
 Ray Train shares the `ray` repository with the [Ray Serve DLC](../ray/index.md), using the `train-ml` tag prefix. Versioned tags (e.g.
-`train-ml-cuda-v1`, `train-ml-cuda-v1.0`, and `train-ml-cuda-v1.0.0`) are published alongside the floating tag. The image is also available on the
+`train-ml-cuda-v1`, `train-ml-cuda-v1.1`, and `train-ml-cuda-v1.1.0`) are published alongside the floating tag. The image is also available on the
 [ECR Public Gallery](https://gallery.ecr.aws/deep-learning-containers/ray). For private ECR URIs, see [Image Access](../get_started/index.md).
 
 ## What's Included
@@ -26,7 +26,7 @@ The image bundles the full distributed-training stack so you can launch multi-GP
   job-submission server that `ray job submit` and KubeRay's health probes use
 - **[PyTorch](https://pytorch.org/) 2.13.0** with `torchvision` 0.28.0 (CUDA 13.0 wheels)
 - **CUDA 13.0.2** with cuDNN and **NCCL 2.29.7** for multi-GPU collectives
-- **[EFA](https://aws.amazon.com/hpc/efa/) 1.47.0** with **OpenMPI** and the **AWS NCCL OFI plugin** for low-latency multi-node communication on
+- **[EFA](https://aws.amazon.com/hpc/efa/) 1.49.0** with **OpenMPI** and the **AWS NCCL OFI plugin** for low-latency multi-node communication on
   EFA-capable instances
 - **[GDRCopy](https://github.com/NVIDIA/gdrcopy) 2.4.4** userspace library for direct GPU-to-NIC memory copies
 - **[flash-attn](https://github.com/Dao-AILab/flash-attention) 2.8.3** — fused attention kernels for transformer training


### PR DESCRIPTION
## Purpose

Ray Train **v1.1** released **2026-09-01** — `train-ml-cuda-v1.1` and `-v1.1.0` are live on the Public Gallery (tags created 2026-09-01 08:14 UTC). This is the docs follow-up promised in #6679.

**EFA 1.47.0 → 1.49.0 is the only change in the image.** Verified rather than assumed: diffing every ray-train path (`.github/config/image/ray-train/`, `docker/ray-train/`, `scripts/docker/ray-train/`, `scripts/ci/build/ray_train/`) against the v1.0 production release commit `11fab90f` shows exactly one commit — #6679 — touching 2 files / 4 lines. The shared `install_efa_amzn2023.sh` was untouched in that range.

### Changes

- **`docs/ray-train/changelog/index.md`** — new `v1.1 — 2026-09-01` entry with the tag set, bundled versions, and the single EFA change. The v1.0 entry keeps EFA 1.47.0, since that is what that image actually shipped.
- **`docs/ray-train/index.md`** — EFA 1.49.0 in "What's Included", and the versioned-tag examples now point at `v1.1` / `v1.1.0` instead of the superseded `v1.0` / `v1.0.0`.
- **`README.md`** — add the v1.1 release highlight, drop the oldest one (vLLM-Omni v1.5, 2026/08/07) to keep the list at 14.

## Notes

- The **Support Updates** entries below Release Highlights (2026/04/28 Ubuntu Pro, 2026/02/10 PyTorch 2.6 extended support) are policy notices rather than release highlights, so they were left in place — only a release entry was rotated out.
- A `train-ml-cuda-v1.0.1` patch tag exists from 2026-08-28. No changelog entry was added for it: it carries no config change, and the Ray Serve changelog likewise documents minor versions only.
- The public gallery About/Usage content carries no EFA version pin, so it needs no update.

## Test Plan

Docs-only change.

1. `pre-commit run --all-files`
2. `mkdocs build --strict`
3. Inspect the rendered changelog and overview pages
4. `pytest test/docs`

## Test Result

1. `pre-commit run --all-files` — exit 0, stable across two runs.
2. `mkdocs build --strict` — exit 0.
3. Rendered output checked, not just the source: changelog shows `Ray Train v1.1 — 2026-09-01` above `Ray Train v1.0 — 2026-08-26`, the v1.1 entry carries `EFA 1.49.0` and `aws-ofi-nccl 1.20.0`, the v1.0 entry still reads `EFA 1.47.0`, and the overview has no stale `1.47` reference left.
4. `pytest test/docs` — **74 passed**.

______________________________________________________________________

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [x] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*