### PR TITLE
fix(pytorch): allowlist mlflow CVE-2026-71211 (PT 2.10 SageMaker training)

### DIFF
--- a/pytorch/training/docker/2.10/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.10/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json
@@ -77,5 +77,32 @@
             "title": "CVE-2026-30922 - pyasn1",
             "reason_to_ignore": "DoS via deeply nested ASN.1 structures - not exploitable in DLC training workflows where ASN.1 input is not user-controlled"
         }
+    ],
+    "mlflow": [
+        {
+            "description": "MLflow's AI Gateway accepts an auth_config.api_base value when creating a gateway secret (mlflow/server/handlers.py, _create_gateway_secret) with no validation of scheme, host, or IP range; the value is stored verbatim. The gateway proxy endpoint (mlflow/server/gateway_api.py, raw_proxy) subsequently issues an HTTP request to that stored api_base plus a caller-supplied path and returns the full response body.",
+            "vulnerability_id": "CVE-2026-71211",
+            "name": "CVE-2026-71211",
+            "package_name": "mlflow",
+            "package_details": {
+                "file_path": "/usr/local/lib/python3.13/site-packages/mlflow-3.15.2.dist-info/METADATA",
+                "name": "mlflow",
+                "package_manager": "PYTHON",
+                "version": "3.15.2",
+                "release": null
+            },
+            "remediation": {"recommendation": {"text": "None Provided"}},
+            "cvss_v3_score": 7.1,
+            "cvss_v30_score": 0.0,
+            "cvss_v31_score": 7.1,
+            "cvss_v2_score": 0.0,
+            "cvss_v3_severity": "HIGH",
+            "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-71211",
+            "source": "NVD",
+            "severity": "HIGH",
+            "status": "ACTIVE",
+            "title": "CVE-2026-71211 - mlflow",
+            "reason_to_ignore": "No upstream fix available (advisory GHSA-h7x2-h6g9-p789 affects mlflow >=3.13.0,<=3.15.2 with no patched version; 3.15.2 is the latest release). The MLflow AI Gateway deployments/proxy server is not run in DLC training containers - mlflow is a sagemaker-required tracking client only - so the raw_proxy SSRF path is unreachable."
+        }
     ]
 }

--- a/pytorch/training/docker/2.10/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
+++ b/pytorch/training/docker/2.10/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json
@@ -129,5 +129,32 @@
             "title": "CVE-2026-30922 - pyasn1",
             "reason_to_ignore": "DoS via deeply nested ASN.1 structures - not exploitable in DLC training workflows where ASN.1 input is not user-controlled"
         }
+    ],
+    "mlflow": [
+        {
+            "description": "MLflow's AI Gateway accepts an auth_config.api_base value when creating a gateway secret (mlflow/server/handlers.py, _create_gateway_secret) with no validation of scheme, host, or IP range; the value is stored verbatim. The gateway proxy endpoint (mlflow/server/gateway_api.py, raw_proxy) subsequently issues an HTTP request to that stored api_base plus a caller-supplied path and returns the full response body.",
+            "vulnerability_id": "CVE-2026-71211",
+            "name": "CVE-2026-71211",
+            "package_name": "mlflow",
+            "package_details": {
+                "file_path": "/usr/local/lib/python3.13/site-packages/mlflow-3.15.2.dist-info/METADATA",
+                "name": "mlflow",
+                "package_manager": "PYTHON",
+                "version": "3.15.2",
+                "release": null
+            },
+            "remediation": {"recommendation": {"text": "None Provided"}},
+            "cvss_v3_score": 7.1,
+            "cvss_v30_score": 0.0,
+            "cvss_v31_score": 7.1,
+            "cvss_v2_score": 0.0,
+            "cvss_v3_severity": "HIGH",
+            "source_url": "https://nvd.nist.gov/vuln/detail/CVE-2026-71211",
+            "source": "NVD",
+            "severity": "HIGH",
+            "status": "ACTIVE",
+            "title": "CVE-2026-71211 - mlflow",
+            "reason_to_ignore": "No upstream fix available (advisory GHSA-h7x2-h6g9-p789 affects mlflow >=3.13.0,<=3.15.2 with no patched version; 3.15.2 is the latest release). The MLflow AI Gateway deployments/proxy server is not run in DLC training containers - mlflow is a sagemaker-required tracking client only - so the raw_proxy SSRF path is unreachable."
+        }
     ]
 }


### PR DESCRIPTION
## Summary

The ECR enhanced-scan sanity test (`sanity/test_ecr_scan.py::test_ecr_enhanced_scan`) fails on the PyTorch 2.10 SageMaker training images (both CPU and GPU) on a single unallowlisted finding:

- **mlflow 3.15.2 — CVE-2026-71211 — HIGH (CVSS 7.1)** — SSRF in the MLflow AI Gateway: `_create_gateway_secret` (mlflow/server/handlers.py) stores an unvalidated `auth_config.api_base`, and the `raw_proxy` endpoint (mlflow/server/gateway_api.py) then issues an HTTP request to that stored value plus a caller-supplied path.

## Why allowlist (not bump)

- **No patched release exists.** Advisory GHSA-h7x2-h6g9-p789 lists affected `>=3.13.0,<=3.15.2` with **no fixed version**, and 3.15.2 is currently the latest mlflow release. mlflow is a sagemaker-required dependency in these images.
- **Not reachable in a training container.** The vulnerable path is the MLflow AI Gateway / deployments proxy server, which is not run in a DLC training container (mlflow is used only as a tracking client), so the `raw_proxy` SSRF path is unreachable.

This matches the reasoning already used for the `onnx` and `pyasn1` entries in the same allowlist files.

## Changes

Add the mlflow CVE-2026-71211 entry to the 2.10 SageMaker enhanced-scan allowlists:

- `pytorch/training/docker/2.10/py3/Dockerfile.sagemaker.cpu.os_scan_allowlist.json`
- `pytorch/training/docker/2.10/py3/cu130/Dockerfile.sagemaker.gpu.os_scan_allowlist.json`

## Test plan

- [ ] `test_ecr_enhanced_scan` passes for PT 2.10 SageMaker CPU + GPU images
