### PR TITLE
change: switching huggingface-pytorch-training family to v2 tags

### DIFF
--- a/.github/config/image/huggingface-pytorch-training/2.11-ec2.yml
+++ b/.github/config/image/huggingface-pytorch-training/2.11-ec2.yml
@@ -11,7 +11,7 @@ metadata:
   device_type: "gpu"
   job_type: "training"
   contributor: "huggingface"
-  prod_image: "huggingface-pytorch-training:2.11.0-transformers5.13.1-gpu-py312-cu130-amzn2023"
+  prod_image: "huggingface-pytorch-training:2.11-transformers5.13-cu130-amzn2023"
 
 build:
   dockerfile: "docker/huggingface/pytorch/Dockerfile"

--- a/.github/config/image/huggingface-pytorch-training/2.11-sagemaker.yml
+++ b/.github/config/image/huggingface-pytorch-training/2.11-sagemaker.yml
@@ -12,7 +12,7 @@ metadata:
   device_type: "gpu"
   job_type: "training"
   contributor: "huggingface"
-  prod_image: "huggingface-pytorch-training:2.11.0-transformers5.13.1-gpu-py312-cu130-amzn2023-sagemaker"
+  prod_image: "huggingface-pytorch-training:2.11-transformers5.13-cu130-amzn2023-sagemaker"
 
 build:
   dockerfile: "docker/huggingface/pytorch/Dockerfile"

--- a/test/security/data/ecr_scan_allowlist/huggingface-pytorch-training/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/huggingface-pytorch-training/framework_allowlist.json
@@ -3,5 +3,10 @@
         "vulnerability_id": "CVE-2026-24747",
         "reason": "Inspector matched torch 2.9.1 only in /opt/venv/lib/python3.12/site-packages/benchmarks/requirements.txt; the installed runtime is torch 2.11.0 from the PyTorch 2.11.0 base image, so the vulnerable package version is not present. Remove this entry when the upstream package stops shipping the stale benchmark manifest.",
         "review_by": "2026-10-31"
+    },
+    {
+        "vulnerability_id": "CVE-2026-82397",
+        "reason": "tornado 6.5.7 is inherited from the current PyTorch 2.11 base image; fixed version 6.5.8 was released after that base was locked. Temporary exception until the base image refreshes tornado or the Hugging Face layer takes the new security floor.",
+        "review_by": "2026-09-30"
     }
 ]


### PR DESCRIPTION
## Purpose

## PR Checklist

- [x] I ran `pre-commit run --all-files` locally before creating this PR. (Read [DEVELOPMENT.md](https://github.com/aws/deep-learning-containers/blob/main/DEVELOPMENT.md) for details).
