### PR TITLE
fix(vllm): allow uv installs on the PEP 668 Ubuntu test image

### DIFF
--- a/test/vllm/scripts/vllm_test_setup.sh
+++ b/test/vllm/scripts/vllm_test_setup.sh
@@ -5,6 +5,13 @@ set -eux
 UV_FLAGS=""
 if [ -z "${VIRTUAL_ENV:-}" ]; then
   UV_FLAGS="--system"
+  # The Ubuntu image installs into the distro interpreter at /usr, which carries PEP 668's
+  # EXTERNALLY-MANAGED marker; without this uv refuses every install with "The interpreter
+  # at /usr is externally managed". Set as an env var rather than appending
+  # --break-system-packages to UV_FLAGS because `uv pip freeze` below shares UV_FLAGS and
+  # rejects that flag ("unexpected argument"), which its `|| true` would hide.
+  # The AL2023 image has a venv at /opt/venv with VIRTUAL_ENV set, so it skips this branch.
+  export UV_BREAK_SYSTEM_PACKAGES=1
 fi
 
 # lightning is quarantined on PyPI — remove terratorch (which depends on it)


### PR DESCRIPTION
## Problem

All `upstream-tests` jobs on **both Ubuntu vLLM variants** fail in the `Setup for vLLM tests` step:

```
+ uv pip install --system -r vllm_source/requirements/dev.txt --torch-backend=auto
Using Python 3.12.3 environment at: /usr
error: The interpreter at /usr is externally managed
hint: Virtual environments were not considered due to the `--system` flag
```

6 jobs across 2 scheduled runs, all identical — same script line, same interpreter path, exit code 2:

| Run | Workflow | Failed jobs |
|---|---|---|
| 33442060593 | Auto Release - vLLM SageMaker Ubuntu | `regression-test`, `example-test`, `cuda-test` |
| 33433924480 | Auto Release - vLLM EC2 Ubuntu | `regression-test`, `example-test`, `cuda-test` |

`vllm.pr-ubuntu.yml` and `vllm.dispatch-efa-test.yml` share the same script, so Ubuntu PRs and EFA dispatch are blocked too.

## Cause

`docker/vllm/Dockerfile` (Ubuntu 24.04, upstream `vllm/vllm-openai` base) has no virtualenv — packages go to the distro interpreter at `/usr`, which carries PEP 668's `EXTERNALLY-MANAGED` marker. `uv` refuses to write there without an explicit opt-in.

The script's branch was already correct in intent, just missing that opt-in:

```sh
# Use --system when not in a virtualenv (Ubuntu image), omit when venv is active (AL2023)
if [ -z "${VIRTUAL_ENV:-}" ]; then
  UV_FLAGS="--system"
```

AL2023 is unaffected: `Dockerfile.amzn2023` creates `/opt/venv` and exports `VIRTUAL_ENV`, so it takes the empty branch and never passes `--system`.

This is environment drift, not a regression from a repo commit. The Aug 26 scheduled run passed on the **same** base image digest (`vllm/vllm-openai:v0.28.0@sha256:61fc8a896b0a`) and the same script, with `uv pip install --system` succeeding against the same `/usr` interpreter. The `EXTERNALLY-MANAGED` marker is also absent at *build* time — the Dockerfile itself runs `uv pip install --system` at lines 29/35/45 and the Aug 31 build succeeded — so it is being introduced into the image after those layers. The `CACHE_REFRESH` build-arg (current date) busts the CVE-patch layer on every build, so a package set pulled between Aug 26 and Aug 31 is the likely source. I did not isolate which one; the fix does not depend on it and is correct whether or not the marker is present.

## Fix

Set `UV_BREAK_SYSTEM_PACKAGES=1` in the existing no-virtualenv branch.

Deliberately an env var rather than appending `--break-system-packages` to `UV_FLAGS`: `UV_FLAGS` is shared with `uv pip freeze` further down, and `freeze` rejects that flag —

```
$ uv pip freeze --system --break-system-packages
error: unexpected argument '--break-system-packages' found
```

That call has `|| true`, so the flag would have silently produced an empty freeze file and broken the constraint dedup downstream instead of erroring. The env var is honoured by `pip install` (`[env: UV_BREAK_SYSTEM_PACKAGES=]`) and harmless to `freeze`.

## Testing

`bash -n` clean. Flag/env behaviour verified against uv 0.11.16 as quoted above.

Not verified: whether the tests themselves pass once setup completes. Every test after this step was skipped in all 6 failing jobs, so this unblocks setup — it does not by itself prove the suites go green.

Related: `uv pip freeze $UV_FLAGS ... || true` at line ~62 masks its own failures. Worth tightening separately — it is why this stayed invisible until the install line surfaced it.
