### PR TITLE
fix(pytorch training 2.10): pin plum-dispatch<2.10 to unblock fastai import

### DIFF
--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = []
+build_frameworks = ["pytorch"]
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = true
+build_inference = false
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = ""
+dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-sm.yml"
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/dlc_developer_config.toml
+++ b/dlc_developer_config.toml
@@ -37,12 +37,12 @@ deep_canary_mode = false
 [build]
 # Add in frameworks you would like to build. By default, builds are disabled unless you specify building an image.
 # available frameworks - ["base", "vllm", "sglang", "autogluon", "huggingface_vllm", "huggingface_vllm_omni", "huggingface_sglang", "huggingface_llamacpp", "huggingface_tensorflow", "huggingface_pytorch", "huggingface_tensorflow_trcomp", "huggingface_pytorch_trcomp", "pytorch_trcomp", "tensorflow", "pytorch", "stabilityai_pytorch"]
-build_frameworks = ["pytorch"]
+build_frameworks = []
 
 
 # By default we build both training and inference containers. Set true/false values to determine which to build.
 build_training = true
-build_inference = false
+build_inference = true
 
 # Set do_build to "false" to skip builds and test the latest image built by this PR
 # Note: at least one build is required to set do_build to "false"
@@ -124,7 +124,7 @@ nightly_pr_test_mode = false
 dlc-pr-base = ""
 
 # Standard Framework Training
-dlc-pr-pytorch-training = "pytorch/training/buildspec-2-10-sm.yml"
+dlc-pr-pytorch-training = ""
 dlc-pr-tensorflow-2-training = ""
 dlc-pr-autogluon-training = ""
 

--- a/pytorch/training/docker/2.10/py3/Dockerfile.cpu
+++ b/pytorch/training/docker/2.10/py3/Dockerfile.cpu
@@ -208,6 +208,9 @@ RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
     fastai \
     # pin fastcore<2: fastcore 2.0 removed L.starmap, which pinned fastai's optimizer.py still calls
     "fastcore<2" \
+    # pin plum-dispatch<2.10: 2.10.0 compiles Function with mypyc, making Function.__doc__
+    # read-only, which breaks fastcore add_docs (f.__doc__=v) during fastai import
+    "plum-dispatch<2.10" \
     accelerate \
     # pin numpy requirement for fastai dependency
     # requires explicit declaration of spacy, thinc, blis

--- a/pytorch/training/docker/2.10/py3/cu130/Dockerfile.gpu
+++ b/pytorch/training/docker/2.10/py3/cu130/Dockerfile.gpu
@@ -129,6 +129,9 @@ RUN pip install --no-cache-dir -U torch==${PYTORCH_VERSION} \
     fastai \
     # pin fastcore<2: fastcore 2.0 removed L.starmap, which pinned fastai's optimizer.py still calls
     "fastcore<2" \
+    # pin plum-dispatch<2.10: 2.10.0 compiles Function with mypyc, making Function.__doc__
+    # read-only, which breaks fastcore add_docs (f.__doc__=v) during fastai import
+    "plum-dispatch<2.10" \
     accelerate \
     # pin numpy requirement for fastai dependency
     # requires explicit declaration of spacy, thinc, blis


### PR DESCRIPTION
## Symptom

The `fastai_mnist` SageMaker local-mode training test for the PyTorch 2.10 (py3.13) training images fails at **import time**, before any training runs, with:

```
AttributeError: 'Function' object attribute '__doc__' is read-only
```

The traceback originates from `from fastai.vision.all import *`.

## Root cause

`plum-dispatch` is an **unpinned transitive dependency** of `fastai`. On 2026-09-03 it released `2.10.0`, which compiles its `Function` class with **mypyc**. mypyc-compiled classes expose a read-only `__doc__`. During `from fastai.vision.all import *`, fastcore's `add_docs` does `f.__doc__ = v` on fastai's typedispatched members — that assignment now raises `AttributeError` because `Function.__doc__` is read-only.

`fastai` (`2.8.7`) and `fastcore` (`1.14.5`) are **unchanged**; only the floating `plum-dispatch` dependency moved (`2.9.0` -> `2.10.0`).

## Fix

Pin `plum-dispatch<2.10` (resolves to `2.9.0`) in the PyTorch 2.10 CPU and cu130 GPU training Dockerfiles, next to the existing `fastcore<2` pin.

## Scope

Only PyTorch **2.10 (py3.13)** is affected. PyTorch 2.8 and 2.9 currently resolve `plum-dispatch` `2.6.0` and are unaffected, so they are intentionally left untouched.

## Validation

Minimal py3.13 reproducer confirms the boundary: assigning `__doc__` to a plum-dispatched function raises `AttributeError: ... '__doc__' is read-only` on `plum-dispatch==2.10.0`, and succeeds on `plum-dispatch==2.9.0`.

### Files changed
- `pytorch/training/docker/2.10/py3/Dockerfile.cpu`
- `pytorch/training/docker/2.10/py3/cu130/Dockerfile.gpu`

-[f6fd1e5](https://github.com/aws/deep-learning-containers/pull/6715/commits/f6fd1e5cb18e7d804d5b68c89edbf98b759200d4) SageMaker test passed.