### PR TITLE
[auto-cve-patch] [whisperx] bump nltk to 3.10.3, allowlist transformers, prune stale torch entry

### DIFF
--- a/docker/whisperx/uv.lock
+++ b/docker/whisperx/uv.lock
@@ -475,7 +475,9 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f3/04/81bd731d6d1e3a469d9a4c36f5eb069bcf0cbb2d5d342c9fec22245b91fc/greenlet-3.5.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3d66250e8b09f182ede05490998c818b5961f7a3640332d44c4927caec7bbfe4", size = 295909, upload-time = "2026-07-22T11:38:09.261Z" },
     { url = "https://files.pythonhosted.org/packages/cc/dd/f5f22903a6ae70f5ea328ed0beaec92ad903f0e3b7d2845133b354abc4b8/greenlet-3.5.4-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c90e930c9c192e5b3ee9fb8bcd920ea3926155e2e3ded39fc697323addecee17", size = 612011, upload-time = "2026-07-22T12:26:40.69Z" },
     { url = "https://files.pythonhosted.org/packages/8e/10/92a4a88d12b915d74ea5b6d288e4afefda4771647caa34442c156f7a454f/greenlet-3.5.4-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:791fdfeeb9c6e0c7b10fa151bf110d2a6974866f13dcb5b1c7efae698245893a", size = 624299, upload-time = "2026-07-22T12:29:02.089Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/f9/03e26be3487c5238e81f2b84714959a86ea8515a869828cf41f4fc54b34e/greenlet-3.5.4-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b7c895310363f310361e0fe2072af85269d2a2a285cd04c0c59e79a5e3670dcf", size = 629603, upload-time = "2026-07-22T12:43:43.456Z" },
     { url = "https://files.pythonhosted.org/packages/50/6d/0b14bb9db2989f32cd9fe7f76afedea01ee8bee3f87c07e69f24adfe7e63/greenlet-3.5.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f88193799d43dbf8c8a806d6405c9c52fe2af40bf75072a606357b33cc336c7f", size = 621541, upload-time = "2026-07-22T11:51:09.464Z" },
+    { url = "https://files.pythonhosted.org/packages/57/6b/7c55ca72ef80d57c16c4a55210f82582622462dc4485799a30f4ec6f3372/greenlet-3.5.4-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:13b980043cb1b3134e81ea469da1250ddcc6bfe6d245bbaa59168d9cdc8f228f", size = 432554, upload-time = "2026-07-22T12:39:51.379Z" },
     { url = "https://files.pythonhosted.org/packages/48/3d/25e9a2d9eb6b2e8b7ca4e80a3a26cb887cce6c8e0a87c921164f11bc5574/greenlet-3.5.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:b7a5f095767c4493afcd06067f2bb3b8716e3f3f9e92b99c88e7e99f885b3d4d", size = 1581444, upload-time = "2026-07-22T12:25:03.818Z" },
     { url = "https://files.pythonhosted.org/packages/b9/96/4c9bf2e2c408dcc0556edce69efa9f802e82223573c53240136a086821f1/greenlet-3.5.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:42afdc1ab5f66da8c586c32af9224a74a706b4f0ea0dc3a4188a0860a09c65c9", size = 1645842, upload-time = "2026-07-22T11:51:12.295Z" },
     { url = "https://files.pythonhosted.org/packages/b5/41/303ecb26a3a56122c0f4d4073ee078881847bd6b6f463ae0ec57ec20223b/greenlet-3.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:60149df8f462d1b230038e6590c23c3b4768bb5d6c022b3b6e82532b34b0b8a3", size = 247169, upload-time = "2026-07-22T11:38:19.893Z" },
@@ -807,7 +809,7 @@ wheels = [
 
 [[package]]
 name = "nltk"
-version = "3.10.0"
+version = "3.10.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -816,9 +818,9 @@ dependencies = [
     { name = "regex" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/02/df4f105b28a7c16b0e41423bc09cf0f1b8a305df4ef0b10ca74a2e4c648c/nltk-3.10.0.tar.gz", hash = "sha256:4fbac1d98203cbcd1b5d94a2877fb822300072d80604a5e7fae49d2c5f84e8c1", size = 3089244, upload-time = "2026-07-08T02:39:13.562Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/e6/fe51d2bb1a3b446f59c5c8165999a9fee208bc346af90a7cbf7657bc0d75/nltk-3.10.3.tar.gz", hash = "sha256:bb9327a461c3811c2fa4900e03840401f2126adfb30c0072827c433bd2444ea4", size = 5137152, upload-time = "2026-08-12T23:46:37.258Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/89/a0b0f35e2820d6a99d75ea1c11977ee6d5c9e6658eceb45b0c7620881faa/nltk-3.10.0-py3-none-any.whl", hash = "sha256:54ff84d4916d3ef127e8953bee0023f6a6b320b75d634a19e06ef056d3d244bf", size = 1716144, upload-time = "2026-07-08T02:39:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6d/ebd2af4640b12168fdf0cb74b6118df2f32a2f62ec7e0c06fbfd80706639/nltk-3.10.3-py3-none-any.whl", hash = "sha256:ff9598a8e20518ee0d557745890cc4435b9578489e2dcbc69c4f81fa060caf7c", size = 1798643, upload-time = "2026-08-12T23:44:13.478Z" },
 ]
 
 [[package]]
@@ -877,7 +879,7 @@ name = "nvidia-cudnn-cu12"
 version = "9.10.2.21"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
@@ -888,7 +890,7 @@ name = "nvidia-cufft-cu12"
 version = "11.3.3.83"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
@@ -915,9 +917,9 @@ name = "nvidia-cusolver-cu12"
 version = "11.7.3.90"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
@@ -928,7 +930,7 @@ name = "nvidia-cusparse-cu12"
 version = "12.5.8.93"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink-cu12", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
@@ -1866,7 +1868,7 @@ name = "triton"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "setuptools" },
+    { name = "setuptools", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/66/b1eb52839f563623d185f0927eb3530ee4d5ffe9d377cdaf5346b306689e/triton-3.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:31c1d84a5c0ec2c0f8e8a072d7fd150cab84a9c239eaddc6706c081bfae4eb04", size = 155560068, upload-time = "2025-07-30T19:58:37.081Z" },

--- a/test/security/data/ecr_scan_allowlist/whisperx/framework_allowlist.json
+++ b/test/security/data/ecr_scan_allowlist/whisperx/framework_allowlist.json
@@ -1,27 +1,22 @@
 [
     {
         "vulnerability_id": "CVE-2026-4372",
-        "reason": "transformers is a transitive dependency pulled by whisperx 3.8.6, which constrains transformers<5; the fix requires transformers>=5.3.0 (a major bump) and cannot be taken without breaking the whisperx contract. Not on the container's inference path (the Trainer class is unused). Tracked for a whisperx version that supports transformers 5.x.",
-        "review_by": "2026-10-13"
+        "reason": "transformers 4.57.6 is a transitive dependency of whisperx 3.8.6; the fix requires transformers>=5.3.0, but transformers 5.x requires huggingface-hub>=1.5.0 while whisperx 3.8.6 pins huggingface-hub<1.0.0, so uv resolution rejects any 5.x bump. Fixable only via a new whisperx release that raises the huggingface-hub cap. The vulnerable Trainer path is not exercised by the ASR inference server.",
+        "review_by": "2026-10-08"
     },
     {
         "vulnerability_id": "CVE-2026-1839",
-        "reason": "transformers is a transitive dependency pulled by whisperx 3.8.6, which constrains transformers<5; the fix requires transformers>=5.0.0 (a major bump) and cannot be taken without breaking the whisperx contract. The vulnerable Trainer._load_rng_state path is not exercised by inference serving. Tracked for a whisperx version that supports transformers 5.x.",
-        "review_by": "2026-10-13"
+        "reason": "transformers 4.57.6 is a transitive dependency of whisperx 3.8.6; the fix requires transformers>=5.0.0, but transformers 5.x requires huggingface-hub>=1.5.0 while whisperx 3.8.6 pins huggingface-hub<1.0.0, so uv resolution rejects any 5.x bump. Fixable only via a new whisperx release that raises the huggingface-hub cap. The vulnerable Trainer._load_rng_state path is not on the inference-serving path.",
+        "review_by": "2026-10-08"
     },
     {
         "vulnerability_id": "CVE-2026-5241",
-        "reason": "transformers is a transitive dependency pulled by whisperx 3.8.6, which constrains transformers<5; the fix requires transformers>=5.5.0 (a major bump) and cannot be taken without breaking the whisperx contract. The vulnerable code path is not exercised by the ASR inference server. Tracked for a whisperx version that supports transformers 5.x.",
-        "review_by": "2026-10-13"
+        "reason": "transformers 4.57.6 is a transitive dependency of whisperx 3.8.6; the fix requires transformers>=5.5.0, but transformers 5.x requires huggingface-hub>=1.5.0 while whisperx 3.8.6 pins huggingface-hub<1.0.0, so uv resolution rejects any 5.x bump. Fixable only via a new whisperx release that raises the huggingface-hub cap. The vulnerable code path is not exercised by the ASR inference server.",
+        "review_by": "2026-09-24"
     },
     {
         "vulnerability_id": "CVE-2026-24747",
         "reason": "torch is pinned to 2.8.0 by whisperx 3.8.6 (torch~=2.8.0, via torchvision~=0.23.0); the fix requires torch>=2.10.0 and cannot be taken without breaking the whisperx contract. torch.load defaults to weights_only=True on 2.8, and model checkpoints are baked or resolved from HuggingFace by default; an operator-supplied model directory is a deployment trust boundary. Tracked for a whisperx version that raises its torch cap.",
-        "review_by": "2026-10-13"
-    },
-    {
-        "vulnerability_id": "CVE-2025-55552",
-        "reason": "torch is pinned to 2.8.0 by whisperx 3.8.6 (torch~=2.8.0); the fix requires torch>=2.9.0 and cannot be taken without breaking the whisperx contract. The reported torch.rot90/torch.randn_like interaction is not on the ASR inference path. Tracked for a whisperx version that raises its torch cap.",
         "review_by": "2026-10-13"
     },
     {
@@ -53,5 +48,10 @@
         "vulnerability_id": "CVE-2026-58659",
         "reason": "lightning is a transitive dependency pulled by pyannote.audio 4.0.7 (its diarization pipeline); it is not imported by the whisperx serving code. The fix (commit d710d68) is on the lightning master branch only and has not shipped in any release: 2.6.5 is the latest published version on PyPI and is the pinned version, so no version bump can remediate this. The vulnerable _load_state path is reached only via LightningModule.load_from_checkpoint on an untrusted, attacker-crafted .ckpt; the container's diarization weights are baked from the trusted CI models bucket, not loaded from untrusted input at inference time. Tracked for the first lightning release > 2.6.5 that contains the fix.",
         "review_by": "2026-10-13"
+    },
+    {
+        "vulnerability_id": "CVE-2026-9856",
+        "reason": "transformers 4.57.6 is a transitive dependency of whisperx 3.8.6; the fix requires transformers>=5.10.0, but transformers 5.x requires huggingface-hub>=1.5.0 while whisperx 3.8.6 pins huggingface-hub<1.0.0, so uv resolution rejects any 5.x bump. Fixable only via a new whisperx release that raises the huggingface-hub cap.",
+        "review_by": "2026-10-08"
     }
 ]


### PR DESCRIPTION
## Purpose

Patch CVEs in the WhisperX DLC image.

## Images affected

`whisperx:3.8.6-cu128-amzn2023` and `whisperx:3.8.6-cu128-amzn2023-sagemaker` (both tags share pyproject/uv.lock).

## CVEs handled

| CVE | Package | Severity | Affected images | Action | Notes |
|---|---|---|---|---|---|
| CVE-2026-62384, -71513, -72818, -78680, -78681, -78682, -79674, -81722, -81727 | nltk | HIGH | ec2 + sagemaker | bump 3.10.0 → 3.10.3 | |
| CVE-2026-79657, CVE-2026-79675 | nltk | CRITICAL | ec2 + sagemaker | bump 3.10.0 → 3.10.3 | |
| CVE-2026-9856 | transformers | HIGH | ec2 + sagemaker | allowlist (new) | fix needs transformers>=5.10.0; transformers 5.x needs huggingface-hub>=1.5.0 but whisperx 3.8.6 pins huggingface-hub<1.0.0 — needs a new whisperx release |
| CVE-2026-4372, CVE-2026-1839 | transformers | HIGH | ec2 + sagemaker | allowlist (reason corrected) | corrected the justification: block is whisperx's huggingface-hub<1.0.0 cap vs transformers 5.x needing huggingface-hub>=1.5.0 (prior text said whisperx caps transformers<5, which is not the actual constraint) |
| CVE-2026-5241 | transformers | CRITICAL | ec2 + sagemaker | allowlist (reason corrected) | same correction as above |

**Prunes:** Pruned 1 stale entry (CVE-2025-55552, torch) — no longer reported in the current scan on either tag.

## Test plan

- [x] CI security tests pass
- [x] CI sanity tests pass
- [x] CI WhisperX tests pass

---
🤖 Generated by [Claude Code](https://claude.com/claude-code).
