### PR TITLE
feat: upgrade vllm amzn2023 to deepep v2 over efa

### DIFF
--- a/.github/config/image/vllm/ec2-amzn2023.yml
+++ b/.github/config/image/vllm/ec2-amzn2023.yml
@@ -4,7 +4,7 @@ image:
 
 metadata:
   framework: "vllm_server"
-  framework_version: "0.27.1"
+  framework_version: "0.29.0"
   os_version: "amzn2023"
   customer_type: "ec2"
   arch_type: "x86"
@@ -17,13 +17,13 @@ build:
   target: "vllm-ec2-amzn2023"
   python_version: "3.12"
   cuda_version: "13.0.2"
-  vllm_ref: "6adad08767583f52eb4d2122111af0bf638ed5e6"
+  vllm_ref: "98dff2a81d747d1dba01a47f939f48c3526d4206"
   # 10.3 == B300 (SM103). Part of the wheel cache key, so changing it forces a recompile.
   torch_cuda_arch_list: "7.0 7.5 8.0 8.9 9.0 10.0 10.3 12.0"
   flashinfer_version: "0.6.16.post3"
-  deepep_commit_hash: "d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb"
+  deepep_commit_hash: "874779c9ccd2294b56304bd6cc5f138f1f71d097"
   dlc_major_version: "2"
-  dlc_minor_version: "4"
+  dlc_minor_version: "5"
   use_sccache: "true"
 
 release:

--- a/.github/config/image/vllm/ec2-amzn2023.yml
+++ b/.github/config/image/vllm/ec2-amzn2023.yml
@@ -20,7 +20,7 @@ build:
   vllm_ref: "98dff2a81d747d1dba01a47f939f48c3526d4206"
   # 10.3 == B300 (SM103). Part of the wheel cache key, so changing it forces a recompile.
   torch_cuda_arch_list: "7.0 7.5 8.0 8.9 9.0 10.0 10.3 12.0"
-  flashinfer_version: "0.6.16.post3"
+  flashinfer_version: "0.6.18"
   deepep_commit_hash: "874779c9ccd2294b56304bd6cc5f138f1f71d097"
   dlc_major_version: "2"
   dlc_minor_version: "5"

--- a/.github/config/image/vllm/sagemaker-amzn2023.yml
+++ b/.github/config/image/vllm/sagemaker-amzn2023.yml
@@ -22,7 +22,7 @@ build:
   vllm_ref: "98dff2a81d747d1dba01a47f939f48c3526d4206"
   # 10.3 == B300 (SM103). Part of the wheel cache key, so changing it forces a recompile.
   torch_cuda_arch_list: "7.0 7.5 8.0 8.9 9.0 10.0 10.3 12.0"
-  flashinfer_version: "0.6.16.post3"
+  flashinfer_version: "0.6.18"
   deepep_commit_hash: "874779c9ccd2294b56304bd6cc5f138f1f71d097"
   dlc_major_version: "2"
   dlc_minor_version: "5"

--- a/.github/config/image/vllm/sagemaker-amzn2023.yml
+++ b/.github/config/image/vllm/sagemaker-amzn2023.yml
@@ -4,7 +4,7 @@ image:
 
 metadata:
   framework: "vllm_server"
-  framework_version: "0.27.1"
+  framework_version: "0.29.0"
   os_version: "amzn2023"
   customer_type: "sagemaker"
   platform: "sagemaker"
@@ -19,13 +19,13 @@ build:
   python_version: "3.12"
   cuda_version: "13.0.2"
   # Kept in lockstep with ec2-amzn2023.yml -- same Dockerfile.
-  vllm_ref: "6adad08767583f52eb4d2122111af0bf638ed5e6"
+  vllm_ref: "98dff2a81d747d1dba01a47f939f48c3526d4206"
   # 10.3 == B300 (SM103). Part of the wheel cache key, so changing it forces a recompile.
   torch_cuda_arch_list: "7.0 7.5 8.0 8.9 9.0 10.0 10.3 12.0"
   flashinfer_version: "0.6.16.post3"
-  deepep_commit_hash: "d4f41e4e93602a15e95f55f6ee8df8f1aaa0e4bb"
+  deepep_commit_hash: "874779c9ccd2294b56304bd6cc5f138f1f71d097"
   dlc_major_version: "2"
-  dlc_minor_version: "4"
+  dlc_minor_version: "5"
   use_sccache: "true"
 
 release:

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -439,6 +439,8 @@ RUN dnf install -y --setopt=install_weak_deps=False make gcc-c++ \
   && curl -fsSL "https://github.com/NVIDIA/nccl-tests/archive/refs/tags/${NCCL_TESTS_VERSION}.tar.gz" | tar xz \
   && make -C "${NCCL_TESTS_DIR}/src" BUILDDIR="${NCCL_TESTS_DIR}/build" \
        MPI=1 MPI_HOME=/opt/amazon/openmpi NCCL_HOME="${NCCL_HOME}" CUDA_HOME=/usr/local/cuda \
+       NVCC_GENCODE="-gencode=arch=compute_80,code=sm_80 -gencode=arch=compute_90,code=sm_90" \
+       CXXSTD="-std=c++17" \
        "${NCCL_TESTS_DIR}/build/all_reduce_perf" \
   && cp "${NCCL_TESTS_DIR}/build/all_reduce_perf" /usr/local/bin/all_reduce_perf \
   && dnf remove -y make gcc-c++ && dnf clean all && rm -rf /var/cache/dnf \

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -218,9 +218,11 @@ ENV UV_INDEX_STRATEGY="unsafe-best-match"
 ENV UV_LINK_MODE=copy
 
 # Match runtime venv NCCL to the DeepEP wheel's compile-time NCCL (see build stage).
+# Pin transformers < 5.16: vLLM 0.29.0 predates the 5.16 Pixtral rename + rope_parameters changes.
 ARG NCCL_VERSION
 RUN CUDA_MAJOR=$(echo $CUDA_VERSION | cut -d. -f1) \
-  && echo "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" >/etc/uv-overrides.txt
+  && echo "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" >/etc/uv-overrides.txt \
+  && echo "transformers==5.15.1" >>/etc/uv-overrides.txt
 ENV UV_OVERRIDE=/etc/uv-overrides.txt
 
 # Install PyTorch

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -2,9 +2,12 @@ ARG CUDA_VERSION=13.0.2
 ARG PYTHON_VERSION=3.12
 ARG FRAMEWORK_VERSION=0.24.0
 ARG FLASHINFER_VERSION=0.6.12
-ARG DEEPEP_COMMIT_HASH=73b6ea4
-# DeepEPv2 GIN needs NCCL >= 2.30.4; override torch's older transitive pin.
-ARG NCCL_VERSION=2.30.7
+# DeepEP v2 from the AWS EFA fork (amazon-contributing/DeepEP).
+ARG DEEPEP_REPO=https://github.com/amazon-contributing/DeepEP.git
+ARG DEEPEP_COMMIT_HASH=874779c9ccd2294b56304bd6cc5f138f1f71d097
+ARG NCCL_VERSION=2.31.2
+ARG NVSHMEM_PIP_VERSION=3.3.24
+ARG GDRCOPY_VERSION=2.5.2
 
 # =============================================================================
 # STAGE 0: source — clone vLLM and apply patches
@@ -54,7 +57,7 @@ ARG PYTHON_VERSION
 ARG PYTORCH_CUDA_INDEX_BASE_URL=https://download.pytorch.org/whl
 
 RUN dnf install -y --setopt=install_weak_deps=False \
-  tar gzip xz git gcc gcc-c++ make cmake ninja-build patch \
+  tar gzip xz git gcc gcc-c++ make cmake ninja-build patch gawk \
   python${PYTHON_VERSION} python${PYTHON_VERSION}-devel python${PYTHON_VERSION}-pip \
   libibverbs-devel \
   && dnf clean all && rm -rf /var/cache/dnf
@@ -142,22 +145,36 @@ RUN --mount=type=cache,target=/root/.cache/ccache --mount=type=cache,target=/roo
       && python3 setup.py bdist_wheel --dist-dir=dist --py-limited-api=cp38; \
     fi
 
-# Build DeepEP wheels. On CUDA 13, NCCL is a separate wheel (not in torch/lib); LIBRARY_PATH puts it on the link search path.
+# Build the DeepEP wheel from the AWS EFA fork. Its setup.py compiles both the legacy NVSHMEM
+# backend and the NCCL/GIN (EFA) backend and finds them from pip-wheel metadata / EP_NCCL_ROOT_DIR,
+# so install those wheels first, then build into the dist dir the runtime stage copies from.
+ARG DEEPEP_REPO
 ARG DEEPEP_COMMIT_HASH
-ARG NVSHMEM_VER
 ARG NCCL_VERSION
-RUN --mount=type=cache,target=/root/.cache/uv mkdir -p /tmp/ep_kernels_workspace/dist \
-  && CUDA_MAJOR=$(echo $CUDA_VERSION | cut -d. -f1) \
-  && echo "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" >/tmp/nccl-override.txt \
-  && export UV_OVERRIDE=/tmp/nccl-override.txt \
-  && export LIBRARY_PATH="/opt/venv/lib/python${PYTHON_VERSION}/site-packages/nvidia/nccl/lib:${LIBRARY_PATH}" \
-  && export TORCH_CUDA_ARCH_LIST='9.0a 10.0a 10.3a' \
-  && tools/ep_kernels/install_python_libraries.sh \
-    --workspace /tmp/ep_kernels_workspace \
-    --mode wheel \
-    ${DEEPEP_COMMIT_HASH:+--deepep-ref "$DEEPEP_COMMIT_HASH"} \
-    ${NVSHMEM_VER:+--nvshmem-ver "$NVSHMEM_VER"} \
-  && find /tmp/ep_kernels_workspace/nvshmem -name '*.a' -delete
+ARG NVSHMEM_PIP_VERSION
+RUN --mount=type=cache,target=/root/.cache/uv CUDA_MAJOR=$(echo $CUDA_VERSION | cut -d. -f1) \
+  && uv pip install --no-deps \
+    "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" \
+    "nvidia-nvshmem-cu${CUDA_MAJOR}==${NVSHMEM_PIP_VERSION}" \
+  && git clone "${DEEPEP_REPO}" /tmp/deepep \
+  && git -C /tmp/deepep checkout "${DEEPEP_COMMIT_HASH}" \
+  && git -C /tmp/deepep submodule update --init --recursive \
+  && mkdir -p /tmp/ep_kernels_workspace/dist \
+  && cd /tmp/deepep \
+  && EP_NCCL_ROOT_DIR="/opt/venv/lib/python${PYTHON_VERSION}/site-packages/nvidia/nccl" \
+    DISABLE_AGGRESSIVE_PTX_INSTRS=1 \
+    TORCH_CUDA_ARCH_LIST='9.0a 10.0a 10.3a' \
+    python3 setup.py bdist_wheel --dist-dir /tmp/ep_kernels_workspace/dist \
+  && cd / && rm -rf /tmp/deepep
+
+ARG GDRCOPY_VERSION
+RUN mkdir -p /tmp/gdrcopy && cd /tmp \
+  && curl --retry 3 -fsSL -o v${GDRCOPY_VERSION}.tar.gz \
+    https://github.com/NVIDIA/gdrcopy/archive/refs/tags/v${GDRCOPY_VERSION}.tar.gz \
+  && tar -xzf v${GDRCOPY_VERSION}.tar.gz && rm v${GDRCOPY_VERSION}.tar.gz \
+  && cd gdrcopy-${GDRCOPY_VERSION} \
+  && make -j"$(nproc)" prefix=/usr/local CUDA=/usr/local/cuda lib lib_install \
+  && cd / && rm -rf /tmp/gdrcopy*
 
 # =============================================================================
 # STAGE: wheel-export — scratch image with built wheels for S3 cache upload
@@ -232,6 +249,10 @@ RUN --mount=type=cache,target=/root/.cache/uv uv pip install accelerate modelsco
 # Audio deps for voxtral / ASR serving (mistral_common is an optional import in vLLM 0.24.0)
 RUN --mount=type=cache,target=/root/.cache/uv uv pip install \
   av scipy soundfile "mistral_common[audio]"
+
+ARG NVSHMEM_PIP_VERSION
+RUN --mount=type=cache,target=/root/.cache/uv CUDA_MAJOR=$(echo $CUDA_VERSION | cut -d. -f1) \
+  && uv pip install --no-deps "nvidia-nvshmem-cu${CUDA_MAJOR}==${NVSHMEM_PIP_VERSION}"
 
 # Install DeepEP wheels from build stage
 COPY --from=build /tmp/ep_kernels_workspace/dist /tmp/ep_kernels/dist
@@ -338,13 +359,13 @@ ENV LANG=C.UTF-8 \
   PYTHONDONTWRITEBYTECODE=1 \
   PYTHONUNBUFFERED=1 \
   PYTHONIOENCODING=UTF-8 \
-  LD_LIBRARY_PATH="/opt/amazon/ofi-nccl/lib64:/opt/amazon/openmpi/lib64:/opt/amazon/efa/lib64:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}" \
+  LD_LIBRARY_PATH="/opt/amazon/ofi-nccl/lib64:/opt/amazon/openmpi/lib64:/opt/amazon/efa/lib64:/usr/local/lib:/usr/local/cuda/lib64:${LD_LIBRARY_PATH}" \
   PATH="/opt/amazon/openmpi/bin:/opt/amazon/efa/bin:/usr/local/cuda/bin:${PATH}"
 
 WORKDIR /
 
 # Install DLC Python dependencies
-RUN uv pip install --no-cache-dir botocore
+RUN uv pip install --no-cache-dir botocore instanttensor modelexpress
 
 # Patch CVEs
 RUN uv pip install --no-cache-dir \
@@ -388,9 +409,11 @@ COPY --from=builder-oss /root/LINUX_PACKAGES_LICENSES /root/LINUX_PACKAGES_LICEN
 COPY --from=builder-oss /root/BUILD_FROM_SOURCE_PACKAGES_LICENCES /root/BUILD_FROM_SOURCE_PACKAGES_LICENCES
 COPY --from=builder-oss /usr/local/bin/testOSSCompliance /usr/local/bin/testOSSCompliance
 
+COPY --from=build /usr/local/lib/libgdrapi.so* /usr/local/lib/
+
 # install EFA
 COPY ./scripts/docker/common/install_efa_amzn2023.sh install_efa_amzn2023.sh
-ARG EFA_VERSION="1.47.0"
+ARG EFA_VERSION="1.50.0"
 RUN echo -e '[cuda-rhel9]\nname=cuda-rhel9\nbaseurl=https://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64\nenabled=1\ngpgcheck=1' >/etc/yum.repos.d/cuda-rhel9.repo \
   && dnf install -y --setopt=install_weak_deps=False libnccl libnccl-devel \
   && ldconfig \

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -443,7 +443,7 @@ RUN dnf install -y --setopt=install_weak_deps=False make \
        CXXSTD="-std=c++17" \
        "${NCCL_TESTS_DIR}/build/all_reduce_perf" \
   && cp "${NCCL_TESTS_DIR}/build/all_reduce_perf" /usr/local/bin/all_reduce_perf \
-  && dnf remove -y make && dnf clean all && rm -rf /var/cache/dnf \
+  && dnf clean all && rm -rf /var/cache/dnf \
   && cd / && rm -rf "${NCCL_TESTS_DIR}"
 
 # ====================== ec2 =========================================

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -162,6 +162,8 @@ RUN --mount=type=cache,target=/root/.cache/uv CUDA_MAJOR=$(echo $CUDA_VERSION | 
   && mkdir -p /tmp/ep_kernels_workspace/dist \
   && cd /tmp/deepep \
   && EP_NCCL_ROOT_DIR="/opt/venv/lib/python${PYTHON_VERSION}/site-packages/nvidia/nccl" \
+    LIBRARY_PATH="/opt/venv/lib/python${PYTHON_VERSION}/site-packages/nvidia/nccl/lib:/usr/local/cuda/lib64/stubs:/usr/local/cuda/targets/x86_64-linux/lib/stubs:${LIBRARY_PATH}" \
+    LD_LIBRARY_PATH="/opt/venv/lib/python${PYTHON_VERSION}/site-packages/nvidia/nccl/lib:${LD_LIBRARY_PATH}" \
     DISABLE_AGGRESSIVE_PTX_INSTRS=1 \
     TORCH_CUDA_ARCH_LIST='9.0a 10.0a 10.3a' \
     python3 setup.py bdist_wheel --dist-dir /tmp/ep_kernels_workspace/dist \

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -429,7 +429,7 @@ RUN echo -e '[cuda-rhel9]\nname=cuda-rhel9\nbaseurl=https://developer.download.n
 
 # Prebuild all_reduce_perf so the CI EFA test's setup_nccl_tests.sh is a no-op.
 ARG NCCL_TESTS_VERSION=v2.20.0
-RUN dnf install -y --setopt=install_weak_deps=False make gcc-c++ \
+RUN dnf install -y --setopt=install_weak_deps=False make \
   && NCCL_HOME=$(/opt/venv/bin/python -c "import nvidia.nccl; print(nvidia.nccl.__path__[0])") \
   && if [ ! -e "${NCCL_HOME}/lib/libnccl.so" ]; then \
        ln -s "$(basename $(ls ${NCCL_HOME}/lib/libnccl.so.* | head -1))" "${NCCL_HOME}/lib/libnccl.so"; \
@@ -443,7 +443,7 @@ RUN dnf install -y --setopt=install_weak_deps=False make gcc-c++ \
        CXXSTD="-std=c++17" \
        "${NCCL_TESTS_DIR}/build/all_reduce_perf" \
   && cp "${NCCL_TESTS_DIR}/build/all_reduce_perf" /usr/local/bin/all_reduce_perf \
-  && dnf remove -y make gcc-c++ && dnf clean all && rm -rf /var/cache/dnf \
+  && dnf remove -y make && dnf clean all && rm -rf /var/cache/dnf \
   && cd / && rm -rf "${NCCL_TESTS_DIR}"
 
 # ====================== ec2 =========================================

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -383,6 +383,12 @@ RUN uv pip install --no-cache-dir \
   # 8.0.1 fixes AttributeError on fastapi 0.138 _IncludedRouter that 500s /health (instrumentator #371)
   "prometheus-fastapi-instrumentator>=8.0.1"
 
+# Pin runtime NCCL to the DeepEP wheel's version (torch's transitive otherwise wins).
+ARG NCCL_VERSION
+RUN CUDA_MAJOR=$(echo "$CUDA_VERSION" | cut -d. -f1) \
+  && uv pip install --no-deps "nvidia-nccl-cu${CUDA_MAJOR}==${NCCL_VERSION}" \
+  && test "$(uv pip show nvidia-nccl-cu${CUDA_MAJOR} | awk '/^Version:/{print $2}')" = "${NCCL_VERSION}"
+
 COPY ./scripts/docker/telemetry/deep_learning_container.py /usr/local/bin/deep_learning_container.py
 COPY ./scripts/docker/telemetry/bash_telemetry.sh.template /tmp/bash_telemetry.sh.template
 

--- a/docker/vllm/Dockerfile.amzn2023
+++ b/docker/vllm/Dockerfile.amzn2023
@@ -427,6 +427,23 @@ RUN echo -e '[cuda-rhel9]\nname=cuda-rhel9\nbaseurl=https://developer.download.n
   && dnf clean all && rm -rf /var/cache/dnf \
   && rm -rf /usr/local/cuda/bin/nvdisasm*
 
+# Prebuild all_reduce_perf so the CI EFA test's setup_nccl_tests.sh is a no-op.
+ARG NCCL_TESTS_VERSION=v2.20.0
+RUN dnf install -y --setopt=install_weak_deps=False make gcc-c++ \
+  && NCCL_HOME=$(/opt/venv/bin/python -c "import nvidia.nccl; print(nvidia.nccl.__path__[0])") \
+  && if [ ! -e "${NCCL_HOME}/lib/libnccl.so" ]; then \
+       ln -s "$(basename $(ls ${NCCL_HOME}/lib/libnccl.so.* | head -1))" "${NCCL_HOME}/lib/libnccl.so"; \
+     fi \
+  && cd /tmp \
+  && NCCL_TESTS_DIR="/tmp/nccl-tests-${NCCL_TESTS_VERSION#v}" \
+  && curl -fsSL "https://github.com/NVIDIA/nccl-tests/archive/refs/tags/${NCCL_TESTS_VERSION}.tar.gz" | tar xz \
+  && make -C "${NCCL_TESTS_DIR}/src" BUILDDIR="${NCCL_TESTS_DIR}/build" \
+       MPI=1 MPI_HOME=/opt/amazon/openmpi NCCL_HOME="${NCCL_HOME}" CUDA_HOME=/usr/local/cuda \
+       "${NCCL_TESTS_DIR}/build/all_reduce_perf" \
+  && cp "${NCCL_TESTS_DIR}/build/all_reduce_perf" /usr/local/bin/all_reduce_perf \
+  && dnf remove -y make gcc-c++ && dnf clean all && rm -rf /var/cache/dnf \
+  && cd / && rm -rf "${NCCL_TESTS_DIR}"
+
 # ====================== ec2 =========================================
 FROM base AS vllm-ec2-amzn2023
 

--- a/test/sanity/scripts/test_sanity_vllm_sglang.py
+++ b/test/sanity/scripts/test_sanity_vllm_sglang.py
@@ -103,6 +103,21 @@ class TestCudaJitDependencies(unittest.TestCase):
 
         self.assertTrue(hasattr(triton, "__version__"))
 
+    def test_deep_ep_v2_available(self):
+        """DeepEP v2 (deep_ep wheel + runtime NCCL >= 2.30.4) present; amzn2023 only."""
+        import importlib.util
+
+        from vllm.utils.import_utils import _get_runtime_nccl_version
+
+        with open("/etc/os-release") as f:
+            if "amzn" not in f.read().lower():
+                self.skipTest("DeepEP v2 ships only on amzn2023 images")
+
+        self.assertIsNotNone(importlib.util.find_spec("deep_ep"), "deep_ep wheel not installed")
+        nccl = _get_runtime_nccl_version()  # ctypes ncclGetVersion on the loaded libnccl
+        self.assertIsNotNone(nccl, "could not read runtime NCCL version")
+        self.assertGreaterEqual(nccl, 23004, f"runtime NCCL {nccl} < 2.30.4; deepep_v2 won't load")
+
 
 class TestEntrypointArgHandling(unittest.TestCase):
     """Category 2: Verify sagemaker_entrypoint.sh handles env vars correctly."""

--- a/test/sanity/scripts/test_sanity_vllm_sglang.py
+++ b/test/sanity/scripts/test_sanity_vllm_sglang.py
@@ -104,19 +104,34 @@ class TestCudaJitDependencies(unittest.TestCase):
         self.assertTrue(hasattr(triton, "__version__"))
 
     def test_deep_ep_v2_available(self):
-        """DeepEP v2 (deep_ep wheel + runtime NCCL >= 2.30.4) present; amzn2023 only."""
-        import importlib.util
+        """DeepEP v2 *prerequisites*: deep_ep wheel installed + NCCL >= 2.30.4; amzn2023 only.
 
-        from vllm.utils.import_utils import _get_runtime_nccl_version
+        GPU-free guard only — it does NOT verify the v2 ElasticBuffer API (that needs
+        `import deep_ep`, i.e. a GPU); the real v2 functional check is the gated
+        test_ep.py on p5en. Framework-agnostic: this file is shared with SGLang (no
+        vllm package), so NCCL comes from the nvidia-nccl wheel metadata, not vllm.
+        """
+        import importlib.metadata
+        import importlib.util
 
         with open("/etc/os-release") as f:
             if "amzn" not in f.read().lower():
                 self.skipTest("DeepEP v2 ships only on amzn2023 images")
 
         self.assertIsNotNone(importlib.util.find_spec("deep_ep"), "deep_ep wheel not installed")
-        nccl = _get_runtime_nccl_version()  # ctypes ncclGetVersion on the loaded libnccl
-        self.assertIsNotNone(nccl, "could not read runtime NCCL version")
-        self.assertGreaterEqual(nccl, 23004, f"runtime NCCL {nccl} < 2.30.4; deepep_v2 won't load")
+
+        nccl_ver = None
+        for pkg in ("nvidia-nccl-cu13", "nvidia-nccl-cu12"):
+            try:
+                nccl_ver = importlib.metadata.version(pkg)
+                break
+            except importlib.metadata.PackageNotFoundError:
+                continue
+        self.assertIsNotNone(nccl_ver, "nvidia-nccl wheel not installed")
+        parts = tuple(int(x) for x in nccl_ver.split(".")[:3])
+        self.assertGreaterEqual(
+            parts, (2, 30, 4), f"NCCL {nccl_ver} < 2.30.4; deepep_v2 won't load"
+        )
 
 
 class TestEntrypointArgHandling(unittest.TestCase):

--- a/test/sanity/scripts/test_sanity_vllm_sglang.py
+++ b/test/sanity/scripts/test_sanity_vllm_sglang.py
@@ -104,34 +104,30 @@ class TestCudaJitDependencies(unittest.TestCase):
         self.assertTrue(hasattr(triton, "__version__"))
 
     def test_deep_ep_v2_available(self):
-        """DeepEP v2 *prerequisites*: deep_ep wheel installed + NCCL >= 2.30.4; amzn2023 only.
+        """DeepEP v2 *prerequisites* (deep_ep wheel + runtime NCCL >= 2.30.4); vLLM amzn2023 only.
 
-        GPU-free guard only — it does NOT verify the v2 ElasticBuffer API (that needs
-        `import deep_ep`, i.e. a GPU); the real v2 functional check is the gated
-        test_ep.py on p5en. Framework-agnostic: this file is shared with SGLang (no
-        vllm package), so NCCL comes from the nvidia-nccl wheel metadata, not vllm.
+        GPU-free; checks prerequisites only, NOT the ElasticBuffer v2 API (that needs
+        `import deep_ep` = a GPU) — real v2 validation is the gated test_ep.py on p5en.
+        Scoped to vLLM: this file is shared with SGLang, which builds DeepEP differently,
+        ships both cu12/cu13 nccl wheels (metadata is ambiguous), and has no `vllm`
+        package. SGLang's DeepEP is covered separately when its 0.5.19 recipe lands.
         """
-        import importlib.metadata
         import importlib.util
 
+        if importlib.util.find_spec("vllm") is None:
+            self.skipTest("not a vLLM image")
         with open("/etc/os-release") as f:
             if "amzn" not in f.read().lower():
                 self.skipTest("DeepEP v2 ships only on amzn2023 images")
 
         self.assertIsNotNone(importlib.util.find_spec("deep_ep"), "deep_ep wheel not installed")
+        # vLLM's own probe: ctypes ncclGetVersion on the actually-loaded libnccl (raw int,
+        # e.g. 23102 for 2.31.2) — avoids the cu12/cu13 wheel-metadata ambiguity.
+        from vllm.utils.import_utils import _get_runtime_nccl_version
 
-        nccl_ver = None
-        for pkg in ("nvidia-nccl-cu13", "nvidia-nccl-cu12"):
-            try:
-                nccl_ver = importlib.metadata.version(pkg)
-                break
-            except importlib.metadata.PackageNotFoundError:
-                continue
-        self.assertIsNotNone(nccl_ver, "nvidia-nccl wheel not installed")
-        parts = tuple(int(x) for x in nccl_ver.split(".")[:3])
-        self.assertGreaterEqual(
-            parts, (2, 30, 4), f"NCCL {nccl_ver} < 2.30.4; deepep_v2 won't load"
-        )
+        nccl = _get_runtime_nccl_version()
+        self.assertIsNotNone(nccl, "could not read runtime NCCL version")
+        self.assertGreaterEqual(nccl, 23004, f"runtime NCCL {nccl} < 2.30.4; deepep_v2 won't load")
 
 
 class TestEntrypointArgHandling(unittest.TestCase):

--- a/test/security/data/ecr_scan_allowlist/global_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/global_allowlist.json
@@ -2,6 +2,6 @@
     {
         "vulnerability_id": "RUSTSEC-2026-0195",
         "reason": "quick-xml 0.39.2 in uv binary, upstream uv has not released a fix yet. XML entity expansion DoS, low risk for pip installer use case.",
-        "review_by": "2026-09-10"
+        "review_by": "2026-10-22"
     }
 ]

--- a/test/security/data/ecr_scan_allowlist/vllm_server/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/vllm_server/framework_allowlist.json
@@ -92,7 +92,7 @@
     {
         "vulnerability_id": "CVE-2026-27145",
         "reason": "go/stdlib 1.24.11 embedded in mooncake libetcd_wrapper.so, x509 VerifyHostname CPU exhaustion, cannot patch without upstream mooncake rebuild with Go 1.26.4+",
-        "review_by": "2026-09-10"
+        "review_by": "2026-10-22"
     },
     {
         "vulnerability_id": "CVE-2026-39822",

--- a/test/vllm/scripts/amzn2023/vllm_sagemaker_examples_test.sh
+++ b/test/vllm/scripts/amzn2023/vllm_sagemaker_examples_test.sh
@@ -43,6 +43,6 @@ python3 basic/offline_inference/embed.py
 python3 basic/offline_inference/score.py
 
 SPEC_DECODE="features/speculative_decoding/spec_decode_offline.py"
-python3 ${SPEC_DECODE} --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048
-# https://github.com/vllm-project/vllm/pull/26682 uses slightly more memory in PyTorch 2.9+ causing this test to OOM in 1xL4 GPU
-python3 ${SPEC_DECODE} --test --method eagle3 --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 1536
+# DeepEP-v2 + 0.29.0 memory growth OOMs spec-decode on 1xL4 at the 0.9 default; raise to 0.95.
+python3 ${SPEC_DECODE} --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048 --gpu-memory-utilization 0.95
+python3 ${SPEC_DECODE} --test --method eagle3 --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 1536 --gpu-memory-utilization 0.95

--- a/test/vllm/scripts/vllm_ec2_examples_test.sh
+++ b/test/vllm/scripts/vllm_ec2_examples_test.sh
@@ -21,13 +21,8 @@ python3 basic/offline_inference/embed.py
 python3 basic/offline_inference/score.py
 
 SPEC_DECODE="features/speculative_decoding/spec_decode_offline.py"
-# vLLM 0.29.0's CUDA graph memory profiler lowers the effective gpu-memory-utilization, and
-# https://github.com/vllm-project/vllm/pull/26682 uses more memory in PyTorch 2.9+, leaving too
-# little KV cache for spec-decode on 1xL4 Ubuntu images. amzn2023 passes at the 0.9 default and
-# OOMs at higher values, so only raise it on Ubuntu.
-GPU_MEM_UTIL=0.9
-if grep -qi ubuntu /etc/os-release 2>/dev/null; then
-  GPU_MEM_UTIL=0.95
-fi
+# 0.29.0's CUDA-graph memory profiler shrinks effective KV; the DeepEP-v2 amzn2023 image's extra
+# footprint needs 0.95 on 1xL4 (same as Ubuntu), else spec-decode OOMs at the old 0.9 default.
+GPU_MEM_UTIL=0.95
 python3 ${SPEC_DECODE} --test --method eagle --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 2048 --gpu-memory-utilization ${GPU_MEM_UTIL}
 python3 ${SPEC_DECODE} --test --method eagle3 --num_spec_tokens 3 --dataset-name hf --dataset-path philschmid/mt-bench --num-prompts 80 --temp 0 --top-p 1.0 --top-k -1 --tp 1 --enable-chunked-prefill --max-model-len 1536 --gpu-memory-utilization ${GPU_MEM_UTIL}


### PR DESCRIPTION
Upgrades the vLLM AL2023 EC2 + SageMaker images to DeepEP v2 over EFA.

**Changes**
- vLLM `0.27.1` → `0.29.0` (NCCL 2.31.2 segfault fix)
- DeepEP → AWS EFA fork `amazon-contributing/DeepEP@874779c`, built as a wheel from the fork (drops the upstream `install_python_libraries.sh` path)
- NCCL `2.30.7` → `2.31.2` (pip wheel; required for the GIN/EFA backend)
- NVSHMEM now via pip wheel `nvidia-nvshmem-cu13==3.3.24`
- GDRCopy `2.5.2` userspace libs built from source (net-new for vLLM)
- EFA `1.47.0` → `1.50.0` (auto `--disable-ngc`)
- Add `instanttensor` + `modelexpress`
- `dlc_minor_version` 4 → 5

**Validation:** DeepEP internode (`test_ep.py` on 2x p5en) pending capacity; gated test wiring to follow. Draft until validated.