### PR TITLE
fix(pytorch): sync black CVE-2026-32274 allowlist (PT 2.9) and pin nccl-tests in EFA test

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -65,8 +65,8 @@ sanity_tests = true
 security_tests = true
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = false
-eks_tests = false
+ecs_tests = true
+eks_tests = true
 ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
@@ -75,10 +75,10 @@ ec2_benchmark_tests = false
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = true
+ec2_tests_on_heavy_instances = false
 ### SM specific tests
 ### On by default
-sagemaker_local_tests = false
+sagemaker_local_tests = true
 ### Set enable_ipv6 = true to run tests with IPv6-enabled resources
 ### Off by default (set to false)
 enable_ipv6 = false
@@ -96,7 +96,7 @@ enable_ipv6 = false
 ipv6_vpc_name = ""
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = false
+sagemaker_remote_tests = true
 # run efa sagemaker tests
 sagemaker_efa_tests = false
 # run release_candidate_integration tests
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-9-ec2.yml"
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-9-sm.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -65,8 +65,8 @@ sanity_tests = true
 security_tests = true
   safety_check_test = false
   ecr_scan_allowlist_feature = false
-ecs_tests = true
-eks_tests = true
+ecs_tests = false
+eks_tests = false
 ec2_tests = true
 # Set it to true if you are preparing a Benchmark related PR
 ec2_benchmark_tests = false
@@ -75,10 +75,10 @@ ec2_benchmark_tests = false
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = false
+ec2_tests_on_heavy_instances = true
 ### SM specific tests
 ### On by default
-sagemaker_local_tests = true
+sagemaker_local_tests = false
 ### Set enable_ipv6 = true to run tests with IPv6-enabled resources
 ### Off by default (set to false)
 enable_ipv6 = false
@@ -96,7 +96,7 @@ enable_ipv6 = false
 ipv6_vpc_name = ""
 
 # run standard sagemaker remote tests from test/sagemaker_tests
-sagemaker_remote_tests = true
+sagemaker_remote_tests = false
 # run efa sagemaker tests
 sagemaker_efa_tests = false
 # run release_candidate_integration tests
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = ""
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-9-ec2.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -75,7 +75,7 @@ ec2_benchmark_tests = false
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = true
+ec2_tests_on_heavy_instances = false
 ### SM specific tests
 ### On by default
 sagemaker_local_tests = true
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-ec2.yml"
+dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -75,7 +75,7 @@ ec2_benchmark_tests = false
 ### default. If false, these types of tests will be skipped while other tests will run as usual.
 ### These tests are run in EC2 test jobs, so ec2_tests must be true if ec2_tests_on_heavy_instances is true.
 ### Off by default (set to false)
-ec2_tests_on_heavy_instances = false
+ec2_tests_on_heavy_instances = true
 ### SM specific tests
 ### On by default
 sagemaker_local_tests = true
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-9-sm.yml"
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-ec2.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/pytorch/training/docker/2.9/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/2.9/py3/Dockerfile.cpu
@@ -282,13 +282,10 @@ ENV SAGEMAKER_TRAINING_MODULE=sagemaker_pytorch_container.training:main
 
 WORKDIR /
 
-# Install SM packages
-# Install s3fs, boto3, awscli together so pip can resolve the
-# aiobotocore -> botocore version constraints in a single pass
+# Split the SageMaker SDK resolve from the s3fs/AWS-SDK resolve below: installing
+# them in one pip pass makes the dependency graph too large to solve
+# (pip fails with resolution-too-deep).
 RUN pip install --no-cache-dir -U \
-    "s3fs>=2026.2.0" \
-    awscli \
-    boto3 \
     smclarify \
     "sagemaker>=2.254.1,<3" \
     sagemaker-experiments \
@@ -297,6 +294,7 @@ RUN pip install --no-cache-dir -U \
     sniffio
 
 # Install extra packages
+# s3fs: pip resolves to ancient 0.4.2 without pin; smclarify needs modern s3fs (which pulls aiobotocore, aioitertools)
 RUN pip install --no-cache-dir -U \
     bokeh \
     imageio \
@@ -307,7 +305,21 @@ RUN pip install --no-cache-dir -U \
     seaborn \
     shap \
     cloudpickle \
-    langcodes
+    langcodes \
+    "s3fs>=2026.2.0"
+
+# Force-upgrade boto3/botocore/awscli/s3transfer above the ceiling that
+# aiobotocore (transitively pulled by s3fs>=2026.2.0) declares (botocore<1.43.1).
+# boto3>=1.43.34 imports DocumentModifiedShape from botocore.docs.utils, which only
+# exists in botocore>=1.43.34, so the boto3/botocore pair must stay aligned on the
+# 1.43.x line. pip prints an aiobotocore-vs-botocore conflict warning here but
+# installation proceeds; aiobotocore is only exercised via smclarify's s3fs path,
+# not at container boot.
+RUN pip install --no-cache-dir -U \
+    "boto3>=1.43.34" \
+    "botocore>=1.43.34" \
+    "awscli>=1.45.34" \
+    "s3transfer>=0.19.0"
 
 # Copy workaround script for incorrect hostname
 COPY changehostname.c /

--- a/pytorch/training/docker/2.9/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json
@@ -1,7 +1,7 @@
 {
   "black": [
     {
-      "description": "Black is the uncompromising Python code formatter. Prior to 26.3.1, Black writes a cache file, the name of which is computed from various formatting options. The value of the --python-cell-magics option was placed in the filename without sanitization, which allowed an attacker who controls the value of this argument to write cache files to arbitrary file system locations. Fixed in Black 26.3.1.",
+      "description": "Black is the uncompromising Python code formatter. Starting in version 24.3.0 and prior to version 26.3.1, Black writes a cache file, the name of which is computed from various formatting options. The value of the --python-cell-magics option was placed in the filename without sanitization, which allowed an attacker who controls the value of this argument to write cache files to arbitrary file system locations. Fixed in Black 26.3.1.",
       "vulnerability_id": "CVE-2026-32274",
       "name": "CVE-2026-32274",
       "package_name": "black",

--- a/pytorch/training/docker/2.9/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
@@ -1,7 +1,7 @@
 {
   "black": [
     {
-      "description": "Black is the uncompromising Python code formatter. Prior to 26.3.1, Black writes a cache file, the name of which is computed from various formatting options. The value of the --python-cell-magics option was placed in the filename without sanitization, which allowed an attacker who controls the value of this argument to write cache files to arbitrary file system locations. Fixed in Black 26.3.1.",
+      "description": "Black is the uncompromising Python code formatter. Starting in version 24.3.0 and prior to version 26.3.1, Black writes a cache file, the name of which is computed from various formatting options. The value of the --python-cell-magics option was placed in the filename without sanitization, which allowed an attacker who controls the value of this argument to write cache files to arbitrary file system locations. Fixed in Black 26.3.1.",
       "vulnerability_id": "CVE-2026-32274",
       "name": "CVE-2026-32274",
       "package_name": "black",

--- a/pytorch/training/docker/2.9/py3/cu130/Dockerfile.ec2.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/cu130/Dockerfile.ec2.gpu.os_scan_allowlist.json
@@ -1,7 +1,7 @@
 {
   "black": [
     {
-      "description": "Black is the uncompromising Python code formatter. Prior to 26.3.1, Black writes a cache file, the name of which is computed from various formatting options. The value of the --python-cell-magics option was placed in the filename without sanitization, which allowed an attacker who controls the value of this argument to write cache files to arbitrary file system locations. Fixed in Black 26.3.1.",
+      "description": "Black is the uncompromising Python code formatter. Starting in version 24.3.0 and prior to version 26.3.1, Black writes a cache file, the name of which is computed from various formatting options. The value of the --python-cell-magics option was placed in the filename without sanitization, which allowed an attacker who controls the value of this argument to write cache files to arbitrary file system locations. Fixed in Black 26.3.1.",
       "vulnerability_id": "CVE-2026-32274",
       "name": "CVE-2026-32274",
       "package_name": "black",

--- a/pytorch/training/docker/2.9/py3/cu130/Dockerfile.gpu
+++ b/pytorch/training/docker/2.9/py3/cu130/Dockerfile.gpu
@@ -250,13 +250,10 @@ ARG PYTHON
 
 WORKDIR /
 
-# Install SM packages
-# Install s3fs, boto3, awscli together so pip can resolve the
-# aiobotocore -> botocore version constraints in a single pass
+# Split the SageMaker SDK resolve from the s3fs/AWS-SDK resolve below: installing
+# them in one pip pass makes the dependency graph too large to solve
+# (pip fails with resolution-too-deep).
 RUN pip install --no-cache-dir -U \
-    "s3fs>=2026.2.0" \
-    awscli \
-    boto3 \
     smclarify \
     "sagemaker>=2.254.1,<3" \
     sagemaker-experiments \
@@ -265,6 +262,7 @@ RUN pip install --no-cache-dir -U \
     sniffio
 
 # Install extra packages
+# s3fs: pip resolves to ancient 0.4.2 without pin; smclarify needs modern s3fs (which pulls aiobotocore, aioitertools)
 RUN pip install --no-cache-dir -U \
     bokeh \
     imageio \
@@ -275,7 +273,21 @@ RUN pip install --no-cache-dir -U \
     scikit-learn \
     seaborn \
     cloudpickle \
-    langcodes
+    langcodes \
+    "s3fs>=2026.2.0"
+
+# Force-upgrade boto3/botocore/awscli/s3transfer above the ceiling that
+# aiobotocore (transitively pulled by s3fs>=2026.2.0) declares (botocore<1.43.1).
+# boto3>=1.43.34 imports DocumentModifiedShape from botocore.docs.utils, which only
+# exists in botocore>=1.43.34, so the boto3/botocore pair must stay aligned on the
+# 1.43.x line. pip prints an aiobotocore-vs-botocore conflict warning here but
+# installation proceeds; aiobotocore is only exercised via smclarify's s3fs path,
+# not at container boot.
+RUN pip install --no-cache-dir -U \
+    "boto3>=1.43.34" \
+    "botocore>=1.43.34" \
+    "awscli>=1.45.34" \
+    "s3transfer>=0.19.0"
 
 COPY setup_oss_compliance.sh setup_oss_compliance.sh
 RUN bash setup_oss_compliance.sh ${PYTHON} && rm setup_oss_compliance.sh

--- a/pytorch/training/docker/2.9/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.9/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
@@ -1,7 +1,7 @@
 {
   "black": [
     {
-      "description": "Black is the uncompromising Python code formatter. Prior to 26.3.1, Black writes a cache file, the name of which is computed from various formatting options. The value of the --python-cell-magics option was placed in the filename without sanitization, which allowed an attacker who controls the value of this argument to write cache files to arbitrary file system locations. Fixed in Black 26.3.1.",
+      "description": "Black is the uncompromising Python code formatter. Starting in version 24.3.0 and prior to version 26.3.1, Black writes a cache file, the name of which is computed from various formatting options. The value of the --python-cell-magics option was placed in the filename without sanitization, which allowed an attacker who controls the value of this argument to write cache files to arbitrary file system locations. Fixed in Black 26.3.1.",
       "vulnerability_id": "CVE-2026-32274",
       "name": "CVE-2026-32274",
       "package_name": "black",

--- a/test/dlc_tests/container_tests/bin/efa/build_all_reduce_perf.sh
+++ b/test/dlc_tests/container_tests/bin/efa/build_all_reduce_perf.sh
@@ -9,12 +9,17 @@ fi
 
 set -e
 
-echo "Building all_reduce_perf from nccl-tests"
+# Pin nccl-tests to a known-good tag and build ONLY all_reduce_perf. A bare `make`
+# builds every test binary, including comm_ops, whose recent revisions reference
+# NCCL APIs (e.g. ncclCommGrow) and curand.h that are absent from the image's NCCL
+# headers, which breaks the build. all_reduce_perf is the only binary this test needs.
+NCCL_TESTS_VERSION=v2.20.0
+echo "Building all_reduce_perf from nccl-tests ${NCCL_TESTS_VERSION}"
 cd /tmp/
 rm -rf nccl-tests/
-git clone https://github.com/NVIDIA/nccl-tests.git
+git clone --branch ${NCCL_TESTS_VERSION} --depth 1 https://github.com/NVIDIA/nccl-tests.git
 cd nccl-tests/
-make MPI=1 MPI_HOME=/opt/amazon/openmpi NCCL_HOME=/usr/local CUDA_HOME=${CUDA_HOME}
+make -C src BUILDDIR="$(pwd)/build" MPI=1 MPI_HOME=/opt/amazon/openmpi NCCL_HOME=/usr/local CUDA_HOME=${CUDA_HOME} "$(pwd)/build/all_reduce_perf"
 cp build/all_reduce_perf /all_reduce_perf
 cd /tmp/
 rm -rf nccl-tests/


### PR DESCRIPTION
## 1. black CVE-2026-32274 allowlist description drift (PT 2.9 training)
The ECR enhanced-scan gate re-flags CVE-2026-32274 (`black` 22.3.0, HIGH) on the PyTorch 2.9 training images even though it is allowlisted. The enhanced-scan allowlist matches findings on the full `description` string, and the upstream NVD text was revised — from "Prior to 26.3.1, ..." to "Starting in version 24.3.0 and prior to version 26.3.1, ...". The committed entries still carry the old phrasing, so the exact-match fails and the finding passes through, failing `test_ecr_enhanced_scan`.

Fix: update the `description` of the CVE-2026-32274 `black` entry to the current NVD text in all four PT 2.9 training variant allowlists (no other field changes).
- `pytorch/training/docker/2.9/py3/Dockerfile.ec2.cpu.os_scan_allowlist.json`
- `pytorch/training/docker/2.9/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json`
- `pytorch/training/docker/2.9/py3/cu130/Dockerfile.ec2.gpu.os_scan_allowlist.json`
- `pytorch/training/docker/2.9/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json`

## 2. Pin nccl-tests in the EFA test build script
The p4de EFA test (`ec2/test_efa.py`) rebuilds nccl-tests on-host via `build_all_reduce_perf.sh`, which did an unpinned `git clone` of NVIDIA/nccl-tests and `make` of the whole suite. Upstream's `comm_ops.cu` now references an NCCL API (`ncclCommGrow`) absent from the image's NCCL headers, so the build fails (`comm_ops.cu: identifier "ncclCommGrow" is undefined`) and `all_reduce_perf` is never produced.

Fix: pin the clone to `v2.20.0` and build only the `all_reduce_perf` target (so `comm_ops.cu` is never compiled) — the only binary this test uses.
- `test/dlc_tests/container_tests/bin/efa/build_all_reduce_perf.sh`

## 3. Unblock PT 2.9 SageMaker image build (pip resolution-too-deep)
Building the PT 2.9 SageMaker training images fails at the SM `pip install` with `resolution-too-deep`: installing the SageMaker SDK, `s3fs`, and the AWS SDK in one pip pass produces a dependency graph too large for pip's resolver (it backtracks across `pygments`/`rich`/`sagemaker-core` and `aiobotocore`). Mirrors the fix already shipped for PT 2.10.

Fix: split the single `pip install` into three passes — SageMaker SDK; extras + `s3fs`; and a pinned AWS SDK quartet (`boto3`/`botocore`/`awscli`/`s3transfer`) to satisfy the aiobotocore→botocore ceiling deterministically. PT 2.9 stays on SageMaker SDK v2 (`>=2.254.1,<3`); no functional change.
- `pytorch/training/docker/2.9/py3/cu130/Dockerfile.gpu`
- `pytorch/training/docker/2.9/py3/Dockerfile.cpu`

## Test plan

- [b502da2](https://github.com/aws/deep-learning-containers/pull/6698/commits/b502da2da6f3bb5ce68174078e4eb8198f5a16f4) PT2.10 ec2 test passed including EFA test.
- [b303c36](https://github.com/aws/deep-learning-containers/pull/6698/commits/b303c362eec43f69797a20c08ba68fa8963c505e) PT2.9 ec2 test passed including EFA test.
- [e98847d](https://github.com/aws/deep-learning-containers/pull/6698/commits/e98847df283a8477048e050f6dd375d8baf8abe5) PT2.9 SM test passed.

