### PR TITLE
Add me-west-1 telemetry region mapping

### DIFF
--- a/src/deep_learning_container.py
+++ b/src/deep_learning_container.py
@@ -58,6 +58,7 @@ REGION_MAPPING = {
     "ca-west-1": "ea83ea06",
     "eu-south-2": "df2c9d70",
     "eu-central-2": "aa7aabcc",
+    "me-west-1": "1b9ff200",
 }
 
 

--- a/test/test_utils/__init__.py
+++ b/test/test_utils/__init__.py
@@ -295,6 +295,7 @@ TELEMETRY_REGION_MAPPING = {
     "ca-west-1": "ea83ea06",
     "eu-south-2": "df2c9d70",
     "eu-central-2": "aa7aabcc",
+    "me-west-1": "1b9ff200",
 }
 
 


### PR DESCRIPTION
Adds the `me-west-1` entry to `REGION_MAPPING` in `src/deep_learning_container.py`, and mirrors it in `TELEMETRY_REGION_MAPPING` in `test/test_utils/__init__.py`.

This lets DLC telemetry resolve the correct regional S3 query bucket for `me-west-1`. The hash `1b9ff200` is `sha256("me-west-1")[:8]`, consistent with how every other region entry in these dicts is derived.