### PR TITLE
fix(vllm): set PEP 668 break-system-packages env on vLLM test containers

### DIFF
--- a/.github/workflows/vllm.tests-upstream.yml
+++ b/.github/workflows/vllm.tests-upstream.yml
@@ -114,6 +114,8 @@ jobs:
             -v ${HOME}/.cache/vllm:/root/.cache/vllm \
             -v .:/workdir --workdir /workdir \
             -e HF_TOKEN=${{ secrets.HUGGING_FACE_HUB_TOKEN }} \
+            -e PIP_BREAK_SYSTEM_PACKAGES=1 \
+            -e UV_BREAK_SYSTEM_PACKAGES=1 \
             ${{ needs.preflight.outputs.image-uri }})
           echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
 
@@ -170,6 +172,8 @@ jobs:
             -v ${HOME}/.cache/vllm:/root/.cache/vllm \
             -v .:/workdir --workdir /workdir \
             -e HF_TOKEN=${{ secrets.HUGGING_FACE_HUB_TOKEN }} \
+            -e PIP_BREAK_SYSTEM_PACKAGES=1 \
+            -e UV_BREAK_SYSTEM_PACKAGES=1 \
             ${{ needs.preflight.outputs.image-uri }})
           echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
 
@@ -226,6 +230,8 @@ jobs:
             -v ${HOME}/.cache/vllm:/root/.cache/vllm \
             -v .:/workdir --workdir /workdir \
             -e HF_TOKEN=${{ secrets.HUGGING_FACE_HUB_TOKEN }} \
+            -e PIP_BREAK_SYSTEM_PACKAGES=1 \
+            -e UV_BREAK_SYSTEM_PACKAGES=1 \
             ${{ needs.preflight.outputs.image-uri }})
           echo "CONTAINER_ID=$CONTAINER_ID" >> $GITHUB_ENV
 


### PR DESCRIPTION
## Problem

The `example-test` and `regression-test` jobs of the vLLM Ubuntu pipeline fail because the upstream test scripts install extra dependencies **inside the test container**, and the Ubuntu image's system interpreter at `/usr` carries PEP 668's `EXTERNALLY-MANAGED` marker:

- `test/vllm/scripts/ubuntu/vllm_sagemaker_examples_test.sh` → `pip install tensorizer` → `error: externally-managed-environment` (exit 1)
- `test/vllm/scripts/vllm_regression_test.sh` → `uv pip install --system "modelscope<1.38"` → `The interpreter at /usr is externally managed` (exit 2)

Example failing run: https://github.com/aws/deep-learning-containers/actions/runs/33557446026

## Why the previous fix (#6686) didn't resolve it

#6686 exported `UV_BREAK_SYSTEM_PACKAGES=1` inside `vllm_test_setup.sh`. But each test step runs its script in a **separate `docker exec`**, which does not inherit an env var exported by an earlier exec; it also only set the `uv` variable, not `pip`'s. So both jobs still fail on a freshly built image.

(They passed in #6686's CI only because `tensorizer` and `modelscope` happened to be pre-installed in the image it tested, making those installs no-ops that never reached the PEP 668 guard.)

## Fix

Set `PIP_BREAK_SYSTEM_PACKAGES=1` and `UV_BREAK_SYSTEM_PACKAGES=1` on the `docker run` that creates the test container, so **every** `docker exec` into it (setup + all test scripts, current and future) inherits the bypass. Applied to all three container starts in `vllm.tests-upstream.yml`. On AL2023 (venv at `/opt/venv`, `VIRTUAL_ENV` set) these vars are harmless no-ops.

_Note: `vllm.dispatch-efa-test.yml` runs the same `vllm_regression_test.sh` and would hit this if dispatched against an Ubuntu image, but it's a manual dispatch not exercised by this pipeline/PR CI, so it's left out of scope here._
