### PR TITLE
docs(sagemaker-tritonserver): Add Triton 26.04 and 26.05 GPU SageMaker

### DIFF
--- a/docs/src/data/sagemaker-tritonserver/26.04-gpu-sagemaker.yml
+++ b/docs/src/data/sagemaker-tritonserver/26.04-gpu-sagemaker.yml
@@ -1,0 +1,10 @@
+framework: Triton
+version: "26.04"
+accelerator: gpu
+python: py3
+platform: sagemaker
+example_ecr_account: "007439368137"
+
+# Image tags (first tag is used in available_images.md)
+tags:
+  - "26.04-py3"

--- a/docs/src/data/sagemaker-tritonserver/26.05-gpu-sagemaker.yml
+++ b/docs/src/data/sagemaker-tritonserver/26.05-gpu-sagemaker.yml
@@ -1,0 +1,10 @@
+framework: Triton
+version: "26.05"
+accelerator: gpu
+python: py3
+platform: sagemaker
+example_ecr_account: "007439368137"
+
+# Image tags (first tag is used in available_images.md)
+tags:
+  - "26.05-py3"


### PR DESCRIPTION
Adds NVIDIA Triton Inference Server for SageMaker versions **26.04** and **26.05** to the available images documentation.