### PR TITLE
fix(xgboost): bump conda openssl 3.6.3 -> 4.0.2 for CVE-2026-75803

### DIFF
--- a/docker/xgboost/3.0-5/Dockerfile
+++ b/docker/xgboost/3.0-5/Dockerfile
@@ -115,7 +115,7 @@ RUN conda config --system --set auto_update_conda false \
   && conda install -y --solver=libmamba \
     python=${PYTHON_VERSION} \
     requests=2.32.3 \
-    openssl=3.6.3 \
+    openssl=4.0.2 \
     "libcurl>=8.19.0" \
     pyarrow=${PYARROW_VERSION} \
   && conda clean -afy


### PR DESCRIPTION
### Description
The ECR enhanced vulnerability scan blocks the `sagemaker-xgboost 3.0.5` (Ubuntu 20.04) release image on **CVE-2026-75803** (CRITICAL): the conda-forge `openssl` `3.6.3` under `/miniconda3`. Upstream fix is `openssl >= 4.0.2` (ChaCha20-Poly1305 / AES-OCB decryption of an empty ciphertext can report success without verifying the authentication tag).

This bumps the pinned conda `openssl` `3.6.3` -> `4.0.2` in `docker/xgboost/3.0-5/Dockerfile` (kept as an exact pin, matching the surrounding style).

### Testing
Relies on PR CI: rebuild the image and re-run the ECR enhanced scan; the CRITICAL should clear. If the conda solve can't satisfy `openssl=4.0.2` alongside the other pinned packages, will adjust.