### PR TITLE
feat(metadata store): record ci image tag on test-skip PASS rows

### DIFF
--- a/.github/actions/record-test-pass/action.yml
+++ b/.github/actions/record-test-pass/action.yml
@@ -13,8 +13,8 @@ inputs:
   suite-code-hash:
     description: "Hash of the test suite's files."
     required: true
-  ci-image-tag:
-    description: 'CI image tag for the image build being tested.'
+  ci-image-uri:
+    description: 'Full CI image URI (…/ci:<tag>) for the image build being tested; the bare tag is stored.'
     required: false
     default: ''
   ci-images-table-account-id:
@@ -30,7 +30,7 @@ runs:
         SUITE: ${{ inputs.suite }}
         IMAGE_CONTENT_HASH: ${{ inputs.image-content-hash }}
         SUITE_CODE_HASH: ${{ inputs.suite-code-hash }}
-        CI_IMAGE_TAG: ${{ inputs.ci-image-tag }}
+        CI_IMAGE_URI: ${{ inputs.ci-image-uri }}
         CI_IMAGES_TABLE_ACCOUNT_ID: ${{ inputs.ci-images-table-account-id }}
       run: |
         set +e

--- a/.github/actions/record-test-pass/record_pass.py
+++ b/.github/actions/record-test-pass/record_pass.py
@@ -16,6 +16,15 @@ import ci_images_db  # noqa: E402
 import hash_suite_code  # noqa: E402
 
 
+def _tag_from_uri(image_uri):
+    """Return the bare CI tag from a full image URI (…/ci:<tag>).
+
+    The only colon in an ECR image URI separates the repo from the tag, so the
+    tag is everything after the last ':'. Returns '' for an empty/missing URI.
+    """
+    return image_uri.rsplit(":", 1)[-1] if image_uri else ""
+
+
 def _write_summary(lines):
     """Append markdown lines to the GitHub step summary, if running in Actions."""
     path = os.getenv("GITHUB_STEP_SUMMARY")
@@ -30,7 +39,8 @@ def main():
     suite = os.environ["SUITE"]
     image_content_hash = os.environ.get("IMAGE_CONTENT_HASH", "")
     suite_code_hash = os.environ.get("SUITE_CODE_HASH", "")
-    ci_image_tag = os.environ.get("CI_IMAGE_TAG", "")
+    # CI_IMAGE_URI carries the full CI image URI (…/ci:<tag>); store only the tag.
+    ci_image_tag = _tag_from_uri(os.environ.get("CI_IMAGE_URI", ""))
 
     # Suites with skip_eligible=false are always run — never record them.
     try:

--- a/.github/workflows/_reusable.efa-tests.yml
+++ b/.github/workflows/_reusable.efa-tests.yml
@@ -126,4 +126,5 @@ jobs:
           suite: efa
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/_reusable.sanity-tests.yml
+++ b/.github/workflows/_reusable.sanity-tests.yml
@@ -338,4 +338,5 @@ jobs:
           suite: sanity
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/_reusable.telemetry-tests.yml
+++ b/.github/workflows/_reusable.telemetry-tests.yml
@@ -155,4 +155,5 @@ jobs:
           suite: telemetry
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/llama-cpp.tests-model.yml
+++ b/.github/workflows/llama-cpp.tests-model.yml
@@ -150,4 +150,5 @@ jobs:
           suite: llama-cpp/model
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/llama-cpp.tests-sagemaker.yml
+++ b/.github/workflows/llama-cpp.tests-sagemaker.yml
@@ -101,4 +101,5 @@ jobs:
           suite: llama-cpp/sagemaker
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/openfold3.tests-sagemaker.yml
+++ b/.github/workflows/openfold3.tests-sagemaker.yml
@@ -107,4 +107,5 @@ jobs:
           suite: openfold3/sagemaker
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/pytorch.tests-multi-gpu.yml
+++ b/.github/workflows/pytorch.tests-multi-gpu.yml
@@ -109,4 +109,5 @@ jobs:
           suite: pytorch/multi_gpu
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/pytorch.tests-multi-node-gpu.yml
+++ b/.github/workflows/pytorch.tests-multi-node-gpu.yml
@@ -135,4 +135,5 @@ jobs:
           suite: pytorch/multi_node
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/pytorch.tests-sagemaker.yml
+++ b/.github/workflows/pytorch.tests-sagemaker.yml
@@ -115,4 +115,5 @@ jobs:
           suite: pytorch/integration/sagemaker
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/pytorch.tests-single-gpu.yml
+++ b/.github/workflows/pytorch.tests-single-gpu.yml
@@ -105,4 +105,5 @@ jobs:
           suite: pytorch/single_gpu
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/pytorch.tests-unit.yml
+++ b/.github/workflows/pytorch.tests-unit.yml
@@ -101,4 +101,5 @@ jobs:
           suite: pytorch/unit
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/ray-llm.tests-ec2.yml
+++ b/.github/workflows/ray-llm.tests-ec2.yml
@@ -126,4 +126,5 @@ jobs:
           suite: ray-llm/ec2
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/ray-llm.tests-eks-multi-node.yml
+++ b/.github/workflows/ray-llm.tests-eks-multi-node.yml
@@ -115,4 +115,5 @@ jobs:
           suite: ray-llm/eks-multi-node
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/ray-llm.tests-unit.yml
+++ b/.github/workflows/ray-llm.tests-unit.yml
@@ -109,4 +109,5 @@ jobs:
           suite: ray-llm/unit
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/ray-train.tests-eks.yml
+++ b/.github/workflows/ray-train.tests-eks.yml
@@ -110,4 +110,5 @@ jobs:
           suite: ray-train/eks
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/ray-train.tests-single-gpu.yml
+++ b/.github/workflows/ray-train.tests-single-gpu.yml
@@ -100,4 +100,5 @@ jobs:
           suite: ray-train/single_gpu
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/ray-train.tests-unit.yml
+++ b/.github/workflows/ray-train.tests-unit.yml
@@ -107,4 +107,5 @@ jobs:
           suite: ray-train/unit
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/ray.tests-ffmpeg.yml
+++ b/.github/workflows/ray.tests-ffmpeg.yml
@@ -138,4 +138,5 @@ jobs:
           suite: ray/ffmpeg
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/ray.tests-sagemaker.yml
+++ b/.github/workflows/ray.tests-sagemaker.yml
@@ -145,4 +145,5 @@ jobs:
           suite: ray/sagemaker
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/ray.tests-serve.yml
+++ b/.github/workflows/ray.tests-serve.yml
@@ -159,4 +159,5 @@ jobs:
           suite: ray/ec2
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/ray.tests-unit.yml
+++ b/.github/workflows/ray.tests-unit.yml
@@ -100,4 +100,5 @@ jobs:
           suite: ray/unit
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/sglang.tests-model.yml
+++ b/.github/workflows/sglang.tests-model.yml
@@ -194,4 +194,5 @@ jobs:
           suite: sglang/model
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/sglang.tests-sagemaker.yml
+++ b/.github/workflows/sglang.tests-sagemaker.yml
@@ -103,4 +103,5 @@ jobs:
           suite: sglang/sagemaker
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/sglang.tests-upstream.yml
+++ b/.github/workflows/sglang.tests-upstream.yml
@@ -169,4 +169,5 @@ jobs:
           suite: sglang/upstream
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/sklearn.tests-sagemaker.yml
+++ b/.github/workflows/sklearn.tests-sagemaker.yml
@@ -115,4 +115,5 @@ jobs:
           suite: sklearn/sagemaker
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/tei.tests-sagemaker.yml
+++ b/.github/workflows/tei.tests-sagemaker.yml
@@ -111,4 +111,5 @@ jobs:
           suite: tei/sagemaker
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/tensorflow-inference.tests-sagemaker.yml
+++ b/.github/workflows/tensorflow-inference.tests-sagemaker.yml
@@ -112,4 +112,5 @@ jobs:
           suite: tensorflow-inference/sagemaker
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/tensorflow-training.tests-sagemaker.yml
+++ b/.github/workflows/tensorflow-training.tests-sagemaker.yml
@@ -115,4 +115,5 @@ jobs:
           suite: tensorflow-training/sagemaker
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/tensorflow-training.tests-single-gpu.yml
+++ b/.github/workflows/tensorflow-training.tests-single-gpu.yml
@@ -103,4 +103,5 @@ jobs:
           suite: tensorflow-training/single_gpu
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/tensorflow-training.tests-unit.yml
+++ b/.github/workflows/tensorflow-training.tests-unit.yml
@@ -102,4 +102,5 @@ jobs:
           suite: tensorflow-training/unit
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/vllm-omni.tests-model.yml
+++ b/.github/workflows/vllm-omni.tests-model.yml
@@ -234,4 +234,5 @@ jobs:
           suite: vllm-omni/model
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/vllm-omni.tests-sagemaker.yml
+++ b/.github/workflows/vllm-omni.tests-sagemaker.yml
@@ -130,4 +130,5 @@ jobs:
           suite: vllm-omni/sagemaker
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/vllm.tests-model.yml
+++ b/.github/workflows/vllm.tests-model.yml
@@ -241,4 +241,5 @@ jobs:
           suite: vllm/model
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/vllm.tests-sagemaker.yml
+++ b/.github/workflows/vllm.tests-sagemaker.yml
@@ -116,4 +116,5 @@ jobs:
           suite: vllm/sagemaker
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/vllm.tests-upstream.yml
+++ b/.github/workflows/vllm.tests-upstream.yml
@@ -278,4 +278,5 @@ jobs:
           suite: vllm/upstream
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/whisperx.tests-ec2.yml
+++ b/.github/workflows/whisperx.tests-ec2.yml
@@ -148,4 +148,5 @@ jobs:
           suite: whisperx/ec2
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/whisperx.tests-sagemaker.yml
+++ b/.github/workflows/whisperx.tests-sagemaker.yml
@@ -106,4 +106,5 @@ jobs:
           suite: whisperx/sagemaker
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/.github/workflows/xgboost.tests-longevity.yml
+++ b/.github/workflows/xgboost.tests-longevity.yml
@@ -105,4 +105,5 @@ jobs:
           suite: xgboost/longevity
           image-content-hash: ${{ inputs.image-content-hash }}
           suite-code-hash: ${{ inputs.suite-code-hash }}
+          ci-image-uri: ${{ inputs.image-uri }}
           ci-images-table-account-id: ${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}

--- a/test/db/test_config_matches_workflows.py
+++ b/test/db/test_config_matches_workflows.py
@@ -20,12 +20,6 @@ TEST_SKIP_ACTIONS = ("check-test-pass", "record-test-pass")
 CHECK_WORKFLOW = "_reusable.check-test-pass.yml"
 RECORD_ACTION = "record-test-pass"
 
-# Every record-test-pass call site must thread these inputs to the store write.
-# `suite` is checked separately (it's a per-suite literal, validated against
-# test-suites.yml by test_invoked_suites_are_configured). image-content-hash and
-# suite-code-hash form the row's keys; ci-image-uri is the recorded tag source;
-# ci-images-table-account-id targets the table. A caller that drops or misspells
-# any of these silently writes a broken/absent row, so pin the exact wiring.
 EXPECTED_RECORD_INPUTS = {
     "image-content-hash": "${{ inputs.image-content-hash }}",
     "suite-code-hash": "${{ inputs.suite-code-hash }}",
@@ -165,12 +159,7 @@ def _record_test_pass_steps():
 
 
 def test_record_test_pass_inputs_are_wired():
-    """Every record-test-pass call site must pass all store attributes, correctly wired.
-
-    ci-image-uri is `required: false` on the action, and GitHub only warns (does not
-    fail) on missing required composite-action inputs, so nothing else guarantees a
-    new suite's call site threads these. This is that guarantee.
-    """
+    """Every record-test-pass call site must pass all store attributes, correctly wired."""
     problems = []
     sites = 0
     for wf_name, step in _record_test_pass_steps():

--- a/test/db/test_config_matches_workflows.py
+++ b/test/db/test_config_matches_workflows.py
@@ -18,6 +18,25 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 WORKFLOWS_DIR = REPO_ROOT / ".github" / "workflows"
 TEST_SKIP_ACTIONS = ("check-test-pass", "record-test-pass")
 CHECK_WORKFLOW = "_reusable.check-test-pass.yml"
+RECORD_ACTION = "record-test-pass"
+
+# Every record-test-pass call site must thread these inputs to the store write.
+# `suite` is checked separately (it's a per-suite literal, validated against
+# test-suites.yml by test_invoked_suites_are_configured). image-content-hash and
+# suite-code-hash form the row's keys; ci-image-uri is the recorded tag source;
+# ci-images-table-account-id targets the table. A caller that drops or misspells
+# any of these silently writes a broken/absent row, so pin the exact wiring.
+EXPECTED_RECORD_INPUTS = {
+    "image-content-hash": "${{ inputs.image-content-hash }}",
+    "suite-code-hash": "${{ inputs.suite-code-hash }}",
+    "ci-image-uri": "${{ inputs.image-uri }}",
+    "ci-images-table-account-id": "${{ vars.CI_IMAGES_TABLE_ACCOUNT_ID }}",
+}
+
+
+def _norm(value):
+    """Collapse whitespace so GHA-expression spacing differences don't matter."""
+    return " ".join(str(value).split())
 
 
 @pytest.fixture(autouse=True)
@@ -130,3 +149,47 @@ def test_check_accessors_are_configured_and_checked():
             elif key not in check_suites:
                 problems.append((wf_path.name, key, "not in the check job's suites list"))
     assert not problems, f"A job that is skippable was not checked by the check job: {problems}"
+
+
+def _record_test_pass_steps():
+    """Yield (workflow_file, step) for every step that invokes the record-test-pass action."""
+    for wf_path in sorted(WORKFLOWS_DIR.glob("*.yml")):
+        try:
+            workflow = yaml.safe_load(wf_path.read_text())
+        except yaml.YAMLError:
+            continue
+        for step in _iter_steps(workflow):
+            uses = step.get("uses", "")
+            if isinstance(uses, str) and RECORD_ACTION in uses:
+                yield wf_path.name, step
+
+
+def test_record_test_pass_inputs_are_wired():
+    """Every record-test-pass call site must pass all store attributes, correctly wired.
+
+    ci-image-uri is `required: false` on the action, and GitHub only warns (does not
+    fail) on missing required composite-action inputs, so nothing else guarantees a
+    new suite's call site threads these. This is that guarantee.
+    """
+    problems = []
+    sites = 0
+    for wf_name, step in _record_test_pass_steps():
+        sites += 1
+        with_ = step.get("with") or {}
+
+        suite = with_.get("suite")
+        if not (isinstance(suite, str) and suite.strip()):
+            problems.append((wf_name, "suite", f"missing or empty (got {suite!r})"))
+
+        for key, expected in EXPECTED_RECORD_INPUTS.items():
+            actual = with_.get(key)
+            if actual is None:
+                problems.append((wf_name, key, "missing"))
+            elif _norm(actual) != _norm(expected):
+                problems.append((wf_name, key, f"expected {expected!r}, got {actual!r}"))
+
+    assert sites, "found no record-test-pass call sites — the step walker matched nothing"
+    assert not problems, (
+        "record-test-pass call sites must thread every store attribute correctly "
+        f"(missing/misspelled inputs write broken or tagless rows): {problems}"
+    )

--- a/test/db/test_record_pass.py
+++ b/test/db/test_record_pass.py
@@ -1,0 +1,28 @@
+"""Unit tests for the record-test-pass action's URI→tag extraction."""
+
+import sys
+from pathlib import Path
+
+# record_pass.py lives in the composite action dir, not on the default path.
+_ACTION_DIR = (
+    Path(__file__).resolve().parents[2] / ".github" / "actions" / "record-test-pass"
+)
+sys.path.insert(0, str(_ACTION_DIR))
+
+import record_pass  # noqa: E402
+
+FULL_URI = "123456789012.dkr.ecr.us-west-2.amazonaws.com/ci:sglang-ec2-amzn2023-0.5.12.dlc1-gpu-py312-cu130-pr-6622"
+BARE_TAG = "sglang-ec2-amzn2023-0.5.12.dlc1-gpu-py312-cu130-pr-6622"
+
+
+def test_extracts_bare_tag_from_full_uri():
+    assert record_pass._tag_from_uri(FULL_URI) == BARE_TAG
+
+
+def test_empty_uri_yields_empty_tag():
+    assert record_pass._tag_from_uri("") == ""
+
+
+def test_bare_tag_passes_through_unchanged():
+    # Defensive: if only a tag (no registry/colon) is ever passed, keep it as-is.
+    assert record_pass._tag_from_uri(BARE_TAG) == BARE_TAG

--- a/test/db/test_record_pass.py
+++ b/test/db/test_record_pass.py
@@ -4,9 +4,7 @@ import sys
 from pathlib import Path
 
 # record_pass.py lives in the composite action dir, not on the default path.
-_ACTION_DIR = (
-    Path(__file__).resolve().parents[2] / ".github" / "actions" / "record-test-pass"
-)
+_ACTION_DIR = Path(__file__).resolve().parents[2] / ".github" / "actions" / "record-test-pass"
 sys.path.insert(0, str(_ACTION_DIR))
 
 import record_pass  # noqa: E402


### PR DESCRIPTION
## Purpose

Record the CI image tag on test-skip PASS rows in the `dlc-ci-images` store so a cached PASS row is traceable to the exact image build that produced it.

- Adds a `ci-image-uri` input to the `record-test-pass` composite action and wires it (`${{ inputs.image-uri }}`) into all 38 `record-test-pass` call sites across `.github/workflows/`.
- `record_pass.py` extracts the bare CI tag from the image URI (`…/ci:<tag>`) before the write, so each PASS row stores `ci_image_tag`.
- Renames the action input `ci-image-tag` → `ci-image-uri` (env `CI_IMAGE_TAG` → `CI_IMAGE_URI`) for clarity: the value passed is the full URI and the tag is derived internally.
- On build-skipped / test-only runs the image is not built: the tested image resolves to the prod fallback and a PASS row is still written against the **prod image's content hash**. But `ci-image-uri` is empty on those runs, so `ci_image_tag` is **omitted entirely** from that row — the attribute is absent, not stored as `""`. Consumers should treat `ci_image_tag` as optional (i.e. `attribute_not_exists`), present only on rows produced by an actual CI build.

## Test Plan

Unit tests under `test/db/` (run as `pytest test/db --confcutdir test/db`, matching `_prcheck.database.yml`):
- `test_record_pass.py` (new) — asserts URI → bare-tag extraction: full URI, empty string, bare-tag passthrough.
- `test_config_matches_workflows.py` (extended) — asserts every `record-test-pass` call site wires all store inputs, so a future unwired suite fails CI.

## Test Result

```
41 passed in 2.68s
```

______________________________________________________________________

<details>
<summary>Toggle if you are merging into master Branch</summary>

By default, docker image builds and tests are disabled. Two ways to run builds and tests:

1. Using dlc_developer_config.toml
1. Using this PR description (currently only supported for PyTorch, TensorFlow, vllm, and base images)

<details>
<summary>How to use the helper utility for updating dlc_developer_config.toml</summary>

Assuming your remote is called `origin` (you can find out more with `git remote -v`)...

- Run default builds and tests for a particular buildspec - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -cp origin`

- Enable specific tests for a buildspec or set of buildspecs - also commits and pushes changes to remote; Example:

`python src/prepare_dlc_dev_environment.py -b </path/to/buildspec.yml> -t sanity_tests -cp origin`

- Restore TOML file when ready to merge

`python src/prepare_dlc_dev_environment.py -rcp origin`

**NOTE: If you are creating a PR for a new framework version, please ensure success of the local, standard, rc, and efa sagemaker tests by updating the dlc_developer_config.toml file:**

- [ ] `sagemaker_remote_tests = true`
- [ ] `sagemaker_efa_tests = true`
- [ ] `sagemaker_rc_tests = true`
- [ ] `sagemaker_local_tests = true`

</details>

<details>
<summary>How to use PR description</summary>
Use the code block below to uncomment commands and run the PR CodeBuild jobs. There are two commands available:

- `# /buildspec <buildspec_path>`
  - e.g.: `# /buildspec pytorch/training/buildspec.yml`
  - If this line is commented out, dlc_developer_config.toml will be used.
- `# /tests <test_list>`
  - e.g.: `# /tests sanity security ec2`
  - If this line is commented out, it will run the default set of tests (same as the defaults in dlc_developer_config.toml): `sanity, security, ec2, ecs, eks, sagemaker, sagemaker-local`.

</details>

```
# /buildspec <buildspec_path>
# /tests <test_list>
```

</details>

<details>
<summary>Toggle if you are merging into main Branch</summary>

## PR Checklist

- [] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).

</details>

