### PR TITLE
[cve-patch] [xgboost] refresh 3.0.5 allowlist (+ expired 3.2.0 dates)

### DIFF
--- a/test/security/data/ecr_scan_allowlist/xgboost/xgboost-3.0.5.json
+++ b/test/security/data/ecr_scan_allowlist/xgboost/xgboost-3.0.5.json
@@ -1,33 +1,8 @@
 [
     {
-        "vulnerability_id": "CVE-2023-30861",
-        "reason": "Flask 1.1.1 \u2014 pinned by sagemaker-containers 2.8.6. Cannot upgrade without breaking serving framework.",
-        "review_by": "2027-01-13"
-    },
-    {
-        "vulnerability_id": "CVE-2024-56326",
-        "reason": "Jinja2 2.11.3 \u2014 pinned by sagemaker-containers 2.8.6. Sandbox escape not exploitable (no user-controlled templates).",
-        "review_by": "2027-01-13"
-    },
-    {
-        "vulnerability_id": "CVE-2025-27516",
-        "reason": "Jinja2 2.11.3 \u2014 pinned by sagemaker-containers 2.8.6. Sandbox escape not exploitable (no user-controlled templates).",
-        "review_by": "2027-01-13"
-    },
-    {
-        "vulnerability_id": "CVE-2023-46136",
-        "reason": "Werkzeug 0.15.6 \u2014 pinned by sagemaker-containers 2.8.6. Multipart upload DoS not exploitable (SageMaker controls input).",
-        "review_by": "2027-01-13"
-    },
-    {
-        "vulnerability_id": "CVE-2024-34069",
-        "reason": "Werkzeug 0.15.6 \u2014 debugger RCE. Debugger not enabled in production container.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2023-25577",
-        "reason": "Werkzeug 0.15.6 \u2014 multipart DoS. SageMaker controls input; not internet-facing.",
-        "review_by": "2026-10-15"
+        "vulnerability_id": "CVE-2021-47378",
+        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-234.254 is not installable from the standard Focal archive (Focal is past standard-support EOL; verified apt candidate is 5.4.0-216.236). linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so this is not a runtime attack surface for the image.",
+        "review_by": "2027-03-02"
     },
     {
         "vulnerability_id": "CVE-2022-29361",
@@ -35,17 +10,22 @@
         "review_by": "2026-10-15"
     },
     {
-        "vulnerability_id": "CVE-2023-43804",
-        "reason": "urllib3 1.26.x \u2014 Cookie header leak on redirect. Container only makes outbound calls to S3/SageMaker APIs.",
+        "vulnerability_id": "CVE-2022-45198",
+        "reason": "Pillow 9.1.1 \u2014 bumped to 12.2.0 in requirements.txt.",
         "review_by": "2026-10-15"
     },
     {
-        "vulnerability_id": "CVE-2023-52757",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime. SMB client deadlock not applicable.",
+        "vulnerability_id": "CVE-2022-49026",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
         "review_by": "2026-10-15"
     },
     {
-        "vulnerability_id": "CVE-2025-38000",
+        "vulnerability_id": "CVE-2022-49267",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime. MMC sysfs sprintf() overflow not reachable; no MMC subsystem in container.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2022-49390",
         "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
         "review_by": "2026-10-15"
     },
@@ -55,113 +35,18 @@
         "review_by": "2026-10-15"
     },
     {
-        "vulnerability_id": "CVE-2024-50061",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "vulnerability_id": "CVE-2023-25577",
+        "reason": "Werkzeug 0.15.6 \u2014 multipart DoS. SageMaker controls input; not internet-facing.",
         "review_by": "2026-10-15"
     },
     {
-        "vulnerability_id": "CVE-2025-21780",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
+        "vulnerability_id": "CVE-2023-30861",
+        "reason": "Flask 1.1.1 \u2014 pinned by sagemaker-containers 2.8.6. Cannot upgrade without breaking serving framework.",
+        "review_by": "2027-01-13"
     },
     {
-        "vulnerability_id": "CVE-2025-37797",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-22020",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-31504",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2024-50047",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-22079",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-22004",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2024-53218",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-22035",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-37838",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-21855",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-21727",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-39735",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-31431",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2024-53168",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-37752",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-31533",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-21796",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2024-56664",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2024-56551",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2023-50447",
-        "reason": "Pillow 9.1.1 \u2014 bumped to 12.2.0 in requirements.txt. If this still appears, conda env has stale version.",
+        "vulnerability_id": "CVE-2023-43804",
+        "reason": "urllib3 1.26.x \u2014 Cookie header leak on redirect. Container only makes outbound calls to S3/SageMaker APIs.",
         "review_by": "2026-10-15"
     },
     {
@@ -170,9 +55,9 @@
         "review_by": "2026-10-15"
     },
     {
-        "vulnerability_id": "CVE-2022-45198",
-        "reason": "Pillow 9.1.1 \u2014 bumped to 12.2.0 in requirements.txt.",
-        "review_by": "2026-10-15"
+        "vulnerability_id": "CVE-2023-46136",
+        "reason": "Werkzeug 0.15.6 \u2014 pinned by sagemaker-containers 2.8.6. Multipart upload DoS not exploitable (SageMaker controls input).",
+        "review_by": "2027-01-13"
     },
     {
         "vulnerability_id": "CVE-2023-4863",
@@ -180,72 +65,17 @@
         "review_by": "2026-10-15"
     },
     {
-        "vulnerability_id": "CVE-2025-21726",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "vulnerability_id": "CVE-2023-50447",
+        "reason": "Pillow 9.1.1 \u2014 bumped to 12.2.0 in requirements.txt. If this still appears, conda env has stale version.",
         "review_by": "2026-10-15"
     },
     {
-        "vulnerability_id": "CVE-2025-21991",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "vulnerability_id": "CVE-2023-52757",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime. SMB client deadlock not applicable.",
         "review_by": "2026-10-15"
     },
     {
         "vulnerability_id": "CVE-2023-52854",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2024-35867",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2024-50073",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-38666",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2024-38541",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-21993",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-37849",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2024-49950",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-38618",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-37785",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-43033",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2024-56640",
         "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
         "review_by": "2026-10-15"
     },
@@ -255,22 +85,52 @@
         "review_by": "2026-10-15"
     },
     {
-        "vulnerability_id": "CVE-2026-43078",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-37890",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
         "vulnerability_id": "CVE-2023-53034",
         "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
         "review_by": "2026-10-15"
     },
     {
-        "vulnerability_id": "CVE-2022-49026",
+        "vulnerability_id": "CVE-2024-34069",
+        "reason": "Werkzeug 0.15.6 \u2014 debugger RCE. Debugger not enabled in production container.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2024-35867",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2024-38541",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2024-39689",
+        "reason": "certifi \u2014 bumped to 2025.4.26 in requirements.txt.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2024-46787",
+        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-219.239 is Ubuntu Pro/ESM-only (Focal is past standard-support EOL) and is not installable without a paid Ubuntu Pro subscription. linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so the userfaultfd huge-PMD race is not a runtime attack surface for this image. No exploit available.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2024-47691",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2024-49950",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2024-50047",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2024-50061",
         "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
         "review_by": "2026-10-15"
     },
@@ -280,14 +140,154 @@
         "review_by": "2026-10-15"
     },
     {
+        "vulnerability_id": "CVE-2024-50073",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2024-53168",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2024-53218",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2024-56326",
+        "reason": "Jinja2 2.11.3 \u2014 pinned by sagemaker-containers 2.8.6. Sandbox escape not exploitable (no user-controlled templates).",
+        "review_by": "2027-01-13"
+    },
+    {
+        "vulnerability_id": "CVE-2024-56551",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2024-56640",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2024-56664",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
         "vulnerability_id": "CVE-2024-58093",
         "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
         "review_by": "2026-10-15"
     },
     {
-        "vulnerability_id": "CVE-2026-23074",
+        "vulnerability_id": "CVE-2025-21726",
         "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
         "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-21727",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-21780",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-21796",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-21855",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-21991",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-21993",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-22004",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-22020",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-22035",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-22079",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-27516",
+        "reason": "Jinja2 2.11.3 \u2014 pinned by sagemaker-containers 2.8.6. Sandbox escape not exploitable (no user-controlled templates).",
+        "review_by": "2027-01-13"
+    },
+    {
+        "vulnerability_id": "CVE-2025-30749",
+        "reason": "java-11-amazon-corretto-headless \u2014 dnf update did not pull latest.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2025-37752",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-37785",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-37797",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-37798",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-37838",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-37849",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-37890",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-38000",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-38083",
+        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-220.240 is Ubuntu Pro/ESM-only (Focal is past standard-support EOL) and is not installable without a paid Ubuntu Pro subscription. linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so the net_sched prio_tune race is not a runtime attack surface for this image. No exploit available.",
+        "review_by": "2026-11-02"
     },
     {
         "vulnerability_id": "CVE-2025-38350",
@@ -300,374 +300,29 @@
         "review_by": "2026-10-15"
     },
     {
-        "vulnerability_id": "CVE-2024-47691",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2022-49390",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-37798",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-53066",
-        "reason": "openjdk-8 \u2014 JAXP vulnerability. Java only used for MMS model server, not in data path.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-39892",
-        "reason": "cryptography 45.0.5 \u2014 bumped to 46.0.7 in requirements.txt.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2024-39689",
-        "reason": "certifi \u2014 bumped to 2025.4.26 in requirements.txt.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2025-23339",
-        "reason": "cuda-toolkit-config-common from NVIDIA CUDA repo \u2014 cuobjdump not used in XGBoost serving/training.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-23308",
-        "reason": "cuda-toolkit-config-common from NVIDIA CUDA repo \u2014 nvdisasm not used in XGBoost serving/training.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-0994",
-        "reason": "protobuf pinned to 3.20.x \u2014 required by smdebug. Cannot upgrade to 6.x.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-23949",
-        "reason": "jaraco.context vendored inside setuptools. tarball() not used in serving/training.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-28387",
-        "reason": "openssl from CUDA base image pins 3.2.2 \u2014 AL2023 repo patch not yet available for this epoch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-15468",
-        "reason": "openssl from CUDA base image pins 3.2.2 \u2014 QUIC not used in XGBoost container.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-15467",
-        "reason": "openssl from CUDA base image pins 3.2.2 \u2014 CMS not used in XGBoost container.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-69421",
-        "reason": "openssl from CUDA base image pins 3.2.2 \u2014 PKCS12 parsing not in serving/training path.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-22796",
-        "reason": "openssl from CUDA base image pins 3.2.2.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-31790",
-        "reason": "openssl from CUDA base image pins 3.2.2.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-27654",
-        "reason": "nginx \u2014 dnf update did not pull latest. ngx_http_dav_module not enabled.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-32647",
-        "reason": "nginx \u2014 ngx_http_mp4_module not used in XGBoost serving.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-27651",
-        "reason": "nginx \u2014 ngx_mail_auth_http_module not enabled.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-27784",
-        "reason": "nginx \u2014 32-bit mp4 module vulnerability, container is 64-bit.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-49794",
-        "reason": "libxml2 \u2014 dnf update did not pull latest patch from AL2023 repo.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-49795",
-        "reason": "libxml2 \u2014 dnf update did not pull latest patch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-49796",
-        "reason": "libxml2 \u2014 dnf update did not pull latest patch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-7425",
-        "reason": "libxml2/libxslt \u2014 XSLT not used in XGBoost container.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-33416",
-        "reason": "libpng \u2014 dnf update did not pull latest patch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-66293",
-        "reason": "libpng \u2014 dnf update did not pull latest patch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-65018",
-        "reason": "libpng \u2014 dnf update did not pull latest patch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-33636",
-        "reason": "libpng \u2014 dnf update did not pull latest patch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-50059",
-        "reason": "java-11-amazon-corretto-headless \u2014 dnf update did not pull latest.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-50106",
-        "reason": "java-11-amazon-corretto-headless \u2014 dnf update did not pull latest.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-30749",
-        "reason": "java-11-amazon-corretto-headless \u2014 dnf update did not pull latest.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-21945",
-        "reason": "java-11-amazon-corretto-headless \u2014 dnf update did not pull latest.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-21932",
-        "reason": "java-11-amazon-corretto-headless \u2014 dnf update did not pull latest.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-13151",
-        "reason": "libtasn1 \u2014 dnf update did not pull latest patch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-68973",
-        "reason": "gnupg2-minimal \u2014 dnf update did not pull latest patch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-24882",
-        "reason": "gnupg2-minimal \u2014 tpm2daemon not used in container.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-13601",
-        "reason": "glib2 \u2014 dnf update did not pull latest patch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-14087",
-        "reason": "glib2 \u2014 dnf update did not pull latest patch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-47912",
-        "reason": "libcap \u2014 Go net/url vulnerability, Go not used in container.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-58188",
-        "reason": "libcap \u2014 Go crypto/x509 vulnerability, Go not used in container.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-27614",
-        "reason": "git \u2014 dnf update did not pull latest. gitk not used in container.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-48384",
-        "reason": "git \u2014 dnf update did not pull latest.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-48385",
-        "reason": "git \u2014 dnf update did not pull latest.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-59375",
-        "reason": "expat \u2014 dnf update did not pull latest patch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-0966",
-        "reason": "libssh \u2014 dnf update did not pull latest patch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-27135",
-        "reason": "libnghttp2 \u2014 dnf update did not pull latest patch.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-8194",
-        "reason": "python3.12 \u2014 tarfile vulnerability, not exploitable in serving/training path.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-4519",
-        "reason": "python3.12 \u2014 webbrowser.open() not used in container.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-21441",
-        "reason": "urllib3 2.4.0 \u2014 streaming API vulnerability. Pinned by dask-cuda compatibility.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-66471",
-        "reason": "urllib3 2.4.0 \u2014 streaming API vulnerability. Pinned by dask-cuda compatibility.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2025-66418",
-        "reason": "urllib3 2.4.0 \u2014 decompression chain vulnerability. Pinned by dask-cuda compatibility.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-35385",
-        "reason": "openssh \u2014 scp setuid/setgid issue with -O flag. Legacy scp protocol not used in container.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-4046",
-        "reason": "glibc \u2014 iconv() crash with IBM1390/IBM1399 charsets. Not used in serving/training path.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-4786",
-        "reason": "python3.12 \u2014 webbrowser.open() bypass of CVE-2026-4519 mitigation. webbrowser not used in container.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-6100",
-        "reason": "python3.12 \u2014 UAF in lzma/bz2/gzip decompressor on MemoryError. Not exploitable in serving/training path.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-22016",
-        "reason": "java-11-amazon-corretto-headless \u2014 JAXP vulnerability. Fix version 11.0.31+11 not yet available in AL2023 repo. Java only used for MMS model server, not in data path.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-34282",
-        "reason": "java-11-amazon-corretto-headless \u2014 Networking vulnerability. Fix version 11.0.31+11 not yet available in AL2023 repo. Java only used for MMS model server, not in data path.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-25087",
-        "reason": "pyarrow 22.0.0 \u2014 use-after-free in Arrow C++ IPC reader. Pinned by upstream sagemaker-xgboost-container test assertion. IPC file reading not in serving/training path.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-6357",
-        "reason": "python3-pip-wheel / python3.12-pip-wheel \u2014 pip self-update check code injection. pip not invoked at runtime in container.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-6654",
-        "reason": "rust-toolset-srpm-macros \u2014 double-free in thin_vec crate. Rust toolchain not used at runtime, only present as build dependency metadata.",
-        "review_by": "2026-08-30"
-    },
-    {
-        "vulnerability_id": "CVE-2026-39820",
-        "reason": "libcap \u2014 Go net/mail ParseAddress DoS. Go not used in container.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-42499",
-        "reason": "libcap \u2014 Go net/mail consumePhrase DoS. Go not used in container.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-33814",
-        "reason": "libcap \u2014 Go net/http2 SETTINGS infinite loop. Go not used in container.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-33811",
-        "reason": "libcap \u2014 Go net LookupCNAME double-free. Go not used in container.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-42010",
-        "reason": "gnutls \u2014 RSA-PSK NUL character auth bypass. DTLS/RSA-PSK not used in serving/training.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-42009",
-        "reason": "gnutls \u2014 DTLS packet ordering undefined behavior. DTLS not used in container.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-33846",
-        "reason": "gnutls \u2014 DTLS fragment heap overwrite. DTLS not used in container.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-42945",
-        "reason": "nginx \u2014 ngx_http_rewrite_module double-free. Rewrite rules not chained in XGBoost MMS config.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-43284",
-        "reason": "linux-libc-dev 5.4.0 \u2014 fix only in Ubuntu Pro / ESM-Infra (focal status: 'Ignored: end of standard support'); base 20.04 archive will not receive the patch.",
-        "review_by": "2026-09-08"
-    },
-    {
-        "vulnerability_id": "CVE-2026-43494",
-        "reason": "linux-libc-dev 5.4.0 \u2014 fix only in Ubuntu Pro / ESM-Infra (focal status: 'Ignored: end of standard support'); base 20.04 archive will not receive the patch.",
-        "review_by": "2026-09-08"
-    },
-    {
-        "vulnerability_id": "CVE-2026-43500",
-        "reason": "linux-libc-dev 5.4.0 \u2014 fix only in Ubuntu Pro / ESM-Infra (focal status: 'Ignored: end of standard support'); base 20.04 archive will not receive the patch.",
-        "review_by": "2026-09-08"
-    },
-    {
-        "vulnerability_id": "CVE-2022-49267",
-        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime. MMC sysfs sprintf() overflow not reachable; no MMC subsystem in container.",
-        "review_by": "2026-10-15"
-    },
-    {
-        "vulnerability_id": "CVE-2026-43414",
-        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-233.253 is Ubuntu Pro/ESM-only (Focal is past standard-support EOL) and is not installable without a paid Ubuntu Pro subscription. linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so the qla2xxx scsi double-free is not a runtime attack surface for this image. No exploit available.",
+        "vulnerability_id": "CVE-2025-38477",
+        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-222.242 is Ubuntu Pro/ESM-only (Focal is past standard-support EOL) and is not installable without a paid Ubuntu Pro subscription. linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so the sch_qfq aggregate race is not a runtime attack surface for this image. No exploit available.",
         "review_by": "2026-11-02"
     },
     {
         "vulnerability_id": "CVE-2025-38617",
         "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-222.242 is Ubuntu Pro/ESM-only (Focal is past standard-support EOL) and is not installable without a paid Ubuntu Pro subscription. linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so the net/packet ring race is not a runtime attack surface for this image. Exploit reported by Inspector but requires local kernel-level access on the host, not reachable from within the container.",
         "review_by": "2026-11-02"
+    },
+    {
+        "vulnerability_id": "CVE-2025-38618",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-38666",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-39735",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
     },
     {
         "vulnerability_id": "CVE-2025-39993",
@@ -680,9 +335,74 @@
         "review_by": "2026-11-02"
     },
     {
-        "vulnerability_id": "CVE-2025-38477",
-        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-222.242 is Ubuntu Pro/ESM-only (Focal is past standard-support EOL) and is not installable without a paid Ubuntu Pro subscription. linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so the sch_qfq aggregate race is not a runtime attack surface for this image. No exploit available.",
+        "vulnerability_id": "CVE-2025-40215",
+        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-227.247 is Ubuntu Pro/ESM-only (Focal is past standard-support EOL) and is not installable without a paid Ubuntu Pro subscription. linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so the xfrm ipcomp tunnel deletion bug is not a runtime attack surface for this image. No exploit available.",
         "review_by": "2026-11-02"
+    },
+    {
+        "vulnerability_id": "CVE-2025-50106",
+        "reason": "java-11-amazon-corretto-headless \u2014 dnf update did not pull latest.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2025-53066",
+        "reason": "openjdk-8 \u2014 JAXP vulnerability. Java only used for MMS model server, not in data path.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2025-66418",
+        "reason": "urllib3 2.4.0 \u2014 decompression chain vulnerability. Pinned by dask-cuda compatibility.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2025-66471",
+        "reason": "urllib3 2.4.0 \u2014 streaming API vulnerability. Pinned by dask-cuda compatibility.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-0994",
+        "reason": "protobuf pinned to 3.20.x \u2014 required by smdebug. Cannot upgrade to 6.x.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-14456",
+        "reason": "openssl 3.6.3 in the bundled miniconda3 environment. The scanner's fixed version 4.0.2 is unreleased upstream; conda-forge tops out at 4.0.1, which is itself within the affected range, so the openssl>=4.0.2 pin is unsatisfiable. Affected TLS paths are not enabled by the XGBoost training/serving code. (3.6.4 exists on the 3.6 branch, which reaches EOL 2026-11-01; durable fix is moving this env to the 3.5 LTS line.)",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-14457",
+        "reason": "openssl 3.6.3 in the bundled miniconda3 environment. The scanner's fixed version 4.0.2 is unreleased upstream; conda-forge tops out at 4.0.1, which is itself within the affected range, so the openssl>=4.0.2 pin is unsatisfiable. Affected TLS paths are not enabled by the XGBoost training/serving code. (3.6.4 exists on the 3.6 branch, which reaches EOL 2026-11-01; durable fix is moving this env to the 3.5 LTS line.)",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-18798",
+        "reason": "openssl 3.6.3 in the bundled miniconda3 environment. The scanner's fixed version 4.0.2 is unreleased upstream; conda-forge tops out at 4.0.1, which is itself within the affected range, so the openssl>=4.0.2 pin is unsatisfiable. Affected TLS paths are not enabled by the XGBoost training/serving code. (3.6.4 exists on the 3.6 branch, which reaches EOL 2026-11-01; durable fix is moving this env to the 3.5 LTS line.)",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-21441",
+        "reason": "urllib3 2.4.0 \u2014 streaming API vulnerability. Pinned by dask-cuda compatibility.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-21932",
+        "reason": "java-11-amazon-corretto-headless \u2014 dnf update did not pull latest.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-21945",
+        "reason": "java-11-amazon-corretto-headless \u2014 dnf update did not pull latest.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-22016",
+        "reason": "java-11-amazon-corretto-headless \u2014 JAXP vulnerability. Fix version 11.0.31+11 not yet available in AL2023 repo. Java only used for MMS model server, not in data path.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-23074",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
     },
     {
         "vulnerability_id": "CVE-2026-23272",
@@ -690,23 +410,163 @@
         "review_by": "2026-11-02"
     },
     {
-        "vulnerability_id": "CVE-2025-40215",
-        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-227.247 is Ubuntu Pro/ESM-only (Focal is past standard-support EOL) and is not installable without a paid Ubuntu Pro subscription. linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so the xfrm ipcomp tunnel deletion bug is not a runtime attack surface for this image. No exploit available.",
-        "review_by": "2026-11-02"
+        "vulnerability_id": "CVE-2026-23949",
+        "reason": "jaraco.context vendored inside setuptools. tarball() not used in serving/training.",
+        "review_by": "2027-03-02"
     },
     {
-        "vulnerability_id": "CVE-2025-38083",
-        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-220.240 is Ubuntu Pro/ESM-only (Focal is past standard-support EOL) and is not installable without a paid Ubuntu Pro subscription. linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so the net_sched prio_tune race is not a runtime attack surface for this image. No exploit available.",
-        "review_by": "2026-11-02"
+        "vulnerability_id": "CVE-2026-25087",
+        "reason": "pyarrow 22.0.0 \u2014 use-after-free in Arrow C++ IPC reader. Pinned by upstream sagemaker-xgboost-container test assertion. IPC file reading not in serving/training path.",
+        "review_by": "2027-03-02"
     },
     {
-        "vulnerability_id": "CVE-2024-46787",
-        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-219.239 is Ubuntu Pro/ESM-only (Focal is past standard-support EOL) and is not installable without a paid Ubuntu Pro subscription. linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so the userfaultfd huge-PMD race is not a runtime attack surface for this image. No exploit available.",
+        "vulnerability_id": "CVE-2026-31431",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
         "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-31448",
+        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-234.254 is not installable from the standard Focal archive (Focal is past standard-support EOL; verified apt candidate is 5.4.0-216.236). linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so this is not a runtime attack surface for the image.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-31504",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-31533",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-33811",
+        "reason": "libcap \u2014 Go net LookupCNAME double-free. Go not used in container.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-33814",
+        "reason": "libcap \u2014 Go net/http2 SETTINGS infinite loop. Go not used in container.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-33846",
+        "reason": "gnutls \u2014 DTLS fragment heap overwrite. DTLS not used in container.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-39820",
+        "reason": "libcap \u2014 Go net/mail ParseAddress DoS. Go not used in container.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-39892",
+        "reason": "cryptography 45.0.5 \u2014 bumped to 46.0.7 in requirements.txt.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-41254",
+        "reason": "openjdk-8 on the Ubuntu 20.04 (Focal) base. Fixed version 8u502-ga~us1-0ubuntu1~20.04 is not available in the standard Focal archive (verified apt candidate is 8u452; Focal is past standard-support EOL). Java is only used by the MMS model server, not in the training/serving data path.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-42009",
+        "reason": "gnutls \u2014 DTLS packet ordering undefined behavior. DTLS not used in container.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-42010",
+        "reason": "gnutls \u2014 RSA-PSK NUL character auth bypass. DTLS/RSA-PSK not used in serving/training.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-42499",
+        "reason": "libcap \u2014 Go net/mail consumePhrase DoS. Go not used in container.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-42945",
+        "reason": "nginx \u2014 ngx_http_rewrite_module double-free. Rewrite rules not chained in XGBoost MMS config.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-43033",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-43071",
+        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-234.254 is not installable from the standard Focal archive (Focal is past standard-support EOL; verified apt candidate is 5.4.0-216.236). linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so this is not a runtime attack surface for the image.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-43078",
+        "reason": "linux-libc-dev \u2014 kernel headers only, not runtime.",
+        "review_by": "2026-10-15"
+    },
+    {
+        "vulnerability_id": "CVE-2026-43284",
+        "reason": "linux-libc-dev 5.4.0 \u2014 fix only in Ubuntu Pro / ESM-Infra (focal status: 'Ignored: end of standard support'); base 20.04 archive will not receive the patch.",
+        "review_by": "2026-09-08"
+    },
+    {
+        "vulnerability_id": "CVE-2026-43414",
+        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-233.253 is Ubuntu Pro/ESM-only (Focal is past standard-support EOL) and is not installable without a paid Ubuntu Pro subscription. linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so the qla2xxx scsi double-free is not a runtime attack surface for this image. No exploit available.",
+        "review_by": "2026-11-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-43494",
+        "reason": "linux-libc-dev 5.4.0 \u2014 fix only in Ubuntu Pro / ESM-Infra (focal status: 'Ignored: end of standard support'); base 20.04 archive will not receive the patch.",
+        "review_by": "2026-09-08"
+    },
+    {
+        "vulnerability_id": "CVE-2026-43500",
+        "reason": "linux-libc-dev 5.4.0 \u2014 fix only in Ubuntu Pro / ESM-Infra (focal status: 'Ignored: end of standard support'); base 20.04 archive will not receive the patch.",
+        "review_by": "2026-09-08"
+    },
+    {
+        "vulnerability_id": "CVE-2026-47057",
+        "reason": "openjdk-8 on the Ubuntu 20.04 (Focal) base. Fixed version 8u502-ga~us1-0ubuntu1~20.04 is not available in the standard Focal archive (verified apt candidate is 8u452; Focal is past standard-support EOL). Java is only used by the MMS model server, not in the training/serving data path.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-47058",
+        "reason": "openjdk-8 on the Ubuntu 20.04 (Focal) base. Fixed version 8u502-ga~us1-0ubuntu1~20.04 is not available in the standard Focal archive (verified apt candidate is 8u452; Focal is past standard-support EOL). Java is only used by the MMS model server, not in the training/serving data path.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-47063",
+        "reason": "openjdk-8 on the Ubuntu 20.04 (Focal) base. Fixed version 8u502-ga~us1-0ubuntu1~20.04 is not available in the standard Focal archive (verified apt candidate is 8u452; Focal is past standard-support EOL). Java is only used by the MMS model server, not in the training/serving data path.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-53359",
+        "reason": "linux-libc-dev (kernel headers) on the Ubuntu 20.04 (Focal, kernel 5.4.0) base. Fixed version 5.4.0-234.254 is not installable from the standard Focal archive (Focal is past standard-support EOL; verified apt candidate is 5.4.0-216.236). linux-libc-dev is a build-time kernel-headers package; the container runs on the host kernel, so this is not a runtime attack surface for the image.",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-54874",
+        "reason": "openssl 3.6.3 in the bundled miniconda3 environment. The scanner's fixed version 4.0.2 is unreleased upstream; conda-forge tops out at 4.0.1, which is itself within the affected range, so the openssl>=4.0.2 pin is unsatisfiable. Affected TLS paths are not enabled by the XGBoost training/serving code. (3.6.4 exists on the 3.6 branch, which reaches EOL 2026-11-01; durable fix is moving this env to the 3.5 LTS line.)",
+        "review_by": "2027-03-02"
     },
     {
         "vulnerability_id": "CVE-2026-54876",
         "reason": "openssl 3.6.3 in the bundled miniconda3 environment. No fix is installable: per the upstream advisory of 2026-08-05 the project did not issue releases for this issue, so the nominal fixed versions 3.6.4 (for the 3.6 branch) and 4.0.2 are both unreleased and exist only as git commits. No openssl-3.6.4 or openssl-4.0.2 tag exists upstream and conda-forge tops out at 3.6.3 / 4.0.1, so the scanner's openssl>=4.0.2 pin is unsatisfiable; moving to 4.0.1 would not help since 4.0.1 is itself in the affected range. Upstream severity is Low (the High here is the NVD-derived score), impact is a client-side memory-leak DoS, and OCSP response checking is off by default and never enabled by the training or serving paths. No exploit available. Note the 3.6 branch reaches end-of-life on 2026-11-01, so if 3.6.4 does not ship the durable fix is moving this environment to the 3.5 LTS line, which is unaffected.",
         "review_by": "2026-09-30"
+    },
+    {
+        "vulnerability_id": "CVE-2026-63072",
+        "reason": "openssl 3.6.3 in the bundled miniconda3 environment. The scanner's fixed version 4.0.2 is unreleased upstream; conda-forge tops out at 4.0.1, which is itself within the affected range, so the openssl>=4.0.2 pin is unsatisfiable. Affected TLS paths are not enabled by the XGBoost training/serving code. (3.6.4 exists on the 3.6 branch, which reaches EOL 2026-11-01; durable fix is moving this env to the 3.5 LTS line.)",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-63075",
+        "reason": "openssl 3.6.3 in the bundled miniconda3 environment. The scanner's fixed version 4.0.2 is unreleased upstream; conda-forge tops out at 4.0.1, which is itself within the affected range, so the openssl>=4.0.2 pin is unsatisfiable. Affected TLS paths are not enabled by the XGBoost training/serving code. (3.6.4 exists on the 3.6 branch, which reaches EOL 2026-11-01; durable fix is moving this env to the 3.5 LTS line.)",
+        "review_by": "2027-03-02"
+    },
+    {
+        "vulnerability_id": "CVE-2026-63076",
+        "reason": "openssl 3.6.3 in the bundled miniconda3 environment. The scanner's fixed version 4.0.2 is unreleased upstream; conda-forge tops out at 4.0.1, which is itself within the affected range, so the openssl>=4.0.2 pin is unsatisfiable. Affected TLS paths are not enabled by the XGBoost training/serving code. (3.6.4 exists on the 3.6 branch, which reaches EOL 2026-11-01; durable fix is moving this env to the 3.5 LTS line.)",
+        "review_by": "2027-03-02"
     }
 ]

--- a/test/security/data/ecr_scan_allowlist/xgboost/xgboost-3.0.5.json
+++ b/test/security/data/ecr_scan_allowlist/xgboost/xgboost-3.0.5.json
@@ -560,6 +560,11 @@
         "review_by": "2027-03-02"
     },
     {
+        "vulnerability_id": "CVE-2026-63073",
+        "reason": "openssl 3.6.3 in the bundled miniconda3 environment. The scanner's fixed version 4.0.2 is unreleased upstream; conda-forge tops out at 4.0.1, which is itself within the affected range, so the openssl>=4.0.2 pin is unsatisfiable. Affected TLS paths are not enabled by the XGBoost training/serving code. (3.6.4 exists on the 3.6 branch, which reaches EOL 2026-11-01; durable fix is moving this env to the 3.5 LTS line.)",
+        "review_by": "2027-03-02"
+    },
+    {
         "vulnerability_id": "CVE-2026-63075",
         "reason": "openssl 3.6.3 in the bundled miniconda3 environment. The scanner's fixed version 4.0.2 is unreleased upstream; conda-forge tops out at 4.0.1, which is itself within the affected range, so the openssl>=4.0.2 pin is unsatisfiable. Affected TLS paths are not enabled by the XGBoost training/serving code. (3.6.4 exists on the 3.6 branch, which reaches EOL 2026-11-01; durable fix is moving this env to the 3.5 LTS line.)",
         "review_by": "2027-03-02"

--- a/test/security/data/ecr_scan_allowlist/xgboost/xgboost-3.2.0.json
+++ b/test/security/data/ecr_scan_allowlist/xgboost/xgboost-3.2.0.json
@@ -1,12 +1,12 @@
 [
     {
         "vulnerability_id": "CVE-2026-0994",
-        "reason": "protobuf pinned to 3.20.x — required by smdebug. Cannot upgrade to 6.x.",
-        "review_by": "2026-08-30"
+        "reason": "protobuf pinned to 3.20.x \u2014 required by smdebug. Cannot upgrade to 6.x.",
+        "review_by": "2027-03-02"
     },
     {
         "vulnerability_id": "CVE-2026-25087",
-        "reason": "pyarrow 22.0.0 — use-after-free in Arrow C++ IPC reader. Pinned by upstream sagemaker-xgboost-container test assertion. IPC file reading not in serving/training path.",
-        "review_by": "2026-08-30"
+        "reason": "pyarrow 22.0.0 \u2014 use-after-free in Arrow C++ IPC reader. Pinned by upstream sagemaker-xgboost-container test assertion. IPC file reading not in serving/training path.",
+        "review_by": "2027-03-02"
     }
 ]


### PR DESCRIPTION
## Purpose

Bring the SageMaker XGBoost CVE allowlists in sync with the current image scans so the security gate passes on actionable findings only.

The 3.0.5 image is built on Ubuntu 20.04 (Focal), which has reached end-of-standard-support. The container ships only the standard Focal archive (no Ubuntu Pro/ESM), so most newly-reported OS CVEs have fixes that live only in ESM and are not installable here — the security gate already skips ESM-only fixes, so those need no action. This change touches only the findings the gate actually enforces.

## Images affected

- `sagemaker-xgboost:3.0-5-cpu-py3`
- `sagemaker-xgboost:3.2-0-cpu-py3` (expired-date refresh only)

## 3.0.5 — CVEs handled

Entries added for the CRITICAL/HIGH findings whose fix versions are non-ESM but still not installable on this base:

| Package | Severity | CVEs | Why allowlisted |
|---|---|---|---|
| linux-libc-dev | CRITICAL/HIGH | CVE-2021-47378, CVE-2026-31448, CVE-2026-43071, CVE-2026-53359 | Kernel headers only (fix 5.4.0-234.254 not in the Focal archive); container runs on the host kernel — not a runtime attack surface |
| openjdk-8 | HIGH | CVE-2026-41254, CVE-2026-47057, CVE-2026-47058, CVE-2026-47063 | Fix 8u502 absent from the Focal archive (apt candidate is 8u452); Java is used only by the MMS model server, not the data path |
| openssl (miniconda) | CRITICAL/HIGH | CVE-2026-14456, CVE-2026-14457, CVE-2026-18798, CVE-2026-54874, CVE-2026-63072, CVE-2026-63073, CVE-2026-63075, CVE-2026-63076 | Bundled openssl 3.6.3; scanner fix 4.0.2 is unreleased upstream and 4.0.1 is itself in-range, so the pin is unsatisfiable |

**Refreshed:** `review_by` extended on 11 still-firing entries that had passed their review date.

**Pruned:** 43 stale entries removed — expired entries the scanner already skips (ESM-only fixes) or that no longer appear in the scan.

## 3.2.0 — expired-date refresh

Two entries had passed their `review_by` date and were failing the aggregate check. Both remain valid; only the dates were refreshed:

- `CVE-2026-0994` — protobuf pinned to 3.20.x, required by smdebug
- `CVE-2026-25087` — pyarrow pinned by the upstream container test assertion; affected IPC path not used in serving/training

## Test plan

- [x] CI security scan passes for the 3.0-5 and 3.2-0 variants
- [x] CI sanity tests pass