### PR TITLE
ci: run ECR allowlist upload at 06:00 UTC, ahead of the daily scan

### DIFF
--- a/.github/workflows/_scheduled.upload-ecr-allowlists.yml
+++ b/.github/workflows/_scheduled.upload-ecr-allowlists.yml
@@ -2,8 +2,10 @@ name: Upload ECR Allowlists to Scanner S3
 
 on:
   schedule:
-    # 4 AM UTC daily
-    - cron: '0 4 * * *'
+    # 6 AM UTC daily — runs ahead of the downstream security scan so a release
+    # pushed overnight has its allowlist in S3 before the scan reads it (was 4 AM,
+    # which left a gap where late pushes were scanned without their allowlist).
+    - cron: '0 6 * * *'
   # pull_request:
   #   paths:
   #     - ".github/actions/upload-ecr-allowlists/**"

--- a/.github/workflows/_scheduled.upload-ecr-allowlists.yml
+++ b/.github/workflows/_scheduled.upload-ecr-allowlists.yml
@@ -2,9 +2,7 @@ name: Upload ECR Allowlists to Scanner S3
 
 on:
   schedule:
-    # 6 AM UTC daily — runs ahead of the downstream security scan so a release
-    # pushed overnight has its allowlist in S3 before the scan reads it (was 4 AM,
-    # which left a gap where late pushes were scanned without their allowlist).
+    # 6 AM UTC daily
     - cron: '0 6 * * *'
   # pull_request:
   #   paths:


### PR DESCRIPTION
Move the daily ECR allowlist upload from 04:00 to 06:00 UTC so it runs just before the daily security scan, covering release pushes that land overnight.