### PR TITLE
docs(readme): add SGLang v0.5.19 release highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ ______________________________________________________________________
 
 ### 🚀 Release Highlights
 
+- **[2026/09/07]** [SGLang v0.5.19 (Ubuntu)](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.19-gpu-py312-ec2` · SageMaker: `0.5.19-gpu-py312` · Qwen3.8, Ling-3.0, Spark2.5, Granite 4.2; beam search; DeepEP v2 MoE all-to-all.
 - **[2026/09/01]** [Ray LLM v1.0 (2.58.0, AL2023)](https://gallery.ecr.aws/deep-learning-containers/ray) — EC2/EKS: `serve-llm-cuda-v1.0` · Initial release: OpenAI-compatible LLM serving with Ray Serve and vLLM 0.26.0 on PyTorch 2.11.0 / CUDA 13.0.2 / Python 3.13; `ray[llm]`'s `build_openai_app` runs vLLM behind Ray Serve — single GPU on EC2, and multi-node serving on EKS via KubeRay.
 - **[2026/09/01]** [Ray Train v1.1 (2.58.0, AL2023)](https://gallery.ecr.aws/deep-learning-containers/ray) — EC2/EKS: `train-ml-cuda-v1.1` · EFA `1.49.0` (up from 1.47.0).
 - **[2026/08/26]** [vLLM v0.28.0 (Ubuntu)](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.28.0-gpu-py312-ec2` · SageMaker: `0.28.0-gpu-py312` · Kimi-K3 stack-wide optimization (Decode Context Parallel, fused FlashKDA kernels, GEMM-RS sequence parallelism); DeepSeek V4 sparse MLA end-to-end with MTP and DSpark speculative decoding; new models Muse Glimmer, Ling 3.0 Flash, Dots3, Interns2mobius; tiered KV cache offloading to disk; runtime base moves to Ubuntu 24.04 and Transformers 5.15.0; `max_num_batched_tokens` default 8192 -> 16384.
@@ -45,7 +46,6 @@ ______________________________________________________________________
 - **[2026/08/14]** [vLLM v0.27.1 (Ubuntu)](https://gallery.ecr.aws/deep-learning-containers/vllm) — EC2: `0.27.1-gpu-py312-ec2` · SageMaker: `0.27.1-gpu-py312` · Kimi K3, Qwen3.5 dense + MoE (EVS video token pruning), K-EXAONE-2.0-750B-A37B, VaultGemma, jina-embeddings-v5-text-nano.
 - **[2026/08/14]** [WhisperX v3.8.6 (AL2023)](https://gallery.ecr.aws/deep-learning-containers/whisperx) — EC2: `3.8.6-cu128-amzn2023` · SageMaker: `3.8.6-cu128-amzn2023-sagemaker` · Initial release: speech transcription with word-level alignment (wav2vec2) and speaker diarization (pyannote) through an OpenAI-compatible API on CUDA 12.8 / Python 3.12; real-time and asynchronous SageMaker endpoints.
 - **[2026/08/12]** [Ray v1.4 (2.57.0, AL2023)](https://gallery.ecr.aws/deep-learning-containers/ray) — EC2: `serve-ml-cuda-v1.4` · `serve-ml-cpu-v1.4` · SageMaker: `serve-ml-sagemaker-cuda-v1.4` · `serve-ml-sagemaker-cpu-v1.4` · Ray `2.57.0` (up from 2.56.1).
-- **[2026/08/08]** [SGLang v0.5.17 (Ubuntu)](https://gallery.ecr.aws/deep-learning-containers/sglang) — EC2: `0.5.17-gpu-py312-ec2` · SageMaker: `0.5.17-gpu-py312` · Kimi K3, MiniMax H3.
 
 ### 📢 Support Updates
 


### PR DESCRIPTION
## Summary
Add the SGLang v0.5.19 (Ubuntu) release highlight (released 2026/09/07) and drop the oldest entry to keep the Release Highlights list at 15.

## Added
- **SGLang v0.5.19 (Ubuntu)** — EC2 `0.5.19-gpu-py312-ec2` · SageMaker `0.5.19-gpu-py312`

## Removed
- SGLang v0.5.17 (Ubuntu), 2026/08/08 — the oldest entry.

## Details
- Tags verified against `docs/src/data/sglang/0.5.19-gpu-{ec2,sagemaker}.yml` on `main`; unchanged shape from 0.5.18 (still `cu130` / `ubuntu24.04`).
- Highlights from the upstream SGLang v0.5.19 release notes.
- Release date confirmed from ECR: the original v1.0 build was pushed 2026-09-06/07 (dated tag `...-sagemaker-v1.0-2026-09-07-05-53-48`); a v1.1 rebuild on 09-08 now carries the floating tags.
- `pre-commit` passes (typos + markdown formatting).