### PR TITLE
test(vllm): allowlist mooncake grpc CVEs for GPU vllm image

### DIFF
--- a/test/security/data/ecr_scan_allowlist/vllm/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/vllm/framework_allowlist.json
@@ -10,6 +10,16 @@
         "review_by": "2026-10-25"
     },
     {
+        "vulnerability_id": "CVE-2026-84304",
+        "reason": "google.golang.org/grpc v1.79.3 embedded in mooncake libetcd_wrapper.so, HTTP/2 DATA-frame fragmentation memory exhaustion fixed in grpc 1.83.1, cannot patch without upstream mooncake rebuild",
+        "review_by": "2026-10-25"
+    },
+    {
+        "vulnerability_id": "GHSA-2v4p-qf9q-27wj",
+        "reason": "google.golang.org/grpc v1.79.3 embedded in mooncake libetcd_wrapper.so, xds server panic on request missing :authority and Host headers, fix only in a grpc 1.85.0-dev pseudo-version, cannot patch without upstream mooncake rebuild",
+        "review_by": "2026-10-25"
+    },
+    {
         "vulnerability_id": "CVE-2026-46600",
         "reason": "golang.org/x/net v0.48.0 embedded in mooncake libetcd_wrapper.so, cannot patch without upstream mooncake rebuild",
         "review_by": "2026-10-25"


### PR DESCRIPTION
## Summary
The GPU vLLM images (`ec2-ubuntu`, `sagemaker-ubuntu`, `*-amzn2023`) scan with `framework: vllm`, so `ecr_scan.py` reads `test/security/data/ecr_scan_allowlist/vllm/framework_allowlist.json`. Two new mooncake grpc findings surfaced there and are not yet allowlisted, failing every vLLM PR's Ubuntu security-test:

- `CVE-2026-84304` — google.golang.org/grpc v1.79.3, HTTP/2 DATA-frame fragmentation memory exhaustion (fixed in grpc 1.83.1)
- `GHSA-2v4p-qf9q-27wj` — google.golang.org/grpc v1.79.3, xds server panic on request missing `:authority`/`Host` (fixed in grpc 1.85.0-dev)

Both are statically linked inside `mooncake/libetcd_wrapper.so` and cannot be patched without an upstream mooncake-transfer-engine rebuild — same class as the existing `GHSA-hrxh-6v49-42gf` grpc entry. Added both with `review_by: 2026-10-25`, matching the grpc cohort.

## Testing
`python3 -m json.tool` validates the file. ECR scan re-run will confirm.