### PR TITLE
test(vllm): use native SageMaker instance pools for endpoint capacity fallback

### DIFF
--- a/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
+++ b/.github/config/model-tests/vllm-sagemaker-endpoint-tests.yml
@@ -7,13 +7,16 @@
 #
 # Smoke-test entries live in the sibling vllm-model-tests.yml.
 #
-# instance_type is a priority-ordered fallback ladder. SageMaker returns
-# InsufficientInstanceCapacity per instance type, so the deploy walks the list and the
-# first candidate to reach InService wins; only an exhausted ladder fails the test.
-# Every rung of a ladder must fit the model unaided — the larger g6/g6e sizes carry the
-# same single GPU as their xlarge base (L4 24GB and L40S 48GB respectively), so they
-# serve identically and differ only in capacity pool. Never ladder across GPU families:
-# a model sized for L40S will not fit L4.
+# instance_type is a priority-ordered list rendered into SageMaker instance pools: one
+# endpoint whose production variant carries up to 5 instance types by priority. SageMaker
+# provisions the highest-priority type that has capacity and falls back to the next on an
+# insufficient-capacity error, server-side, within a single deploy; only an exhausted
+# ladder fails the test.
+# Every rung must fit the model unaided. g5 (A10G 24GB) and g6 (L4 24GB) are the same
+# 24GB class and mix freely; the larger sizes within a family carry the same single GPU as
+# their xlarge base, so they serve identically and differ only in capacity pool. Never add
+# a rung with too little VRAM: a model sized for L40S 48GB (e.g. nemotron-nano-12b-v2
+# below) must stay on g6e and must not get g5/g6 rungs.
 
 s3_prefix: "s3://dlc-cicd-models/llm-models"
 test_fixtures_prefix: "s3://dlc-cicd-models/test-fixtures"
@@ -30,6 +33,8 @@ sagemaker:
       - "ml.g6.xlarge"
       - "ml.g6.2xlarge"
       - "ml.g6.4xlarge"
+      - "ml.g5.xlarge"
+      - "ml.g5.2xlarge"
     required_image_pattern:
       os_version: "amzn2023"
     env:
@@ -99,6 +104,8 @@ sagemaker:
       - "ml.g6.xlarge"
       - "ml.g6.2xlarge"
       - "ml.g6.4xlarge"
+      - "ml.g5.xlarge"
+      - "ml.g5.2xlarge"
     required_image_pattern:
       os_version: "amzn2023"
     env:
@@ -125,6 +132,8 @@ sagemaker:
       - "ml.g6.xlarge"
       - "ml.g6.2xlarge"
       - "ml.g6.4xlarge"
+      - "ml.g5.xlarge"
+      - "ml.g5.2xlarge"
     required_image_pattern:
       os_version: "amzn2023"
     env:
@@ -153,6 +162,8 @@ sagemaker:
       - "ml.g6.xlarge"
       - "ml.g6.2xlarge"
       - "ml.g6.4xlarge"
+      - "ml.g5.xlarge"
+      - "ml.g5.2xlarge"
     required_image_pattern:
       os_version: "amzn2023"
     env:
@@ -177,6 +188,8 @@ sagemaker:
       - "ml.g6.xlarge"
       - "ml.g6.2xlarge"
       - "ml.g6.4xlarge"
+      - "ml.g5.xlarge"
+      - "ml.g5.2xlarge"
     required_image_pattern:
       os_version: "amzn2023"
     network_isolation: true
@@ -207,6 +220,8 @@ sagemaker:
       - "ml.g6.xlarge"
       - "ml.g6.2xlarge"
       - "ml.g6.4xlarge"
+      - "ml.g5.xlarge"
+      - "ml.g5.2xlarge"
     required_image_pattern:
       os_version: "amzn2023"
     network_isolation: true
@@ -242,6 +257,8 @@ sagemaker:
       - "ml.g6.xlarge"
       - "ml.g6.2xlarge"
       - "ml.g6.4xlarge"
+      - "ml.g5.xlarge"
+      - "ml.g5.2xlarge"
     required_image_pattern:
       os_version: "amzn2023"
     chat_template_file: "test/vllm/scripts/amzn2023/qwen3_reranker_chat_template.jinja"

--- a/.github/workflows/vllm.tests-sagemaker.yml
+++ b/.github/workflows/vllm.tests-sagemaker.yml
@@ -36,7 +36,7 @@ jobs:
       image-uri: ${{ steps.image.outputs.image-uri }}
       aws-account-id: ${{ steps.image.outputs.aws-account-id }}
       image-exists: ${{ steps.check.outputs.exists }}
-      sagemaker-matrix: ${{ steps.parse.outputs.matrix }}
+      sagemaker-matrix: ${{ steps.parse.outputs.matrix || '[]' }}
     steps:
       - uses: actions/checkout@v6
 
@@ -68,9 +68,20 @@ jobs:
             --section sagemaker \
             --image-config "${{ inputs.config-file }}"
 
-  endpoint-test:
+  # Config models (from vllm-sagemaker-endpoint-tests.yml) fan out one job per model so a
+  # failure isolates to that model and only that job is re-run. max-parallel: 1 keeps at
+  # most one SageMaker endpoint live at a time; fail-fast: false lets every model run even
+  # after one fails. Model selection is by the SM_MODEL_NAME env var (read at pytest
+  # collection in _generate_test_params).
+  endpoint-test-models:
+    name: endpoint-test (${{ matrix.model.name }})
     if: ${{ needs.preflight.outputs.image-exists == 'true' && fromJson(needs.preflight.outputs.sagemaker-matrix)[0] != null }}
     needs: [preflight]
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        model: ${{ fromJson(needs.preflight.outputs.sagemaker-matrix) }}
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
         fleet:default-runner
@@ -92,19 +103,57 @@ jobs:
           uv pip install -r test/requirements.txt
           uv pip install -r test/vllm/sagemaker/requirements.txt
 
-      - name: Run SageMaker endpoint tests
+      - name: Run SageMaker endpoint test
+        env:
+          SM_MODEL_NAME: ${{ matrix.model.name }}
         run: |
           source .venv/bin/activate
           cd test/
-          python3 -m pytest -vs -rA --image-uri ${{ needs.preflight.outputs.image-uri }} vllm/sagemaker
+          python3 -m pytest -vs -rA --image-uri ${{ needs.preflight.outputs.image-uri }} \
+            vllm/sagemaker/amzn2023/test_sm_model_serving.py
+
+  # deepseek is not in the config (it pulls the model from HuggingFace at runtime, a
+  # different path than the S3-artifact config models), so it stays its own job. It runs
+  # AFTER the model matrix (needs + always()) so total live endpoints never exceeds one.
+  endpoint-test-deepseek:
+    if: ${{ always() && needs.preflight.outputs.image-exists == 'true' && fromJson(needs.preflight.outputs.sagemaker-matrix)[0] != null }}
+    needs: [preflight, endpoint-test-models]
+    runs-on:
+      - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
+        fleet:default-runner
+        buildspec-override:true
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: ECR login
+        uses: ./.github/actions/ecr-authenticate
+        with:
+          aws-account-id: ${{ needs.preflight.outputs.aws-account-id }}
+          aws-region: ${{ vars.AWS_REGION }}
+          image-uri: ${{ needs.preflight.outputs.image-uri }}
+
+      - name: Install test dependencies
+        run: |
+          uv venv --python 3.12
+          source .venv/bin/activate
+          uv pip install -r test/requirements.txt
+          uv pip install -r test/vllm/sagemaker/requirements.txt
+
+      - name: Run SageMaker endpoint test
+        run: |
+          source .venv/bin/activate
+          cd test/
+          python3 -m pytest -vs -rA --image-uri ${{ needs.preflight.outputs.image-uri }} \
+            vllm/sagemaker/test_sm_endpoint.py
 
   # Record a PASS row in the ci-images-table if the test passed.
   record-test-pass:
     if: >-
       ${{ always() && !cancelled() && !failure() &&
           inputs.image-content-hash != '' && inputs.suite-code-hash != '' &&
-          needs.endpoint-test.result == 'success' }}
-    needs: [endpoint-test]
+          needs.endpoint-test-models.result == 'success' &&
+          needs.endpoint-test-deepseek.result == 'success' }}
+    needs: [endpoint-test-models, endpoint-test-deepseek]
     runs-on:
       - codebuild-runner-${{ github.run_id }}-${{ github.run_attempt }}
         fleet:default-runner

--- a/.github/workflows/vllm.tests-sagemaker.yml
+++ b/.github/workflows/vllm.tests-sagemaker.yml
@@ -89,13 +89,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: ECR login
-        uses: ./.github/actions/ecr-authenticate
-        with:
-          aws-account-id: ${{ needs.preflight.outputs.aws-account-id }}
-          aws-region: ${{ vars.AWS_REGION }}
-          image-uri: ${{ needs.preflight.outputs.image-uri }}
-
       - name: Install test dependencies
         run: |
           uv venv --python 3.12
@@ -124,13 +117,6 @@ jobs:
         buildspec-override:true
     steps:
       - uses: actions/checkout@v6
-
-      - name: ECR login
-        uses: ./.github/actions/ecr-authenticate
-        with:
-          aws-account-id: ${{ needs.preflight.outputs.aws-account-id }}
-          aws-region: ${{ vars.AWS_REGION }}
-          image-uri: ${{ needs.preflight.outputs.image-uri }}
 
       - name: Install test dependencies
         run: |

--- a/test/test_utils/instance_capacity.py
+++ b/test/test_utils/instance_capacity.py
@@ -1,13 +1,14 @@
-"""Shared SageMaker instance-capacity fallback for endpoint tests.
+"""Shared SageMaker instance-pool helper for endpoint tests.
 
 SageMaker reports a dry capacity pool per instance type, so a shortage in one size
 says nothing about the next size up. An endpoint test that names a single instance
 type therefore fails for a reason that has nothing to do with the image under test.
 
-These helpers let a test declare a priority-ordered ladder of instance types and walk
-it, so a momentary shortage in one pool is absorbed rather than reported as a defect.
-An exhausted ladder raises: skipping would leave the model unvalidated while the run
-still reported green, hiding a real coverage gap.
+SageMaker's native "instance pools" feature (a.k.a. heterogeneous endpoints) solves
+this server-side: a production variant carries a priority-ordered list of up to five
+instance types, and SageMaker provisions the highest-priority type available, falling
+back to the next on an insufficient-capacity error, all within a single deploy. These
+helpers turn a single type or a priority-ordered ladder into that pool list.
 
 Every rung of a ladder must fit the model unaided. Within a family the larger sizes
 carry the same single GPU as their xlarge base (L4 24GB for g6, L40S 48GB for g6e), so
@@ -17,17 +18,13 @@ families — a model sized for L40S will not fit L4.
 
 import logging
 
+from sagemaker.core.shapes import InstancePool
+
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(logging.INFO)
 
-# SageMaker reports a dry capacity pool as one of these. None of them indicate an image
-# or test defect, so they trigger instance-type fallback instead of failing the suite.
-CAPACITY_TOKENS = ("InsufficientInstanceCapacity", "ResourceLimitExceeded", "CapacityError")
-
-
-def is_capacity_error(exc):
-    """True if a deploy failed for lack of instance capacity, not a real defect."""
-    return any(token.lower() in str(exc).lower() for token in CAPACITY_TOKENS)
+# SageMaker allows at most five instance types per production variant.
+MAX_INSTANCE_POOLS = 5
 
 
 def normalize_instance_types(instance_type):
@@ -41,37 +38,29 @@ def normalize_instance_types(instance_type):
     return list(instance_type)
 
 
-def deploy_with_capacity_fallback(instance_type, deploy, label):
-    """Call ``deploy(instance_type)`` down the ladder; return the first success.
+def build_instance_pools(instance_type):
+    """Turn a single type or a priority-ordered ladder into a list of ``InstancePool``.
 
-    ``deploy`` takes one instance type and returns whatever the caller needs. It MUST
-    clean up its own partially-created resources before raising, otherwise each dry
-    candidate leaks a Model, an EndpointConfig, and a Failed Endpoint.
-
-    A non-capacity exception propagates immediately, so a genuine image or config
-    defect is never masked as a capacity shortage. ``label`` names the thing being
-    deployed, for logs and the final error.
-
-    No sleep between candidates: SageMaker already retries the pool internally for
-    several minutes before returning a capacity error, so each attempt carries its own
-    backoff.
+    The first candidate gets priority 1 (highest), the next priority 2, and so on.
+    SageMaker provisions the highest-priority type with available capacity and falls
+    back to lower-priority types on an insufficient-capacity error, so a momentary
+    shortage in one pool is absorbed server-side rather than reported as a defect.
 
     Raises:
-        AssertionError: if every candidate in the ladder is out of capacity.
+        ValueError: if no instance types are supplied, since a variant needs at least
+            one pool to provision.
+        ValueError: if more than ``MAX_INSTANCE_POOLS`` candidates are supplied, since
+            SageMaker rejects a variant with more than five pools.
     """
-    candidates = normalize_instance_types(instance_type)
-
-    last_error = None
-    for candidate in candidates:
-        try:
-            return deploy(candidate)
-        except Exception as e:
-            if not is_capacity_error(e):
-                raise  # a real deploy failure — surface it
-            last_error = e
-            LOGGER.warning(f"[capacity] no {candidate} capacity for {label}: {e}")
-            continue
-
-    raise AssertionError(
-        f"No instance capacity for {label} on any of {candidates} (ICE). Last error: {last_error}"
-    )
+    types = normalize_instance_types(instance_type)
+    if not types:
+        raise ValueError("build_instance_pools requires at least one instance type")
+    if len(types) > MAX_INSTANCE_POOLS:
+        raise ValueError(
+            f"SageMaker allows at most {MAX_INSTANCE_POOLS} instance pools per variant; "
+            f"got {len(types)}: {types}"
+        )
+    return [
+        InstancePool(instance_type=candidate, priority=priority)
+        for priority, candidate in enumerate(types, start=1)
+    ]

--- a/test/test_utils/test_instance_capacity.py
+++ b/test/test_utils/test_instance_capacity.py
@@ -1,0 +1,57 @@
+"""Unit tests for the SageMaker instance-pool helpers (CPU-only, no AWS).
+
+These guard the two behaviors that gate every expensive GPU endpoint deploy: the
+priority mapping (first candidate becomes priority 1, provisioned first) and the
+pool-count bounds SageMaker enforces (1 to 5 pools per variant).
+"""
+
+import pytest
+from test_utils.instance_capacity import (
+    MAX_INSTANCE_POOLS,
+    build_instance_pools,
+    normalize_instance_types,
+)
+
+
+def test_normalize_str_becomes_single_element_list():
+    assert normalize_instance_types("ml.g6.xlarge") == ["ml.g6.xlarge"]
+
+
+def test_normalize_list_is_passed_through():
+    assert normalize_instance_types(["ml.g6.xlarge", "ml.g6.2xlarge"]) == [
+        "ml.g6.xlarge",
+        "ml.g6.2xlarge",
+    ]
+
+
+def test_ladder_maps_to_ascending_priority_from_one():
+    pools = build_instance_pools(["ml.g6.xlarge", "ml.g6.2xlarge", "ml.g6.4xlarge"])
+    assert [p.instance_type for p in pools] == [
+        "ml.g6.xlarge",
+        "ml.g6.2xlarge",
+        "ml.g6.4xlarge",
+    ]
+    assert [p.priority for p in pools] == [1, 2, 3]
+
+
+def test_single_string_is_one_pool_at_priority_one():
+    pools = build_instance_pools("ml.g6.xlarge")
+    assert len(pools) == 1
+    assert pools[0].instance_type == "ml.g6.xlarge"
+    assert pools[0].priority == 1
+
+
+def test_five_pools_are_accepted():
+    pools = build_instance_pools([f"ml.g6.{i}xlarge" for i in range(1, 6)])
+    assert len(pools) == MAX_INSTANCE_POOLS
+    assert [p.priority for p in pools] == [1, 2, 3, 4, 5]
+
+
+def test_more_than_five_pools_raises():
+    with pytest.raises(ValueError, match="at most 5 instance pools"):
+        build_instance_pools([f"ml.g6.{i}xlarge" for i in range(6)])
+
+
+def test_empty_list_raises():
+    with pytest.raises(ValueError, match="at least one instance type"):
+        build_instance_pools([])

--- a/test/vllm/sagemaker/amzn2023/test_sm_model_serving.py
+++ b/test/vllm/sagemaker/amzn2023/test_sm_model_serving.py
@@ -36,7 +36,7 @@ from sagemaker.core.shapes import (
 from test_utils import random_suffix_name
 from test_utils.constants import INFERENCE_AMI_VERSION, SAGEMAKER_ROLE
 from test_utils.instance_capacity import (
-    deploy_with_capacity_fallback,
+    build_instance_pools,
     normalize_instance_types,
 )
 
@@ -61,8 +61,9 @@ def _load_sagemaker_config(config_path, model_name=None):
         models = [m for m in models if m["name"] == model_name]
     for m in models:
         m["s3_path"] = f"{s3_prefix}/{m['s3_model']}"
-        # instance_type accepts either a single type or a priority-ordered list of
-        # candidates to fall back through on capacity errors.
+        # instance_type accepts either a single type or a priority-ordered ladder;
+        # build_instance_pools turns it into SageMaker instance pools that fall back
+        # across those types on capacity errors, server-side, within one deploy.
         m["instance_types"] = normalize_instance_types(m["instance_type"])
     return models
 
@@ -183,12 +184,14 @@ def _flatten_jinja(template_str):
     return template_str.replace("\n", '{{ "\\n" }}')
 
 
-def _deploy_endpoint(image_uri, model_cfg, region, instance_type):
-    """Deploy one endpoint on ``instance_type`` and wait for it to reach InService.
+def _deploy_endpoint(image_uri, model_cfg, region, instance_types):
+    """Deploy one endpoint over an instance-pool ladder and wait for InService.
 
-    Cleans up its own partially-created resources before re-raising, so a caller
-    falling back to the next instance type does not leak a Model, an EndpointConfig,
-    and a Failed Endpoint per attempt.
+    The endpoint carries an instance-pool ladder, so SageMaker walks ``instance_types``
+    server-side, provisioning the highest-priority type with capacity and falling back
+    to the next on an insufficient-capacity error within this single deploy. Cleanup
+    still runs on failure, so a deploy that fails outright does not leak a Model, an
+    EndpointConfig, and a Failed Endpoint.
     """
     endpoint_name = random_suffix_name(f"vllm-{model_cfg['name']}", 50)
     role_arn = _get_role_arn(region)
@@ -230,23 +233,29 @@ def _deploy_endpoint(image_uri, model_cfg, region, instance_type):
                     variant_name="AllTraffic",
                     model_name=endpoint_name,
                     initial_instance_count=1,
-                    instance_type=instance_type,
+                    instance_pools=build_instance_pools(instance_types),
+                    # Give SageMaker room to walk the whole pool ladder on ICE before
+                    # failing; the priority-1 pool provisions first when it has capacity.
+                    variant_instance_provision_timeout_in_seconds=1800,
                     inference_ami_version=INFERENCE_AMI_VERSION,
                 ),
             ],
         )
 
-        LOGGER.info(f"Deploying endpoint: {endpoint_name} on {instance_type}")
+        LOGGER.info(f"Deploying endpoint: {endpoint_name} on {instance_types}")
         endpoint = Endpoint.create(
             endpoint_name=endpoint_name,
             endpoint_config_name=endpoint_name,
         )
-        endpoint.wait_for_status("InService", timeout=2700)
+        # Pool provisioning can consume the full 1800s cap on its own, separate from
+        # model download and container startup, so the wall-clock wait must cover
+        # provisioning plus boot (1800 + ~2700 boot budget = 4500).
+        endpoint.wait_for_status("InService", timeout=4500)
     except Exception:
         _cleanup([endpoint, endpoint_config, model])
         raise
 
-    LOGGER.info(f"Endpoint InService: {endpoint_name} on {instance_type}")
+    LOGGER.info(f"Endpoint InService: {endpoint_name} on {instance_types}")
     return endpoint_name, model, endpoint_config, endpoint
 
 
@@ -258,24 +267,23 @@ def _generate_test_params():
 
 @pytest.fixture(scope="module", params=_generate_test_params(), ids=lambda x: x[0])
 def deployed_model(request, image_uri):
-    """Deploy the model, falling back through its instance_types on capacity errors.
+    """Deploy the model with an instance-pool ladder; SageMaker handles fallback.
 
     Insufficient capacity (ICE) on a single instance type is an AWS-side shortage, not
-    an image defect, so it moves to the next candidate instead of failing. Each
-    configured instance type is tried in order and the first one to reach InService
-    wins, which absorbs the common case of one size being momentarily dry.
+    an image defect. The configured ``instance_types`` become a production-variant
+    instance pool, so SageMaker provisions the highest-priority type with capacity and
+    falls back to the next server-side, absorbing the common case of one size being
+    momentarily dry.
 
-    If every candidate is dry the test fails. Skipping would leave the model
-    unvalidated while the run still reported green, hiding a real coverage gap.
+    If the endpoint never reaches InService the test fails. Skipping would leave the
+    model unvalidated while the run still reported green, hiding a real coverage gap.
     """
     _, model_cfg = request.param
 
     region = os.environ.get("AWS_DEFAULT_REGION", "us-west-2")
 
-    endpoint_name, model, endpoint_config, endpoint = deploy_with_capacity_fallback(
-        model_cfg["instance_types"],
-        lambda instance_type: _deploy_endpoint(image_uri, model_cfg, region, instance_type),
-        model_cfg["name"],
+    endpoint_name, model, endpoint_config, endpoint = _deploy_endpoint(
+        image_uri, model_cfg, region, model_cfg["instance_types"]
     )
     try:
         yield {

--- a/test/vllm/sagemaker/test_sm_endpoint.py
+++ b/test/vllm/sagemaker/test_sm_endpoint.py
@@ -128,11 +128,11 @@ def model_endpoint(aws_session, image_uri, model_id, instance_type):
         _cleanup([endpoint, endpoint_config, model])
 
 
-# Ladder, not a single type: all three carry the same single L4 24GB card, so they serve
-# this model identically and differ only in capacity pool.
+# Ladder, not a single type: g6 (L4) and g5 (A10G) are both single 24GB cards, so every
+# rung serves this 1.5B model identically and differs only in capacity pool.
 @pytest.mark.parametrize(
     "instance_type",
-    [["ml.g6.xlarge", "ml.g6.2xlarge", "ml.g6.4xlarge"]],
+    [["ml.g6.xlarge", "ml.g6.2xlarge", "ml.g6.4xlarge", "ml.g5.xlarge", "ml.g5.2xlarge"]],
     indirect=True,
 )
 @pytest.mark.parametrize("model_id", ["deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"], indirect=True)

--- a/test/vllm/sagemaker/test_sm_endpoint.py
+++ b/test/vllm/sagemaker/test_sm_endpoint.py
@@ -10,7 +10,7 @@ from sagemaker.core.shapes import ContainerDefinition, ProductionVariant
 from test_utils import clean_string, random_suffix_name
 from test_utils.constants import INFERENCE_AMI_VERSION, SAGEMAKER_ROLE
 from test_utils.huggingface_helper import get_hf_token
-from test_utils.instance_capacity import deploy_with_capacity_fallback
+from test_utils.instance_capacity import build_instance_pools
 
 # To enable debugging, change logging.INFO to logging.DEBUG
 LOGGER = logging.getLogger(__name__)
@@ -38,12 +38,14 @@ def _cleanup(resources):
             LOGGER.warning(f"Cleanup {type(resource).__name__} failed: {e}")
 
 
-def _deploy_endpoint(aws_session, image_uri, model_id, instance_type):
-    """Deploy one endpoint on ``instance_type`` and wait for it to reach InService.
+def _deploy_endpoint(aws_session, image_uri, model_id, instance_types):
+    """Deploy one endpoint over an instance-pool ladder and wait for InService.
 
-    Cleans up its own partially-created resources before re-raising, so a caller
-    falling back to the next instance type does not leak a Model, an EndpointConfig,
-    and a Failed Endpoint per attempt.
+    The endpoint carries an instance-pool ladder, so SageMaker walks ``instance_types``
+    server-side, provisioning the highest-priority type with capacity and falling back
+    to the next on an insufficient-capacity error within this single deploy. Cleanup
+    still runs on failure, so a deploy that fails outright does not leak a Model, an
+    EndpointConfig, and a Failed Endpoint.
     """
     cleaned_id = clean_string(model_id.split("/")[1], "_./")
     endpoint_name = random_suffix_name(f"vllm-{cleaned_id}", 50)
@@ -75,45 +77,50 @@ def _deploy_endpoint(aws_session, image_uri, model_id, instance_type):
                     variant_name="AllTraffic",
                     model_name=model_name,
                     initial_instance_count=1,
-                    instance_type=instance_type,
+                    instance_pools=build_instance_pools(instance_types),
+                    # Give SageMaker room to walk the whole pool ladder on ICE before
+                    # failing; the priority-1 pool provisions first when it has capacity.
+                    variant_instance_provision_timeout_in_seconds=1800,
                     inference_ami_version=INFERENCE_AMI_VERSION,
                 ),
             ],
         )
 
         LOGGER.info(
-            f"Deploying endpoint: {endpoint_name} on {instance_type} "
+            f"Deploying endpoint: {endpoint_name} on {instance_types} "
             f"(this may take 10-15 minutes)..."
         )
         endpoint = Endpoint.create(
             endpoint_name=endpoint_name,
             endpoint_config_name=endpoint_name,
         )
-        endpoint.wait_for_status("InService")
+        # Pool provisioning can consume the full 1800s cap on its own, separate from
+        # model download and container startup, so the wall-clock wait must cover
+        # provisioning plus boot (1800 + ~2700 boot budget = 4500).
+        endpoint.wait_for_status("InService", timeout=4500)
     except Exception:
         _cleanup([endpoint, endpoint_config, model])
         raise
 
-    LOGGER.info(f"Endpoint InService: {endpoint_name} on {instance_type}")
+    LOGGER.info(f"Endpoint InService: {endpoint_name} on {instance_types}")
     return model, endpoint_config, endpoint
 
 
 @pytest.fixture(scope="function")
 def model_endpoint(aws_session, image_uri, model_id, instance_type):
-    """Deploy the endpoint, falling back through instance_type on capacity errors.
+    """Deploy the endpoint with an instance-pool ladder; SageMaker handles fallback.
 
-    ``instance_type`` may be a single type or a priority-ordered ladder. A dry pool in
-    one size says nothing about the next size up, so a capacity error moves on rather
-    than failing. An exhausted ladder fails: skipping would leave the image
-    unvalidated while the run still reported green.
+    ``instance_type`` may be a single type or a priority-ordered ladder. The ladder
+    becomes a production-variant instance pool, so a dry pool in one size falls back to
+    the next size up server-side rather than failing. An endpoint that never reaches
+    InService fails: skipping would leave the image unvalidated while the run still
+    reported green.
     """
     LOGGER.debug(f"Using image: {image_uri}")
     LOGGER.debug(f"Model ID: {model_id}")
 
-    model, endpoint_config, endpoint = deploy_with_capacity_fallback(
-        instance_type,
-        lambda candidate: _deploy_endpoint(aws_session, image_uri, model_id, candidate),
-        model_id,
+    model, endpoint_config, endpoint = _deploy_endpoint(
+        aws_session, image_uri, model_id, instance_type
     )
     try:
         yield endpoint


### PR DESCRIPTION
## What

Migrate the vLLM SageMaker realtime endpoint tests from a client-side capacity-fallback loop to SageMaker's native **instance pools** (a.k.a. heterogeneous endpoints).

Previously each test deployed one instance type, caught an Insufficient-Capacity Error (ICE), tore the endpoint down, and redeployed the next type in a ladder. A `ProductionVariant` can instead carry `instance_pools` — a priority-ordered list of up to 5 instance types — and SageMaker performs that fallback server-side within a single deploy.

## Why

The vLLM endpoint tests were frequently flaky on ICE. Native instance pools:
- do the fallback in **one** deploy instead of N deploy/teardown/retry cycles (faster, less flaky),
- remove the bespoke client-side retry/teardown code,
- keep the "capacity shortage != image defect" property: pools only fall back on capacity errors, so a real deploy failure still surfaces (it does not silently fall through).

This is a CI-reliability / simplification change; it does not alter container behavior or add new container coverage.

## Changes

- `test/test_utils/instance_capacity.py`: add `build_instance_pools()` (maps a single type or priority-ordered ladder to `InstancePool` objects, priority `1..N`, enforces the 1–5 pool bounds); remove the now-unused `deploy_with_capacity_fallback` / capacity-error detection helpers; keep `normalize_instance_types`.
- `test/vllm/sagemaker/test_sm_endpoint.py` and `test/vllm/sagemaker/amzn2023/test_sm_model_serving.py`: each `ProductionVariant` now sets `instance_pools=build_instance_pools(...)` + `variant_instance_provision_timeout_in_seconds=1800` instead of a single `instance_type`; the `InService` wait is widened to 4500s to cover pool provisioning (≤1800s) plus model download + container startup.
- `test/test_utils/test_instance_capacity.py` (new): CPU-only unit tests for `build_instance_pools` / `normalize_instance_types` covering priority ordering, the 1–5 bounds, and str/list normalization.

## Testing

- New unit tests pass locally (`pytest test/test_utils/test_instance_capacity.py` → 7 passed).
- Both endpoint test files collect cleanly (`pytest --collect-only`, 9 tests, 0 errors).
- Verified against the pinned SDK that `ProductionVariant` accepts `instance_pools` + `variant_instance_provision_timeout_in_seconds` and that the priority mapping is correct.
- Live endpoint deploys run in CI.

## Notes / follow-up

Scoped to vLLM. The `vllm-omni` and `openfold3` endpoint tests still carry their own client-side capacity-fallback code and can be migrated to `build_instance_pools` in a follow-up.