### PR TITLE
docs: categorize ray-llm under LLM Serving

### DIFF
--- a/docs/src/global.yml
+++ b/docs/src/global.yml
@@ -198,6 +198,7 @@ image_categories:
       - base-ubuntu
   - title: "LLM Serving"
     repositories:
+      - ray-llm
       - sglang
       - sglang-server
       - vllm

--- a/docs/src/tables/ray-llm.yml
+++ b/docs/src/tables/ray-llm.yml
@@ -1,5 +1,5 @@
 # Table Configuration - Ray LLM
-note: "Ray LLM images share the `ray` ECR repository with the Ray Serve image above and the Ray Train image below, and are identified by the `serve-llm` tag prefix. See the [Ray LLM guide](../ray-llm/index.md)."
+note: "Ray LLM images share the `ray` ECR repository with the Ray Serve and Ray Train images (listed under Framework Containers), and are identified by the `serve-llm` tag prefix. See the [Ray LLM guide](../ray-llm/index.md)."
 columns:
   - field: framework_version
     header: "Framework"


### PR DESCRIPTION
Moves the Ray LLM table under the LLM Serving section on the Available Images page.